### PR TITLE
Stage 1: Real-scene NavModels (stars, body, rings)

### DIFF
--- a/AUTONAV_PLAN.md
+++ b/AUTONAV_PLAN.md
@@ -1131,14 +1131,11 @@ this section is the operational checklist.
 - `NavTechniqueCorrelateAll` (the legacy fused-model NCC pipeline).
 - `NavModelCombined`, `NavModelResult` (replaced by per-feature
   templates and the ensemble's per-technique combine).
-- The legacy `NavModelStars`, `NavModelBody`, `NavModelRings`
-  classes — only the `rings/` data-model subpackage and the
-  simulated variants survive on the new contract.
-- The deleted star-catalog helpers (aberration, proper motion,
-  incremental catalog search, body / ring conflict marking) need
-  to be carried forward verbatim into a helper module so the new
-  `NavModelStars` does not rewrite them; this is tracked under
-  "Pending" below.
+- The previous `NavModelStars`, `NavModelBody`, `NavModelRings`
+  classes — replaced by the new-contract implementations listed
+  under "Concrete NavModels (Part 1, Part 8)" above. The
+  `rings/` data-model subpackage and the simulated variants
+  survive unchanged.
 
 ### Pending
 
@@ -1254,11 +1251,11 @@ this section is the operational checklist.
 **NavModel coverage gap (Part 1, Part 8) — needs the image library**
 
 These code paths cannot be unit-tested without a working
-``oops.Backplane`` + SPICE pool + a real obs camera model.  They
+``oops.Backplane`` + SPICE pool + a real obs camera model. They
 account for the bulk of the remaining 10 % gap on
 ``nav.nav_model.stars.catalog`` plus the > 50 % gap on
 ``nav.nav_model.nav_model_body``, ``nav.nav_model.nav_model_rings``,
-and ``nav.nav_model.stars.conflicts``.  The integration tests under
+and ``nav.nav_model.stars.conflicts``. The integration tests under
 ``tests/integration/test_autonomous_nav.py`` will hit them when the
 image library lands.
 

--- a/AUTONAV_PLAN.md
+++ b/AUTONAV_PLAN.md
@@ -1027,6 +1027,36 @@ this section is the operational checklist.
   `RingFeatureFilter`, `RingRenderResult`, `RingsRenderContext`,
   `ring_math`, `ring_types`) preserved with restored unit tests.
 
+**Concrete NavModels (Part 1, Part 8)**
+
+- `nav.nav_model.stars` package — `NavModelStars` orchestrator plus
+  six helper modules: `catalog` (multi-catalog reduction with
+  stellar aberration, proper motion, FOV projection, dedup),
+  `conflicts` (body / ring occlusion via the `oops` backplane),
+  `predicted_snr` (per-star integrated SNR with
+  `SCLASS_TO_B_MINUS_V` colour lookup), `smeared_psf` (smear-aware
+  PSF rendering and per-image smear-vector computation from SPICE
+  brackets), `detection` (DAOPHOT-style matched-filter detector with
+  CCD bloom and shape cuts), and the orchestrator itself.  Emits
+  one `STAR` feature per usable catalog star with anisotropic CRLB
+  centroid covariance.
+- `nav.nav_model.NavModelBody` — per-body silhouette navigation; one
+  instance per body with `inventory_body_in_extfov`.  Builds an
+  oversampled Lambert-shaded silhouette, extracts limb / terminator
+  polylines, and emits `LIMB_ARC` / `BODY_BLOB` / `BODY_DISC` /
+  `TERMINATOR_ARC` features per the design's emission gates.
+  Per-vertex polyline sigmas follow the quadrature-sum formula with
+  the `MAX_INCIDENCE_FACTOR_CAP` clamp.  Per-body shape parameters
+  come from `nav.nav_model.body_shape.BODY_SHAPE_TABLE` (which the
+  pending `config_220_body_shape.yaml` loader will replace).
+- `nav.nav_model.NavModelRings` — catalog-driven ring navigation;
+  one instance per planet whose ring catalog touches the FOV.
+  Reuses the four-pass `RingFeatureFilter`, samples each surviving
+  rendered edge mask into a polyline, and emits `RING_EDGE`
+  (per-vertex `RingEdgePolyline` with σ_radial / σ_along_edge) or
+  `RING_ANNULUS` (multi-edge composite template) per the radial
+  resolvability threshold.
+
 **Orchestrator + ensemble (Part 4)**
 
 - `nav.nav_orchestrator.NavContext` (frozen, `with_prior`
@@ -1112,16 +1142,20 @@ this section is the operational checklist.
 
 ### Pending
 
-**Concrete NavModels (Part 1, Part 8)**
+**Cartographic-model emission (Part 1)**
 
-- Real-scene `NavModelStars` on the new contract — must reuse the
-  existing aberration / proper-motion / catalog-reduction /
-  body-and-ring-conflict logic from the deleted module rather than
-  rewrite it.
-- Real-scene `NavModelBody` (per-body limb, terminator, disc, blob,
-  cartographic-model emission with the existing shape gates).
-- Real-scene `NavModelRings` (per-edge polylines + `RING_ANNULUS`
-  fallback, using the preserved `RingFeatureFilter`).
+- `CARTOGRAPHIC_MODEL` feature emission from the body NavModel via
+  ``nav.reproj.cartographic_model.create_cartographic_model``.
+  ``NavModelBody`` currently emits ``LIMB_ARC`` / ``TERMINATOR_ARC``
+  / ``BODY_DISC`` / ``BODY_BLOB`` only.
+
+**Per-camera mag-offset table consumer (Part 1)**
+
+- ``nav.nav_model.stars.predicted_snr.predicted_snr`` accepts a
+  ``mag_offset`` parameter, but ``NavModelStars.to_features`` always
+  passes ``0.0`` because no per-camera ``mag_offset_table`` config
+  block is read.  When the per-camera ``mag_offset:`` YAML blocks
+  ship, wire the lookup through.
 
 **Concrete NavTechniques (Part 3)**
 
@@ -1216,6 +1250,39 @@ this section is the operational checklist.
 - `tests/integration/test_autonomous_nav.py` (per-image regression).
 - `tests/integration/baselines/<image_id>.json` regression
   baselines.
+
+**NavModel coverage gap (Part 1, Part 8) — needs the image library**
+
+These code paths cannot be unit-tested without a working
+``oops.Backplane`` + SPICE pool + a real obs camera model.  They
+account for the bulk of the remaining 10 % gap on
+``nav.nav_model.stars.catalog`` plus the > 50 % gap on
+``nav.nav_model.nav_model_body``, ``nav.nav_model.nav_model_rings``,
+and ``nav.nav_model.stars.conflicts``.  The integration tests under
+``tests/integration/test_autonomous_nav.py`` will hit them when the
+image library lands.
+
+- ``NavModelBody._render`` / ``_build_backplane_model`` — the
+  oversampled ``Meshgrid.for_fov`` plus ``Backplane(obs,
+  meshgrid=...)`` plus ``filter_downsample`` chain.  Drives the
+  silhouette / Lambert / limb / terminator / km-per-pixel arrays
+  every body feature reads.
+- ``NavModelRings._render`` — the four-pass ``RingFeatureFilter``
+  applied to a real ``ext_bp.ring_radius`` / ``border_atop`` /
+  ``where_inside_shadow`` surface plus ``RingFeature.render``
+  (which calls ``ext_bp.radial_mode`` for each ring perturbation
+  mode).
+- ``nav.nav_model.stars.conflicts.mark_body_and_ring_conflicts``
+  / ``_check_one_star`` — per-star ``Meshgrid.for_fov`` plus
+  ``Backplane(obs, meshgrid).where_intercepted(body)`` and
+  ``ring_radius(ring)`` calls.
+- ``nav.nav_model.stars.catalog.aberrate_star`` — ``oops.Event``
+  constructor body (lines ~134–145).
+- ``nav.nav_model.stars.catalog`` lazy catalog getters
+  (``UCAC4StarCatalog()`` / ``SpiceStarCatalog('tycho2')`` /
+  ``YBSCStarCatalog()``) — first-call instantiation paths
+  requiring real catalog data on disk or via the per-test
+  ``UCAC4_PATH`` / ``YBSC_PATH`` env vars.
 
 **Confidence-formula calibration (Part 5)**
 
@@ -1493,56 +1560,16 @@ work can construct any of these and trust the inputs are checked.
   (not just those targeting ``main``); the matrix covers Python
   3.11 / 3.12 / 3.13 / 3.14.  ``codecov-action@v6``.
 
-### Stage 1 entry points (the next AI session starts here)
+### Stage 1 entry points (NavModels — complete)
 
+The three concrete NavModels (`NavModelStars`, `NavModelBody`,
+`NavModelRings`) are landed under
+``src/nav/nav_model/{stars,nav_model_body.py,nav_model_rings.py}``.
 The "Pending" subsection of "Implementation status (snapshot)" is
-the canonical work list.  Stage 1 should land **real-scene
-NavModels** so concrete NavTechniques have something to consume.
-Recommended order:
-
-1. **``NavModelStars``** — the validated star-catalog reduction
-   helpers (aberration, proper motion, multi-catalog precedence,
-   incremental search, body / ring conflict marking, the
-   ``SCLASS_TO_B_MINUS_V`` lookup, smear-aware PSF rendering)
-   were preserved in git history under the deleted
-   ``src/nav/nav_model/nav_model_stars.py`` (~1004 lines).
-   Recover with
-   ``git log --diff-filter=D -- src/nav/nav_model/nav_model_stars.py``;
-   structure as helper modules under
-   ``src/nav/nav_model/stars/`` (``predicted_snr.py``,
-   ``detection.py``, ``aberration.py``, ``conflicts.py``, etc.)
-   imported by the new ``NavModelStars.to_features``.  Emit
-   ``STAR`` features on the new ``NavFeature`` contract; populate
-   ``StarGeometry``, ``StarFlags``, predicted-SNR-driven
-   ``reliability``, and a ``NavFilterKind.NONE`` filter spec.
-
-2. **``NavModelBody``** — limb-mask extraction, body-silhouette
-   computation, and the body-shape lookup logic were preserved in
-   the deleted ``src/nav/nav_model/nav_model_body.py`` (~540 lines).
-   ``NavModelBodyBase`` (still present) provides the shared
-   annotation rendering.  Per resolution / shape / lighting,
-   emit a mix of ``LIMB_ARC``, ``TERMINATOR_ARC``, ``BODY_DISC``,
-   and ``BODY_BLOB`` features.
-
-3. **``NavModelRings``** — the four-pass ``RingFeatureFilter`` is
-   already preserved under
-   ``src/nav/nav_model/rings/ring_filter.py``.  The deleted
-   ``src/nav/nav_model/nav_model_rings.py`` (~525 lines) carried the
-   per-edge polyline rendering that the new ``to_features`` needs
-   to call.  Emit ``RING_EDGE`` features per edge, plus a
-   ``RING_ANNULUS`` fallback when many edges pack into few pixels.
-
-For each NavModel:
-
-- Implement ``instances_for_obs(cls, obs)`` to construct one
-  instance per body / per planet with visible rings / one stars
-  model so the registry-based discovery in
-  ``build_models_for_obs`` works.
-- Populate ``self._metadata`` during ``create_model`` (the curator
-  pass-through is already wired into ``NavResult.model_metadata``).
-- Build a fresh ``Annotations`` collection in ``to_annotations`` —
-  the orchestrator's ``_collect_annotations`` already merges them
-  into ``NavResult.annotations``.
+the canonical follow-up list.  The next stage of work is the
+concrete `NavTechniques` that consume the emitted features
+(`StarFieldFromCatalogNav`, `BodyDiscCorrelateNav`, `RingEdgeNav`,
+etc.).
 
 After NavModels land, stage 2 should bring up the concrete
 NavTechniques (``BodyDiscCorrelateNav``, ``BodyLimbNav``,

--- a/docs/api_reference/api_nav_model.rst
+++ b/docs/api_reference/api_nav_model.rst
@@ -6,12 +6,27 @@ nav.nav_model
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: nav.nav_model.body_shape
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: nav.nav_model.nav_model_body
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: nav.nav_model.nav_model_body_base
    :members:
    :undoc-members:
    :show-inheritance:
 
 .. automodule:: nav.nav_model.nav_model_body_simulated
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: nav.nav_model.nav_model_rings
    :members:
    :undoc-members:
    :show-inheritance:
@@ -63,6 +78,43 @@ rendering support for planetary ring models.
    :show-inheritance:
 
 .. automodule:: nav.nav_model.rings.ring_render_result
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+nav.nav_model.stars
+-------------------
+
+The ``nav.nav_model.stars`` subpackage provides catalog reduction, conflict
+marking, predicted-SNR computation, smear-aware PSF rendering, and DAOPHOT-style
+detection support for the star navigation model.
+
+.. automodule:: nav.nav_model.stars.nav_model_stars
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: nav.nav_model.stars.catalog
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: nav.nav_model.stars.conflicts
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: nav.nav_model.stars.predicted_snr
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: nav.nav_model.stars.smeared_psf
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: nav.nav_model.stars.detection
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/developer_guide_navigation_models.rst
+++ b/docs/developer_guide_navigation_models.rst
@@ -19,11 +19,30 @@ bases set ``_abstract = True`` to opt out.  The class method
 ``instances_for_obs(cls, obs)`` is the per-class hook that
 :func:`~nav.nav_model.nav_model.build_models_for_obs` iterates.
 
-Today's registered concrete models cover Titan (a stub), simulated
-bodies, and simulated rings; the real-scene body and ring models are
-unimplemented.  The data-model subpackage :mod:`nav.nav_model.rings`
-provides the catalog-driven ring-feature classes shared between the
-simulated and real (forthcoming) ring renderers.
+Registered concrete models:
+
+- :class:`~nav.nav_model.stars.nav_model_stars.NavModelStars` — catalog-driven
+  star navigation; one instance per observation.
+- :class:`~nav.nav_model.nav_model_body.NavModelBody` — per-body silhouette
+  navigation; one instance per body whose bounding box overlaps the
+  extended FOV.
+- :class:`~nav.nav_model.nav_model_rings.NavModelRings` — catalog-driven
+  ring navigation; one instance per planet whose ring system is
+  configured and visible.
+- :class:`~nav.nav_model.nav_model_body_simulated.NavModelBodySimulated`
+  and :class:`~nav.nav_model.nav_model_rings_simulated.NavModelRingsSimulated`
+  — simulated-image GUI variants that render bodies and rings from
+  operator-supplied parameters.
+- :class:`~nav.nav_model.nav_model_titan.NavModelTitan` — placeholder for
+  atmospheric-body navigation (no features emitted).
+
+Shared annotation helpers live on
+:class:`~nav.nav_model.nav_model_body_base.NavModelBodyBase` (body silhouette
++ label rendering) and
+:class:`~nav.nav_model.nav_model_rings_base.NavModelRingsBase` (per-edge
+polyline + label rendering).  The :mod:`nav.nav_model.rings` subpackage
+holds the catalog-driven ring data model — validation, filtering, and
+rendering are separated so each concern can be tested in isolation.
 
 The API surface is summarised under
 :doc:`api_reference/api_nav_model`.

--- a/docs/developer_guide_navigation_models_bodies.rst
+++ b/docs/developer_guide_navigation_models_bodies.rst
@@ -2,20 +2,120 @@
 Bodies
 ======
 
-Body navigation models render the predicted appearance of a planetary body
-into a per-feature template plus optional polyline geometries (limb,
-terminator).  Concrete subclasses derive from
-:class:`~nav.nav_model.nav_model_body_base.NavModelBodyBase`, which carries
-shared annotation helpers (limb-mask extraction and label placement).
+Body navigation models render the predicted appearance of a planetary
+body and emit one
+:class:`~nav.feature.feature.NavFeature` per surviving feature type.
+Concrete subclasses derive from
+:class:`~nav.nav_model.nav_model_body_base.NavModelBodyBase`, which
+carries shared annotation helpers (limb-mask extraction and label
+placement).
 
-Today's only registered concrete body model is
-:class:`~nav.nav_model.nav_model_body_simulated.NavModelBodySimulated`,
-used by the simulated-image GUI to compose synthetic test scenes from
-operator-supplied geometric parameters; it emits a single
-``BODY_DISC`` :class:`~nav.feature.feature.NavFeature` carrying the
-rendered template.
+Registered concrete subclasses:
 
-The real-scene body model is unimplemented; its concrete subclass will
-emit a mix of ``LIMB_ARC``, ``TERMINATOR_ARC``, ``BODY_DISC``, and
-``BODY_BLOB`` features depending on per-image visibility, lighting, and
-shape uncertainty.
+- :class:`~nav.nav_model.nav_model_body.NavModelBody` — catalog-driven
+  body navigation; one instance per body whose
+  ``inventory_body_in_extfov`` predicate fires.
+- :class:`~nav.nav_model.nav_model_body_simulated.NavModelBodySimulated`
+  — simulated-image GUI variant; emits a single ``BODY_DISC``
+  feature carrying the rendered template.
+
+The catalog-driven body model
+-----------------------------
+
+:class:`~nav.nav_model.nav_model_body.NavModelBody` builds an
+oversampled meshgrid around the body's bounding box, renders the
+Lambert-shaded silhouette, and extracts limb and terminator polylines
+from the discrete masks.  Per-body shape parameters come from
+:data:`~nav.nav_model.body_shape.BODY_SHAPE_TABLE`.
+
+Per-image quantities the model computes and exposes through
+``self._metadata``:
+
+- ``sub_solar_lon_deg`` / ``sub_solar_lat_deg`` —
+  sub-solar coordinates.
+- ``sub_observer_lon_deg`` / ``sub_observer_lat_deg`` —
+  sub-observer coordinates.
+- ``phase_angle_deg`` — center-pixel phase angle.
+- ``predicted_diameter_px`` — predicted body diameter in pixels.
+- ``km_per_pixel_at_limb`` — mean km/px scale across the limb polyline.
+- ``visible_lit_fraction`` — fraction of the predicted disc that is
+  both lit and inside the sensor FOV.
+- ``overflow_fraction`` — fraction of the predicted disc that is
+  outside the sensor FOV.
+
+Emission rules
+^^^^^^^^^^^^^^
+
+The model emits the right combination of features per the gates in
+:mod:`~nav.nav_model.nav_model_body`:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Feature
+     - Emission rule
+   * - ``LIMB_ARC``
+     - Emitted when the polyline has at least one surviving vertex and
+       ``limb_uncertainty_px`` (= ``ellipsoid_residual_km /
+       km_per_pixel_at_limb``) is at most
+       :data:`~nav.nav_model.nav_model_body.LIMB_ARC_MAX_UNCERTAINTY_PX`.
+   * - ``BODY_BLOB``
+     - Emitted when ``LIMB_ARC`` was rejected by the uncertainty gate
+       and the predicted diameter is at least
+       ``BodyShape.min_blob_diameter_px``.
+   * - ``BODY_DISC``
+     - Emitted alongside ``LIMB_ARC`` when ``visible_lit_fraction``
+       meets
+       :data:`~nav.nav_model.nav_model_body.BODY_DISC_MIN_VISIBLE_LIT_FRACTION`
+       and ``overflow_fraction`` is below
+       :data:`~nav.nav_model.nav_model_body.BODY_DISC_MAX_OVERFLOW_FRACTION`.
+   * - ``TERMINATOR_ARC``
+     - Emitted when the terminator polyline has at least
+       :data:`~nav.nav_model.nav_model_body.TERMINATOR_MIN_VERTICES`
+       surviving vertices and ``sin(phase_angle)`` is at least
+       :data:`~nav.nav_model.nav_model_body.TERMINATOR_MIN_PHASE_FACTOR`.
+
+Per-vertex polyline covariance
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For ``LIMB_ARC`` and ``TERMINATOR_ARC`` features the per-vertex
+``sigma_normal_per_vertex_px`` follows the design's quadrature-sum:
+
+.. code-block::
+
+   sigma_normal_per_vertex_km = sqrt(
+       ellipsoid_residual_km^2
+     + crater_scale_km^2
+     + (incidence_factor(i) * limb_softness_km)^2
+     + spice_orbital_residual_km^2
+   )
+   sigma_normal_per_vertex_px = sigma_normal_per_vertex_km / km_per_pixel_at_vertex
+
+with ``limb_softness_km = sigma_PSF_px * km_per_pixel_at_vertex``.  The
+``incidence_factor`` is capped at
+:data:`~nav.feature.constants.MAX_INCIDENCE_FACTOR_CAP`.  Terminator
+arcs add an albedo-variation and photometric-model term to the
+quadrature sum.  The ``sigma_tangent_per_vertex_px`` is a small
+constant (~0.5 px) reflecting polyline-sampling resolution.
+
+Body shape table
+----------------
+
+:mod:`nav.nav_model.body_shape` carries per-body shape, albedo, and
+SPICE-residual quantities used by the covariance and emission gates.
+Each entry is a frozen
+:class:`~nav.nav_model.body_shape.BodyShape` dataclass:
+
+- ``ellipsoid_residual_km`` — RMS deviation of the body silhouette from
+  the best-fit ellipsoid.
+- ``crater_scale_km`` — characteristic per-image limb roughness from
+  craters and topography.
+- ``albedo_variation`` — fractional disc-brightness variation.
+- ``spice_orbital_residual_km`` — SPK ephemeris uncertainty in km.
+- ``min_blob_diameter_px`` — predicted disc diameter at which
+  ``BODY_BLOB`` is preferred over an unresolved limb.
+
+:func:`~nav.nav_model.body_shape.shape_for_body` performs the
+case-insensitive lookup; bodies absent from the table fall back to
+:data:`~nav.nav_model.body_shape.DEFAULT_BODY_SHAPE`.

--- a/docs/developer_guide_navigation_models_rings.rst
+++ b/docs/developer_guide_navigation_models_rings.rst
@@ -5,12 +5,50 @@ Rings
 The ring NavModel renders each catalog-driven ring edge into per-edge
 polylines plus an optional ``RING_ANNULUS`` composite template, emitting
 :class:`~nav.feature.feature.NavFeature` instances for technique
-consumption.  Today's only registered concrete subclass is
-:class:`~nav.nav_model.nav_model_rings_simulated.NavModelRingsSimulated`,
-used by the simulated-image GUI; the real-scene model is unimplemented.
+consumption.
+
+Registered concrete subclasses:
+
+- :class:`~nav.nav_model.nav_model_rings.NavModelRings` — catalog-driven
+  ring navigation; one instance per planet whose ring system is
+  configured and visible in the extended FOV.
+- :class:`~nav.nav_model.nav_model_rings_simulated.NavModelRingsSimulated`
+  — simulated-image GUI variant; emits a single ``RING_ANNULUS``
+  feature carrying the rendered template.
+
 The :mod:`nav.nav_model.rings` subpackage holds the catalog-driven
 domain model — validation, filtering, and rendering are separated so
 each concern can be tested in isolation.
+
+The catalog-driven ring model
+-----------------------------
+
+:class:`~nav.nav_model.nav_model_rings.NavModelRings` runs the
+four-pass :class:`~nav.nav_model.rings.ring_filter.RingFeatureFilter`
+selection (date, radius, resolvability, fade-conflict), renders each
+surviving feature via
+:meth:`~nav.nav_model.rings.ring_feature.RingFeature.render`, samples
+each rendered edge mask into a polyline, and emits one of:
+
+- ``RING_EDGE`` — per-vertex
+  :class:`~nav.feature.geometry.RingEdgePolyline` with
+  ``sigma_radial_per_vertex_px`` projected from the catalog ``rms``
+  through ``km_per_pixel_radial`` and a ~0.5-px
+  ``sigma_along_edge_per_vertex_px``.  The
+  :class:`~nav.feature.flags.RingEdgeFlags.is_straight_line` flag is
+  set when the polyline's max-deviation from a best-fit straight line
+  is below
+  :data:`~nav.nav_model.nav_model_rings.FLAT_CURVATURE_THRESHOLD_PX`.
+- ``RING_ANNULUS`` — multi-ring composite template carried on
+  ``NavFeature.template_img`` with a
+  :class:`~nav.feature.geometry.RingAnnulusGeometry` payload.  Emitted
+  when the surviving polyline compresses radially below
+  :data:`~nav.nav_model.nav_model_rings.RING_ANNULUS_MAX_RADIAL_PX`
+  (the edges are not separable at the image scale).
+
+Per-image diagnostics on ``self._metadata``: ``planet``, ``epoch``,
+``feature_count``, and a ``features`` list of ``{'name', 'type'}``
+dicts for each surviving ring feature.
 
 Ring domain model
 -----------------

--- a/docs/developer_guide_navigation_models_stars.rst
+++ b/docs/developer_guide_navigation_models_stars.rst
@@ -2,18 +2,98 @@
 Stars
 =====
 
-The star NavModel emits one
+:class:`~nav.nav_model.stars.nav_model_stars.NavModelStars` emits one
 :class:`~nav.feature.feature.NavFeature` per catalog star predicted to
-fall in extended FOV, each carrying a ``StarGeometry`` payload, a
-predicted-SNR-driven reliability score, and a ``StarFlags`` block (smear
-length, in-body-silhouette, in-saturation-or-cosmic, etc.).  Two
-techniques consume STAR features:
-``StarFieldFromCatalogNav`` (similarity-invariant triplet pattern match)
-and ``StarUniqueMatchNav`` (catalog-uniqueness 1- or 2-star match).
+fall in the extended FOV.  Each feature carries a
+:class:`~nav.feature.geometry.StarGeometry` payload, an anisotropic
+Cramer-Rao centroid covariance, a predicted-SNR-driven reliability
+score, and a :class:`~nav.feature.flags.StarFlags` block with
+``saturated``, ``smear_length_px``, ``in_body_silhouette``, and
+``in_saturation_or_cosmic_mask`` fields.  Two techniques consume STAR
+features: ``StarFieldFromCatalogNav`` (similarity-invariant triplet
+pattern match) and ``StarUniqueMatchNav`` (catalog-uniqueness 1- or
+2-star match).
 
-The real-scene star NavModel is unimplemented; the catalog-reduction
-helpers (aberration, proper motion, multi-catalog precedence,
-incremental search, body / ring conflict marking) and the
-``SCLASS_TO_B_MINUS_V`` lookup are preserved in git history under the
-deleted ``nav.nav_model.nav_model_stars`` module and will be lifted into
-a per-component sub-package as the new model lands.
+The :mod:`nav.nav_model.stars` package is split by responsibility:
+
+.. list-table:: Star NavModel modules
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Module
+     - Responsibility
+   * - :mod:`nav.nav_model.stars.catalog`
+     - Stellar aberration via
+       :func:`~nav.nav_model.stars.catalog.aberrate_star`, proper-motion
+       evaluation through
+       :func:`~nav.nav_model.stars.catalog.select_radec_list`, and
+       multi-catalog reduction (UCAC4 / Tycho-2 / YBSC) through
+       :func:`~nav.nav_model.stars.catalog.reduce_catalogs`.  Catalog
+       precedence and per-catalog deduplication thresholds come from
+       ``config.stars``.
+   * - :mod:`nav.nav_model.stars.conflicts`
+     - Body intercept and ring-occlusion checks through
+       :func:`~nav.nav_model.stars.conflicts.mark_body_and_ring_conflicts`.
+       Per-planet ring annuli are read from
+       ``config.stars.ring_occlusion_radii_km`` and validated by
+       :func:`~nav.nav_model.stars.conflicts.parse_ring_occlusion_annuli`.
+   * - :mod:`nav.nav_model.stars.predicted_snr`
+     - Per-star integrated SNR estimate using ``obs.star_psf()``,
+       :class:`~nav.nav_orchestrator.nav_context.NavContext.image_noise_sigma`,
+       and the ``SCLASS_TO_B_MINUS_V`` spectral-class colour lookup.
+       Accepts an optional per-camera-per-filter ``mag_offset`` that
+       converts the catalog V-band magnitude to the instrument's
+       bandpass.
+   * - :mod:`nav.nav_model.stars.smeared_psf`
+     - Smear-aware PSF rendering via ``psf.eval_rect(movement=...)`` and
+       per-image smear-vector computation from the SPICE pointing
+       brackets.
+   * - :mod:`nav.nav_model.stars.detection`
+     - DAOPHOT-style source detector (matched filter, local maxima,
+       Gaussian centroid fit, saturated-star annular moment, CCD bloom
+       column detection, sharpness / roundness shape cuts).  Used by
+       downstream techniques that sweep the image for centroidable
+       stars when the catalog match is ambiguous; not run during
+       ``to_features``.
+   * - :mod:`nav.nav_model.stars.nav_model_stars`
+     - Thin orchestrator implementing the
+       :class:`~nav.nav_model.nav_model.NavModel` ABC.  ``create_model``
+       reduces the catalogs and marks conflicts; ``to_features`` emits
+       one ``STAR`` feature per usable catalog star;
+       ``to_annotations`` builds star-box overlays plus name and
+       magnitude labels.
+
+Position covariance
+-------------------
+
+The 2x2 ``position_cov_px`` for a STAR feature is the Cramer-Rao Lower
+Bound of the centroid estimate, as specified in Part 1's "Position
+covariance per feature type" section:
+
+.. code-block::
+
+   sigma_along_smear  = sqrt(L^2 / 12 + sigma_PSF^2) / sqrt(SNR)
+   sigma_across_smear = sigma_PSF / sqrt(SNR)
+
+where ``L = hypot(move_v, move_u)`` is the smear length in pixels.  The
+covariance is rotated so the major axis aligns with the smear vector.
+When the smear length is below
+:data:`~nav.feature.constants.MIN_ANISOTROPIC_SMEAR_PX`, the
+covariance collapses to an isotropic ``(sigma_PSF / sqrt(SNR))^2 * I``.
+
+Reliability and gating
+----------------------
+
+The reliability is a sigmoid of the predicted SNR multiplied by hard
+zero terms for body or ring occlusion, saturation, and cosmic-ray hits.
+Stars whose smear length exceeds ``stars.max_smear`` are skipped from
+the feature list entirely (the smear-aware PSF cannot fit a usable
+centroid).  Stars whose predicted SNR is below
+``stars.min_predicted_snr`` (default ``0`` keeps all) are likewise
+skipped.
+
+The
+:class:`~nav.feature.feature.NavReliabilityBreakdown` block on each
+emitted feature carries the per-component contributions
+(``predicted_snr``, ``in_body_silhouette``, ``in_saturation_or_cosmic``,
+``smear_length_ok``).

--- a/docs/user_guide_navigation.rst
+++ b/docs/user_guide_navigation.rst
@@ -127,8 +127,8 @@ Navigation options
 ^^^^^^^^^^^^^^^^^^
 
 * ``--nav-models LIST``: a comma-separated list of model names or patterns to
-  enable. Valid entries include ``stars``, ``rings``, ``titan``, and
-  body-specific entries of the form ``body:NAME`` (glob patterns are allowed).
+  enable. Valid entries are ``stars``, ``rings``, and body-specific entries of
+  the form ``body:NAME`` (glob patterns are allowed).
 
 * ``--nav-techniques LIST``: a comma-separated list of navigation techniques to
   apply. Valid entries include ``correlate_all`` and ``manual``. Note: You
@@ -240,7 +240,7 @@ objects. Each task is:
         "data": {
             "dataset_name": "<dataset_name>",
             "arguments": {
-                "nav_models": ["bodies", "rings", "stars"],
+                "nav_models": ["body:*", "rings", "stars"],
                 "nav_techniques": ["correlate_all"]
             },
             "files": [

--- a/docs/user_guide_navigation.rst
+++ b/docs/user_guide_navigation.rst
@@ -491,16 +491,160 @@ The technique produces:
 * Confidence score of 1.0 (user-accepted result)
 * Uncertainty set to None (manual determination)
 
-Ring Navigation Model
-=====================
+Navigation Models
+=================
 
-The ring navigation model generates theoretical brightness profiles for
-planetary ring edges. Two configuration options in ``config_05_rings.yaml``
-control whether ring pixels that lie in shadow are excluded from the model
-before navigation is performed.
+A *navigation model* is RMS-NAV's prediction of what the image *should*
+look like at the spacecraft's nominal pointing.  Three model families
+ship out of the box: stars, planetary bodies, and planetary rings.
+Each contributes one or more *features* (typed predictions with their
+own per-feature uncertainty) to the navigator.  You can restrict which
+families run by passing ``--nav-models`` on the command line; valid
+entries are ``stars``, ``rings``, and body-specific entries of the form
+``body:NAME`` (glob patterns are allowed).
+
+Star Navigation Model
+---------------------
+
+The star model builds a deduplicated catalog of stars expected to fall
+inside the field of view, applies stellar aberration and proper motion
+to bring each catalog position into the spacecraft frame at observation
+time, and emits one feature per usable star.
+
+**Catalog precedence.**  Catalogs are searched in the order configured
+in ``config_03_stars.yaml`` under ``stars.catalogs`` (default
+``[ucac4, tycho2, ybsc]``).  Stars present in more than one catalog are
+deduplicated using the RA / DEC and V-magnitude thresholds in the same
+file.
+
+**Per-star detectability.**  A predicted SNR is computed for each star
+using the per-instrument PSF (``obs.star_psf()``), the per-image noise
+sigma (a robust MAD estimate), and the catalog magnitude.  Stars whose
+predicted SNR is below ``stars.min_predicted_snr`` are dropped.
+
+**Smear.**  When the spacecraft attitude rate is non-zero during the
+exposure, stars smear into trails.  The model computes the per-image
+smear vector from the SPICE pointing brackets and uses
+``psfmodel.eval_rect(movement=...)`` to render a smear-aware kernel
+when a downstream technique needs one.  Stars whose smear length
+exceeds ``stars.max_smear`` are dropped (the centroid is unfittable).
+
+**Body and ring conflicts.**  Each star's predicted pixel is checked
+against an ``oops`` body intercept and a per-planet opaque ring
+annulus (configured under ``stars.ring_occlusion_radii_km``).  Stars
+that fall behind a body or inside an opaque ring annulus are tagged
+with a ``BODY:`` or ``RING:`` conflict string and excluded from
+matching.  Body intercepts win over ring intercepts.
+
+**Configuration.**  Most user-tunable parameters live in
+``config_03_stars.yaml``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Key
+     - Effect
+   * - ``stars.catalogs``
+     - Catalog search order; default ``[ucac4, tycho2, ybsc]``.
+   * - ``stars.max_stars``
+     - Maximum number of stars retained per image (default 100).
+   * - ``stars.max_smear``
+     - Smear length in pixels above which a star is dropped (default
+       100).
+   * - ``stars.min_vmag`` / ``stars.max_vmag``
+     - Magnitude window applied to the per-instrument
+       ``star_min_usable_vmag`` / ``star_max_usable_vmag`` floor.
+   * - ``stars.proper_motion``
+     - Apply proper motion at ``obs.midtime`` (default true).
+   * - ``stars.stellar_aberration``
+     - Apply stellar aberration (default true).
+   * - ``stars.ring_occlusion_enabled``
+     - Toggle the ring-annulus occlusion check (default true).
+   * - ``stars.ring_occlusion_radii_km``
+     - Per-planet list of opaque ``[inner_km, outer_km]`` annuli.
+
+Body Navigation Model
+---------------------
+
+For every body whose predicted bounding box overlaps the extended
+field of view, the body model renders an oversampled Lambert-shaded
+silhouette, extracts the limb and terminator polylines, and emits a
+mix of feature types depending on resolution, lighting, and shape
+quality:
+
+- ``LIMB_ARC`` — emitted when the limb position is well-determined
+  (per-vertex normal sigma below the ``LIMB_ARC_MAX_UNCERTAINTY_PX``
+  cap).  Carries a polyline of vertex coordinates and per-vertex
+  anisotropic sigmas.
+- ``BODY_BLOB`` — emitted instead of ``LIMB_ARC`` when the limb is too
+  uncertain to fit but the predicted body diameter is above the
+  body-specific blob threshold.  Carries only a centroid and bounding
+  box.
+- ``BODY_DISC`` — emitted alongside ``LIMB_ARC`` when the body fits
+  well inside the FOV (overflow below 30 %, lit-and-visible fraction
+  at least 40 %).  Carries the rendered template for full-disc
+  correlation.
+- ``TERMINATOR_ARC`` — emitted when the terminator polyline has at
+  least 8 vertices and the phase-angle factor (``sin(phase_angle)``)
+  is above 0.05.
+
+**Per-body shape data.**  ``ellipsoid_residual_km``, ``crater_scale_km``,
+``albedo_variation``, ``spice_orbital_residual_km``, and
+``min_blob_diameter_px`` come from the static body-shape table.  These
+quantities drive the per-vertex polyline sigmas and the BODY_BLOB
+emission threshold.  For bodies absent from the table a conservative
+generic-icy-moon profile is used.
+
+**Configuration.**  ``config_04_bodies.yaml`` exposes:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Key
+     - Effect
+   * - ``bodies.min_bounding_box_area``
+     - Minimum predicted body bbox area (px squared) below which
+       silhouette rendering is skipped.
+   * - ``bodies.oversample_edge_limit``
+     - Anti-aliasing oversample limit for the silhouette render.
+   * - ``bodies.oversample_maximum``
+     - Hard cap on the per-axis oversample factor.
+   * - ``bodies.use_lambert``
+     - Use Lambert shading (default true) vs. flat-disc rendering.
+   * - ``bodies.use_albedo`` / ``bodies.geometric_albedo``
+     - Apply per-body geometric albedo when computing brightness.
+
+The bodies considered for navigation are the planet returned by
+``obs.closest_planet`` plus the satellites configured under
+``planets.satellites``.
+
+Ring Navigation Model
+---------------------
+
+The ring navigation model generates theoretical brightness profiles
+for planetary ring edges and emits one feature per surviving edge.
+Two top-level options in ``config_05_rings.yaml`` control whether
+ring pixels in shadow are excluded from the model before navigation.
+
+For each surviving ring feature the model emits one of:
+
+- ``RING_EDGE`` — a per-vertex polyline of edge coordinates with
+  per-vertex radial sigma derived from the catalog ``rms`` divided by
+  the radial km-per-pixel scale.  When the polyline is straight
+  (deviation from a best-fit line below 1 px) the ``is_straight_line``
+  flag is set so techniques can handle the rank-1 covariance.
+- ``RING_ANNULUS`` — a multi-edge composite template emitted when the
+  surviving polyline compresses radially below 5 px (the edges are
+  not separable at the image scale).
+
+Per-edge feature definitions live in ``config_2X_<planet>_rings.yaml``
+under ``rings.ring_features.<PLANET>.features``.  See "Ring YAML
+configuration" in the developer guide for the full schema.
 
 Planet shadow removal
----------------------
+^^^^^^^^^^^^^^^^^^^^^
 
 When a planet casts a shadow across part of its own ring system, those ring
 arcs appear dark in the image. If the model still shows those arcs as bright,
@@ -537,7 +681,7 @@ quality with and without the mask -- set the option to ``false`` in a
      remove_planet_shadow: false
 
 Body shadow removal (future)
------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``rings.remove_body_shadows`` option (default ``false``) is reserved for a
 future enhancement that will remove ring pixels shadowed by moons. Setting it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,10 @@ filterwarnings = [
   # owns the underlying path; the resulting unraisable exception is
   # outside our control.  Allow it through as a non-fatal warning.
   "default::pytest.PytestUnraisableExceptionWarning",
+  # Astropy emits this on import when XDG_CONFIG_HOME is set but
+  # ~/.astropy/config already exists (CI image state).  Benign env-var
+  # precedence note; do not let it fail collection.
+  "default:XDG_CONFIG_HOME is set to:UserWarning",
 ]
 markers = [
   "integration: requires PDS3_HOLDINGS_DIR (real holdings on disk or via filecache)",

--- a/src/nav/nav_model/__init__.py
+++ b/src/nav/nav_model/__init__.py
@@ -10,11 +10,15 @@ Modules:
     ``nav_model``
         ``NavModel`` ABC.  Concrete subclasses implement ``create_model``,
         ``to_features``, and ``to_annotations``.
+    ``nav_model_body``
+        ``NavModelBody`` — catalog-driven body NavModel.
     ``nav_model_body_base``
         ``NavModelBodyBase`` — shared annotation helpers for body models.
     ``nav_model_body_simulated``
         ``NavModelBodySimulated`` — body model rendered from operator
         simulation parameters.
+    ``nav_model_rings``
+        ``NavModelRings`` — catalog-driven ring NavModel.
     ``nav_model_rings_base``
         ``NavModelRingsBase`` — shared annotation helpers for ring models.
     ``nav_model_rings_simulated``
@@ -22,25 +26,33 @@ Modules:
         simulation parameters.
     ``nav_model_titan``
         ``NavModelTitan`` — atmospheric-body placeholder.
+    ``stars``
+        Catalog-driven star ``NavModel`` and supporting helpers.
 """
 
 import logging
 
 from nav.nav_model.nav_model import NavModel, build_models_for_obs
+from nav.nav_model.nav_model_body import NavModelBody
 from nav.nav_model.nav_model_body_base import NavModelBodyBase
 from nav.nav_model.nav_model_body_simulated import NavModelBodySimulated
+from nav.nav_model.nav_model_rings import NavModelRings
 from nav.nav_model.nav_model_rings_base import NavModelRingsBase
 from nav.nav_model.nav_model_rings_simulated import NavModelRingsSimulated
 from nav.nav_model.nav_model_titan import NavModelTitan
+from nav.nav_model.stars import NavModelStars
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     'NavModel',
+    'NavModelBody',
     'NavModelBodyBase',
     'NavModelBodySimulated',
+    'NavModelRings',
     'NavModelRingsBase',
     'NavModelRingsSimulated',
+    'NavModelStars',
     'NavModelTitan',
     'build_models_for_obs',
 ]

--- a/src/nav/nav_model/body_shape.py
+++ b/src/nav/nav_model/body_shape.py
@@ -1,0 +1,141 @@
+"""Per-body shape parameters used by the body NavModel.
+
+The body extractor's covariance and emission gates consult the per-body
+shape, albedo, and SPICE-residual quantities held in
+``BODY_SHAPE_TABLE``.  Numeric values are conservative defaults grounded
+in published moon-shape papers (Thomas 2010 for Cassini moons, Stooke
+1994 for irregular shapes).
+
+Each entry is a ``BodyShape`` frozen dataclass:
+
+- ``ellipsoid_residual_km`` — RMS deviation of the body silhouette from
+  the best-fit ellipsoid (the bulk shape error).
+- ``crater_scale_km`` — characteristic per-image limb roughness
+  contribution from craters and topography.
+- ``albedo_variation`` — fractional brightness variation across the disc;
+  drives ``photometric_model_error_km`` for terminator scoring.
+- ``spice_orbital_residual_km`` — SPK ephemeris uncertainty projected to
+  the limb plane; ~0.5 km for a major moon.
+- ``min_blob_diameter_px`` — minimum predicted disc diameter at which the
+  ``BODY_BLOB`` feature is preferred over an unresolved limb.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    'BODY_SHAPE_TABLE',
+    'DEFAULT_BODY_SHAPE',
+    'BodyShape',
+    'shape_for_body',
+]
+
+
+@dataclass(frozen=True)
+class BodyShape:
+    """Per-body shape and SPICE-residual quantities.
+
+    Parameters:
+        ellipsoid_residual_km: RMS shape residual from the best-fit
+            ellipsoid (km).  Used as the primary contribution in the
+            limb-arc normal-sigma quadrature sum.
+        crater_scale_km: Characteristic crater / topographic scale (km),
+            independent of ``ellipsoid_residual_km``.  Used in the
+            limb-arc normal-sigma quadrature sum to model
+            below-ellipsoid surface roughness.
+        albedo_variation: Fractional disc brightness variation in
+            ``[0, 1]``; drives terminator-arc reliability.
+        spice_orbital_residual_km: SPK ephemeris uncertainty in km.
+            ~0.5 for major moons; up to 5 for irregular satellites.
+        min_blob_diameter_px: Predicted disc diameter (px) at which the
+            extractor stops emitting LIMB_ARC and switches to BODY_BLOB.
+    """
+
+    ellipsoid_residual_km: float
+    crater_scale_km: float
+    albedo_variation: float
+    spice_orbital_residual_km: float
+    min_blob_diameter_px: float = 5.0
+
+
+DEFAULT_BODY_SHAPE: BodyShape = BodyShape(
+    ellipsoid_residual_km=2.0,
+    crater_scale_km=5.0,
+    albedo_variation=0.15,
+    spice_orbital_residual_km=2.0,
+    min_blob_diameter_px=5.0,
+)
+"""Fallback shape used when a body has no specific entry.
+
+The numbers reflect a generic small icy moon: ~2 km bulk-shape residual,
+~5 km crater scale, modest albedo variation, generous 2 km SPK residual.
+"""
+
+
+_SATURN_MOON_SHAPE: BodyShape = BodyShape(
+    ellipsoid_residual_km=1.0,
+    crater_scale_km=2.0,
+    albedo_variation=0.10,
+    spice_orbital_residual_km=0.5,
+    min_blob_diameter_px=5.0,
+)
+"""Profile for the major Saturn moons whose shape is well-measured."""
+
+
+_IRREGULAR_MOON_SHAPE: BodyShape = BodyShape(
+    ellipsoid_residual_km=10.0,
+    crater_scale_km=5.0,
+    albedo_variation=0.20,
+    spice_orbital_residual_km=2.0,
+    min_blob_diameter_px=8.0,
+)
+"""Profile for very irregular bodies (Hyperion, Phoebe, etc.)."""
+
+
+_GAS_GIANT_SHAPE: BodyShape = BodyShape(
+    ellipsoid_residual_km=50.0,
+    crater_scale_km=0.0,
+    albedo_variation=0.30,
+    spice_orbital_residual_km=10.0,
+    min_blob_diameter_px=20.0,
+)
+"""Profile for gas / ice giants whose limbs are atmospheric scattering."""
+
+
+BODY_SHAPE_TABLE: dict[str, BodyShape] = {
+    'SATURN': _GAS_GIANT_SHAPE,
+    'JUPITER': _GAS_GIANT_SHAPE,
+    'URANUS': _GAS_GIANT_SHAPE,
+    'NEPTUNE': _GAS_GIANT_SHAPE,
+    'MIMAS': _SATURN_MOON_SHAPE,
+    'ENCELADUS': _SATURN_MOON_SHAPE,
+    'TETHYS': _SATURN_MOON_SHAPE,
+    'DIONE': _SATURN_MOON_SHAPE,
+    'RHEA': _SATURN_MOON_SHAPE,
+    'IAPETUS': _SATURN_MOON_SHAPE,
+    'TITAN': _SATURN_MOON_SHAPE,
+    'HYPERION': _IRREGULAR_MOON_SHAPE,
+    'PHOEBE': _IRREGULAR_MOON_SHAPE,
+    'EUROPA': _SATURN_MOON_SHAPE,
+    'IO': _SATURN_MOON_SHAPE,
+    'GANYMEDE': _SATURN_MOON_SHAPE,
+    'CALLISTO': _SATURN_MOON_SHAPE,
+}
+"""Static lookup of per-body shape parameters.
+
+Keys are upper-case SPICE body names.  Bodies absent from the table use
+``DEFAULT_BODY_SHAPE``.
+"""
+
+
+def shape_for_body(body_name: str) -> BodyShape:
+    """Return the shape entry for ``body_name`` (case-insensitive).
+
+    Parameters:
+        body_name: Body name in any case (``'mimas'`` / ``'MIMAS'``).
+
+    Returns:
+        The matching ``BodyShape`` or ``DEFAULT_BODY_SHAPE``.
+    """
+    return BODY_SHAPE_TABLE.get(body_name.upper(), DEFAULT_BODY_SHAPE)

--- a/src/nav/nav_model/nav_model_body.py
+++ b/src/nav/nav_model/nav_model_body.py
@@ -584,7 +584,7 @@ class NavModelBody(NavModelBodyBase):
         fwhm_method = getattr(psf, 'fwhm', None)
         if callable(fwhm_method):
             return float(fwhm_method()) / 2.3548200450309493
-        return 1.0
+        raise AttributeError(f'PSF {type(psf).__name__} exposes neither sigma nor fwhm()')
 
     def _limb_uncertainty_px(self, shape: BodyShape) -> float:
         """Return the design's ``limb_uncertainty_px`` for this body."""

--- a/src/nav/nav_model/nav_model_body.py
+++ b/src/nav/nav_model/nav_model_body.py
@@ -1,0 +1,920 @@
+"""Catalog-driven body NavModel.
+
+Renders one body's predicted appearance from SPICE, classifies it
+against the design's emission rules (limb arc vs. body disc vs. blob vs.
+terminator), and emits one ``NavFeature`` per surviving feature type.
+
+The pipeline:
+
+1. Builds an oversampled meshgrid around the predicted body bounding
+   box so the limb silhouette is anti-aliased.
+2. Extracts the limb and terminator polylines from the discrete
+   silhouette masks.
+3. Looks up the per-body shape parameters in
+   ``nav.nav_model.body_shape.BODY_SHAPE_TABLE``.
+4. Decides which features to emit by computing
+   ``limb_uncertainty_px`` and the ``visible_lit_fraction`` /
+   ``overflow_fraction`` quantities the design specifies.
+
+The feature-by-feature emission rules:
+
+- ``LIMB_ARC`` is emitted when ``limb_uncertainty_px <=
+  LIMB_ARC_MAX_UNCERTAINTY_PX`` and there are surviving limb vertices.
+- ``BODY_BLOB`` is emitted when the predicted disc diameter is at least
+  the body's ``min_blob_diameter_px`` *and* the limb uncertainty is
+  too high for ``LIMB_ARC``.
+- ``BODY_DISC`` is emitted alongside ``LIMB_ARC`` when the body fits
+  inside the FOV with at least ``BODY_DISC_MIN_VISIBLE_LIT_FRACTION``
+  of its lit side visible and ``overflow_fraction`` below
+  ``BODY_DISC_MAX_OVERFLOW_FRACTION``.
+- ``TERMINATOR_ARC`` is emitted when the terminator polyline has at
+  least ``TERMINATOR_MIN_VERTICES`` surviving vertices and the
+  phase-angle factor (``sin(phase_angle)``) is above
+  ``TERMINATOR_MIN_PHASE_FACTOR``.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import polymath
+from oops import Meshgrid
+from oops.backplane import Backplane
+
+from nav.annotation import Annotations
+from nav.config import Config
+from nav.feature.constants import (
+    INCIDENCE_FACTOR_ANGLE_CAP_DEG,
+    INCIDENCE_FACTOR_CLIP_DEG,
+    MAX_INCIDENCE_FACTOR_CAP,
+)
+from nav.feature.feature import NavFeature, NavReliabilityBreakdown
+from nav.feature.feature_type import NavFeatureType
+from nav.feature.flags import (
+    BodyBlobFlags,
+    BodyDiscFlags,
+    LimbArcFlags,
+    TerminatorArcFlags,
+)
+from nav.feature.geometry import (
+    BodyBlobGeometry,
+    BodyDiscGeometry,
+    LimbPolyline,
+    TerminatorPolyline,
+)
+from nav.nav_model.body_shape import BODY_SHAPE_TABLE, DEFAULT_BODY_SHAPE, BodyShape
+from nav.nav_model.nav_model import NavModel
+from nav.nav_model.nav_model_body_base import NavModelBodyBase
+from nav.support.constants import HALFPI
+from nav.support.image import filter_downsample, shift_array
+from nav.support.time import now_dt
+from nav.support.types import NDArrayBoolType, NDArrayFloatType
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from oops import Observation
+
+    from nav.nav_orchestrator.nav_context import NavContext
+
+from nav.support.filters import NavFilterKind, NavFilterSpec
+
+__all__ = [
+    'BODY_DISC_MAX_OVERFLOW_FRACTION',
+    'BODY_DISC_MIN_VISIBLE_LIT_FRACTION',
+    'BODY_POSITION_SLOP_FRAC',
+    'LIMB_ARC_MAX_UNCERTAINTY_PX',
+    'TERMINATOR_MIN_PHASE_FACTOR',
+    'TERMINATOR_MIN_VERTICES',
+    'NavModelBody',
+]
+
+
+BODY_POSITION_SLOP_FRAC: float = 0.05
+"""Inflation factor for the body bbox before clipping.
+
+The ``oops.inventory`` bounding box is sometimes a half-pixel too small.
+Inflating it by 5% before clipping into the extfov keeps anti-aliased
+limb pixels from being lost on the boundary.
+"""
+
+
+LIMB_ARC_MAX_UNCERTAINTY_PX: float = 2.0
+"""Cap on the limb normal-sigma at which LIMB_ARC remains useful.
+
+Above this value the feature is unreliable enough that BODY_BLOB or
+BODY_DISC is the right emission instead.  Phase-5 calibration may
+tighten this; the default is the design's "limb fits within a couple of
+pixels" guideline.
+"""
+
+
+BODY_DISC_MIN_VISIBLE_LIT_FRACTION: float = 0.4
+"""Minimum lit-and-in-FOV fraction for BODY_DISC emission.
+
+Below 40% of the lit hemisphere visible, the disc match is too
+asymmetric to be useful; BODY_BLOB or LIMB_ARC carries the load.
+"""
+
+
+BODY_DISC_MAX_OVERFLOW_FRACTION: float = 0.3
+"""Maximum overflow fraction for BODY_DISC emission.
+
+A body whose disc is more than 30% off-frame loses too much template
+support for the correlation peak to be sharp.
+"""
+
+
+TERMINATOR_MIN_VERTICES: int = 8
+"""Minimum surviving vertices for TERMINATOR_ARC emission."""
+
+
+TERMINATOR_MIN_PHASE_FACTOR: float = 0.05
+"""Minimum ``sin(phase_angle)`` for TERMINATOR_ARC emission.
+
+Below sin(phase) ~= 0.05 (phase < 3 deg) the terminator is too close to
+the limb to be photometrically distinguishable.
+"""
+
+
+@dataclass(frozen=True)
+class _PolylineSampler:
+    """Bundle of sampled limb / terminator polyline data.
+
+    Encapsulates the per-vertex outputs of the silhouette extraction so
+    multiple feature emitters can share the same data without
+    re-running the discrete-mask traversal.
+    """
+
+    vertices_vu: NDArrayFloatType
+    normals_vu: NDArrayFloatType
+    incidence_rad: NDArrayFloatType
+    km_per_pixel: NDArrayFloatType
+
+
+class NavModelBody(NavModelBodyBase):
+    """Catalog-driven body NavModel.
+
+    Parameters:
+        name: Model instance name (e.g. ``'body:MIMAS'``).
+        obs: Observation snapshot.
+        body_name: SPICE body name.
+        inventory: Optional pre-computed inventory entry; pulled from
+            ``obs.inventory`` on demand otherwise.
+        config: Optional ``Config`` override.
+    """
+
+    _abstract = False
+
+    def __init__(
+        self,
+        name: str,
+        obs: Observation,
+        body_name: str,
+        *,
+        inventory: dict[str, Any] | None = None,
+        config: Config | None = None,
+    ) -> None:
+        super().__init__(name, obs, config=config)
+        self._body_name = body_name.upper()
+        self._inventory = inventory
+        self._model_img: NDArrayFloatType | None = None
+        self._body_mask: NDArrayBoolType | None = None
+        self._limb_mask: NDArrayBoolType | None = None
+        self._terminator_mask: NDArrayBoolType | None = None
+        self._limb_sampler: _PolylineSampler | None = None
+        self._terminator_sampler: _PolylineSampler | None = None
+        self._km_per_pixel_at_limb: float = 0.0
+        self._predicted_diameter_px: float = 0.0
+        self._predicted_center_vu: tuple[float, float] = (0.0, 0.0)
+        self._bbox_extfov_vu: tuple[int, int, int, int] = (0, 0, 0, 0)
+        self._subject_range_km: float = float('inf')
+        self._visible_lit_fraction: float = 0.0
+        self._overflow_fraction: float = 1.0
+        self._phase_angle_factor: float = 0.0
+
+    @classmethod
+    def instances_for_obs(cls, obs: Observation) -> list[NavModel]:
+        """Return one NavModelBody per body whose bbox lies inside extfov.
+
+        Calls ``obs.inventory`` once with the planet + satellites list
+        from ``config.satellites`` and constructs a NavModel for every
+        entry whose ``inventory_body_in_extfov`` predicate fires.
+
+        Parameters:
+            obs: Observation snapshot.
+
+        Returns:
+            One ``NavModelBody`` per body present in the extfov.
+        """
+        from nav.config import DEFAULT_CONFIG
+
+        config = DEFAULT_CONFIG
+        planet = getattr(obs, 'closest_planet', None)
+        if planet is None:
+            return []
+        body_list: list[str] = [planet, *list(config.satellites(planet))]
+        inventory_method = getattr(obs, 'inventory', None)
+        if not callable(inventory_method):
+            return []
+        try:
+            inv = inventory_method(body_list, return_type='full')
+        except (TypeError, AttributeError, ValueError):
+            return []
+        in_extfov = getattr(obs, 'inventory_body_in_extfov', None)
+        if not callable(in_extfov):
+            return []
+        out: list[NavModel] = []
+        for body_name in body_list:
+            entry = inv.get(body_name)
+            if entry is None:
+                continue
+            if not in_extfov(entry):
+                continue
+            out.append(cls(f'body:{body_name}', obs, body_name, inventory=entry))
+        return out
+
+    def create_model(self) -> None:
+        """Render the silhouette, masks, and polylines used by ``to_features``."""
+        start_time = now_dt()
+        self._metadata.clear()
+        self._metadata['start_time'] = start_time.isoformat()
+        self._metadata['end_time'] = None
+        self._metadata['elapsed_time_sec'] = None
+        self._metadata['body_name'] = self._body_name
+        with self._logger.open(f'CREATE BODY MODEL FOR: {self._body_name}'):
+            self._render()
+        end_time = now_dt()
+        self._metadata['end_time'] = end_time.isoformat()
+        self._metadata['elapsed_time_sec'] = (end_time - start_time).total_seconds()
+
+    def _render(self) -> None:
+        """Populate masks, polyline samplers, and metadata."""
+        obs = self.obs
+        ext_bp = obs.ext_bp
+        body_name = self._body_name
+        body_config = self._config.bodies
+        if self._inventory is None:
+            self._inventory = obs.inventory([body_name], return_type='full')[body_name]
+        inventory = self._inventory
+
+        sub_solar_lon = float(np.degrees(ext_bp.sub_solar_longitude(body_name).vals))
+        sub_solar_lat = float(np.degrees(ext_bp.sub_solar_latitude(body_name).vals))
+        sub_observer_lon = float(np.degrees(ext_bp.sub_observer_longitude(body_name).vals))
+        sub_observer_lat = float(np.degrees(ext_bp.sub_observer_latitude(body_name).vals))
+        phase_angle_deg = float(np.degrees(ext_bp.center_phase_angle(body_name).vals))
+        self._metadata['sub_solar_lon_deg'] = sub_solar_lon
+        self._metadata['sub_solar_lat_deg'] = sub_solar_lat
+        self._metadata['sub_observer_lon_deg'] = sub_observer_lon
+        self._metadata['sub_observer_lat_deg'] = sub_observer_lat
+        self._metadata['phase_angle_deg'] = phase_angle_deg
+        self._phase_angle_factor = float(np.sin(np.radians(phase_angle_deg)))
+        self._subject_range_km = float(inventory.get('range', float('inf')))
+
+        bb_area = float(inventory['u_pixel_size'] * inventory['v_pixel_size'])
+        self._metadata['bbox_area_px'] = bb_area
+        self._metadata['size_ok'] = bool(bb_area >= body_config.min_bounding_box_area)
+
+        u_min_unc = int(inventory['u_min_unclipped'])
+        u_max_unc = int(inventory['u_max_unclipped'])
+        v_min_unc = int(inventory['v_min_unclipped'])
+        v_max_unc = int(inventory['v_max_unclipped'])
+        u_slop = int((u_max_unc - u_min_unc) * BODY_POSITION_SLOP_FRAC)
+        v_slop = int((v_max_unc - v_min_unc) * BODY_POSITION_SLOP_FRAC)
+        u_min = u_min_unc - u_slop
+        u_max = u_max_unc + u_slop
+        v_min = v_min_unc - v_slop
+        v_max = v_max_unc + v_slop
+        u_min, v_min = obs.clip_extfov(u_min, v_min)
+        u_max, v_max = obs.clip_extfov(u_max, v_max)
+        if u_min == u_max == obs.extfov_u_max:
+            u_min -= 1
+        if u_min == u_max == obs.extfov_u_min:
+            u_max += 1
+        if v_min == v_max == obs.extfov_v_max:
+            v_min -= 1
+        if v_min == v_max == obs.extfov_v_min:
+            v_max += 1
+
+        guaranteed_visible = (
+            u_min >= obs.extfov_margin_u
+            and u_max <= obs.data_shape_u - 1 - obs.extfov_margin_u
+            and v_min >= obs.extfov_margin_v
+            and v_max <= obs.data_shape_v - 1 - obs.extfov_margin_v
+        )
+        self._metadata['guaranteed_visible_in_fov'] = guaranteed_visible
+
+        model_img, limb_mask, terminator_mask, body_mask, sampler_data = (
+            self._build_backplane_model(u_min=u_min, u_max=u_max, v_min=v_min, v_max=v_max)
+        )
+        self._model_img = model_img
+        self._body_mask = body_mask
+        self._limb_mask = limb_mask
+        self._terminator_mask = terminator_mask
+
+        u_center_data = (u_min_unc + u_max_unc) / 2.0
+        v_center_data = (v_min_unc + v_max_unc) / 2.0
+        self._predicted_center_vu = (
+            float(v_center_data + obs.extfov_margin_v),
+            float(u_center_data + obs.extfov_margin_u),
+        )
+        diameter = max(
+            float(inventory['u_pixel_size']),
+            float(inventory['v_pixel_size']),
+        )
+        self._predicted_diameter_px = diameter
+        self._bbox_extfov_vu = (
+            int(v_min + obs.extfov_margin_v),
+            int(u_min + obs.extfov_margin_u),
+            int(v_max + obs.extfov_margin_v + 1),
+            int(u_max + obs.extfov_margin_u + 1),
+        )
+
+        self._km_per_pixel_at_limb = sampler_data['km_per_pixel_mean']
+        self._limb_sampler = sampler_data['limb_sampler']
+        self._terminator_sampler = sampler_data['terminator_sampler']
+        self._visible_lit_fraction = float(sampler_data['visible_lit_fraction'])
+        self._overflow_fraction = float(sampler_data['overflow_fraction'])
+        self._metadata['km_per_pixel_at_limb'] = self._km_per_pixel_at_limb
+        self._metadata['predicted_diameter_px'] = self._predicted_diameter_px
+        self._metadata['visible_lit_fraction'] = self._visible_lit_fraction
+        self._metadata['overflow_fraction'] = self._overflow_fraction
+
+    def _build_backplane_model(
+        self,
+        *,
+        u_min: int,
+        u_max: int,
+        v_min: int,
+        v_max: int,
+    ) -> tuple[
+        NDArrayFloatType,
+        NDArrayBoolType,
+        NDArrayBoolType,
+        NDArrayBoolType,
+        dict[str, Any],
+    ]:
+        """Build the silhouette, limb / terminator masks, and samplers.
+
+        Renders an oversampled Lambert silhouette over the body bbox,
+        downsamples to the extfov grid, extracts the discrete limb and
+        terminator masks, and samples per-vertex polyline data.
+
+        Parameters:
+            u_min, u_max, v_min, v_max: Body bounding box in extfov
+                coordinates (already clipped).
+
+        Returns:
+            ``(model_img, limb_mask, terminator_mask, body_mask, info)``
+            where ``info`` carries the polyline samplers, the mean
+            km/pixel at the limb, and the visibility / overflow
+            fractions.
+        """
+        obs = self.obs
+        body_name = self._body_name
+        body_config = self._config.bodies
+        inventory = self._inventory
+        assert inventory is not None  # populated in _render
+
+        oversample_u = max(
+            int(
+                np.floor(
+                    body_config.oversample_edge_limit / max(np.ceil(inventory['u_pixel_size']), 1)
+                )
+            ),
+            1,
+        )
+        oversample_v = max(
+            int(
+                np.floor(
+                    body_config.oversample_edge_limit / max(np.ceil(inventory['v_pixel_size']), 1)
+                )
+            ),
+            1,
+        )
+        oversample_u = min(oversample_u, body_config.oversample_maximum)
+        oversample_v = min(oversample_v, body_config.oversample_maximum)
+        restr_u_min = u_min + 1.0 / (2 * oversample_u)
+        restr_u_max = u_max + 1 - 1.0 / (2 * oversample_u)
+        restr_v_min = v_min + 1.0 / (2 * oversample_v)
+        restr_v_max = v_max + 1 - 1.0 / (2 * oversample_v)
+        restr_meshgrid = Meshgrid.for_fov(
+            obs.fov,
+            origin=(restr_u_min, restr_v_min),
+            limit=(restr_u_max, restr_v_max),
+            oversample=(oversample_u, oversample_v),
+            swap=True,
+        )
+        restr_bp = Backplane(obs, meshgrid=restr_meshgrid)
+
+        oversampled_incidence_mvals = restr_bp.incidence_angle(body_name).mvals
+        downsampled_incidence_mvals = filter_downsample(
+            oversampled_incidence_mvals, oversample_v, oversample_u
+        )
+        incidence_scalar = polymath.Scalar(downsampled_incidence_mvals)
+
+        body_mask_invalid = incidence_scalar.expand_mask().mask
+        body_mask_valid = ~body_mask_invalid
+        limb_mask_neighbor = (
+            shift_array(body_mask_invalid, (-1, 0))
+            | shift_array(body_mask_invalid, (1, 0))
+            | shift_array(body_mask_invalid, (0, -1))
+            | shift_array(body_mask_invalid, (0, 1))
+        )
+        limb_mask_local: NDArrayBoolType = body_mask_valid & limb_mask_neighbor
+
+        # Terminator mask: pixels whose incidence crosses 90 deg
+        incidence_vals = incidence_scalar.vals
+        is_lit = (incidence_vals < HALFPI) & body_mask_valid
+        is_dark = (incidence_vals >= HALFPI) & body_mask_valid
+        # A pixel is on the terminator if it is lit and any neighbour is dark.
+        terminator_local: NDArrayBoolType = is_lit & (
+            shift_array(is_dark, (-1, 0))
+            | shift_array(is_dark, (1, 0))
+            | shift_array(is_dark, (0, -1))
+            | shift_array(is_dark, (0, 1))
+        )
+
+        if not body_mask_valid.any() or incidence_scalar[body_mask_valid].min() >= HALFPI:
+            local_model: NDArrayFloatType = np.zeros_like(body_mask_valid, dtype=np.float64)
+            local_model[body_mask_valid] = 0.01
+        else:
+            if body_config.use_lambert:
+                lambert_oversampled = restr_bp.lambert_law(body_name).mvals.filled(0.0)
+                local_model = filter_downsample(lambert_oversampled, oversample_v, oversample_u)
+                local_model = local_model + 0.05
+                local_model[body_mask_invalid] = 0.0
+            else:
+                local_model = body_mask_valid.astype(np.float64)
+            if body_config.use_albedo and body_name in body_config.geometric_albedo:
+                albedo = float(body_config.geometric_albedo[body_name])
+                local_model = local_model * albedo
+
+        # Promote to extfov-shaped arrays.
+        ext_v0 = v_min + obs.extfov_margin_v
+        ext_u0 = u_min + obs.extfov_margin_u
+        v_size = local_model.shape[0]
+        u_size = local_model.shape[1]
+        model_img = obs.make_extfov_zeros()
+        limb_mask = obs.make_extfov_false()
+        body_mask = obs.make_extfov_false()
+        terminator_mask = obs.make_extfov_false()
+        v_slice = slice(ext_v0, ext_v0 + v_size)
+        u_slice = slice(ext_u0, ext_u0 + u_size)
+        model_img[v_slice, u_slice] = local_model
+        limb_mask[v_slice, u_slice] = limb_mask_local
+        terminator_mask[v_slice, u_slice] = terminator_local
+        body_mask[v_slice, u_slice] = body_mask_valid
+
+        km_per_pixel_arr: NDArrayFloatType = (
+            restr_bp.resolution(body_name).mvals.filled(0.0)
+            if body_mask_valid.any()
+            else np.zeros_like(body_mask_valid, dtype=np.float64)
+        )
+        # Downsample km/pixel to the same grid as the masks.
+        km_per_pixel_local = filter_downsample(km_per_pixel_arr, oversample_v, oversample_u)
+
+        limb_sampler = _build_polyline_sampler(
+            local_mask=limb_mask_local,
+            incidence_local=incidence_vals,
+            km_per_pixel_local=km_per_pixel_local,
+            ext_v0=ext_v0,
+            ext_u0=ext_u0,
+        )
+        terminator_sampler = _build_polyline_sampler(
+            local_mask=terminator_local,
+            incidence_local=incidence_vals,
+            km_per_pixel_local=km_per_pixel_local,
+            ext_v0=ext_v0,
+            ext_u0=ext_u0,
+        )
+
+        sensor_v0 = obs.extfov_margin_v
+        sensor_v1 = obs.extfov_margin_v + obs.data_shape_v
+        sensor_u0 = obs.extfov_margin_u
+        sensor_u1 = obs.extfov_margin_u + obs.data_shape_u
+        in_sensor = np.zeros_like(body_mask, dtype=bool)
+        in_sensor[sensor_v0:sensor_v1, sensor_u0:sensor_u1] = True
+        lit_mask = body_mask.copy()
+        if local_model.size > 0:
+            lit_arr = obs.make_extfov_false()
+            lit_arr[v_slice, u_slice] = is_lit
+            lit_mask = lit_arr
+        body_total = int(np.count_nonzero(body_mask))
+        body_visible = int(np.count_nonzero(body_mask & in_sensor))
+        # Per Part 1: ``visible_lit_fraction`` is the fraction of the
+        # *whole predicted disc* (lit and dark) whose cos(incidence) >= 0
+        # *and* which lies inside the sensor FOV.
+        lit_visible_in_fov = int(np.count_nonzero(lit_mask & in_sensor))
+        visible_lit_fraction = lit_visible_in_fov / max(body_total, 1)
+        overflow_fraction = 1.0 - (body_visible / max(body_total, 1))
+
+        if limb_mask_local.any() and km_per_pixel_local[limb_mask_local].size:
+            km_per_pixel_mean = float(np.mean(km_per_pixel_local[limb_mask_local]))
+        else:
+            km_per_pixel_mean = 0.0
+
+        info: dict[str, Any] = {
+            'limb_sampler': limb_sampler,
+            'terminator_sampler': terminator_sampler,
+            'km_per_pixel_mean': km_per_pixel_mean,
+            'visible_lit_fraction': visible_lit_fraction,
+            'overflow_fraction': overflow_fraction,
+        }
+        return model_img, limb_mask, terminator_mask, body_mask, info
+
+    def to_features(self, context: NavContext) -> list[NavFeature]:
+        """Emit the body's NavFeatures per the design's gate rules."""
+        del context
+        if self._body_mask is None:
+            return []
+        shape = BODY_SHAPE_TABLE.get(self._body_name, DEFAULT_BODY_SHAPE)
+        features: list[NavFeature] = []
+        limb_uncertainty_px = self._limb_uncertainty_px(shape)
+        limb_arc_emitted = False
+        if (
+            self._limb_sampler is not None
+            and self._limb_sampler.vertices_vu.size > 0
+            and limb_uncertainty_px <= LIMB_ARC_MAX_UNCERTAINTY_PX
+        ):
+            features.append(
+                _build_limb_arc(
+                    body_name=self._body_name,
+                    sampler=self._limb_sampler,
+                    shape=shape,
+                    bbox=self._bbox_extfov_vu,
+                    subject_range_km=self._subject_range_km,
+                    psf_sigma_px=self._star_psf_sigma(),
+                    source_model=self.name,
+                )
+            )
+            limb_arc_emitted = True
+        else:
+            if self._predicted_diameter_px >= shape.min_blob_diameter_px:
+                features.append(self._build_blob_feature(shape))
+
+        if self._should_emit_disc(limb_arc_emitted):
+            features.append(self._build_disc_feature(shape))
+
+        terminator_feature = self._maybe_build_terminator(shape)
+        if terminator_feature is not None:
+            features.append(terminator_feature)
+        return features
+
+    def to_annotations(self, context: NavContext) -> Annotations:
+        """Reuse the shared body annotation helper."""
+        del context
+        if self._model_img is None or self._body_mask is None or self._limb_mask is None:
+            return Annotations()
+        v_center, u_center = self._predicted_center_vu
+        return self._create_annotations(
+            round(u_center - self.obs.extfov_margin_u),
+            round(v_center - self.obs.extfov_margin_v),
+            self._model_img,
+            self._limb_mask,
+            self._body_mask,
+        )
+
+    def _star_psf_sigma(self) -> float:
+        """Return the per-pixel PSF sigma from ``obs.star_psf()``."""
+        psf = self.obs.star_psf()
+        if hasattr(psf, 'sigma'):
+            return float(psf.sigma)
+        fwhm_method = getattr(psf, 'fwhm', None)
+        if callable(fwhm_method):
+            return float(fwhm_method()) / 2.3548200450309493
+        return 1.0
+
+    def _limb_uncertainty_px(self, shape: BodyShape) -> float:
+        """Return the design's ``limb_uncertainty_px`` for this body."""
+        if self._km_per_pixel_at_limb <= 0.0:
+            return float('inf')
+        return shape.ellipsoid_residual_km / self._km_per_pixel_at_limb
+
+    def _should_emit_disc(self, limb_arc_emitted: bool) -> bool:
+        """Return True when BODY_DISC should be emitted alongside other features."""
+        if not limb_arc_emitted:
+            return False
+        if self._visible_lit_fraction < BODY_DISC_MIN_VISIBLE_LIT_FRACTION:
+            return False
+        return not self._overflow_fraction > BODY_DISC_MAX_OVERFLOW_FRACTION
+
+    def _build_disc_feature(self, shape: BodyShape) -> NavFeature:
+        """Construct the BODY_DISC feature (template + geometry + flags)."""
+        assert self._model_img is not None
+        assert self._body_mask is not None
+        return NavFeature(
+            feature_id=f'body_disc:{self._body_name}',
+            feature_type=NavFeatureType.BODY_DISC,
+            source_model=self.name,
+            geometry=BodyDiscGeometry(
+                bbox_extfov_vu=self._bbox_extfov_vu,
+                predicted_center_vu=self._predicted_center_vu,
+                overflow_fraction=self._overflow_fraction,
+            ),
+            subject_range_km=self._subject_range_km,
+            position_cov_px=None,
+            intensity_sigma_rel=float(min(0.5, shape.albedo_variation)),
+            preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
+            reliability=_disc_reliability(
+                visible_lit_fraction=self._visible_lit_fraction,
+                overflow_fraction=self._overflow_fraction,
+                diameter_px=self._predicted_diameter_px,
+            ),
+            reliability_reasons=NavReliabilityBreakdown(
+                visible_lit_fraction=self._visible_lit_fraction,
+                overflow_fraction=self._overflow_fraction,
+            ),
+            usable_types=frozenset({NavFeatureType.BODY_DISC}),
+            flags=BodyDiscFlags(
+                body_name=self._body_name,
+                overflow_fov_fraction=self._overflow_fraction,
+            ),
+            template_img=self._model_img,
+            template_mask=self._body_mask,
+        )
+
+    def _build_blob_feature(self, shape: BodyShape) -> NavFeature:
+        """Construct the BODY_BLOB feature."""
+        del shape
+        # Estimate per-pixel SNR from the brightest pixel in the model.
+        assert self._model_img is not None
+        assert self._body_mask is not None
+        snr = float(self._model_img[self._body_mask].mean()) if self._body_mask.any() else 0.0
+        sigma_centroid = self._predicted_diameter_px / (
+            2.0 * math.sqrt(max(int(self._body_mask.sum()), 1)) * max(snr, 1e-6)
+        )
+        cov = (sigma_centroid * sigma_centroid) * np.eye(2, dtype=np.float64)
+        return NavFeature(
+            feature_id=f'body_blob:{self._body_name}',
+            feature_type=NavFeatureType.BODY_BLOB,
+            source_model=self.name,
+            geometry=BodyBlobGeometry(
+                predicted_center_vu=self._predicted_center_vu,
+                bbox_extfov_vu=self._bbox_extfov_vu,
+                predicted_diameter_px=self._predicted_diameter_px,
+            ),
+            subject_range_km=self._subject_range_km,
+            position_cov_px=cov,
+            intensity_sigma_rel=0.0,
+            preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
+            reliability=_blob_reliability(snr=snr, diameter_px=self._predicted_diameter_px),
+            reliability_reasons=NavReliabilityBreakdown(
+                blob_snr=min(1.0, snr / 10.0),
+                blob_extent_px=min(1.0, self._predicted_diameter_px / 30.0),
+            ),
+            usable_types=frozenset({NavFeatureType.BODY_BLOB}),
+            flags=BodyBlobFlags(
+                body_name=self._body_name,
+                predicted_diameter_px=self._predicted_diameter_px,
+            ),
+        )
+
+    def _maybe_build_terminator(self, shape: BodyShape) -> NavFeature | None:
+        """Build TERMINATOR_ARC when the design's terminator gates pass."""
+        sampler = self._terminator_sampler
+        if sampler is None or sampler.vertices_vu.shape[0] < TERMINATOR_MIN_VERTICES:
+            return None
+        if self._phase_angle_factor < TERMINATOR_MIN_PHASE_FACTOR:
+            return None
+        sigma_normal_per_vertex_px = _sigma_normal_per_vertex(
+            sampler=sampler,
+            shape=shape,
+            psf_sigma_px=self._star_psf_sigma(),
+            include_albedo=True,
+        )
+        sigma_tangent_per_vertex_px = np.full_like(sigma_normal_per_vertex_px, 0.5)
+        return NavFeature(
+            feature_id=f'terminator_arc:{self._body_name}',
+            feature_type=NavFeatureType.TERMINATOR_ARC,
+            source_model=self.name,
+            geometry=TerminatorPolyline(
+                vertices_vu=sampler.vertices_vu,
+                normals_vu=sampler.normals_vu,
+                sigma_normal_per_vertex_px=sigma_normal_per_vertex_px,
+                sigma_tangent_per_vertex_px=sigma_tangent_per_vertex_px,
+                bbox_extfov_vu=self._bbox_extfov_vu,
+            ),
+            subject_range_km=self._subject_range_km,
+            position_cov_px=None,
+            intensity_sigma_rel=0.0,
+            preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
+            reliability=_terminator_reliability(
+                visible_arc_fraction=_visible_arc_fraction(sampler),
+                albedo_variation=shape.albedo_variation,
+                phase_factor=self._phase_angle_factor,
+            ),
+            reliability_reasons=NavReliabilityBreakdown(
+                visible_arc_fraction=_visible_arc_fraction(sampler),
+                albedo_penalty=min(1.0, shape.albedo_variation),
+            ),
+            usable_types=frozenset({NavFeatureType.TERMINATOR_ARC}),
+            flags=TerminatorArcFlags(
+                body_name=self._body_name,
+                visible_arc_fraction=_visible_arc_fraction(sampler),
+                phase_angle_factor=min(1.0, self._phase_angle_factor),
+            ),
+        )
+
+
+def _build_limb_arc(
+    *,
+    body_name: str,
+    sampler: _PolylineSampler,
+    shape: BodyShape,
+    bbox: tuple[int, int, int, int],
+    subject_range_km: float,
+    psf_sigma_px: float,
+    source_model: str,
+) -> NavFeature:
+    """Construct the LIMB_ARC NavFeature for one body."""
+    sigma_normal_per_vertex_px = _sigma_normal_per_vertex(
+        sampler=sampler, shape=shape, psf_sigma_px=psf_sigma_px, include_albedo=False
+    )
+    sigma_tangent_per_vertex_px = np.full_like(sigma_normal_per_vertex_px, 0.5)
+    visible_arc_fraction = _visible_arc_fraction(sampler)
+    incidence_factor_mean = float(np.mean(_incidence_factor_array(sampler.incidence_rad)))
+    return NavFeature(
+        feature_id=f'limb_arc:{body_name}',
+        feature_type=NavFeatureType.LIMB_ARC,
+        source_model=source_model,
+        geometry=LimbPolyline(
+            vertices_vu=sampler.vertices_vu,
+            normals_vu=sampler.normals_vu,
+            sigma_normal_per_vertex_px=sigma_normal_per_vertex_px,
+            sigma_tangent_per_vertex_px=sigma_tangent_per_vertex_px,
+            bbox_extfov_vu=bbox,
+        ),
+        subject_range_km=subject_range_km,
+        position_cov_px=None,
+        intensity_sigma_rel=0.0,
+        preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
+        reliability=_limb_reliability(
+            visible_arc_fraction=visible_arc_fraction,
+            visible_arc_px=float(sampler.vertices_vu.shape[0]),
+            mean_incidence_factor=incidence_factor_mean,
+        ),
+        reliability_reasons=NavReliabilityBreakdown(
+            visible_arc_fraction=visible_arc_fraction,
+            incidence_factor=min(1.0, incidence_factor_mean / MAX_INCIDENCE_FACTOR_CAP),
+        ),
+        usable_types=frozenset({NavFeatureType.LIMB_ARC}),
+        flags=LimbArcFlags(
+            body_name=body_name,
+            visible_arc_fraction=visible_arc_fraction,
+        ),
+    )
+
+
+def _build_polyline_sampler(
+    *,
+    local_mask: NDArrayBoolType,
+    incidence_local: NDArrayFloatType,
+    km_per_pixel_local: NDArrayFloatType,
+    ext_v0: int,
+    ext_u0: int,
+) -> _PolylineSampler:
+    """Sample a polyline along the True pixels of ``local_mask``.
+
+    The local mask is a 1-pixel-wide ridge inside the body silhouette; we
+    return a parallel array of vertex coordinates in extfov space, the
+    outward-pointing normal at each vertex (from the discrete-mask
+    gradient), the per-vertex incidence angle, and the per-vertex km/px
+    scale.
+    """
+    vs, us = np.where(local_mask)
+    if vs.size == 0:
+        empty: NDArrayFloatType = np.empty((0, 2), dtype=np.float64)
+        return _PolylineSampler(
+            vertices_vu=empty,
+            normals_vu=empty,
+            incidence_rad=np.empty(0, dtype=np.float64),
+            km_per_pixel=np.empty(0, dtype=np.float64),
+        )
+    vertices_vu: NDArrayFloatType = np.stack(
+        [vs.astype(np.float64) + ext_v0, us.astype(np.float64) + ext_u0], axis=1
+    )
+    rows, cols = local_mask.shape
+    normals_vu = np.zeros_like(vertices_vu)
+    for i, (v, u) in enumerate(zip(vs, us, strict=True)):
+        # Outward normal: gradient of body-mask values around the vertex.
+        # The body-side neighbour is True; the off-body neighbour is False.
+        v_dir = 0.0
+        u_dir = 0.0
+        if v > 0 and not local_mask[v - 1, u]:
+            v_dir = -1.0
+        elif v < rows - 1 and not local_mask[v + 1, u]:
+            v_dir = 1.0
+        if u > 0 and not local_mask[v, u - 1]:
+            u_dir = -1.0
+        elif u < cols - 1 and not local_mask[v, u + 1]:
+            u_dir = 1.0
+        norm = math.hypot(v_dir, u_dir) or 1.0
+        normals_vu[i, 0] = v_dir / norm
+        normals_vu[i, 1] = u_dir / norm
+    incidence_rad = incidence_local[vs, us].astype(np.float64)
+    km_per_pixel = km_per_pixel_local[vs, us].astype(np.float64)
+    return _PolylineSampler(
+        vertices_vu=vertices_vu,
+        normals_vu=normals_vu,
+        incidence_rad=incidence_rad,
+        km_per_pixel=km_per_pixel,
+    )
+
+
+def _incidence_factor_array(incidence_rad: NDArrayFloatType) -> NDArrayFloatType:
+    """Return the design's ``incidence_factor`` array, capped per the constants."""
+    deg = np.degrees(incidence_rad)
+    deg_clipped = np.clip(deg, 0.0, INCIDENCE_FACTOR_CLIP_DEG)
+    factor = 1.0 / np.cos(np.radians(np.minimum(deg_clipped, INCIDENCE_FACTOR_ANGLE_CAP_DEG))) - 1.0
+    factor = np.clip(factor, 0.0, MAX_INCIDENCE_FACTOR_CAP)
+    out: NDArrayFloatType = factor.astype(np.float64)
+    return out
+
+
+def _sigma_normal_per_vertex(
+    *,
+    sampler: _PolylineSampler,
+    shape: BodyShape,
+    psf_sigma_px: float,
+    include_albedo: bool,
+) -> NDArrayFloatType:
+    """Compute the per-vertex normal-sigma per the design.
+
+    Implements the formula from Part 1's "Position covariance per
+    feature type" section, including the limb-softness term that uses
+    the per-vertex km/px scale and the optional albedo / photometric
+    contribution for terminator arcs.
+    """
+    incidence_factor = _incidence_factor_array(sampler.incidence_rad)
+    km_per_pixel = np.where(sampler.km_per_pixel > 0.0, sampler.km_per_pixel, np.nan)
+    limb_softness_km = psf_sigma_px * km_per_pixel
+    base = (
+        shape.ellipsoid_residual_km**2
+        + shape.crater_scale_km**2
+        + (incidence_factor * limb_softness_km) ** 2
+        + shape.spice_orbital_residual_km**2
+    )
+    if include_albedo:
+        albedo_term = (shape.albedo_variation * limb_softness_km) ** 2
+        photometric_term = (limb_softness_km * 0.5) ** 2
+        base = base + albedo_term + photometric_term
+    sigma_km = np.sqrt(np.maximum(base, 0.0))
+    sigma_px = sigma_km / km_per_pixel
+    return np.nan_to_num(sigma_px, nan=LIMB_ARC_MAX_UNCERTAINTY_PX, posinf=1e3, neginf=1e3)
+
+
+def _visible_arc_fraction(sampler: _PolylineSampler) -> float:
+    """Fraction of polyline vertices that are usable.
+
+    The sampler already drops shadow / off-FOV vertices during
+    construction; for the purposes of the reliability reason we report
+    1.0 when any vertices survive.  When the table-driven shadow
+    extractor is wired, this will be replaced by
+    ``len(survivors) / len(total)``.
+    """
+    return 1.0 if sampler.vertices_vu.shape[0] > 0 else 0.0
+
+
+def _limb_reliability(
+    *, visible_arc_fraction: float, visible_arc_px: float, mean_incidence_factor: float
+) -> float:
+    """Sigmoid-of-sum reliability for LIMB_ARC features."""
+    z = (
+        -1.0
+        + 1.5 * visible_arc_fraction
+        + 1.0 * _sigmoid(visible_arc_px / 50.0)
+        - 0.7 * mean_incidence_factor
+    )
+    return float(_sigmoid(z))
+
+
+def _terminator_reliability(
+    *, visible_arc_fraction: float, albedo_variation: float, phase_factor: float
+) -> float:
+    """Reliability of TERMINATOR_ARC mirroring the design's formula."""
+    base = _sigmoid(-1.0 + 1.5 * visible_arc_fraction - 1.5 * albedo_variation)
+    return float(base * min(1.0, phase_factor))
+
+
+def _disc_reliability(
+    *, visible_lit_fraction: float, overflow_fraction: float, diameter_px: float
+) -> float:
+    """Reliability of BODY_DISC per the design (no scoring alpha coefficients yet)."""
+    sigmoid_term = _sigmoid(diameter_px / 30.0 - 1.0)
+    return float(visible_lit_fraction * (1.0 - overflow_fraction) * sigmoid_term)
+
+
+def _blob_reliability(*, snr: float, diameter_px: float) -> float:
+    """Reliability of BODY_BLOB per the design (cap at 0.4)."""
+    return float(_sigmoid(snr) * _sigmoid(diameter_px / 8.0 - 1.0) * 0.4)
+
+
+def _sigmoid(x: float) -> float:
+    """Logistic sigmoid (numerically safe)."""
+    if x >= 0:
+        z = math.exp(-x)
+        return 1.0 / (1.0 + z)
+    z = math.exp(x)
+    return z / (1.0 + z)

--- a/src/nav/nav_model/nav_model_rings.py
+++ b/src/nav/nav_model/nav_model_rings.py
@@ -1,0 +1,670 @@
+"""Catalog-driven ring NavModel.
+
+The orchestrator iterates one ``NavModelRings`` per planet whose ring
+system has any radius inside the extfov.  Per ring feature surviving
+the four-pass ``RingFeatureFilter``, the model emits either:
+
+- one ``RING_EDGE`` ``NavFeature`` carrying a per-vertex ``RingEdgePolyline``
+  with its own sigma_radial / sigma_along_edge derived from the catalog ``rms``,
+  or
+- one ``RING_ANNULUS`` ``NavFeature`` carrying the rendered annulus
+  template when the surviving edge polyline compresses radially below
+  the resolvability threshold.
+
+The per-edge polylines come from sampling the rendered model + edge
+mask: each ``True`` pixel in the edge mask contributes one polyline
+vertex, and the gradient direction across the edge gives the radial
+normal.  Curvature is measured by the maximum deviation of the polyline
+from its best-fit straight line.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import oops
+
+from nav.annotation import Annotations
+from nav.config import Config
+from nav.feature.feature import NavFeature, NavReliabilityBreakdown
+from nav.feature.feature_type import NavFeatureType
+from nav.feature.flags import RingAnnulusFlags, RingEdgeFlags
+from nav.feature.geometry import RingAnnulusGeometry, RingEdgePolyline
+from nav.nav_model.nav_model import NavModel
+from nav.nav_model.nav_model_rings_base import NavModelRingsBase
+from nav.nav_model.rings import (
+    RingFeature,
+    RingFeatureFilter,
+    RingsRenderContext,
+    validate_no_date_overlaps,
+)
+from nav.support.filters import NavFilterKind, NavFilterSpec
+from nav.support.time import now_dt, utc_to_et
+from nav.support.types import NDArrayBoolType, NDArrayFloatType
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from nav.nav_orchestrator.nav_context import NavContext
+
+
+__all__ = [
+    'FLAT_CURVATURE_THRESHOLD_PX',
+    'RING_ANNULUS_MAX_RADIAL_PX',
+    'RING_EDGE_DEFAULT_RELIABILITY',
+    'RING_EDGE_SIGMA_ALONG_PX',
+    'NavModelRings',
+]
+
+
+RING_EDGE_DEFAULT_RELIABILITY: float = 0.7
+"""Catalog default reliability for ring edges before per-image scaling.
+
+Mirrors the design's "catalog_default_reliability" term in the RING_EDGE
+sigmoid.  Phase-5 calibration may override it per planet ring.
+"""
+
+
+RING_EDGE_SIGMA_ALONG_PX: float = 0.5
+"""Per-vertex sigma_along_edge in pixels.
+
+Reflects polyline-sampling resolution; the design specifies ~0.5 px.
+"""
+
+
+FLAT_CURVATURE_THRESHOLD_PX: float = 1.0
+"""Pixel-deviation threshold below which a polyline is flagged straight.
+
+When the maximum deviation of the polyline from its best-fit straight
+line is below this value, the corresponding ``RING_EDGE`` feature is
+emitted with ``is_straight_line=True``.  The technique-level fitter
+then handles its rank-1 covariance.
+"""
+
+
+RING_ANNULUS_MAX_RADIAL_PX: float = 5.0
+"""Maximum radial extent for a ``RING_EDGE`` polyline.
+
+When all vertices of a surviving feature fall inside a radial band of
+this width, the model emits a ``RING_ANNULUS`` template instead of
+per-edge polylines (the edges are not separable at the image scale).
+"""
+
+
+def _require_positive_finite_planet_scalar(
+    planet: str, key: str, planet_config: dict[str, Any]
+) -> float:
+    """Return a positive finite float from ``planet_config[key]``.
+
+    Performs explicit type and finiteness checks so misconfigured YAML
+    fails at config-read, not in the math.
+
+    Parameters:
+        planet: Planet name (used in error messages).
+        key: Config key to read.
+        planet_config: The per-planet config dict.
+
+    Returns:
+        A positive finite float.
+
+    Raises:
+        ValueError: If ``key`` is missing or the value is not a positive
+            finite float.
+    """
+    if key not in planet_config:
+        raise ValueError(f'Missing required ring configuration key {key!r} for planet {planet}')
+    raw: Any = planet_config[key]
+    if isinstance(raw, bool):
+        raise ValueError(
+            f'Invalid {key} for planet {planet}: expected a finite numeric value, got bool'
+        )
+    try:
+        v = float(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f'Invalid {key} for planet {planet}: expected a finite numeric value, got {raw!r}'
+        ) from exc
+    if not math.isfinite(v):
+        raise ValueError(f'Invalid {key} {v} for planet {planet} (must be finite)')
+    if v <= 0.0:
+        raise ValueError(f'Invalid {key} {v} for planet {planet}')
+    return v
+
+
+class NavModelRings(NavModelRingsBase):
+    """Catalog-driven ring NavModel for one planet.
+
+    Parameters:
+        name: Model instance name (e.g. ``'rings:SATURN'``).
+        obs: Observation snapshot.
+        config: Optional ``Config`` override.
+    """
+
+    _abstract = False
+
+    def __init__(
+        self,
+        name: str,
+        obs: oops.Observation,
+        *,
+        config: Config | None = None,
+    ) -> None:
+        super().__init__(name, obs, config=config)
+        self._planet: str | None = None
+        self._render_results: list[
+            tuple[
+                RingFeature,
+                NDArrayFloatType,
+                NDArrayBoolType,
+                float,
+                list[tuple[NDArrayBoolType, str, str]],
+            ]
+        ] = []
+        self._km_per_pixel_radial: float = 0.0
+        self._extfov_v_size: int = 0
+        self._extfov_u_size: int = 0
+        self._predicted_center_vu: tuple[float, float] = (0.0, 0.0)
+        self._subject_range_km: float = float('inf')
+
+    @classmethod
+    def instances_for_obs(cls, obs: oops.Observation) -> list[NavModel]:
+        """Return one NavModelRings per planet whose ring catalog touches the FOV."""
+        planet = getattr(obs, 'closest_planet', None)
+        if planet is None:
+            return []
+        # The model also needs the extfov shape and the ext_bp surface; obs
+        # stand-ins that don't expose those are not applicable.
+        if not hasattr(obs, 'extdata_shape_vu') or not hasattr(obs, 'ext_bp'):
+            return []
+        from nav.config import DEFAULT_CONFIG
+
+        rings_config = DEFAULT_CONFIG.rings
+        ring_features_dict = getattr(rings_config, 'ring_features', None)
+        if not ring_features_dict or planet not in ring_features_dict:
+            return []
+        return [cls(f'rings:{planet}', obs)]
+
+    def create_model(self) -> None:
+        """Run the four-pass filter, render surviving features, populate metadata."""
+        start_time = now_dt()
+        self._metadata.clear()
+        self._metadata['start_time'] = start_time.isoformat()
+        self._metadata['end_time'] = None
+        self._metadata['elapsed_time_sec'] = None
+        log_level = self._config.general.get('log_level_model_rings')
+        with self._logger.open('CREATE RINGS MODEL', level=log_level):
+            self._render()
+        end_time = now_dt()
+        self._metadata['end_time'] = end_time.isoformat()
+        self._metadata['elapsed_time_sec'] = (end_time - start_time).total_seconds()
+
+    def _render(self) -> None:
+        """Filter + render every surviving ring feature for this observation."""
+        obs = self.obs
+        planet = obs.closest_planet
+        if planet is None:
+            self._logger.warning('No closest planet found -- cannot create ring model')
+            return
+        self._planet = planet
+        self._extfov_v_size = obs.extdata_shape_vu[0]
+        self._extfov_u_size = obs.extdata_shape_vu[1]
+        self._predicted_center_vu = (
+            float(self._extfov_v_size) / 2.0,
+            float(self._extfov_u_size) / 2.0,
+        )
+
+        rings_config = self._config.rings
+        ring_features_dict = getattr(rings_config, 'ring_features', {})
+        if planet not in ring_features_dict:
+            self._logger.info('No ring features configured for planet %s', planet)
+            return
+        planet_config = ring_features_dict[planet]
+        if not isinstance(planet_config, dict):
+            raise ValueError(
+                f'Ring config error: rings.ring_features entry for planet {planet!r} must be '
+                f'a dict (got {type(planet_config).__name__!r})'
+            )
+        epoch_str = planet_config.get('epoch')
+        if epoch_str is None:
+            raise ValueError(f'No epoch configured for planet {planet}')
+        if not isinstance(epoch_str, str):
+            raise ValueError(
+                f'Ring config error: epoch for planet {planet!r} must be a string, '
+                f'got {type(epoch_str).__name__!r}'
+            )
+        try:
+            epoch = utc_to_et(epoch_str)
+        except ValueError as exc:
+            raise ValueError(
+                f'Ring config error: epoch for planet {planet!r} is not a valid UTC '
+                f'string ({epoch_str!r}): {exc}'
+            ) from exc
+        fade_width_pix = _require_positive_finite_planet_scalar(
+            planet, 'fade_width_pix', planet_config
+        )
+        min_allowed_fade_width_pix = _require_positive_finite_planet_scalar(
+            planet, 'min_allowed_fade_width_pix', planet_config
+        )
+        min_feature_pixels = _require_positive_finite_planet_scalar(
+            planet, 'min_feature_pixels', planet_config
+        )
+        if 'features' not in planet_config:
+            raise ValueError(
+                f'Missing required ring configuration key "features" for planet {planet}'
+            )
+        features_raw = planet_config['features']
+        if not isinstance(features_raw, dict):
+            raise ValueError(
+                f'Ring config error: "features" for planet {planet!r} must be a dict '
+                f'(got {type(features_raw).__name__!r})'
+            )
+        if not features_raw:
+            return
+        ring_target = f'{planet.lower()}:ring'
+        bp_radii = obs.ext_bp.ring_radius(ring_target)
+        if bp_radii.is_all_masked():
+            self._logger.info('No rings visible in observation')
+            return
+        min_radius = float(bp_radii.min().vals)
+        max_radius = float(bp_radii.max().vals)
+        features: list[RingFeature] = []
+        for key, data in features_raw.items():
+            if not isinstance(data, dict):
+                raise ValueError(
+                    f'Ring config error: planet {planet!r} features.{key!r} must be a dict '
+                    f'(got {type(data).__name__!r})'
+                )
+            features.append(RingFeature.from_config(key, data))
+        validate_no_date_overlaps(features)
+        max_feature_extent = max(f.max_extent_radius for f in features)
+        if min_radius > max_feature_extent:
+            return
+        resolutions: NDArrayFloatType = obs.ext_bp.ring_radial_resolution(ring_target).vals
+        self._km_per_pixel_radial = float(np.mean(resolutions[np.isfinite(resolutions)]))
+
+        def min_res_at_radius(a: float) -> float | None:
+            border_arr: NDArrayBoolType = (
+                obs.ext_bp.border_atop(bp_radii.key, a).mvals.astype('bool').filled(False)
+            )
+            res_at_edge = resolutions[border_arr]
+            res_ma = np.ma.asarray(res_at_edge)
+            if res_ma.count() == 0:
+                return None
+            vals = np.asarray(res_ma.compressed(), dtype=np.float64)
+            vals = vals[np.isfinite(vals)]
+            if vals.size == 0:
+                return None
+            min_val = float(np.min(vals))
+            return min_val if min_val > 0.0 else None
+
+        feature_filter = RingFeatureFilter(
+            obs_time_et=obs.midtime,
+            min_radius=min_radius,
+            max_radius=max_radius,
+            min_res_at_radius=min_res_at_radius,
+            fade_width_pix=fade_width_pix,
+            min_allowed_fade_width_pix=min_allowed_fade_width_pix,
+            min_feature_pixels=min_feature_pixels,
+            logger=self._logger,
+        )
+        surviving = feature_filter.filter(features)
+        if not surviving:
+            return
+        all_edge_radii: list[tuple[float, str]] = []
+        for feat in surviving:
+            all_edge_radii.extend(feat.all_base_radii())
+        all_edge_radii.sort(key=lambda x: x[0])
+        bp_distance = obs.ext_bp.distance(ring_target, direction='dep')
+        distance_arr = bp_distance.mvals.filled(math.inf)
+        # Subject range — closest visible ring radius
+        if np.any(np.isfinite(distance_arr)):
+            self._subject_range_km = float(distance_arr[np.isfinite(distance_arr)].min())
+        else:
+            self._subject_range_km = float('inf')
+
+        shadow_mask: NDArrayBoolType | None = None
+        if rings_config.get('remove_planet_shadow', False):
+            try:
+                raw_shadow = obs.ext_bp.where_inside_shadow(ring_target, planet.lower())
+                shadow_mask = raw_shadow.mvals.filled(False).astype(bool)
+            except Exception:
+                self._logger.warning(
+                    'Failed to compute planet shadow for %s; shadow removal skipped',
+                    planet,
+                    exc_info=True,
+                )
+
+        render_context = RingsRenderContext(
+            obs=obs,
+            ring_target=ring_target,
+            epoch=epoch,
+            resolutions=resolutions,
+            fade_width_pix=fade_width_pix,
+            all_edge_radii=tuple(all_edge_radii),
+            logger=self._logger,
+        )
+        rendered: list[
+            tuple[
+                RingFeature,
+                NDArrayFloatType,
+                NDArrayBoolType,
+                float,
+                list[tuple[NDArrayBoolType, str, str]],
+            ]
+        ] = []
+        for feature in surviving:
+            for render_result in feature.render(render_context):
+                feat_model = render_result.model_img
+                feat_mask = render_result.model_mask
+                if shadow_mask is not None:
+                    feat_model = np.where(shadow_mask, 0.0, feat_model)
+                    feat_mask = feat_mask & ~shadow_mask
+                rendered.append(
+                    (
+                        feature,
+                        feat_model,
+                        feat_mask,
+                        float(render_result.uncertainty),
+                        render_result.edge_info_list,
+                    )
+                )
+        self._render_results = rendered
+        self._metadata['planet'] = planet
+        self._metadata['epoch'] = epoch_str
+        self._metadata['feature_count'] = len(surviving)
+        self._metadata['features'] = [
+            {'name': f.name, 'type': f.feature_type.value} for f in surviving
+        ]
+
+    def to_features(self, context: NavContext) -> list[NavFeature]:
+        """Emit RING_EDGE / RING_ANNULUS features per surviving render result."""
+        del context
+        features: list[NavFeature] = []
+        for (
+            ring_feat,
+            model_img,
+            model_mask,
+            uncertainty_km,
+            edge_info_list,
+        ) in self._render_results:
+            if not edge_info_list:
+                continue
+            for edge_mask, label_text, edge_label in edge_info_list:
+                vertices_vu, normals_vu = _polyline_from_edge_mask(edge_mask)
+                if vertices_vu.shape[0] == 0:
+                    continue
+                radial_extent_px = _radial_extent_px(vertices_vu, normals_vu)
+                straight = _is_straight_line(vertices_vu)
+                if radial_extent_px <= RING_ANNULUS_MAX_RADIAL_PX and not straight:
+                    features.append(
+                        _build_annulus_feature(
+                            ring_name=label_text,
+                            planet=self._planet or '',
+                            model_img=model_img,
+                            model_mask=model_mask,
+                            bbox=_mask_bbox(model_mask),
+                            predicted_center_vu=self._predicted_center_vu,
+                            subject_range_km=self._subject_range_km,
+                            constituent_count=1,
+                            source_model=self.name,
+                        )
+                    )
+                else:
+                    features.append(
+                        _build_edge_feature(
+                            ring_feat=ring_feat,
+                            edge_label=edge_label,
+                            label_text=label_text,
+                            planet=self._planet or '',
+                            vertices_vu=vertices_vu,
+                            normals_vu=normals_vu,
+                            uncertainty_km=uncertainty_km,
+                            km_per_pixel_radial=max(self._km_per_pixel_radial, 1.0),
+                            is_straight_line=straight,
+                            bbox=_mask_bbox(edge_mask),
+                            subject_range_km=self._subject_range_km,
+                            source_model=self.name,
+                        )
+                    )
+        return features
+
+    def to_annotations(self, context: NavContext) -> Annotations:
+        """Render per-edge polyline overlays + ring labels."""
+        del context
+        out = Annotations()
+        for _ring_feat, _model_img, model_mask, _u, edge_info_list in self._render_results:
+            if not edge_info_list:
+                continue
+            out.add_annotations(self._create_edge_annotations(self.obs, edge_info_list, model_mask))
+        return out
+
+
+def _polyline_from_edge_mask(
+    mask: NDArrayBoolType,
+) -> tuple[NDArrayFloatType, NDArrayFloatType]:
+    """Extract a polyline + per-vertex normal from a 1-pixel-wide edge mask.
+
+    Each True pixel becomes one polyline vertex.  The normal at each
+    vertex is the gradient direction across the local edge: the +1
+    side is the "high-radius" side (mask remains True looking outward)
+    and the -1 side is the gap (mask is False).  When no off-edge
+    neighbour is found (interior of a thick ridge), the normal is left
+    at zero, which is acceptable because the renderer's edge mask is
+    one pixel wide so interior ridge pixels do not occur.
+
+    Parameters:
+        mask: 2-D boolean ``(rows, cols)`` array of edge pixels in
+            extfov coordinates.
+
+    Returns:
+        ``(vertices_vu, normals_vu)`` arrays each of shape ``(N, 2)``.
+    """
+    if not mask.any():
+        empty: NDArrayFloatType = np.empty((0, 2), dtype=np.float64)
+        return empty, empty
+    vs, us = np.where(mask)
+    vertices_vu: NDArrayFloatType = np.stack([vs.astype(np.float64), us.astype(np.float64)], axis=1)
+    rows, cols = mask.shape
+    normals_vu = np.zeros_like(vertices_vu)
+    for i, (v, u) in enumerate(zip(vs, us, strict=True)):
+        v_dir = 0.0
+        u_dir = 0.0
+        if v > 0 and not mask[v - 1, u]:
+            v_dir = -1.0
+        elif v < rows - 1 and not mask[v + 1, u]:
+            v_dir = 1.0
+        if u > 0 and not mask[v, u - 1]:
+            u_dir = -1.0
+        elif u < cols - 1 and not mask[v, u + 1]:
+            u_dir = 1.0
+        norm = math.hypot(v_dir, u_dir) or 1.0
+        normals_vu[i, 0] = v_dir / norm
+        normals_vu[i, 1] = u_dir / norm
+    return vertices_vu, normals_vu
+
+
+def _radial_extent_px(vertices_vu: NDArrayFloatType, normals_vu: NDArrayFloatType) -> float:
+    """Return the polyline's radial extent (max - min projection on mean normal)."""
+    if vertices_vu.shape[0] == 0:
+        return 0.0
+    mean_normal = normals_vu.mean(axis=0)
+    norm = float(np.linalg.norm(mean_normal))
+    if norm == 0.0:
+        return 0.0
+    mean_normal = mean_normal / norm
+    projections = vertices_vu @ mean_normal
+    return float(projections.max() - projections.min())
+
+
+def _is_straight_line(vertices_vu: NDArrayFloatType) -> bool:
+    """Return True when the polyline's max-deviation from a best-fit line is tiny.
+
+    The polyline is straight when its maximum perpendicular deviation
+    from the best-fit straight line is below
+    ``FLAT_CURVATURE_THRESHOLD_PX``.  Computed by SVD of the centred
+    point cloud (the smallest singular vector is the normal direction).
+    """
+    if vertices_vu.shape[0] < 3:
+        return True
+    centred = vertices_vu - vertices_vu.mean(axis=0)
+    _, _, vh = np.linalg.svd(centred, full_matrices=False)
+    normal = vh[-1]
+    deviations = centred @ normal
+    return bool(float(np.max(np.abs(deviations))) <= FLAT_CURVATURE_THRESHOLD_PX)
+
+
+def _mask_bbox(mask: NDArrayBoolType) -> tuple[int, int, int, int]:
+    """Return ``(v_min, u_min, v_max, u_max)`` half-open bbox of True pixels."""
+    if not mask.any():
+        return (0, 0, 0, 0)
+    vs, us = np.where(mask)
+    return (
+        int(vs.min()),
+        int(us.min()),
+        int(vs.max()) + 1,
+        int(us.max()) + 1,
+    )
+
+
+def _build_edge_feature(
+    *,
+    ring_feat: RingFeature,
+    edge_label: str,
+    label_text: str,
+    planet: str,
+    vertices_vu: NDArrayFloatType,
+    normals_vu: NDArrayFloatType,
+    uncertainty_km: float,
+    km_per_pixel_radial: float,
+    is_straight_line: bool,
+    bbox: tuple[int, int, int, int],
+    subject_range_km: float,
+    source_model: str,
+) -> NavFeature:
+    """Construct a RING_EDGE NavFeature from polyline data."""
+    n = vertices_vu.shape[0]
+    sigma_radial_px = np.full(n, uncertainty_km / km_per_pixel_radial, dtype=np.float64)
+    sigma_along_px = np.full(n, RING_EDGE_SIGMA_ALONG_PX, dtype=np.float64)
+    visible_arc_fraction = 1.0
+    feature_id = f'ring_edge:{planet}:{ring_feat.key}:{edge_label}'
+    reliability = _ring_edge_reliability(
+        catalog_default=RING_EDGE_DEFAULT_RELIABILITY,
+        visible_arc_fraction=visible_arc_fraction,
+        shadow_occluded_fraction=0.0,
+        is_straight_line=is_straight_line,
+    )
+    return NavFeature(
+        feature_id=feature_id,
+        feature_type=NavFeatureType.RING_EDGE,
+        source_model=source_model,
+        geometry=RingEdgePolyline(
+            vertices_vu=vertices_vu,
+            normals_vu=normals_vu,
+            sigma_radial_per_vertex_px=sigma_radial_px,
+            sigma_along_edge_per_vertex_px=sigma_along_px,
+            is_straight_line=is_straight_line,
+            bbox_extfov_vu=bbox,
+        ),
+        subject_range_km=subject_range_km,
+        position_cov_px=None,
+        intensity_sigma_rel=0.0,
+        preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
+        reliability=reliability,
+        reliability_reasons=NavReliabilityBreakdown(
+            visible_arc_fraction=visible_arc_fraction,
+            shadow_occluded_fraction=0.0,
+        ),
+        usable_types=frozenset({NavFeatureType.RING_EDGE}),
+        flags=RingEdgeFlags(
+            is_straight_line=is_straight_line,
+            polarity_predictable=False,
+            edge_name=f'{ring_feat.key}:{edge_label}',
+            planet_name=planet,
+        ),
+    )
+
+
+def _build_annulus_feature(
+    *,
+    ring_name: str,
+    planet: str,
+    model_img: NDArrayFloatType,
+    model_mask: NDArrayBoolType,
+    bbox: tuple[int, int, int, int],
+    predicted_center_vu: tuple[float, float],
+    subject_range_km: float,
+    constituent_count: int,
+    source_model: str,
+) -> NavFeature:
+    """Construct a RING_ANNULUS NavFeature when edges compress radially."""
+    feature_id = f'ring_annulus:{planet}:{ring_name}'
+    return NavFeature(
+        feature_id=feature_id,
+        feature_type=NavFeatureType.RING_ANNULUS,
+        source_model=source_model,
+        geometry=RingAnnulusGeometry(
+            bbox_extfov_vu=bbox,
+            predicted_center_vu=predicted_center_vu,
+        ),
+        subject_range_km=subject_range_km,
+        position_cov_px=None,
+        intensity_sigma_rel=0.0,
+        preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
+        reliability=_ring_annulus_reliability(
+            constituent_count=constituent_count,
+            radial_extent_px=float(bbox[2] - bbox[0]),
+        ),
+        reliability_reasons=NavReliabilityBreakdown(visible_arc_fraction=1.0),
+        usable_types=frozenset({NavFeatureType.RING_ANNULUS}),
+        flags=RingAnnulusFlags(
+            planet_name=planet,
+            constituent_edge_count=constituent_count,
+        ),
+        template_img=model_img,
+        template_mask=model_mask,
+    )
+
+
+def _ring_edge_reliability(
+    *,
+    catalog_default: float,
+    visible_arc_fraction: float,
+    shadow_occluded_fraction: float,
+    is_straight_line: bool,
+) -> float:
+    """Reliability of RING_EDGE per the design's formula.
+
+    ``catalog_default * visible_arc_fraction * (1 - shadow_occluded_fraction)``
+    times a sigmoid of the (yet-uncalibrated) emission-angle factor; we
+    approximate the sigmoid by a constant in this implementation pending
+    Phase-5 calibration.  Straight-line edges get a 70% multiplier
+    because they contribute rank-1 constraints only.
+    """
+    base = catalog_default * visible_arc_fraction * (1.0 - shadow_occluded_fraction)
+    if is_straight_line:
+        base = base * 0.7
+    return float(np.clip(base, 0.0, 1.0))
+
+
+def _ring_annulus_reliability(*, constituent_count: int, radial_extent_px: float) -> float:
+    """Reliability of RING_ANNULUS per the design's formula.
+
+    The plan specifies
+    ``mean(constituent_reliabilities) * sigmoid(radial_extent_px / 50 - 1)``.
+    Per-edge constituent reliabilities are not tracked yet (the catalog
+    surfaces edge ``rms`` but no per-edge reliability scalar), so we
+    substitute the catalog-default reliability scaled by the number of
+    constituent edges (more edges -> more confident annulus, capped at 1).
+
+    Parameters:
+        constituent_count: Number of catalog edges fused into this annulus.
+        radial_extent_px: Width of the annulus in the radial direction.
+
+    Returns:
+        Reliability in ``[0, 1]``.
+    """
+    if constituent_count <= 0:
+        return 0.0
+    sigmoid_term = 1.0 / (1.0 + math.exp(-(radial_extent_px / 50.0 - 1.0)))
+    constituent_term = min(1.0, constituent_count / 5.0) * RING_EDGE_DEFAULT_RELIABILITY
+    return float(np.clip(constituent_term * sigmoid_term, 0.0, 1.0))

--- a/src/nav/nav_model/stars/__init__.py
+++ b/src/nav/nav_model/stars/__init__.py
@@ -1,0 +1,90 @@
+"""Catalog-driven star NavModel package.
+
+The package is organised as a small set of helper modules around a thin
+orchestrator class:
+
+- ``catalog`` — multi-catalog reduction, stellar aberration, proper
+  motion, FOV projection, dedup.
+- ``conflicts`` — body and ring occlusion checks for catalog stars.
+- ``predicted_snr`` — per-star integrated-SNR estimate plus the
+  ``SCLASS_TO_B_MINUS_V`` spectral-class colour lookup.
+- ``smeared_psf`` — smear-aware PSF rendering and per-image smear vector.
+- ``detection`` — DAOPHOT-style source detection (matched filter,
+  centroid fit, shape cuts) used by downstream techniques.
+- ``nav_model_stars`` — ``NavModelStars`` orchestrator implementing the
+  ``NavModel`` ABC.
+"""
+
+import logging
+
+from nav.nav_model.stars.catalog import (
+    CATALOG_MAGNITUDE_BINS,
+    aberrate_star,
+    reduce_catalogs,
+    select_radec_list,
+    stars_in_extfov,
+)
+from nav.nav_model.stars.conflicts import (
+    mark_body_and_ring_conflicts,
+    parse_ring_occlusion_annuli,
+)
+from nav.nav_model.stars.detection import (
+    DAOPHOT_DEFAULT_DETECTION_SIGMA,
+    DAOPHOT_DEFAULT_ROUNDNESS_BOUND,
+    DAOPHOT_DEFAULT_SHARPNESS_MAX,
+    DAOPHOT_DEFAULT_SHARPNESS_MIN,
+    DetectedSource,
+    apply_shape_cuts,
+    centroid_gaussian_fit,
+    centroid_saturated,
+    detect_ccd_bloom_columns,
+    detect_sources,
+    matched_filter_image,
+)
+from nav.nav_model.stars.nav_model_stars import NavModelStars
+from nav.nav_model.stars.predicted_snr import (
+    SCLASS_TO_B_MINUS_V,
+    integrated_signal_dn,
+    predicted_snr,
+    psf_aperture_pixels,
+    psf_sigma_px,
+)
+from nav.nav_model.stars.smeared_psf import (
+    compute_smear_vector_px,
+    movement_granularity_px,
+    render_smeared_psf,
+    smear_length_px,
+)
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+__all__ = [
+    'CATALOG_MAGNITUDE_BINS',
+    'DAOPHOT_DEFAULT_DETECTION_SIGMA',
+    'DAOPHOT_DEFAULT_ROUNDNESS_BOUND',
+    'DAOPHOT_DEFAULT_SHARPNESS_MAX',
+    'DAOPHOT_DEFAULT_SHARPNESS_MIN',
+    'SCLASS_TO_B_MINUS_V',
+    'DetectedSource',
+    'NavModelStars',
+    'aberrate_star',
+    'apply_shape_cuts',
+    'centroid_gaussian_fit',
+    'centroid_saturated',
+    'compute_smear_vector_px',
+    'detect_ccd_bloom_columns',
+    'detect_sources',
+    'integrated_signal_dn',
+    'mark_body_and_ring_conflicts',
+    'matched_filter_image',
+    'movement_granularity_px',
+    'parse_ring_occlusion_annuli',
+    'predicted_snr',
+    'psf_aperture_pixels',
+    'psf_sigma_px',
+    'reduce_catalogs',
+    'render_smeared_psf',
+    'select_radec_list',
+    'smear_length_px',
+    'stars_in_extfov',
+]

--- a/src/nav/nav_model/stars/catalog.py
+++ b/src/nav/nav_model/stars/catalog.py
@@ -1,0 +1,610 @@
+"""Star catalog reduction for the star NavModel.
+
+The star pipeline pulls catalog records, then reduces them through:
+
+1. **Stellar aberration.**  ``aberrate_star`` shifts a catalog RA/DEC into
+   the spacecraft frame so the comparison against the image is fair.
+2. **Proper motion.**  ``select_radec_list`` evaluates each star's
+   proper-motion vector at ``obs.midtime`` so the predicted pixel
+   reflects the star's position at the observation epoch.
+3. **Multi-catalog precedence.**  ``reduce_catalogs`` walks the
+   configured catalog order (``ucac4`` → ``tycho2`` → ``ybsc`` by
+   default), pulls stars in incremental magnitude bins, and dedupes
+   matching entries so the most precise catalog wins per star.
+4. **FOV projection + edge culling.**  Stars too close to the extfov
+   edge for their PSF support to fit, or whose smear motion would push
+   them off the edge mid-exposure, are dropped.
+
+The reduction is exposed as small free functions so ``NavModelStars``
+composes them without subclassing.
+
+Three module-level cached catalog instances avoid the expense of
+re-loading UCAC4 / Tycho-2 / YBSC on every navigation; the getters
+construct each catalog lazily on first call.
+"""
+
+from __future__ import annotations
+
+import copy
+import itertools
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+import polymath
+from oops import Event
+from starcat import (
+    SCLASS_TO_SURFACE_TEMP,
+    SpiceStarCatalog,
+    UCAC4StarCatalog,
+    YBSCStarCatalog,
+)
+
+from nav.nav_model.stars.predicted_snr import SCLASS_TO_B_MINUS_V
+from nav.support.flux import clean_sclass
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from nav.config import Config
+    from nav.obs import ObsSnapshot
+    from nav.support.types import MutableStar
+
+__all__ = [
+    'CATALOG_MAGNITUDE_BINS',
+    'aberrate_star',
+    'get_tycho2_catalog',
+    'get_ucac4_catalog',
+    'get_ybsc_catalog',
+    'reduce_catalogs',
+    'select_radec_list',
+    'stars_in_extfov',
+]
+
+
+# Public so tests can pin against the same coarse magnitude grid the
+# pipeline uses.  Stars are pulled bin by bin until the configured
+# ``max_stars`` budget is hit; this avoids the worst case of pulling
+# every dim star in a degree-square chunk of UCAC4.
+CATALOG_MAGNITUDE_BINS: tuple[float, ...] = (
+    0.0,
+    8.0,
+    9.0,
+    10.0,
+    10.5,
+    11.0,
+    11.5,
+    12.0,
+    12.5,
+    13.0,
+    14.0,
+    15.0,
+    16.0,
+    17.0,
+)
+"""Magnitude bin edges used to walk catalogs incrementally.
+
+The bins are tighter near the threshold (10.0-13.0) where most catalog
+stars in a typical Cassini-WAC FOV live, and looser at the bright and
+faint ends.  The walk stops when the configured ``max_stars`` budget is
+reached or the next bin's lower edge exceeds the obs's
+``star_max_usable_vmag()``.
+"""
+
+
+_STAR_CATALOG_UCAC4: UCAC4StarCatalog | None = None
+_STAR_CATALOG_TYCHO2: SpiceStarCatalog | None = None
+_STAR_CATALOG_YBSC: YBSCStarCatalog | None = None
+
+
+def get_ucac4_catalog() -> UCAC4StarCatalog:
+    """Return the UCAC4 catalog, lazily constructing on first call."""
+    global _STAR_CATALOG_UCAC4
+    if _STAR_CATALOG_UCAC4 is None:
+        _STAR_CATALOG_UCAC4 = UCAC4StarCatalog()
+    return _STAR_CATALOG_UCAC4
+
+
+def get_tycho2_catalog() -> SpiceStarCatalog:
+    """Return the Tycho-2 catalog, lazily constructing on first call."""
+    global _STAR_CATALOG_TYCHO2
+    if _STAR_CATALOG_TYCHO2 is None:
+        _STAR_CATALOG_TYCHO2 = SpiceStarCatalog('tycho2')
+    return _STAR_CATALOG_TYCHO2
+
+
+def get_ybsc_catalog() -> YBSCStarCatalog:
+    """Return the YBSC catalog, lazily constructing on first call."""
+    global _STAR_CATALOG_YBSC
+    if _STAR_CATALOG_YBSC is None:
+        _STAR_CATALOG_YBSC = YBSCStarCatalog()
+    return _STAR_CATALOG_YBSC
+
+
+def aberrate_star(obs: ObsSnapshot, star: MutableStar) -> None:
+    """Apply stellar aberration to a star in place.
+
+    Builds an ``oops.Event`` at ``obs.midtime`` in the spacecraft frame,
+    points its inverse-arrival vector at the catalog RA/DEC, and reads
+    back the aberration-corrected RA/DEC from
+    ``neg_arr_ap_j2000``.  ``star.ra`` and ``star.dec`` are overwritten.
+
+    Parameters:
+        obs: Observation snapshot supplying ``midtime``, ``path``, and
+            ``frame``.
+        star: Star record to mutate.
+    """
+    event = Event(
+        obs.midtime,
+        (polymath.Vector3.ZERO, polymath.Vector3.ZERO),
+        obs.path,
+        obs.frame,
+    )
+    event.neg_arr_j2000 = polymath.Vector3.from_ra_dec_length(
+        star.ra, star.dec, 1.0, recursive=False
+    )
+    abb_ra, abb_dec, _ = event.neg_arr_ap_j2000.to_ra_dec_length(recursive=False)
+    star.ra = abb_ra.vals
+    star.dec = abb_dec.vals
+
+
+def select_radec_list(
+    stars: list[MutableStar],
+    *,
+    use_proper_motion: bool,
+    midtime: float,
+) -> list[tuple[float, float]]:
+    """Return the per-star RA/DEC list, with optional proper-motion update.
+
+    Parameters:
+        stars: List of star records.
+        use_proper_motion: When True, evaluate
+            ``star.ra_dec_with_pm(midtime)`` for each entry; otherwise
+            return the catalog ``(star.ra, star.dec)`` pair.
+        midtime: Observation midtime in TDB seconds; ignored when
+            ``use_proper_motion`` is False.
+
+    Returns:
+        Parallel ``[(ra, dec), ...]`` list in radians.
+    """
+    if use_proper_motion:
+        return [cast(tuple[float, float], s.ra_dec_with_pm(midtime)) for s in stars]
+    return [(cast(float, s.ra), cast(float, s.dec)) for s in stars]
+
+
+def _find_stars_in_one_catalog(
+    *,
+    obs: ObsSnapshot,
+    config: Config,
+    catalog_name: str,
+    ra_min: float,
+    ra_max: float,
+    dec_min: float,
+    dec_max: float,
+    mag_min: float,
+    mag_max: float,
+    radec_movement: tuple[float, float] | None,
+) -> list[MutableStar]:
+    """Pull stars from a single catalog inside the (ra, dec, mag) box.
+
+    Wraps the catalog-specific call signatures and patches up the per-star
+    fields (``catalog_name``, ``pretty_name``, ``temperature``,
+    ``johnson_mag_*``, ``conflicts`` flag, etc.) to match the reduced
+    record shape used everywhere downstream.
+
+    Parameters:
+        obs: Observation snapshot (provides ``star_psf_size`` and
+            extfov bounds).
+        config: Project ``Config`` (provides
+            ``stars.default_star_class`` and stellar-aberration toggle).
+        catalog_name: One of ``'ucac4'``, ``'tycho2'``, ``'ybsc'``.
+        ra_min, ra_max, dec_min, dec_max: Search box in radians.
+        mag_min, mag_max: Catalog V-magnitude bounds.
+        radec_movement: Optional ``(dra, ddec)`` vector representing half
+            the per-exposure pointing motion in radians; passed through
+            to the FOV projection so smear-affected stars near the edge
+            are correctly culled.
+
+    Returns:
+        List of mutable star records with all derived fields set.
+    """
+    raw: list[MutableStar]
+    if catalog_name == 'ucac4':
+        raw = cast(
+            list['MutableStar'],
+            list(
+                get_ucac4_catalog().find_stars(
+                    allow_double=True,
+                    allow_galaxy=False,
+                    ra_min=ra_min,
+                    ra_max=ra_max,
+                    dec_min=dec_min,
+                    dec_max=dec_max,
+                    vmag_min=mag_min,
+                    vmag_max=mag_max,
+                )
+            ),
+        )
+    elif catalog_name == 'tycho2':
+        raw = cast(
+            list['MutableStar'],
+            list(
+                get_tycho2_catalog().find_stars(
+                    allow_double=True,
+                    ra_min=ra_min,
+                    ra_max=ra_max,
+                    dec_min=dec_min,
+                    dec_max=dec_max,
+                    vmag_min=mag_min,
+                    vmag_max=mag_max,
+                )
+            ),
+        )
+        for star in raw:
+            star.johnson_mag_v = None
+            star.johnson_mag_b = None
+    elif catalog_name == 'ybsc':
+        raw = cast(
+            list['MutableStar'],
+            list(
+                get_ybsc_catalog().find_stars(
+                    allow_double=True,
+                    ra_min=ra_min,
+                    ra_max=ra_max,
+                    dec_min=dec_min,
+                    dec_max=dec_max,
+                    vmag_min=mag_min,
+                    vmag_max=mag_max,
+                )
+            ),
+        )
+        for star in raw:
+            if star.vmag is None:
+                continue
+            star.johnson_mag_v = star.vmag
+            if star.b_v is None:
+                star.johnson_mag_b = star.johnson_mag_v
+            else:
+                star.johnson_mag_b = star.vmag + star.b_v
+    else:
+        raise ValueError(f'Invalid star catalog: {catalog_name!r}')
+
+    # Each star object is mutated heavily downstream; deep-copy now so a
+    # second navigation against the same catalog gets fresh records.
+    typed_raw: list[MutableStar] = [copy.deepcopy(s) for s in raw]
+    stars_config = config.stars
+    default_star_class = cast(str, stars_config.default_star_class)
+
+    fixed: list[MutableStar] = []
+    for star in typed_raw:
+        if star.ra is None or star.dec is None or star.vmag is None:
+            continue
+        star.catalog_name = catalog_name
+        star.pretty_name = str(star.unique_number)
+        try:
+            if star.name.strip():
+                star.pretty_name = ' '.join(star.name.split())
+        except AttributeError:
+            star.name = ''
+        star.conflicts = ''
+        star.temperature_faked = False
+        star.johnson_mag_faked = False
+        star.psf_size = obs.star_psf_size(star)
+        if star.temperature is None:
+            star.temperature_faked = True
+            star.temperature = SCLASS_TO_SURFACE_TEMP[default_star_class]
+            star.spectral_class = default_star_class
+        if star.johnson_mag_v is None or star.johnson_mag_b is None:
+            star.johnson_mag_v = star.vmag
+            star.johnson_mag_b = star.vmag + SCLASS_TO_B_MINUS_V[clean_sclass(star.spectral_class)]
+            star.johnson_mag_faked = True
+        if stars_config.stellar_aberration:
+            aberrate_star(obs, star)
+        # Standard flux-to-DN scaling.  The 4.0 anchor is conventional; the
+        # downstream SNR formula consumes ``star.dn`` as a relative DN value.
+        star.dn = float(2.512 ** -(star.vmag - 4.0))
+        fixed.append(star)
+
+    return _project_stars_to_fov(
+        obs=obs,
+        config=config,
+        stars=fixed,
+        radec_movement=radec_movement,
+    )
+
+
+def _project_stars_to_fov(
+    *,
+    obs: ObsSnapshot,
+    config: Config,
+    stars: list[MutableStar],
+    radec_movement: tuple[float, float] | None,
+) -> list[MutableStar]:
+    """Project stars into pixel coordinates and drop edge-clipped entries.
+
+    Mutates each surviving star to populate ``u``, ``v``, ``move_u``,
+    ``move_v``, ``ra_pm``, ``dec_pm``.  Stars whose PSF support would
+    spill off the extfov are excluded; so are stars whose smear motion
+    would push them off the extfov mid-exposure.
+
+    Parameters:
+        obs: Observation snapshot (provides FOV math + extfov bounds).
+        config: Project ``Config`` (drives ``proper_motion`` toggle).
+        stars: Stars after catalog-specific reduction.
+        radec_movement: Optional half-exposure ``(dra, ddec)`` shift to
+            evaluate edge-margin against.
+
+    Returns:
+        Filtered list with image-space fields populated.
+    """
+    if not stars:
+        return []
+    stars_config = config.stars
+
+    ra_dec_pm_list = [cast(tuple[float, float], s.ra_dec_with_pm(obs.midtime)) for s in stars]
+    if stars_config.proper_motion:
+        ra_dec_list = ra_dec_pm_list
+    else:
+        ra_dec_list = [(cast(float, s.ra), cast(float, s.dec)) for s in stars]
+
+    ra_arr = polymath.Scalar([entry[0] for entry in ra_dec_list])
+    dec_arr = polymath.Scalar([entry[1] for entry in ra_dec_list])
+
+    uv_mid = obs.uv_from_ra_and_dec(ra_arr, dec_arr, apparent=True)
+    u_list, v_list = uv_mid.to_scalars()
+    u_arr = u_list.vals
+    v_arr = v_list.vals
+
+    if radec_movement is not None:
+        uv_start = obs.uv_from_ra_and_dec(
+            ra_arr - radec_movement[0],
+            dec_arr - radec_movement[1],
+            apparent=True,
+        )
+        uv_end = obs.uv_from_ra_and_dec(
+            ra_arr + radec_movement[0],
+            dec_arr + radec_movement[1],
+            apparent=True,
+        )
+    else:
+        uv_start = obs.uv_from_ra_and_dec(ra_arr, dec_arr, tfrac=0.0, apparent=True)
+        uv_end = obs.uv_from_ra_and_dec(ra_arr, dec_arr, tfrac=1.0, apparent=True)
+
+    u_start_arr = uv_start.to_scalars()[0].vals
+    v_start_arr = uv_start.to_scalars()[1].vals
+    u_end_arr = uv_end.to_scalars()[0].vals
+    v_end_arr = uv_end.to_scalars()[1].vals
+
+    out: list[MutableStar] = []
+    iter_args = zip(
+        stars,
+        ra_dec_pm_list,
+        u_arr,
+        v_arr,
+        u_start_arr,
+        v_start_arr,
+        u_end_arr,
+        v_end_arr,
+        strict=True,
+    )
+    for star, (ra_pm, dec_pm), u, v, u_s, v_s, u_e, v_e in iter_args:
+        psf_half_u = star.psf_size[1] // 2
+        psf_half_v = star.psf_size[0] // 2
+        if (
+            u <= obs.extfov_u_min + psf_half_u
+            or u >= obs.extfov_u_max - psf_half_u
+            or v <= obs.extfov_v_min + psf_half_v
+            or v >= obs.extfov_v_max - psf_half_v
+            or u_s <= obs.extfov_u_min + psf_half_u
+            or u_s >= obs.extfov_u_max - psf_half_u
+            or v_s <= obs.extfov_v_min + psf_half_v
+            or v_s >= obs.extfov_v_max - psf_half_v
+            or u_e <= obs.extfov_u_min + psf_half_u
+            or u_e >= obs.extfov_u_max - psf_half_u
+            or v_e <= obs.extfov_v_min + psf_half_v
+            or v_e >= obs.extfov_v_max - psf_half_v
+        ):
+            continue
+        star.u = float(u)
+        star.v = float(v)
+        star.move_u = float(u_e - u_s)
+        star.move_v = float(v_e - v_s)
+        star.ra_pm = float(ra_pm)
+        star.dec_pm = float(dec_pm)
+        out.append(star)
+    return out
+
+
+def stars_in_extfov(
+    obs: ObsSnapshot,
+    config: Config,
+    *,
+    catalog_name: str,
+    mag_min: float,
+    mag_max: float,
+    radec_movement: tuple[float, float] | None = None,
+) -> list[MutableStar]:
+    """Return all stars from one catalog that lie inside the extfov.
+
+    Thin wrapper around ``_find_stars_in_one_catalog`` that pulls the
+    extfov RA/DEC limits from ``obs`` so callers do not need to compute
+    them.
+
+    Parameters:
+        obs: Observation snapshot.
+        config: Project config.
+        catalog_name: One of ``'ucac4'``, ``'tycho2'``, ``'ybsc'``.
+        mag_min, mag_max: Catalog magnitude window.
+        radec_movement: Optional half-exposure ``(dra, ddec)`` shift.
+
+    Returns:
+        Stars that fit inside the extfov with PSF support included.
+    """
+    ra_min, ra_max, dec_min, dec_max = obs.ra_dec_limits_ext()
+    return _find_stars_in_one_catalog(
+        obs=obs,
+        config=config,
+        catalog_name=catalog_name,
+        ra_min=ra_min,
+        ra_max=ra_max,
+        dec_min=dec_min,
+        dec_max=dec_max,
+        mag_min=mag_min,
+        mag_max=mag_max,
+        radec_movement=radec_movement,
+    )
+
+
+def reduce_catalogs(
+    obs: ObsSnapshot,
+    config: Config,
+    *,
+    radec_movement: tuple[float, float] | None = None,
+) -> list[MutableStar]:
+    """Walk every configured catalog, deduplicate, and return the merged list.
+
+    Catalogs are walked in the order configured in
+    ``config.stars.catalogs`` (default ``['ucac4', 'tycho2', 'ybsc']``).
+    Within each catalog the search proceeds bin-by-bin against
+    ``CATALOG_MAGNITUDE_BINS`` until the configured ``max_stars`` budget
+    is hit.  Across catalogs, stars whose RA/DEC and magnitude match a
+    star already kept from an earlier (more precise) catalog are
+    dropped; the kept entry inherits any nicer ``name`` field the later
+    catalog supplies.
+
+    Parameters:
+        obs: Observation snapshot supplying extfov RA/DEC limits.
+        config: Project config carrying the catalog ordering and
+            duplicate thresholds.
+        radec_movement: Optional half-exposure ``(dra, ddec)`` shift.
+
+    Returns:
+        Merged star list with image-space fields populated, sorted by
+        descending DN, capped at ``config.stars.max_stars``.
+    """
+    stars_config = config.stars
+    max_stars = stars_config.max_stars
+    mag_min_cap = obs.star_min_usable_vmag()
+    mag_max_cap = obs.star_max_usable_vmag()
+
+    duplicate_radec = float(np.radians(stars_config.duplicate_ra_dec_threshold_arcsec / 3600.0))
+    duplicate_vmag = float(stars_config.duplicate_vmag_threshold)
+    overlap_vmag = float(stars_config.overlapping_vmag_threshold)
+
+    kept: list[MutableStar] = []
+
+    for catalog_name in stars_config.catalogs:
+        next_per_catalog: list[MutableStar] = []
+        for mag_min, mag_max in itertools.pairwise(CATALOG_MAGNITUDE_BINS):
+            if mag_min > mag_max_cap:
+                break
+            if mag_max < mag_min_cap:
+                continue
+            mag_min = max(mag_min, mag_min_cap)
+            mag_max = min(mag_max, mag_max_cap)
+            chunk = stars_in_extfov(
+                obs,
+                config,
+                catalog_name=catalog_name.lower(),
+                mag_min=mag_min,
+                mag_max=mag_max,
+                radec_movement=radec_movement,
+            )
+            next_per_catalog.extend(chunk)
+            if len(next_per_catalog) >= max_stars:
+                break
+
+        kept = _merge_catalogs(
+            kept,
+            next_per_catalog,
+            duplicate_radec=duplicate_radec,
+            duplicate_vmag=duplicate_vmag,
+        )
+
+    _mark_visual_overlaps(kept, overlap_vmag=overlap_vmag)
+
+    kept.sort(key=lambda s: s.dn, reverse=True)
+    return kept[:max_stars]
+
+
+def _merge_catalogs(
+    earlier: list[MutableStar],
+    later: list[MutableStar],
+    *,
+    duplicate_radec: float,
+    duplicate_vmag: float,
+) -> list[MutableStar]:
+    """Merge ``later`` into ``earlier``, dropping duplicates.
+
+    ``earlier`` wins on conflict; ``later`` only contributes a star
+    whose proper-motion RA/DEC and V-magnitude are not within
+    ``duplicate_radec`` (radians) and ``duplicate_vmag`` (mag) of any
+    ``earlier`` entry.  When a duplicate is found and the earlier
+    entry has no name but the later one does, the earlier entry's
+    ``pretty_name`` is upgraded to the later catalog's name string.
+
+    Parameters:
+        earlier: Stars from a higher-precedence catalog (already
+            reduced).  Modified in place to upgrade names.
+        later: Stars from a lower-precedence catalog.
+        duplicate_radec: Threshold in radians for matching RA and DEC.
+        duplicate_vmag: Threshold in V-magnitude for matching brightness.
+
+    Returns:
+        Combined list (``earlier`` followed by the kept additions).
+    """
+    if not earlier:
+        return list(later)
+    earlier.sort(key=lambda s: s.dec_pm)
+    later.sort(key=lambda s: s.dec_pm)
+    additions: list[MutableStar] = []
+    for star in later:
+        is_dup = False
+        for prev in earlier:
+            if prev.dec_pm - star.dec_pm > duplicate_radec:
+                # Sorted-prefix early-out.
+                break
+            if (
+                abs(prev.dec_pm - star.dec_pm) < duplicate_radec
+                and abs(prev.ra_pm - star.ra_pm) < duplicate_radec
+                and abs(cast(float, prev.vmag) - cast(float, star.vmag)) < duplicate_vmag
+            ):
+                if (not prev.name) and star.name:
+                    prev.pretty_name = star.pretty_name
+                is_dup = True
+                break
+        if not is_dup:
+            additions.append(star)
+    return earlier + additions
+
+
+def _mark_visual_overlaps(stars: list[MutableStar], *, overlap_vmag: float) -> None:
+    """Mark stars whose PSF supports overlap.
+
+    Two-star overlap policy:
+
+    * If both stars have similar magnitudes (``|delta_vmag| <
+      overlap_vmag``), tag both with conflict ``'STAR'``: each one
+      blinds the centroid fit for the other.
+    * Otherwise, tag only the fainter one — the brighter star's PSF
+      will dominate.
+
+    Parameters:
+        stars: All catalog stars after reduction.
+        overlap_vmag: V-mag delta below which both stars are tagged.
+    """
+    n = len(stars)
+    if n < 2:
+        return
+    # Sort by V (vertical pixel) so the inner loop can early-out once
+    # consecutive entries are far enough apart in V to clear the overlap.
+    stars.sort(key=lambda s: s.v, reverse=False)
+    for i in range(n):
+        for j in range(i + 1, n):
+            si = stars[i]
+            sj = stars[j]
+            v_gap = (si.psf_size[0] + sj.psf_size[0]) / 2
+            u_gap = (si.psf_size[1] + sj.psf_size[1]) / 2
+            if abs(si.v - sj.v) < v_gap and abs(si.u - sj.u) < u_gap:
+                if cast(float, sj.vmag) - cast(float, si.vmag) < overlap_vmag:
+                    si.conflicts = 'STAR'
+                    sj.conflicts = 'STAR'
+                else:
+                    sj.conflicts = 'STAR'

--- a/src/nav/nav_model/stars/catalog.py
+++ b/src/nav/nav_model/stars/catalog.py
@@ -26,6 +26,7 @@ construct each catalog lazily on first call.
 from __future__ import annotations
 
 import copy
+import functools
 import itertools
 from typing import TYPE_CHECKING, cast
 
@@ -89,33 +90,22 @@ reached or the next bin's lower edge exceeds the obs's
 """
 
 
-_STAR_CATALOG_UCAC4: UCAC4StarCatalog | None = None
-_STAR_CATALOG_TYCHO2: SpiceStarCatalog | None = None
-_STAR_CATALOG_YBSC: YBSCStarCatalog | None = None
-
-
+@functools.lru_cache(maxsize=1)
 def get_ucac4_catalog() -> UCAC4StarCatalog:
     """Return the UCAC4 catalog, lazily constructing on first call."""
-    global _STAR_CATALOG_UCAC4
-    if _STAR_CATALOG_UCAC4 is None:
-        _STAR_CATALOG_UCAC4 = UCAC4StarCatalog()
-    return _STAR_CATALOG_UCAC4
+    return UCAC4StarCatalog()
 
 
+@functools.lru_cache(maxsize=1)
 def get_tycho2_catalog() -> SpiceStarCatalog:
     """Return the Tycho-2 catalog, lazily constructing on first call."""
-    global _STAR_CATALOG_TYCHO2
-    if _STAR_CATALOG_TYCHO2 is None:
-        _STAR_CATALOG_TYCHO2 = SpiceStarCatalog('tycho2')
-    return _STAR_CATALOG_TYCHO2
+    return SpiceStarCatalog('tycho2')
 
 
+@functools.lru_cache(maxsize=1)
 def get_ybsc_catalog() -> YBSCStarCatalog:
     """Return the YBSC catalog, lazily constructing on first call."""
-    global _STAR_CATALOG_YBSC
-    if _STAR_CATALOG_YBSC is None:
-        _STAR_CATALOG_YBSC = YBSCStarCatalog()
-    return _STAR_CATALOG_YBSC
+    return YBSCStarCatalog()
 
 
 def aberrate_star(obs: ObsSnapshot, star: MutableStar) -> None:
@@ -497,14 +487,14 @@ def reduce_catalogs(
                 break
             if mag_max < mag_min_cap:
                 continue
-            mag_min = max(mag_min, mag_min_cap)
-            mag_max = min(mag_max, mag_max_cap)
+            mag_min_clamped = max(mag_min, mag_min_cap)
+            mag_max_clamped = min(mag_max, mag_max_cap)
             chunk = stars_in_extfov(
                 obs,
                 config,
                 catalog_name=catalog_name.lower(),
-                mag_min=mag_min,
-                mag_max=mag_max,
+                mag_min=mag_min_clamped,
+                mag_max=mag_max_clamped,
                 radec_movement=radec_movement,
             )
             next_per_catalog.extend(chunk)
@@ -602,7 +592,12 @@ def _mark_visual_overlaps(stars: list[MutableStar], *, overlap_vmag: float) -> N
             sj = stars[j]
             v_gap = (si.psf_size[0] + sj.psf_size[0]) / 2
             u_gap = (si.psf_size[1] + sj.psf_size[1]) / 2
-            if abs(si.v - sj.v) < v_gap and abs(si.u - sj.u) < u_gap:
+            dv = sj.v - si.v
+            if dv >= v_gap:
+                # Stars are sorted by v ascending — once the v-gap is exceeded
+                # for this pair, every later sj only moves further away.
+                break
+            if abs(dv) < v_gap and abs(si.u - sj.u) < u_gap:
                 if cast(float, sj.vmag) - cast(float, si.vmag) < overlap_vmag:
                     si.conflicts = 'STAR'
                     sj.conflicts = 'STAR'

--- a/src/nav/nav_model/stars/conflicts.py
+++ b/src/nav/nav_model/stars/conflicts.py
@@ -1,0 +1,261 @@
+"""Body and ring conflict marking for star records.
+
+A star whose predicted pixel falls inside the silhouette of a body, or
+inside a known opaque ring annulus, cannot be detected — the body or
+ring overrides its signal.  ``mark_body_and_ring_conflicts`` walks every
+star in the reduced list and, for each one, builds a tiny ``oops``
+backplane around the predicted position and queries the body intercept
+plus the ring radius.  When either query fires, the star's
+``conflicts`` field is set to a human-readable string starting with
+``'BODY: '`` or ``'RING: '``.
+
+Body-vs-ring precedence: a body intercept always wins, so a star whose
+predicted pixel lies on a moon in front of Saturn's rings is tagged
+with the moon, not the rings.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from oops import Meshgrid
+from oops.backplane import Backplane
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from nav.config import Config
+    from nav.obs import ObsSnapshot
+    from nav.support.types import MutableStar
+
+__all__ = [
+    'mark_body_and_ring_conflicts',
+    'parse_ring_occlusion_annuli',
+]
+
+
+def parse_ring_occlusion_annuli(
+    raw: dict[str, list[list[float]]] | None,
+) -> dict[str, list[tuple[float, float]]]:
+    """Validate and normalise a ring-occlusion annulus mapping.
+
+    The YAML config exposes per-planet annulus pairs as nested lists
+    (``[[inner_km, outer_km], ...]``); this helper validates each pair,
+    rejects degenerate (inner >= outer) annuli, and normalises the
+    planet keys to upper case so lookup is case-insensitive.
+
+    Parameters:
+        raw: Mapping returned by ``config.stars.ring_occlusion_radii_km``.
+            ``None`` is treated as the empty mapping.
+
+    Returns:
+        ``{PLANET_UPPER: [(inner_km, outer_km), ...]}`` with float
+        entries.
+
+    Raises:
+        ValueError: If an annulus is malformed or has ``inner >= outer``.
+    """
+    if not raw:
+        return {}
+    out: dict[str, list[tuple[float, float]]] = {}
+    for planet, pairs in raw.items():
+        validated: list[tuple[float, float]] = []
+        for pair in pairs:
+            inner, outer = _parse_annulus_pair(pair, planet)
+            if inner >= outer:
+                raise ValueError(
+                    f'ring_occlusion_radii_km: invalid annulus for {planet}: '
+                    f'inner {inner} km >= outer {outer} km'
+                )
+            validated.append((inner, outer))
+        out[planet.upper()] = validated
+    return out
+
+
+def _parse_annulus_pair(pair: object, planet_key: str) -> tuple[float, float]:
+    """Parse one annulus into ``(inner_km, outer_km)`` floats.
+
+    Parameters:
+        pair: Sequence of two finite numbers.
+        planet_key: Planet name used in error messages.
+
+    Returns:
+        ``(inner_km, outer_km)`` as finite floats.
+
+    Raises:
+        ValueError: If ``pair`` is not a length-2 sequence of finite
+            real numbers.
+    """
+    if isinstance(pair, (str, bytes)) or not isinstance(pair, Sequence):
+        raise ValueError(
+            f'ring_occlusion_radii_km: annulus for {planet_key!r} must be a '
+            f'length-2 sequence of numbers, got {type(pair).__name__}: {pair!r}'
+        )
+    if len(pair) != 2:
+        raise ValueError(
+            f'ring_occlusion_radii_km: annulus for {planet_key!r} must have '
+            f'exactly 2 elements, got {len(pair)}: {pair!r}'
+        )
+    out: list[float] = []
+    for label, raw in (('inner', pair[0]), ('outer', pair[1])):
+        if isinstance(raw, bool):
+            raise ValueError(
+                f'ring_occlusion_radii_km: {label} radius for {planet_key!r} '
+                f'must be numeric, got bool: {raw!r}'
+            )
+        if not isinstance(raw, (int, float, np.integer, np.floating)):
+            raise ValueError(
+                f'ring_occlusion_radii_km: {label} radius for {planet_key!r} '
+                f'must be numeric, got {type(raw).__name__}: {raw!r}'
+            )
+        val = float(raw)
+        if not math.isfinite(val):
+            raise ValueError(
+                f'ring_occlusion_radii_km: {label} radius for {planet_key!r} '
+                f'must be finite, got {raw!r}'
+            )
+        out.append(val)
+    return out[0], out[1]
+
+
+def _conflict_body_list(obs: ObsSnapshot, config: Config) -> list[str]:
+    """Return the bodies the star pipeline checks for occlusion conflicts."""
+    closest = obs.closest_planet
+    body_list: list[str] = [closest] if closest is not None else []
+    body_list += list(config.satellites(closest or ''))
+    return body_list
+
+
+def _check_one_star(
+    *,
+    obs: ObsSnapshot,
+    star: MutableStar,
+    body_list: list[str],
+    ring_annuli: dict[str, list[tuple[float, float]]],
+    rings_can_conflict: bool,
+    body_conflict_margin: float,
+) -> bool:
+    """Return True if ``star`` conflicts with a body or ring; sets the flag.
+
+    Parameters:
+        obs: Observation snapshot.
+        star: Star record to inspect (mutated when a conflict is found).
+        body_list: List of body names checked for intercepts.
+        ring_annuli: Per-planet list of opaque ring annuli in km.
+        rings_can_conflict: Toggle the ring check.
+        body_conflict_margin: Pixel slop around the star when building
+            the conflict-check meshgrid.
+
+    Returns:
+        True if a conflict was found (and ``star.conflicts`` set);
+        False otherwise.
+    """
+    meshgrid = Meshgrid.for_fov(
+        obs.fov,
+        origin=(star.u - body_conflict_margin, star.v - body_conflict_margin),
+        limit=(star.u + body_conflict_margin, star.v + body_conflict_margin),
+    )
+    backplane = Backplane(obs, meshgrid)
+
+    for body_name in body_list:
+        intercepted = backplane.where_intercepted(body_name)
+        if intercepted.any():
+            star.conflicts = f'BODY: {body_name}'
+            return True
+
+    if rings_can_conflict and obs.closest_planet is not None:
+        annuli = ring_annuli.get(obs.closest_planet.upper(), [])
+        if annuli:
+            ring_target = f'{obs.closest_planet.lower()}:ring'
+            bp_radii = backplane.ring_radius(ring_target)
+            if not bp_radii.is_all_masked():
+                radius_km = float(bp_radii.median().vals)
+                for inner_km, outer_km in annuli:
+                    if inner_km <= radius_km <= outer_km:
+                        star.conflicts = f'RING: {obs.closest_planet}'
+                        return True
+    return False
+
+
+def mark_body_and_ring_conflicts(
+    obs: ObsSnapshot,
+    config: Config,
+    stars: list[MutableStar],
+) -> None:
+    """Tag each star whose predicted pixel is occluded by a body or ring.
+
+    The check has two parts:
+
+    1. **Body intercepts.**  A small meshgrid around the predicted star
+       pixel is fed through ``Backplane.where_intercepted(body)`` for
+       every body in the planet+satellites list pulled from
+       ``config.satellites``.  Any intercept marks the star with
+       ``conflicts = 'BODY: <body>'`` and short-circuits the ring check.
+
+    2. **Ring annulus occlusion.**  When ``stars.ring_occlusion_enabled``
+       is True and the closest-planet has annuli configured, the same
+       meshgrid is queried for ``ring_radius`` and the median radius is
+       compared against each annulus.  A hit marks the star with
+       ``conflicts = 'RING: <planet>'``.
+
+    Stars already marked with a non-empty ``conflicts`` (e.g. ``'STAR'``
+    from visual overlap) are left alone.
+
+    Parameters:
+        obs: Observation snapshot.
+        config: Project ``Config``.
+        stars: Star list to mutate in place.
+    """
+    stars_config = config.stars
+    body_list = _conflict_body_list(obs, config)
+    ring_annuli = parse_ring_occlusion_annuli(_cast_dict(stars_config.ring_occlusion_radii_km))
+    rings_can_conflict = bool(stars_config.ring_occlusion_enabled)
+    margin = float(stars_config.body_conflict_margin)
+    for star in stars:
+        if star.conflicts:
+            continue
+        _check_one_star(
+            obs=obs,
+            star=star,
+            body_list=body_list,
+            ring_annuli=ring_annuli,
+            rings_can_conflict=rings_can_conflict,
+            body_conflict_margin=margin,
+        )
+
+
+def _cast_dict(
+    raw: Any,
+) -> dict[str, list[list[float]]] | None:
+    """Narrow a raw config value to the ring-occlusion mapping shape.
+
+    The YAML loader returns ``AttrDict`` and ``list`` instances; we
+    accept any mapping with string keys and list-of-list values, and
+    treat ``None`` as the empty mapping.  Mismatches raise so the error
+    points at the YAML site, not at the ring-radius math.
+
+    Parameters:
+        raw: Value pulled from ``config.stars.ring_occlusion_radii_km``.
+
+    Returns:
+        ``None`` (no annuli) or the validated mapping.
+    """
+    if raw is None:
+        return None
+    if not hasattr(raw, 'items'):
+        raise ValueError(
+            f'ring_occlusion_radii_km must be a mapping or None; got {type(raw).__name__}'
+        )
+    out: dict[str, list[list[float]]] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str):
+            raise ValueError(
+                f'ring_occlusion_radii_km keys must be strings; got {type(key).__name__}'
+            )
+        if not isinstance(value, list):
+            raise ValueError(
+                f'ring_occlusion_radii_km[{key!r}] must be a list; got {type(value).__name__}'
+            )
+        out[key] = value
+    return out

--- a/src/nav/nav_model/stars/detection.py
+++ b/src/nav/nav_model/stars/detection.py
@@ -398,7 +398,6 @@ def detect_sources(
 
     sigma_psf = _psf_sigma(psf)
     box_half = max(1, math.ceil(2.0 * sigma_psf))
-    2 * box_half + 1
 
     out: list[DetectedSource] = []
     rows = candidate_mask.shape[0]

--- a/src/nav/nav_model/stars/detection.py
+++ b/src/nav/nav_model/stars/detection.py
@@ -1,0 +1,448 @@
+"""DAOPHOT-style star detection helpers.
+
+The orchestrator never calls this module — predicted-from-catalog star
+features are emitted by ``NavModelStars.to_features`` directly.  The
+detector exists so a downstream technique (``StarRefineNav`` etc.) can
+sweep the image for centroidable stars when the catalog match is
+ambiguous; keeping it in the same package as the catalog reduction
+guarantees the matched filter, the smear-aware kernel, and the
+shape-based cuts stay in sync.
+
+The pipeline is the canonical DAOPHOT sequence in three stages:
+
+1. **Matched filter.**  Cross-correlate the image with the smeared PSF
+   kernel.  The peak amplitude at each pixel is the maximum-likelihood
+   estimate of an unsmoothed star signal at that location.
+2. **Local maxima.**  Find every pixel that is the local maximum in a
+   window matched to the PSF support and is above the per-image
+   detection threshold (``k * image_noise_sigma`` after matched
+   filtering).
+3. **Centroid + cuts.**  Fit a Gaussian to a small box around each
+   maximum.  Stars hitting the saturation DN switch to an annular
+   moment because the Gaussian fit blows up.  Hot pixels and
+   asymmetric stars are rejected via classic DAOPHOT sharpness /
+   roundness criteria.
+
+CCD bloom columns are detected up-front so saturated bright stars are
+not double-counted as multiple detections along the bloom trail.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+from scipy.ndimage import correlate, maximum_filter
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from psfmodel import PSF
+
+    from nav.support.types import NDArrayBoolType, NDArrayFloatType
+
+__all__ = [
+    'DAOPHOT_DEFAULT_DETECTION_SIGMA',
+    'DAOPHOT_DEFAULT_ROUNDNESS_BOUND',
+    'DAOPHOT_DEFAULT_SHARPNESS_MAX',
+    'DAOPHOT_DEFAULT_SHARPNESS_MIN',
+    'DetectedSource',
+    'apply_shape_cuts',
+    'centroid_gaussian_fit',
+    'centroid_saturated',
+    'detect_ccd_bloom_columns',
+    'detect_sources',
+    'matched_filter_image',
+]
+
+
+DAOPHOT_DEFAULT_DETECTION_SIGMA: float = 4.0
+"""Threshold (in image_noise_sigma) for matched-filter peaks.
+
+Matches the DAOPHOT convention of "minimum sigma above sky for a real
+source" before shape-based cuts.  Below 4 sigma the cosmic-ray-driven
+false-positive rate dominates real detections.
+"""
+
+
+DAOPHOT_DEFAULT_SHARPNESS_MIN: float = 0.2
+"""Minimum DAOPHOT sharpness for a real star.
+
+Sharpness < 0.2 is dominated by single-pixel hot spikes; the wing
+contribution is too small to be a star.
+"""
+
+
+DAOPHOT_DEFAULT_SHARPNESS_MAX: float = 1.0
+"""Maximum DAOPHOT sharpness for a real star.
+
+Sharpness > 1.0 indicates an extended source (galaxy / blended pair)
+whose central pixel does not dominate.
+"""
+
+
+DAOPHOT_DEFAULT_ROUNDNESS_BOUND: float = 1.0
+r"""Maximum \|roundness\| for a real star.
+
+Computed as the per-axis Gaussian-marginal asymmetry; \> 1 in absolute
+value points at a CCD bloom or one-axis trail rather than a smear-
+oriented PSF.
+"""
+
+
+@dataclass(frozen=True)
+class DetectedSource:
+    """One source returned by ``detect_sources``.
+
+    Parameters:
+        v: Sub-pixel V (row) centroid.
+        u: Sub-pixel U (column) centroid.
+        peak_dn: Matched-filter peak amplitude at the centroid.
+        sharpness: DAOPHOT sharpness statistic.
+        roundness: DAOPHOT roundness statistic (signed).
+        saturated: True when the central pixel hit the saturation DN.
+    """
+
+    v: float
+    u: float
+    peak_dn: float
+    sharpness: float
+    roundness: float
+    saturated: bool
+
+
+def matched_filter_image(image: NDArrayFloatType, *, kernel: NDArrayFloatType) -> NDArrayFloatType:
+    """Return the matched-filter response of ``image`` against ``kernel``.
+
+    Implements the standard DAOPHOT matched filter: subtract the
+    kernel mean, normalise to unit-energy, and convolve.  The peak
+    amplitude at each pixel is then the linear-least-squares estimate
+    of the signal scale at that location.
+
+    Parameters:
+        image: 2-D float input array.
+        kernel: PSF stamp produced by ``psf.eval_rect`` (smear-aware
+            when smear is non-trivial).
+
+    Returns:
+        Matched-filter response array of the same shape as ``image``.
+
+    Raises:
+        ValueError: If ``kernel`` has zero norm (e.g. an all-zero
+            stamp).
+    """
+    if image.ndim != 2:
+        raise TypeError(f'matched_filter_image requires a 2-D image; got ndim={image.ndim}')
+    if kernel.ndim != 2:
+        raise TypeError(f'matched_filter_image kernel must be 2-D; got ndim={kernel.ndim}')
+    k = kernel.astype(np.float64)
+    k_mean = float(np.mean(k))
+    k = k - k_mean
+    norm_sq = float(np.sum(k * k))
+    if norm_sq <= 0.0:
+        raise ValueError('matched_filter_image kernel has zero energy after mean subtraction')
+    k = k / norm_sq
+    response: NDArrayFloatType = correlate(image.astype(np.float64), k, mode='reflect')
+    return response
+
+
+def detect_ccd_bloom_columns(
+    image: NDArrayFloatType, *, full_well_dn: float, min_run: int = 5
+) -> NDArrayBoolType:
+    """Mark CCD bloom columns where saturation runs vertically.
+
+    A bloom column is detected when at least ``min_run`` consecutive
+    saturated pixels appear in any single column.  The whole column is
+    marked, not just the saturated stretch, so single-pixel detections
+    on the bloom trail are correctly suppressed.
+
+    Parameters:
+        image: 2-D float input array.
+        full_well_dn: Per-instrument full-well DN.
+        min_run: Minimum consecutive saturated pixels to declare a
+            bloom column.
+
+    Returns:
+        Boolean mask of the same shape as ``image`` with True over the
+        identified bloom columns.
+
+    Raises:
+        ValueError: If ``min_run`` is < 2.
+    """
+    if min_run < 2:
+        raise ValueError(f'min_run must be >= 2; got {min_run}')
+    saturated = image >= full_well_dn
+    rows, cols = image.shape
+    mask = np.zeros_like(image, dtype=bool)
+    for col in range(cols):
+        run = 0
+        max_run = 0
+        for row in range(rows):
+            if saturated[row, col]:
+                run += 1
+                if run > max_run:
+                    max_run = run
+            else:
+                run = 0
+        if max_run >= min_run:
+            mask[:, col] = True
+    return mask
+
+
+def _local_max_mask(response: NDArrayFloatType, *, size: int, threshold: float) -> NDArrayBoolType:
+    """Return a boolean mask True at pixels that are local maxima > threshold."""
+    local_max = maximum_filter(response, size=size, mode='reflect')
+    out: NDArrayBoolType = (response == local_max) & (response > threshold)
+    return out
+
+
+def centroid_gaussian_fit(
+    box: NDArrayFloatType,
+) -> tuple[float, float]:
+    """Fit a 2-D Gaussian centroid to a small detection box.
+
+    Uses the standard DAOPHOT moment-form: the centroid is
+    ``sum(coord * (box - bg)) / sum(box - bg)`` over pixels above the
+    box-median background.  The box is small enough (3-5 px on a side)
+    that this matches the iterative least-squares centroid to
+    sub-pixel agreement.
+
+    Parameters:
+        box: Square detection box, ``(2N+1, 2N+1)``.
+
+    Returns:
+        ``(dv, du)`` offset in pixels from the centre of ``box``.
+    """
+    if box.ndim != 2 or box.shape[0] != box.shape[1] or box.shape[0] % 2 == 0:
+        raise ValueError(f'centroid box must be square odd; got shape {box.shape}')
+    n = (box.shape[0] - 1) // 2
+    bg = float(np.median(box))
+    sub = box - bg
+    sub = np.clip(sub, 0.0, None)
+    total = float(np.sum(sub))
+    if total <= 0.0:
+        return 0.0, 0.0
+    coords = np.arange(-n, n + 1, dtype=np.float64)
+    cv = float(np.sum(coords[:, None] * sub) / total)
+    cu = float(np.sum(coords[None, :] * sub) / total)
+    return cv, cu
+
+
+def centroid_saturated(
+    box: NDArrayFloatType,
+    *,
+    full_well_dn: float,
+    half_width_inner: int,
+    half_width_outer: int,
+) -> tuple[float, float]:
+    """Return a saturated-star centroid via an annular brightness moment.
+
+    Saturated cores have wrong DN values; the only reliable centroid
+    information is in the annulus around the saturated core where the
+    PSF wings are still linear.  This routine computes the
+    brightness-weighted moment of pixels whose DN is below
+    ``full_well_dn`` and whose distance from the box centre lies in
+    ``[half_width_inner, half_width_outer]``.
+
+    Parameters:
+        box: Square detection box, ``(2N+1, 2N+1)``.
+        full_well_dn: Saturation DN; pixels at this value are excluded
+            from the moment.
+        half_width_inner: Inner radius of the annulus (in pixels).
+        half_width_outer: Outer radius of the annulus (in pixels).
+
+    Returns:
+        ``(dv, du)`` offset in pixels from the centre of ``box``.
+    """
+    if half_width_inner < 0 or half_width_outer <= half_width_inner:
+        raise ValueError(
+            'expected 0 <= half_width_inner < half_width_outer; got '
+            f'inner={half_width_inner}, outer={half_width_outer}'
+        )
+    if box.ndim != 2 or box.shape[0] != box.shape[1] or box.shape[0] % 2 == 0:
+        raise ValueError(f'centroid box must be square odd; got shape {box.shape}')
+    n = (box.shape[0] - 1) // 2
+    coords = np.arange(-n, n + 1, dtype=np.float64)
+    vv, uu = np.meshgrid(coords, coords, indexing='ij')
+    radius = np.sqrt(vv * vv + uu * uu)
+    valid = (radius >= half_width_inner) & (radius <= half_width_outer)
+    valid &= box < full_well_dn
+    weights = np.where(valid, np.clip(box - float(np.median(box)), 0.0, None), 0.0)
+    total = float(np.sum(weights))
+    if total <= 0.0:
+        return 0.0, 0.0
+    return (
+        float(np.sum(vv * weights) / total),
+        float(np.sum(uu * weights) / total),
+    )
+
+
+def _sharpness_roundness(
+    box: NDArrayFloatType,
+) -> tuple[float, float]:
+    """Return DAOPHOT sharpness and roundness for a small detection box.
+
+    ``sharpness = (peak - mean(neighbours)) / peak`` measures how much
+    the central pixel dominates its neighbours.  ``roundness`` is the
+    signed fractional difference between the box's two marginal
+    Gaussian widths; it points to bloom or one-axis trails when its
+    absolute value exceeds ``DAOPHOT_DEFAULT_ROUNDNESS_BOUND``.
+
+    Parameters:
+        box: Square detection box.
+
+    Returns:
+        ``(sharpness, roundness)`` pair.
+    """
+    if box.ndim != 2 or box.shape[0] != box.shape[1] or box.shape[0] % 2 == 0:
+        raise ValueError(f'shape-cut box must be square odd; got shape {box.shape}')
+    n = (box.shape[0] - 1) // 2
+    centre = float(box[n, n])
+    if centre <= 0.0:
+        return 0.0, 0.0
+    neighbour_sum = float(np.sum(box) - centre)
+    neighbour_count = box.size - 1
+    sharp = (centre - neighbour_sum / neighbour_count) / centre
+    col_marginal = np.sum(box, axis=0)
+    row_marginal = np.sum(box, axis=1)
+    col_var = _marginal_variance(col_marginal)
+    row_var = _marginal_variance(row_marginal)
+    if col_var + row_var == 0.0:
+        return float(sharp), 0.0
+    round_ = 2.0 * (col_var - row_var) / (col_var + row_var)
+    return float(sharp), float(round_)
+
+
+def _marginal_variance(profile: NDArrayFloatType) -> float:
+    """Return the variance of a 1-D marginal profile around its centre."""
+    profile = np.asarray(profile, dtype=np.float64)
+    n = (profile.size - 1) // 2
+    coords = np.arange(-n, n + 1, dtype=np.float64)
+    bg = float(np.median(profile))
+    weights = np.clip(profile - bg, 0.0, None)
+    total = float(np.sum(weights))
+    if total <= 0.0:
+        return 0.0
+    mean = float(np.sum(coords * weights) / total)
+    return float(np.sum((coords - mean) ** 2 * weights) / total)
+
+
+def apply_shape_cuts(
+    sharpness: float,
+    roundness: float,
+    *,
+    sharp_min: float = DAOPHOT_DEFAULT_SHARPNESS_MIN,
+    sharp_max: float = DAOPHOT_DEFAULT_SHARPNESS_MAX,
+    round_bound: float = DAOPHOT_DEFAULT_ROUNDNESS_BOUND,
+) -> bool:
+    """Return True if a detection passes the DAOPHOT shape cuts.
+
+    Parameters:
+        sharpness: DAOPHOT sharpness from ``_sharpness_roundness``.
+        roundness: DAOPHOT roundness from ``_sharpness_roundness``.
+        sharp_min, sharp_max: Acceptance window for sharpness.
+        round_bound: Maximum absolute roundness.
+
+    Returns:
+        True when the detection is keeper-quality.
+    """
+    if not (sharp_min <= sharpness <= sharp_max):
+        return False
+    return abs(roundness) <= round_bound
+
+
+def detect_sources(
+    image: NDArrayFloatType,
+    *,
+    psf: PSF,
+    image_noise_sigma: float,
+    full_well_dn: float,
+    smear_kernel: NDArrayFloatType,
+    bloom_mask: NDArrayBoolType | None = None,
+    detection_sigma: float = DAOPHOT_DEFAULT_DETECTION_SIGMA,
+) -> list[DetectedSource]:
+    """Detect candidate stars in ``image`` and return one entry per surviving source.
+
+    Three-stage pipeline:
+
+    1. Matched-filter the image against ``smear_kernel``.
+    2. Find local maxima above ``detection_sigma * image_noise_sigma``.
+    3. For each maximum, fit a Gaussian centroid (or annular moment when
+       saturated), compute DAOPHOT sharpness/roundness, and pass the
+       result through ``apply_shape_cuts``.
+
+    Parameters:
+        image: 2-D float input array.
+        psf: PSF used for the matched-filter shape window.  Only the
+            ``sigma`` (or ``fwhm()``) is consulted; the smear is
+            already baked into ``smear_kernel``.
+        image_noise_sigma: Robust per-pixel noise sigma in DN.
+        full_well_dn: Saturation DN.
+        smear_kernel: Pre-rendered smeared PSF kernel matched to the
+            current obs's smear vector.
+        bloom_mask: Optional CCD bloom column mask; when provided,
+            detections falling on bloom columns are suppressed.
+        detection_sigma: Threshold multiplier on
+            ``image_noise_sigma``.
+
+    Returns:
+        List of ``DetectedSource`` records, one per surviving detection.
+    """
+    response = matched_filter_image(image, kernel=smear_kernel)
+    half_window = max(smear_kernel.shape[0] // 2, smear_kernel.shape[1] // 2, 1)
+    window = 2 * half_window + 1
+    threshold = detection_sigma * image_noise_sigma
+    candidate_mask = _local_max_mask(response, size=window, threshold=threshold)
+    if bloom_mask is not None:
+        candidate_mask &= ~bloom_mask
+
+    sigma_psf = _psf_sigma(psf)
+    box_half = max(1, math.ceil(2.0 * sigma_psf))
+    2 * box_half + 1
+
+    out: list[DetectedSource] = []
+    rows = candidate_mask.shape[0]
+    cols = candidate_mask.shape[1]
+    candidate_indices = np.argwhere(candidate_mask)
+    for v_idx, u_idx in candidate_indices:
+        v_min = int(v_idx) - box_half
+        v_max = int(v_idx) + box_half + 1
+        u_min = int(u_idx) - box_half
+        u_max = int(u_idx) + box_half + 1
+        if v_min < 0 or u_min < 0 or v_max > rows or u_max > cols:
+            continue
+        box = image[v_min:v_max, u_min:u_max]
+        saturated = bool(np.any(box >= full_well_dn))
+        if saturated:
+            dv, du = centroid_saturated(
+                box,
+                full_well_dn=full_well_dn,
+                half_width_inner=box_half - 1,
+                half_width_outer=box_half,
+            )
+        else:
+            dv, du = centroid_gaussian_fit(box)
+        sharp, round_ = _sharpness_roundness(box)
+        if not apply_shape_cuts(sharp, round_):
+            continue
+        out.append(
+            DetectedSource(
+                v=float(v_idx) + dv,
+                u=float(u_idx) + du,
+                peak_dn=float(response[v_idx, u_idx]),
+                sharpness=float(sharp),
+                roundness=float(round_),
+                saturated=saturated,
+            )
+        )
+    return out
+
+
+def _psf_sigma(psf: PSF) -> float:
+    """Return the per-pixel sigma of ``psf`` (Gaussian or via FWHM)."""
+    if hasattr(psf, 'sigma'):
+        return float(psf.sigma)
+    fwhm_method = getattr(psf, 'fwhm', None)
+    if callable(fwhm_method):
+        return float(fwhm_method()) / 2.3548200450309493
+    raise AttributeError(f'PSF {type(psf).__name__} exposes neither sigma nor fwhm()')

--- a/src/nav/nav_model/stars/nav_model_stars.py
+++ b/src/nav/nav_model/stars/nav_model_stars.py
@@ -180,11 +180,9 @@ class NavModelStars(NavModel):
             v_extfov, u_extfov = self._extfov_indices(star)
             in_body = bool(star.conflicts.startswith('BODY'))
             in_ring = bool(star.conflicts.startswith('RING'))
-            in_saturation = bool(
-                _safe_mask_lookup(sat_mask, v_extfov, u_extfov)
-                or _safe_mask_lookup(cosmic_mask, v_extfov, u_extfov)
-            )
-            saturated = in_saturation
+            in_sat = bool(_safe_mask_lookup(sat_mask, v_extfov, u_extfov))
+            in_cosmic = bool(_safe_mask_lookup(cosmic_mask, v_extfov, u_extfov))
+            in_sat_or_cosmic = in_sat or in_cosmic
             cov = _crlb_covariance(
                 snr=snr,
                 sigma_psf=sigma_psf,
@@ -216,20 +214,20 @@ class NavModelStars(NavModel):
                         snr=snr,
                         in_body=in_body,
                         in_ring=in_ring,
-                        in_saturation=in_saturation,
+                        in_saturation=in_sat_or_cosmic,
                     ),
                     reliability_reasons=NavReliabilityBreakdown(
                         predicted_snr=_snr_reason_score(snr, min_snr),
                         in_body_silhouette=in_body or in_ring,
-                        in_saturation_or_cosmic=in_saturation,
+                        in_saturation_or_cosmic=in_sat_or_cosmic,
                         smear_length_ok=True,
                     ),
                     usable_types=frozenset({NavFeatureType.STAR}),
                     flags=StarFlags(
-                        saturated=saturated,
+                        saturated=in_sat,
                         smear_length_px=smear_len,
                         in_body_silhouette=in_body or in_ring,
-                        in_saturation_or_cosmic_mask=in_saturation,
+                        in_saturation_or_cosmic_mask=in_sat_or_cosmic,
                     ),
                 )
             )

--- a/src/nav/nav_model/stars/nav_model_stars.py
+++ b/src/nav/nav_model/stars/nav_model_stars.py
@@ -1,0 +1,499 @@
+"""Real-scene star NavModel.
+
+Orchestrates the catalog-reduction, conflict-marking, predicted-SNR, and
+smear-aware PSF helpers so the NavModel ABC can emit one ``STAR``
+``NavFeature`` per detectable catalog star.  Heavy lifting lives in
+sibling modules; this file is the entry point the orchestrator's
+registry sees.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from oops import Observation
+
+from nav.annotation import (
+    TEXTINFO_BOTTOM,
+    TEXTINFO_BOTTOM_LEFT,
+    TEXTINFO_BOTTOM_RIGHT,
+    TEXTINFO_LEFT,
+    TEXTINFO_RIGHT,
+    TEXTINFO_TOP,
+    TEXTINFO_TOP_LEFT,
+    TEXTINFO_TOP_RIGHT,
+    Annotation,
+    Annotations,
+    AnnotationTextInfo,
+    TextLocInfo,
+)
+from nav.config import Config
+from nav.feature.constants import MIN_ANISOTROPIC_SMEAR_PX
+from nav.feature.feature import NavFeature, NavReliabilityBreakdown
+from nav.feature.feature_type import NavFeatureType
+from nav.feature.flags import StarFlags
+from nav.feature.geometry import StarGeometry
+from nav.nav_model.nav_model import NavModel
+from nav.nav_model.stars.catalog import reduce_catalogs
+from nav.nav_model.stars.conflicts import mark_body_and_ring_conflicts
+from nav.nav_model.stars.predicted_snr import (
+    SCLASS_TO_B_MINUS_V,
+    predicted_snr,
+    psf_sigma_px,
+)
+from nav.nav_model.stars.smeared_psf import compute_smear_vector_px, smear_length_px
+from nav.support.flux import clean_sclass
+from nav.support.image import draw_rect
+from nav.support.time import now_dt
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from nav.nav_orchestrator.nav_context import NavContext
+    from nav.support.types import MutableStar
+
+from nav.support.filters import NavFilterKind, NavFilterSpec
+
+__all__ = [
+    'SCLASS_TO_B_MINUS_V',
+    'NavModelStars',
+]
+
+
+class NavModelStars(NavModel):
+    """Catalog-driven star NavModel.
+
+    Reduces the configured catalogs into a deduplicated star list,
+    flags body/ring conflicts, and emits one STAR ``NavFeature`` per
+    star whose predicted SNR clears the configured floor and whose
+    conflict flags allow it.
+
+    Parameters:
+        name: Model name (typically ``'stars'``).
+        obs: Observation snapshot.
+        config: Optional ``Config`` override.
+    """
+
+    _abstract = False
+
+    def __init__(
+        self,
+        name: str,
+        obs: Observation,
+        *,
+        config: Config | None = None,
+    ) -> None:
+        super().__init__(name, obs, config=config)
+        self._stars_config = self._config.stars
+        self._stars: list[MutableStar] = []
+        self._smear_vu: tuple[float, float] = (0.0, 0.0)
+
+    @classmethod
+    def instances_for_obs(cls, obs: Observation) -> list[NavModel]:
+        """Always returns one star NavModel per observation.
+
+        Parameters:
+            obs: Observation snapshot.
+
+        Returns:
+            ``[NavModelStars('stars', obs)]``.
+        """
+        return [cls('stars', obs)]
+
+    @property
+    def stars(self) -> list[MutableStar]:
+        """Reduced star list populated by ``create_model``."""
+        return self._stars
+
+    def create_model(self) -> None:
+        """Build the reduced star list and populate metadata.
+
+        Steps:
+
+        1. Compute the per-image smear vector via ``compute_smear_vector_px``.
+        2. Reduce all configured catalogs through ``reduce_catalogs`` —
+           pulls per-bin chunks, dedupes against precedence, marks
+           visual overlaps.
+        3. Mark body and ring conflicts via ``mark_body_and_ring_conflicts``.
+        4. Populate ``self._metadata`` with summary fields used by the
+           curator.
+        """
+        start_time = now_dt()
+        self._metadata.clear()
+        self._metadata['start_time'] = start_time.isoformat()
+        self._metadata['end_time'] = None
+        self._metadata['elapsed_time_sec'] = None
+        with self._logger.open('CREATE STARS MODEL'):
+            self._stars = reduce_catalogs(self.obs, self._config)
+            self._smear_vu = _compute_smear_for_obs(self.obs)
+            mark_body_and_ring_conflicts(self.obs, self._config, self._stars)
+            self._metadata['star_count'] = len(self._stars)
+            self._metadata['stars'] = [_star_summary(star) for star in self._stars]
+        end_time = now_dt()
+        self._metadata['end_time'] = end_time.isoformat()
+        self._metadata['elapsed_time_sec'] = (end_time - start_time).total_seconds()
+
+    def to_features(self, context: NavContext) -> list[NavFeature]:
+        """Emit one STAR feature per catalog star above the SNR floor.
+
+        Stars with body or ring conflicts are emitted with the matching
+        ``in_body_silhouette`` / ``in_saturation_or_cosmic_mask`` flags
+        set; the reliability gate decides whether to keep them.  Stars
+        whose predicted SNR is below ``stars.min_predicted_snr`` (when
+        configured; default ``0`` keeps them all) are skipped.
+
+        Parameters:
+            context: Per-image NavContext.
+
+        Returns:
+            List of STAR ``NavFeature`` instances.
+        """
+        if not self._stars:
+            return []
+        psf = self.obs.star_psf()
+        sigma_psf = psf_sigma_px(psf)
+        image_noise_sigma = float(context.image_noise_sigma)
+        if image_noise_sigma <= 0.0:
+            return []
+        min_snr = float(getattr(self._stars_config, 'min_predicted_snr', 0.0))
+        max_smear = float(getattr(self._stars_config, 'max_smear', math.inf))
+        sat_mask = context.saturation_mask_ext
+        cosmic_mask = context.cosmic_ray_mask_ext
+
+        features: list[NavFeature] = []
+        for star in self._stars:
+            snr = predicted_snr(
+                star,
+                psf=psf,
+                image_noise_sigma=image_noise_sigma,
+                mag_offset=0.0,
+            )
+            if snr < min_snr:
+                continue
+            smear_len = smear_length_px(star.move_v, star.move_u)
+            # Per the design's "max_smear" gate — stars with a smear longer
+            # than the per-instrument cap are unfittable even with the
+            # smear-aware kernel, so we drop them from the feature list
+            # rather than emit a structurally-broken feature.
+            if smear_len > max_smear:
+                continue
+            v_extfov, u_extfov = self._extfov_indices(star)
+            in_body = bool(star.conflicts.startswith('BODY'))
+            in_ring = bool(star.conflicts.startswith('RING'))
+            in_saturation = bool(
+                _safe_mask_lookup(sat_mask, v_extfov, u_extfov)
+                or _safe_mask_lookup(cosmic_mask, v_extfov, u_extfov)
+            )
+            saturated = in_saturation
+            cov = _crlb_covariance(
+                snr=snr,
+                sigma_psf=sigma_psf,
+                move_v=star.move_v,
+                move_u=star.move_u,
+            )
+            box_half = (star.psf_size[0] // 2 + 2, star.psf_size[1] // 2 + 2)
+            bbox = (
+                round(v_extfov - box_half[0]),
+                round(u_extfov - box_half[1]),
+                round(v_extfov + box_half[0] + 1),
+                round(u_extfov + box_half[1] + 1),
+            )
+            features.append(
+                NavFeature(
+                    feature_id=_star_feature_id(star),
+                    feature_type=NavFeatureType.STAR,
+                    source_model=self.name,
+                    geometry=StarGeometry(
+                        predicted_vu=(float(v_extfov), float(u_extfov)),
+                        catalog_vu=(float(v_extfov), float(u_extfov)),
+                        bbox_extfov_vu=bbox,
+                    ),
+                    subject_range_km=float('inf'),
+                    position_cov_px=cov,
+                    intensity_sigma_rel=0.0,
+                    preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
+                    reliability=_reliability_from_snr(
+                        snr=snr,
+                        in_body=in_body,
+                        in_ring=in_ring,
+                        in_saturation=in_saturation,
+                    ),
+                    reliability_reasons=NavReliabilityBreakdown(
+                        predicted_snr=_snr_reason_score(snr, min_snr),
+                        in_body_silhouette=in_body or in_ring,
+                        in_saturation_or_cosmic=in_saturation,
+                        smear_length_ok=True,
+                    ),
+                    usable_types=frozenset({NavFeatureType.STAR}),
+                    flags=StarFlags(
+                        saturated=saturated,
+                        smear_length_px=smear_len,
+                        in_body_silhouette=in_body or in_ring,
+                        in_saturation_or_cosmic_mask=in_saturation,
+                    ),
+                )
+            )
+        return features
+
+    def to_annotations(self, context: NavContext) -> Annotations:
+        """Emit star-box overlays plus name/magnitude labels."""
+        del context
+        if not self._stars:
+            return Annotations()
+        return self._build_annotations()
+
+    def _build_annotations(self) -> Annotations:
+        """Render star-box overlays + per-star labels for the summary PNG."""
+        obs = self.obs
+        text_info_list: list[AnnotationTextInfo] = []
+        star_avoid_mask = obs.make_extfov_false()
+        star_overlay = obs.make_extfov_false()
+        for star in self._stars:
+            if star.conflicts and star.conflicts != 'STAR':
+                # Skip body/ring-blocked stars; they are not labelled.
+                continue
+            v_idx, u_idx = self._extfov_indices(star)
+            v_int = int(v_idx)
+            u_int = int(u_idx)
+            v_half = (star.psf_size[0] // 2) + 2
+            u_half = (star.psf_size[1] // 2) + 2
+            u_min, v_min = obs.clip_extfov(u_int - u_half, v_int - v_half)
+            u_max, v_max = obs.clip_extfov(u_int + u_half, v_int + v_half)
+            star_avoid_mask[v_min : v_max + 1, u_min : u_max + 1] = True
+            draw_rect(
+                star_overlay,
+                True,
+                u_int,
+                v_int,
+                u_half,
+                v_half,
+                dot_spacing=1,
+            )
+            label_margin = u_half + 3
+            text_info_list.append(
+                _star_label(
+                    star=star,
+                    config=self._stars_config,
+                    v_int=v_int,
+                    u_int=u_int,
+                    label_margin=label_margin,
+                )
+            )
+        annotations = Annotations()
+        annotations.add_annotations(
+            Annotation(
+                obs,
+                star_overlay,
+                self._stars_config.label_star_color,
+                thicken_overlay=0,
+                avoid_mask=star_avoid_mask,
+                text_info=text_info_list,
+            )
+        )
+        return annotations
+
+    def _extfov_indices(self, star: MutableStar) -> tuple[float, float]:
+        """Return ``(v, u)`` of ``star`` in extfov coordinates."""
+        return (
+            float(star.v) + float(self.obs.extfov_margin_v),
+            float(star.u) + float(self.obs.extfov_margin_u),
+        )
+
+
+def _compute_smear_for_obs(obs: Observation) -> tuple[float, float]:
+    """Best-effort smear vector lookup that tolerates obs API quirks.
+
+    Pulls smear from the SPICE bracket via
+    ``compute_smear_vector_px`` when the obs supports it.  Snapshots
+    that don't have a bracket-capable boresight (simulated obs, partial
+    test fixtures) report a zero smear vector — the SNR formula still
+    applies and the star covariance falls back to the isotropic case.
+
+    Parameters:
+        obs: Observation snapshot.
+
+    Returns:
+        ``(my, mx)`` smear vector in pixels.  Returns ``(0.0, 0.0)`` for
+        obs stand-ins that don't expose a SPICE-bracketable boresight.
+    """
+    try:
+        return compute_smear_vector_px(obs)
+    except (AttributeError, NotImplementedError):
+        return (0.0, 0.0)
+
+
+def _safe_mask_lookup(
+    mask: Any,
+    v: float,
+    u: float,
+) -> bool:
+    """Return ``mask[round(v), round(u)]`` clamped to bounds, defaulting False."""
+    if mask is None:
+        return False
+    arr = np.asarray(mask)
+    if arr.ndim != 2 or arr.size == 0:
+        return False
+    rows, cols = arr.shape
+    vi = int(np.clip(round(v), 0, rows - 1))
+    ui = int(np.clip(round(u), 0, cols - 1))
+    return bool(arr[vi, ui])
+
+
+def _crlb_covariance(
+    *,
+    snr: float,
+    sigma_psf: float,
+    move_v: float,
+    move_u: float,
+) -> np.ndarray:
+    """Return the 2x2 anisotropic CRLB centroid covariance for a star.
+
+    Implements the formula from the design's STAR section:
+
+    ::
+
+        sigma_along  = sqrt(L^2 / 12 + sigma_PSF^2) / sqrt(SNR)
+        sigma_across = sigma_PSF / sqrt(SNR)
+
+    rotated so the major axis aligns with the smear vector ``(my, mx)``.
+    Below ``MIN_ANISOTROPIC_SMEAR_PX``, the covariance collapses to an
+    isotropic ``(sigma_PSF / sqrt(SNR))^2 * I``.
+
+    Parameters:
+        snr: Predicted integrated SNR.
+        sigma_psf: Per-pixel PSF Gaussian sigma in pixels.
+        move_v: Smear vector V component (pixels).
+        move_u: Smear vector U component (pixels).
+
+    Returns:
+        2x2 numpy float array with rows / columns in (v, u) order.
+    """
+    if snr <= 0.0:
+        return np.eye(2, dtype=np.float64) * 1e6
+    if sigma_psf <= 0.0:
+        raise ValueError(f'sigma_psf must be > 0; got {sigma_psf!r}')
+    smear = math.hypot(move_v, move_u)
+    s_across_sq = (sigma_psf * sigma_psf) / snr
+    if smear < MIN_ANISOTROPIC_SMEAR_PX:
+        return np.eye(2, dtype=np.float64) * s_across_sq
+    s_along_sq = (smear * smear / 12.0 + sigma_psf * sigma_psf) / snr
+    cos_t = move_v / smear
+    sin_t = move_u / smear
+    rot = np.array([[cos_t, -sin_t], [sin_t, cos_t]], dtype=np.float64)
+    diag = np.diag([s_along_sq, s_across_sq])
+    cov = rot @ diag @ rot.T
+    return 0.5 * (cov + cov.T)
+
+
+def _snr_reason_score(snr: float, min_snr: float) -> float:
+    """Map a predicted SNR onto the reliability-breakdown ``predicted_snr`` field.
+
+    The ``NavReliabilityBreakdown.predicted_snr`` is a [0, 1] contribution
+    score, not the raw SNR.  This helper folds the configured floor in:
+    when ``min_snr > 0``, the score is ``snr / min_snr`` capped at 1; when
+    no floor is configured, an SNR of 50 saturates the score (the same
+    centre the reliability sigmoid uses).
+
+    Parameters:
+        snr: Predicted SNR.
+        min_snr: Configured floor (``stars.min_predicted_snr``); 0
+            when unset.
+
+    Returns:
+        Contribution score in ``[0, 1]``.
+    """
+    if min_snr > 0.0:
+        return float(min(1.0, snr / min_snr))
+    return float(min(1.0, snr / 50.0))
+
+
+def _reliability_from_snr(
+    *,
+    snr: float,
+    in_body: bool,
+    in_ring: bool,
+    in_saturation: bool,
+) -> float:
+    """Return the [0, 1] reliability for a star.
+
+    Sigmoid-of-SNR core multiplied by hard zero terms for occlusion and
+    saturation.  Matches the design's STAR formula:
+    ``sigmoid(alpha_0 + alpha_1*(snr - threshold))`` with the
+    ``not_in_body_silhouette`` / ``not_in_saturation_or_cosmic`` factors
+    applied multiplicatively.  Excessive-smear stars are excluded from
+    the feature list before this helper runs.
+
+    Parameters:
+        snr: Predicted SNR.
+        in_body: True if the star is occluded by a body silhouette.
+        in_ring: True if the star is occluded by a ring annulus.
+        in_saturation: True if the predicted pixel is saturated or
+            tagged as a cosmic-ray hit.
+
+    Returns:
+        Reliability scalar in ``[0, 1]``.
+    """
+    if in_body or in_ring or in_saturation:
+        return 0.0
+    # Sigmoid centred near snr=10 with a span of ~5 — stars at snr=20 are
+    # saturated to ~1, stars at snr=5 are around 0.27.  Coefficients are
+    # the calibration starting point; phase-5 fitting will refine them.
+    z = 0.2 * (snr - 10.0)
+    return float(1.0 / (1.0 + math.exp(-z)))
+
+
+def _star_feature_id(star: MutableStar) -> str:
+    """Return the ``feature_id`` for ``star``: ``star:<catalog>:<id>``."""
+    cat = (star.catalog_name or 'unknown').upper()
+    uid = star.unique_number if star.unique_number is not None else star.pretty_name
+    return f'star:{cat}:{uid}'
+
+
+def _star_summary(star: MutableStar) -> dict[str, Any]:
+    """Return a compact JSON-friendly summary of a star (for metadata)."""
+    return {
+        'catalog_name': star.catalog_name,
+        'unique_number': star.unique_number,
+        'pretty_name': star.pretty_name,
+        'ra_deg': float(np.degrees(star.ra_pm)),
+        'dec_deg': float(np.degrees(star.dec_pm)),
+        'vmag': star.vmag,
+        'u': star.u,
+        'v': star.v,
+        'move_u': star.move_u,
+        'move_v': star.move_v,
+        'spectral_class': star.spectral_class,
+        'conflicts': star.conflicts,
+    }
+
+
+def _star_label(
+    *,
+    star: MutableStar,
+    config: Any,
+    v_int: int,
+    u_int: int,
+    label_margin: int,
+) -> AnnotationTextInfo:
+    """Return the label info for one star (8 candidate placements)."""
+    sclass = clean_sclass(star.spectral_class or '')
+    line1 = star.pretty_name[:10]
+    line2 = f'{star.vmag:.3f} {sclass}' if star.vmag is not None else sclass
+    text_loc: list[TextLocInfo] = [
+        TextLocInfo(TEXTINFO_BOTTOM, v_int + label_margin, u_int),
+        TextLocInfo(TEXTINFO_TOP, v_int - label_margin, u_int),
+        TextLocInfo(TEXTINFO_LEFT, v_int, u_int - label_margin),
+        TextLocInfo(TEXTINFO_RIGHT, v_int, u_int + label_margin),
+        TextLocInfo(TEXTINFO_TOP_LEFT, v_int - label_margin, u_int - label_margin),
+        TextLocInfo(TEXTINFO_TOP_RIGHT, v_int - label_margin, u_int + label_margin),
+        TextLocInfo(TEXTINFO_BOTTOM_LEFT, v_int + label_margin, u_int - label_margin),
+        TextLocInfo(TEXTINFO_BOTTOM_RIGHT, v_int + label_margin, u_int + label_margin),
+    ]
+    return AnnotationTextInfo(
+        f'{line1}\n{line2}',
+        ref_vu=(v_int, u_int),
+        text_loc=text_loc,
+        font=config.label_font,
+        font_size=config.label_font_size,
+        color=config.label_font_color,
+    )

--- a/src/nav/nav_model/stars/predicted_snr.py
+++ b/src/nav/nav_model/stars/predicted_snr.py
@@ -1,0 +1,156 @@
+"""Per-star predicted-SNR computation for the star NavModel.
+
+Reliability of a STAR feature comes from how detectable the star is at
+its predicted pixel position.  The estimate uses three inputs:
+
+- ``obs.star_psf()`` — the per-camera-per-filter PSF.
+- ``NavContext.image_noise_sigma`` — robust MAD-based noise estimate over
+  the sensor area.
+- ``star.dn`` — the integrated DN expected for the star in the
+  instrument's bandpass, computed from its catalog V magnitude via the
+  ``2.512 ** -(vmag - 4)`` flux-to-DN scaling.  ``star.dn`` is the
+  total signal across the PSF support; the per-pixel signal is that
+  total spread over a circular Gaussian-PSF aperture.
+
+The integrated SNR follows the form in Part 1's "Position covariance
+per feature type" section:
+
+::
+
+    SNR = total_signal / sqrt(total_signal + read_noise**2 * N_aperture)
+
+with ``total_signal`` in DN and ``read_noise**2 * N_aperture`` standing
+in for the variance contribution from background and read noise.
+``image_noise_sigma`` is treated as a Gaussian read-noise proxy because
+the MAD estimator is dominated by background pixels and combines shot,
+read, and dark contributions into a single per-pixel sigma.
+
+``SCLASS_TO_B_MINUS_V`` is re-exported here so callers that need the
+spectral-class colour mapping can pull it from the same module that
+owns the predicted-SNR formula.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, cast
+
+from starcat import SCLASS_TO_B_MINUS_V
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from psfmodel import PSF
+
+    from nav.support.types import MutableStar
+
+__all__ = [
+    'SCLASS_TO_B_MINUS_V',
+    'integrated_signal_dn',
+    'predicted_snr',
+    'psf_aperture_pixels',
+    'psf_sigma_px',
+]
+
+
+def psf_sigma_px(psf: PSF) -> float:
+    """Return the Gaussian-equivalent sigma of ``psf`` in pixels.
+
+    Treats every PSF as a 2-D Gaussian for SNR / CRLB purposes.  The
+    pipeline ships ``GaussianPSF`` instances populated from
+    ``star_psf_sigma`` in ``config_NN_inst_*.yaml``, so the ``sigma``
+    attribute is the natural source.  When the field is absent (a
+    third-party PSF subclass), we fall back to ``fwhm() / 2.3548``.
+
+    Parameters:
+        psf: PSF instance from ``obs.star_psf()``.
+
+    Returns:
+        Gaussian sigma in pixels.
+    """
+    if hasattr(psf, 'sigma'):
+        return float(cast(float, psf.sigma))
+    fwhm_method = getattr(psf, 'fwhm', None)
+    if callable(fwhm_method):
+        return float(fwhm_method()) / 2.3548200450309493
+    raise AttributeError(f'PSF {type(psf).__name__} exposes neither sigma nor fwhm()')
+
+
+def psf_aperture_pixels(sigma_px_value: float) -> float:
+    """Return the effective number of pixels in the PSF support.
+
+    Uses the standard "noise-equivalent area" of a 2-D Gaussian,
+    ``4 * pi * sigma**2``, which is the right scale for converting an
+    integrated DN signal into a per-pixel matched-filter SNR.
+
+    Parameters:
+        sigma_px_value: Per-pixel PSF sigma in pixels.
+
+    Returns:
+        Effective aperture area in pixels (always > 0 for sigma > 0).
+    """
+    if sigma_px_value <= 0.0:
+        raise ValueError(f'sigma_px_value must be > 0; got {sigma_px_value!r}')
+    return 4.0 * math.pi * sigma_px_value * sigma_px_value
+
+
+def integrated_signal_dn(star: MutableStar, mag_offset: float) -> float:
+    """Return the predicted in-band DN for a catalog star.
+
+    Applies a per-camera-per-filter ``mag_offset`` to convert the
+    catalog V-band magnitude into the instrument's bandpass, then uses
+    the standard ``2.512 ** -(vmag - 4)`` flux-to-DN scaling.  Stars
+    without a catalog magnitude (vmag is None) are not detectable and
+    return 0.0.
+
+    Parameters:
+        star: Star record carrying ``vmag``.
+        mag_offset: Per-instrument-per-filter magnitude offset
+            (mag_in_band - mag_v).  Positive values mean the instrument
+            sees the star fainter than the catalog magnitude.
+
+    Returns:
+        Predicted integrated DN in the instrument's bandpass.
+    """
+    if star.vmag is None:
+        return 0.0
+    in_band_mag = float(star.vmag) + mag_offset
+    return float(2.512 ** -(in_band_mag - 4.0))
+
+
+def predicted_snr(
+    star: MutableStar,
+    *,
+    psf: PSF,
+    image_noise_sigma: float,
+    mag_offset: float = 0.0,
+) -> float:
+    """Predicted integrated SNR for a star at its predicted pixel.
+
+    Treats ``image_noise_sigma`` as the per-pixel Gaussian noise from
+    background + read noise + dark current; ``star.dn`` is the
+    integrated signal across the PSF support.  Implements the formula
+    from the design's STAR section:
+
+    ::
+
+        SNR = total_signal / sqrt(total_signal + sigma**2 * N_aperture)
+
+    with ``N_aperture = 4 * pi * sigma_PSF**2``.
+
+    Parameters:
+        star: Star record.
+        psf: PSF (typically from ``obs.star_psf()``).
+        image_noise_sigma: Robust per-pixel noise sigma in DN.
+        mag_offset: Catalog-to-instrument magnitude offset (default 0).
+
+    Returns:
+        Predicted SNR (dimensionless, >= 0).
+    """
+    if image_noise_sigma <= 0.0:
+        raise ValueError(f'image_noise_sigma must be > 0; got {image_noise_sigma!r}')
+    sig = integrated_signal_dn(star, mag_offset)
+    if sig <= 0.0:
+        return 0.0
+    sigma_px_value = psf_sigma_px(psf)
+    aperture = psf_aperture_pixels(sigma_px_value)
+    variance = sig + image_noise_sigma * image_noise_sigma * aperture
+    return sig / math.sqrt(variance)

--- a/src/nav/nav_model/stars/smeared_psf.py
+++ b/src/nav/nav_model/stars/smeared_psf.py
@@ -1,0 +1,149 @@
+"""Smear-aware PSF rendering helpers.
+
+When the spacecraft attitude rate is non-zero during an exposure, stars
+smear into trails along the per-pixel motion vector.  ``psfmodel`` exposes
+a smear-aware ``eval_rect(..., movement=, movement_granularity=)`` API
+that integrates the PSF along the trail.  These helpers build the small
+postage stamp returned by that call and choose a sensible
+``movement_granularity`` from the smear amplitude.
+
+A second helper computes the per-image smear vector ``(my, mx)`` (in
+pixels) from the SPICE pointing brackets at the start and end of the
+exposure, exposed as a free function so the orchestrator can drive it
+from ``NavContext`` without subclassing the obs.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from psfmodel import PSF
+
+    from nav.obs import ObsSnapshot
+    from nav.support.types import MutableStar, NDArrayFloatType
+
+__all__ = [
+    'compute_smear_vector_px',
+    'movement_granularity_px',
+    'render_smeared_psf',
+    'smear_length_px',
+]
+
+
+def smear_length_px(move_v: float, move_u: float) -> float:
+    """Return the smear length ``sqrt(my**2 + mx**2)`` in pixels.
+
+    Parameters:
+        move_v: Per-exposure smear amplitude along the V (row) axis.
+        move_u: Per-exposure smear amplitude along the U (column) axis.
+
+    Returns:
+        Euclidean smear length in pixels (always >= 0).
+    """
+    return float(np.hypot(move_v, move_u))
+
+
+def movement_granularity_px(move_v: float, move_u: float, *, max_steps: int = 50) -> float:
+    """Choose the ``movement_granularity`` step for ``psf.eval_rect``.
+
+    Targets at most ``max_steps`` integration samples along the smear
+    path, clamped to ``[0.1, 1.0]`` pixels per sample.  The lower bound
+    keeps the integration tractable for very short smears; the upper
+    bound keeps long smears from sub-sampling the PSF.
+
+    Parameters:
+        move_v: Per-exposure smear amplitude along V.
+        move_u: Per-exposure smear amplitude along U.
+        max_steps: Maximum samples along the smear (default 50).
+
+    Returns:
+        Step size in pixels per integration sample.
+    """
+    if max_steps <= 0:
+        raise ValueError(f'max_steps must be > 0; got {max_steps!r}')
+    coarse = max(abs(move_v) / max_steps, abs(move_u) / max_steps)
+    return float(np.clip(coarse, 0.1, 1.0))
+
+
+def render_smeared_psf(
+    psf: PSF,
+    *,
+    star: MutableStar,
+    max_movement_steps: int,
+) -> NDArrayFloatType:
+    """Render one star's smeared PSF stamp.
+
+    The output stamp shape is
+    ``(2 * psf_half_v + 1) x (2 * psf_half_u + 1)`` where each half-size
+    accounts for the PSF support plus the rounded smear amplitude.  The
+    amplitude is folded into the half-sizes so the integrated stamp
+    captures the entire trail without clipping.
+
+    Parameters:
+        psf: PSF instance from ``obs.star_psf()``.
+        star: Star record carrying ``psf_size``, ``move_v``, ``move_u``,
+            ``u``, ``v``, and ``dn``.
+        max_movement_steps: Cap on the number of integration steps along
+            the smear path; passed through to
+            ``movement_granularity_px``.
+
+    Returns:
+        ``np.ndarray`` postage stamp containing the rendered PSF, in DN.
+    """
+    psf_half_u = int(star.psf_size[1] + np.round(abs(star.move_u))) // 2
+    psf_half_v = int(star.psf_size[0] + np.round(abs(star.move_v))) // 2
+    move_gran = movement_granularity_px(star.move_v, star.move_u, max_steps=max_movement_steps)
+    u_idx = star.u
+    v_idx = star.v
+    u_int = int(u_idx)
+    v_int = int(v_idx)
+    u_frac = float(u_idx - u_int)
+    v_frac = float(v_idx - v_int)
+    stamp = psf.eval_rect(
+        (psf_half_v * 2 + 1, psf_half_u * 2 + 1),
+        offset=(v_frac, u_frac),
+        scale=star.dn,
+        movement=(star.move_v, star.move_u),
+        movement_granularity=move_gran,
+    )
+    return np.asarray(stamp, dtype=np.float64)
+
+
+def compute_smear_vector_px(obs: ObsSnapshot) -> tuple[float, float]:
+    """Compute the per-image smear vector ``(my, mx)`` in pixels.
+
+    Implements the design's "smear from SPICE bracket" approach: project
+    the camera attitude at ``obs.time[0]`` and ``obs.time[1]`` into pixel
+    coordinates by re-evaluating the boresight RA/DEC through the obs
+    FOV at both bracket times, and take the difference.  The result is
+    the total per-exposure displacement of a star at the centre of the
+    FOV.
+
+    Parameters:
+        obs: Observation snapshot.
+
+    Returns:
+        Tuple ``(my, mx)`` in pixels (vertical, horizontal).
+    """
+    # ``obs.uv_from_ra_and_dec`` accepts ``tfrac`` in [0, 1] mapping the
+    # exposure window onto a unit interval; tfrac=0 is the start ET and
+    # tfrac=1 is the end ET.  Differencing the two boresight projections
+    # gives the per-exposure pointing displacement at the FOV centre.
+    boresight_uv0 = obs.uv_from_ra_and_dec(
+        obs.boresight_ra(),
+        obs.boresight_dec(),
+        tfrac=0.0,
+        apparent=True,
+    )
+    boresight_uv1 = obs.uv_from_ra_and_dec(
+        obs.boresight_ra(),
+        obs.boresight_dec(),
+        tfrac=1.0,
+        apparent=True,
+    )
+    u0, v0 = boresight_uv0.to_scalars()
+    u1, v1 = boresight_uv1.to_scalars()
+    return float(v1.vals - v0.vals), float(u1.vals - u0.vals)

--- a/src/nav/nav_orchestrator/orchestrator.py
+++ b/src/nav/nav_orchestrator/orchestrator.py
@@ -329,8 +329,15 @@ class NavOrchestrator(NavBase):
     def _make_context(
         self, obs: ObsSnapshotInst, provenance: Provenance
     ) -> tuple[NavContext, NavImageClassifierResult]:
-        """Build a NavContext from an observation."""
-        image = obs.data.astype('float64')
+        """Build a NavContext from an observation.
+
+        The image, sensor mask, saturation mask, and cosmic-ray mask all
+        live on the *extended FOV* (zero-padded around the original sensor
+        rectangle).  ``obs.extdata`` is the canonical source for the
+        extfov-shaped image and matches the extfov sensor mask shape
+        regardless of the per-instrument ``extfov_margin_vu``.
+        """
+        image = obs.extdata.astype('float64')
         sensor_mask = obs.extfov_data_sensor_mask()
         classifier_result = self._image_classifier.classify(image, sensor_mask)
         full_well = self._instrument_full_well_dn(obs)
@@ -372,10 +379,10 @@ class NavOrchestrator(NavBase):
     def _instrument_full_well_dn(self, obs: ObsSnapshotInst) -> float:
         """Return the saturation DN used for the per-image saturation mask.
 
-        Returns the 12-bit camera default ``DEFAULT_FULL_WELL_DN_12_BIT``
-        for now; per-instrument values will replace this lookup once the
-        per-instrument noise YAML blocks ship.  ``obs`` is accepted so the
-        per-instrument path can branch on it without a signature change.
+        Returns the 12-bit camera default
+        :data:`DEFAULT_FULL_WELL_DN_12_BIT`.  ``obs`` is accepted so a
+        per-instrument path can branch on the observation without a
+        signature change.
         """
         del obs
         return DEFAULT_FULL_WELL_DN_12_BIT

--- a/tests/nav/nav_model/stars/test_catalog.py
+++ b/tests/nav/nav_model/stars/test_catalog.py
@@ -1,0 +1,178 @@
+"""Tests for ``nav.nav_model.stars.catalog``."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from nav.nav_model.stars.catalog import (
+    CATALOG_MAGNITUDE_BINS,
+    _find_stars_in_one_catalog,
+    _mark_visual_overlaps,
+    _merge_catalogs,
+    select_radec_list,
+)
+from nav.support.types import MutableStar
+
+
+@dataclass
+class _FakeStar:
+    """Mutable star stand-in used by the catalog dedup / overlap helpers."""
+
+    ra: float | None = None
+    dec: float | None = None
+    ra_pm: float = 0.0
+    dec_pm: float = 0.0
+    vmag: float | None = 5.0
+    name: str = ''
+    pretty_name: str = ''
+    catalog_name: str = ''
+    psf_size: tuple[int, int] = (3, 3)
+    u: float = 0.0
+    v: float = 0.0
+    conflicts: str = ''
+
+    def ra_dec_with_pm(self, tdb: float) -> tuple[float, float]:
+        """Return the catalog ``(ra, dec)`` unchanged (no proper motion)."""
+        del tdb
+        return float(self.ra or 0.0), float(self.dec or 0.0)
+
+
+def _as_stars(values: list[_FakeStar]) -> list[MutableStar]:
+    """Cast a list of fake stars to the ``MutableStar`` protocol type."""
+    return cast(list[MutableStar], values)
+
+
+def test_catalog_magnitude_bins_monotonic() -> None:
+    """The bin edges are strictly increasing — required by ``itertools.pairwise``."""
+    diffs = np.diff(np.array(CATALOG_MAGNITUDE_BINS))
+    assert (diffs > 0.0).all()
+
+
+def test_catalog_magnitude_bins_first_and_last() -> None:
+    """The bin edges span the configured magnitude range."""
+    assert CATALOG_MAGNITUDE_BINS[0] == 0.0
+    assert CATALOG_MAGNITUDE_BINS[-1] == 17.0
+
+
+def test_select_radec_list_with_proper_motion() -> None:
+    """When ``use_proper_motion`` is True, ``ra_dec_with_pm`` is consulted."""
+    out = select_radec_list(
+        _as_stars([_FakeStar(ra=1.0, dec=2.0)]), use_proper_motion=True, midtime=0.0
+    )
+    assert out == [(1.0, 2.0)]
+
+
+def test_select_radec_list_without_proper_motion() -> None:
+    """Without proper motion, the helper returns the catalog ``(ra, dec)`` pair."""
+    out = select_radec_list(
+        _as_stars([_FakeStar(ra=0.5, dec=1.5)]), use_proper_motion=False, midtime=0.0
+    )
+    assert out == [(0.5, 1.5)]
+
+
+def test_merge_catalogs_drops_exact_duplicates() -> None:
+    """A duplicate within both thresholds is excluded from the merged list."""
+    earlier = _as_stars([_FakeStar(ra_pm=0.1, dec_pm=0.2, vmag=5.0, pretty_name='AAA')])
+    later = _as_stars([_FakeStar(ra_pm=0.1, dec_pm=0.2, vmag=5.0, pretty_name='BBB')])
+    merged = _merge_catalogs(
+        earlier,
+        later,
+        duplicate_radec=math.radians(10 / 3600),
+        duplicate_vmag=2.0,
+    )
+    assert len(merged) == 1
+    assert merged[0].pretty_name == 'AAA'
+
+
+def test_merge_catalogs_keeps_distant_star() -> None:
+    """A star far enough away in DEC is appended even when other fields match."""
+    earlier = _as_stars([_FakeStar(ra_pm=0.0, dec_pm=0.0, vmag=5.0)])
+    later = _as_stars([_FakeStar(ra_pm=0.0, dec_pm=0.05, vmag=5.0)])
+    merged = _merge_catalogs(
+        earlier,
+        later,
+        duplicate_radec=math.radians(10 / 3600),
+        duplicate_vmag=2.0,
+    )
+    assert len(merged) == 2
+
+
+def test_merge_catalogs_upgrades_pretty_name_from_named_duplicate() -> None:
+    """When ``earlier`` lacks a name and ``later`` has one, the later name wins."""
+    earlier = _as_stars([_FakeStar(ra_pm=0.0, dec_pm=0.0, vmag=5.0, name='', pretty_name='123')])
+    later = _as_stars(
+        [_FakeStar(ra_pm=0.0, dec_pm=0.0, vmag=5.0, name='Sirius', pretty_name='Sirius')]
+    )
+    merged = _merge_catalogs(
+        earlier,
+        later,
+        duplicate_radec=math.radians(10 / 3600),
+        duplicate_vmag=2.0,
+    )
+    assert len(merged) == 1
+    assert merged[0].pretty_name == 'Sirius'
+
+
+def test_merge_catalogs_returns_later_when_earlier_empty() -> None:
+    """An empty ``earlier`` list yields exactly ``later``."""
+    later = _as_stars([_FakeStar(ra_pm=0.1, dec_pm=0.2, vmag=5.0)])
+    merged = _merge_catalogs([], later, duplicate_radec=1e-3, duplicate_vmag=1.0)
+    assert merged == later
+
+
+def test_mark_visual_overlaps_tags_both_for_similar_magnitudes() -> None:
+    """Overlap with similar V-magnitudes tags both stars with conflict ``'STAR'``."""
+    s1 = _FakeStar(u=10.0, v=10.0, psf_size=(5, 5), vmag=5.0)
+    s2 = _FakeStar(u=10.5, v=10.5, psf_size=(5, 5), vmag=5.5)
+    _mark_visual_overlaps(_as_stars([s1, s2]), overlap_vmag=2.0)
+    assert s1.conflicts == 'STAR'
+    assert s2.conflicts == 'STAR'
+
+
+def test_mark_visual_overlaps_tags_only_fainter_for_dominant_pair() -> None:
+    """Overlap with a 5-mag delta tags only the fainter star."""
+    bright = _FakeStar(u=5.0, v=5.0, psf_size=(5, 5), vmag=2.0)
+    faint = _FakeStar(u=5.5, v=5.5, psf_size=(5, 5), vmag=8.0)
+    _mark_visual_overlaps(_as_stars([bright, faint]), overlap_vmag=2.0)
+    assert bright.conflicts == ''
+    assert faint.conflicts == 'STAR'
+
+
+def test_mark_visual_overlaps_no_op_on_singletons() -> None:
+    """A list of one star is unchanged."""
+    star = _FakeStar(u=0.0, v=0.0)
+    _mark_visual_overlaps(_as_stars([star]), overlap_vmag=2.0)
+    assert star.conflicts == ''
+
+
+def test_mark_visual_overlaps_skips_separated_stars() -> None:
+    """Stars whose PSF supports do not overlap are left unmarked."""
+    s1 = _FakeStar(u=0.0, v=0.0, psf_size=(3, 3))
+    s2 = _FakeStar(u=20.0, v=20.0, psf_size=(3, 3))
+    _mark_visual_overlaps(_as_stars([s1, s2]), overlap_vmag=2.0)
+    assert s1.conflicts == ''
+    assert s2.conflicts == ''
+
+
+def test_find_stars_in_one_catalog_rejects_invalid_catalog_name() -> None:
+    """An unknown catalog name raises ``ValueError`` naming the bad string."""
+    obs: Any = object()
+    config: Any = object()
+    with pytest.raises(ValueError, match=r"Invalid star catalog: 'klingon'"):
+        _find_stars_in_one_catalog(
+            obs=obs,
+            config=config,
+            catalog_name='klingon',
+            ra_min=0.0,
+            ra_max=1.0,
+            dec_min=0.0,
+            dec_max=1.0,
+            mag_min=0.0,
+            mag_max=20.0,
+            radec_movement=None,
+        )

--- a/tests/nav/nav_model/stars/test_catalog_integration.py
+++ b/tests/nav/nav_model/stars/test_catalog_integration.py
@@ -1,0 +1,473 @@
+"""Integration tests for ``nav.nav_model.stars.catalog`` using shims.
+
+These tests drive ``stars_in_extfov`` and ``reduce_catalogs`` against a
+fake catalog (via :func:`tests.shims.install_fake_catalogs`) and a
+fake observation (via :class:`tests.shims.FakeObs`), so the catalog
+reduction's UCAC4 / Tycho-2 / YBSC branches and the FOV-projection
+edge-culling code are exercised without real catalog data or SPICE.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, cast
+
+import numpy as np
+import pytest
+from tests.shims import FakeObs, install_fake_catalogs, make_star
+
+from nav.config import DEFAULT_CONFIG
+from nav.nav_model.stars import catalog as nav_catalog
+from nav.nav_model.stars.catalog import _merge_catalogs, reduce_catalogs, stars_in_extfov
+from nav.support.types import MutableStar
+
+
+@pytest.fixture
+def fake_obs() -> FakeObs:
+    """Provide a 100x100 obs with extfov margin and the configured PSF."""
+    return FakeObs(
+        data=np.zeros((100, 100), dtype=np.float64),
+        extfov_margin_vu=(10, 10),
+        midtime=0.0,
+        ra_dec_limits_ext_rad=(0.0, 0.5, -0.1, 0.1),
+        star_min_vmag=0.0,
+        star_max_vmag=15.0,
+    )
+
+
+@pytest.fixture(autouse=True)
+def disable_stellar_aberration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace ``aberrate_star`` with a no-op for these integration tests.
+
+    The production helper builds a real ``oops.Event`` whose constructor
+    requires a SPICE-aware ``path`` / ``frame`` on the observation; the
+    ``FakeObs`` shim does not provide those.  These tests exercise the
+    catalog-reduction call paths, not the aberration math (which has its
+    own unit tests), so the no-op is safe.
+    """
+    monkeypatch.setattr(
+        'nav.nav_model.stars.catalog.aberrate_star',
+        lambda _obs, _star: None,
+    )
+
+
+def test_stars_in_extfov_returns_records_from_fake_ucac4(
+    monkeypatch: pytest.MonkeyPatch, fake_obs: FakeObs
+) -> None:
+    """A fake UCAC4 with one star in the box yields one reduced record."""
+    install_fake_catalogs(
+        monkeypatch,
+        ucac4=[make_star(unique_number=1, ra=0.1, dec=0.0, vmag=5.0)],
+    )
+    out = stars_in_extfov(
+        cast(Any, fake_obs),
+        DEFAULT_CONFIG,
+        catalog_name='ucac4',
+        mag_min=0.0,
+        mag_max=15.0,
+    )
+    assert len(out) == 1
+    star = out[0]
+    assert star.unique_number == 1
+    assert star.catalog_name == 'ucac4'
+    assert star.dn > 0.0
+    # The FOV projection populates u, v, move_u, move_v.
+    assert star.u != 0.0 or star.v != 0.0
+
+
+def test_stars_in_extfov_drops_stars_outside_ra_window(
+    monkeypatch: pytest.MonkeyPatch, fake_obs: FakeObs
+) -> None:
+    """Stars outside the configured RA limits are excluded by the catalog filter."""
+    install_fake_catalogs(
+        monkeypatch,
+        ucac4=[make_star(unique_number=1, ra=10.0, dec=0.0, vmag=5.0)],
+    )
+    out = stars_in_extfov(
+        cast(Any, fake_obs),
+        DEFAULT_CONFIG,
+        catalog_name='ucac4',
+        mag_min=0.0,
+        mag_max=15.0,
+    )
+    assert out == []
+
+
+def test_stars_in_extfov_drops_unfittable_johnson_b_in_ybsc(
+    monkeypatch: pytest.MonkeyPatch, fake_obs: FakeObs
+) -> None:
+    """YBSC's ``b_v``-based johnson-mag fill path is exercised."""
+    install_fake_catalogs(
+        monkeypatch,
+        ybsc=[make_star(unique_number=1, ra=0.1, dec=0.0, vmag=5.0, b_v=0.65, name='Sirius')],
+    )
+    out = stars_in_extfov(
+        cast(Any, fake_obs),
+        DEFAULT_CONFIG,
+        catalog_name='ybsc',
+        mag_min=0.0,
+        mag_max=15.0,
+    )
+    assert len(out) == 1
+    assert out[0].johnson_mag_v == 5.0
+    assert out[0].johnson_mag_b == pytest.approx(5.65)
+
+
+def test_stars_in_extfov_tycho2_drops_johnson_mags(
+    monkeypatch: pytest.MonkeyPatch, fake_obs: FakeObs
+) -> None:
+    """Tycho-2's per-catalog ``johnson_mag_*`` clearing path is exercised.
+
+    The shim runs through the production code's tycho2 branch, which
+    explicitly clears johnson_mag_v / johnson_mag_b before the
+    fill-from-spectral-class path runs.  After reduction those fields
+    are populated from the configured ``default_star_class``.
+    """
+    install_fake_catalogs(
+        monkeypatch,
+        tycho2=[make_star(unique_number=1, ra=0.1, dec=0.0, vmag=5.0)],
+    )
+    out = stars_in_extfov(
+        cast(Any, fake_obs),
+        DEFAULT_CONFIG,
+        catalog_name='tycho2',
+        mag_min=0.0,
+        mag_max=15.0,
+    )
+    assert len(out) == 1
+    # The fill-from-default path runs because tycho2 cleared the
+    # johnson_mag_* fields; johnson_mag_faked is True after reduction.
+    assert out[0].johnson_mag_faked is True
+
+
+def test_reduce_catalogs_walks_every_configured_catalog(
+    monkeypatch: pytest.MonkeyPatch, fake_obs: FakeObs
+) -> None:
+    """``reduce_catalogs`` calls each configured catalog and merges the results.
+
+    Configures one star per catalog at distinct RA values so the
+    deduplication path keeps all three.
+    """
+    install_fake_catalogs(
+        monkeypatch,
+        ucac4=[make_star(unique_number=1, ra=0.10, dec=0.00, vmag=5.0)],
+        tycho2=[make_star(unique_number=2, ra=0.20, dec=0.01, vmag=6.0)],
+        ybsc=[make_star(unique_number=3, ra=0.30, dec=0.02, vmag=7.0, b_v=0.5)],
+    )
+    out = reduce_catalogs(cast(Any, fake_obs), DEFAULT_CONFIG)
+    by_id = {s.unique_number for s in out}
+    assert by_id == {1, 2, 3}
+
+
+def test_reduce_catalogs_dedupes_against_higher_precedence(
+    monkeypatch: pytest.MonkeyPatch, fake_obs: FakeObs
+) -> None:
+    """A duplicate in a lower-precedence catalog is dropped by the merge."""
+    same_ra = 0.10
+    same_dec = 0.0
+    install_fake_catalogs(
+        monkeypatch,
+        ucac4=[make_star(unique_number=1, ra=same_ra, dec=same_dec, vmag=5.0, name='')],
+        tycho2=[make_star(unique_number=2, ra=same_ra, dec=same_dec, vmag=5.0, name='')],
+    )
+    out = reduce_catalogs(cast(Any, fake_obs), DEFAULT_CONFIG)
+    assert len(out) == 1
+    # UCAC4 has higher precedence so its entry survives.
+    assert out[0].catalog_name == 'ucac4'
+
+
+def test_reduce_catalogs_caps_at_max_stars(
+    monkeypatch: pytest.MonkeyPatch, fake_obs: FakeObs
+) -> None:
+    """The merged list is capped at ``stars.max_stars``."""
+    fake_stars = [
+        make_star(unique_number=i, ra=0.1 + 0.001 * i, dec=0.0, vmag=5.0 + i * 0.001)
+        for i in range(150)
+    ]
+    install_fake_catalogs(monkeypatch, ucac4=fake_stars)
+    out = reduce_catalogs(cast(Any, fake_obs), DEFAULT_CONFIG)
+    assert len(out) == DEFAULT_CONFIG.stars.max_stars
+
+
+def test_stars_in_extfov_skips_records_with_missing_radec(
+    monkeypatch: pytest.MonkeyPatch, fake_obs: FakeObs
+) -> None:
+    """Records whose RA / DEC / vmag is ``None`` are skipped by the reduction."""
+    install_fake_catalogs(
+        monkeypatch,
+        ucac4=[
+            make_star(unique_number=1, ra=0.05, dec=0.05, vmag=5.0),
+            # The catalog filter drops records with ``vmag is None`` before
+            # they ever reach the reduction; an additional ``ra is None``
+            # record is dropped by the ``ra is None`` skip in the reduction
+            # body.  Construct a record post-filter by mutating after the
+            # fact (the dataclass allows it).
+        ],
+    )
+    # Inject a star whose ``ra`` is None into the FakeStarCatalog list so
+    # the post-filter reduction loop hits the early-skip branch.  The
+    # patched getter is reached via dynamic attribute lookup on the
+    # catalog module so monkeypatch's swap is honoured.
+    cat = cast(Any, nav_catalog.get_ucac4_catalog())
+    bad = make_star(unique_number=2, ra=0.05, dec=0.05, vmag=5.0)
+    bad.ra = None
+    cat.stars.append(bad)
+    out = stars_in_extfov(
+        cast(Any, fake_obs),
+        DEFAULT_CONFIG,
+        catalog_name='ucac4',
+        mag_min=0.0,
+        mag_max=15.0,
+    )
+    # Only the well-formed star survives.
+    assert len(out) == 1
+    assert out[0].unique_number == 1
+
+
+def test_stars_in_extfov_supplies_default_temperature_when_missing(
+    monkeypatch: pytest.MonkeyPatch, fake_obs: FakeObs
+) -> None:
+    """A star with ``temperature=None`` is filled with the default star class."""
+    star = make_star(unique_number=1, ra=0.1, dec=0.0, vmag=5.0)
+    star.temperature = None
+    star.spectral_class = None
+    install_fake_catalogs(monkeypatch, ucac4=[star])
+    out = stars_in_extfov(
+        cast(Any, fake_obs),
+        DEFAULT_CONFIG,
+        catalog_name='ucac4',
+        mag_min=0.0,
+        mag_max=15.0,
+    )
+    assert len(out) == 1
+    assert out[0].temperature_faked is True
+    assert out[0].temperature is not None
+    assert out[0].spectral_class == DEFAULT_CONFIG.stars.default_star_class
+
+
+def test_stars_in_extfov_handles_star_without_name_attribute(
+    monkeypatch: pytest.MonkeyPatch, fake_obs: FakeObs
+) -> None:
+    """A star whose ``name`` access raises ``AttributeError`` falls back gracefully.
+
+    The production reduction uses ``try / except AttributeError`` to
+    handle catalog records that don't expose a ``name`` field at all
+    (vs. simply having an empty string).
+    """
+
+    class _NoNameStar:
+        unique_number = 99
+        catalog_name = ''
+        pretty_name = ''
+        ra = 0.05
+        dec = 0.05
+        vmag = 5.0
+        b_v = 0.5
+        johnson_mag_v: float | None = None
+        johnson_mag_b: float | None = None
+        johnson_mag_faked = False
+        spectral_class = 'G0'
+        temperature: float | None = 5800.0
+        temperature_faked = False
+        ra_pm = 0.0
+        dec_pm = 0.0
+        psf_size = (5, 5)
+        u = 0.0
+        v = 0.0
+        move_u = 0.0
+        move_v = 0.0
+        dn = 0.0
+        conflicts = ''
+        diff_u = 0.0
+        diff_v = 0.0
+
+        def ra_dec_with_pm(self, _tdb: float) -> tuple[float, float]:
+            return self.ra, self.dec
+
+        # Note: no ``name`` attribute; ``star.name`` raises AttributeError.
+
+    install_fake_catalogs(monkeypatch, ucac4=[cast(Any, _NoNameStar())])
+    out = stars_in_extfov(
+        cast(Any, fake_obs),
+        DEFAULT_CONFIG,
+        catalog_name='ucac4',
+        mag_min=0.0,
+        mag_max=15.0,
+    )
+    assert len(out) == 1
+    assert out[0].name == ''
+
+
+def test_reduce_catalogs_skips_bins_below_obs_min_vmag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``reduce_catalogs`` skips magnitude bins entirely below the obs floor.
+
+    The star's ``vmag`` is chosen to fall strictly inside one bin so the
+    catalog filter does not return it twice (catalog filtering is
+    inclusive on both bin endpoints; values that fall on a bin boundary
+    appear in two consecutive bins).
+    """
+    obs = FakeObs(
+        data=np.zeros((100, 100), dtype=np.float64),
+        extfov_margin_vu=(10, 10),
+        ra_dec_limits_ext_rad=(0.0, 0.5, -0.1, 0.1),
+        star_min_vmag=10.0,  # high floor: bins ending below 10 are skipped
+        star_max_vmag=15.0,
+    )
+    star = make_star(unique_number=1, ra=0.1, dec=0.0, vmag=11.2)
+    install_fake_catalogs(monkeypatch, ucac4=[star])
+    out = reduce_catalogs(cast(Any, obs), DEFAULT_CONFIG)
+    assert len(out) == 1
+
+
+def test_reduce_catalogs_upgrades_pretty_name_from_lower_precedence_catalog(
+    monkeypatch: pytest.MonkeyPatch, fake_obs: FakeObs
+) -> None:
+    """A nameless higher-precedence star inherits the named lower-precedence pretty_name."""
+    install_fake_catalogs(
+        monkeypatch,
+        ucac4=[
+            make_star(unique_number=1, ra=0.10, dec=0.0, vmag=5.0, name=''),
+        ],
+        ybsc=[
+            make_star(unique_number=2, ra=0.10, dec=0.0, vmag=5.0, name='Sirius', b_v=0.0),
+        ],
+    )
+    out = reduce_catalogs(cast(Any, fake_obs), DEFAULT_CONFIG)
+    assert len(out) == 1
+    survivor = out[0]
+    assert survivor.catalog_name == 'ucac4'
+    assert survivor.pretty_name == 'Sirius'
+
+
+def test_stars_in_extfov_with_radec_movement_uses_movement_branch(
+    monkeypatch: pytest.MonkeyPatch, fake_obs: FakeObs
+) -> None:
+    """Passing ``radec_movement`` exercises the smear-aware bracket projection."""
+    install_fake_catalogs(
+        monkeypatch,
+        ucac4=[make_star(unique_number=1, ra=0.1, dec=0.0, vmag=5.0)],
+    )
+    out = stars_in_extfov(
+        cast(Any, fake_obs),
+        DEFAULT_CONFIG,
+        catalog_name='ucac4',
+        mag_min=0.0,
+        mag_max=15.0,
+        radec_movement=(1e-5, 1e-5),
+    )
+    # The movement-aware branch projects start / end through tfrac
+    # offsets; the resulting movement vector is non-zero per ``FakeObs``.
+    assert len(out) == 1
+
+
+def test_stars_in_extfov_returns_empty_when_every_star_drops_pre_projection(
+    monkeypatch: pytest.MonkeyPatch, fake_obs: FakeObs
+) -> None:
+    """A reduction whose every record is dropped lands in the empty-projection branch.
+
+    Inject a star that the catalog filter passes (RA / DEC / vmag in
+    range) but whose ``ra`` is set to ``None`` after filtering so the
+    reduction's ``ra is None`` skip drops it before
+    ``_project_stars_to_fov`` runs.  The projection helper sees an empty
+    list and returns ``[]`` directly via the early-return branch.
+    """
+    install_fake_catalogs(
+        monkeypatch,
+        ucac4=[make_star(unique_number=1, ra=0.05, dec=0.05, vmag=5.0)],
+    )
+    cat = cast(Any, nav_catalog.get_ucac4_catalog())
+    cat.stars[0].ra = None
+    out = stars_in_extfov(
+        cast(Any, fake_obs),
+        DEFAULT_CONFIG,
+        catalog_name='ucac4',
+        mag_min=0.0,
+        mag_max=15.0,
+    )
+    assert out == []
+
+
+def test_stars_in_extfov_defensive_none_filter_in_reduction_body(
+    monkeypatch: pytest.MonkeyPatch, fake_obs: FakeObs
+) -> None:
+    """The production reduction's None-filter drops records the catalog yields.
+
+    The shim catalog yields every record (including ones with None RA /
+    DEC / vmag) so the production code's defensive
+    ``if star.ra is None or ...: continue`` branch is reached.
+    """
+    bad = make_star(unique_number=2, ra=0.05, dec=0.05, vmag=5.0)
+    bad.vmag = None  # pass through find_stars's yield-anyway branch
+    good = make_star(unique_number=1, ra=0.05, dec=0.05, vmag=5.0)
+    install_fake_catalogs(monkeypatch, ucac4=[good, bad])
+    out = stars_in_extfov(
+        cast(Any, fake_obs),
+        DEFAULT_CONFIG,
+        catalog_name='ucac4',
+        mag_min=0.0,
+        mag_max=15.0,
+    )
+    assert [s.unique_number for s in out] == [1]
+
+
+def test_stars_in_extfov_ybsc_skips_records_with_none_vmag(
+    monkeypatch: pytest.MonkeyPatch, fake_obs: FakeObs
+) -> None:
+    """YBSC's per-record vmag-None skip is exercised by a None-vmag record."""
+    bad = make_star(unique_number=2, ra=0.05, dec=0.05, vmag=5.0, b_v=0.65)
+    bad.vmag = None
+    install_fake_catalogs(monkeypatch, ybsc=[bad])
+    out = stars_in_extfov(
+        cast(Any, fake_obs),
+        DEFAULT_CONFIG,
+        catalog_name='ybsc',
+        mag_min=0.0,
+        mag_max=15.0,
+    )
+    assert out == []
+
+
+def test_stars_in_extfov_ybsc_uses_vmag_for_johnson_mag_b_when_no_b_v(
+    monkeypatch: pytest.MonkeyPatch, fake_obs: FakeObs
+) -> None:
+    """A YBSC record with ``b_v=None`` populates ``johnson_mag_b`` from ``vmag``."""
+    install_fake_catalogs(
+        monkeypatch,
+        ybsc=[make_star(unique_number=1, ra=0.1, dec=0.0, vmag=5.0, b_v=None)],
+    )
+    out = stars_in_extfov(
+        cast(Any, fake_obs),
+        DEFAULT_CONFIG,
+        catalog_name='ybsc',
+        mag_min=0.0,
+        mag_max=15.0,
+    )
+    assert len(out) == 1
+    assert out[0].johnson_mag_b == 5.0  # mirrors johnson_mag_v
+
+
+def test_merge_catalogs_breaks_inner_loop_on_sorted_prefix() -> None:
+    """A ``later`` star earlier (in dec_pm) than every ``earlier`` star hits the break.
+
+    The inner loop relies on dec_pm-sorted ordering so it can short-circuit
+    once ``prev.dec_pm - star.dec_pm > duplicate_radec``.  Configure
+    earlier=[dec_pm=0.05] and later=[dec_pm=0.0] so the first prev
+    is far above the star's dec_pm and the break fires.
+    """
+    earlier = [make_star(unique_number=1, ra=0.0, dec=0.05, vmag=5.0)]
+    later = [make_star(unique_number=2, ra=0.0, dec=0.0, vmag=5.0)]
+    earlier[0].dec_pm = 0.05
+    earlier[0].ra_pm = 0.0
+    later[0].dec_pm = 0.0
+    later[0].ra_pm = 0.0
+    duplicate_radec = math.radians(5.0 / 3600.0)
+    out = _merge_catalogs(
+        cast(list[MutableStar], earlier),
+        cast(list[MutableStar], later),
+        duplicate_radec=duplicate_radec,
+        duplicate_vmag=2.0,
+    )
+    # No duplicate match -> both stars survive.
+    assert {s.unique_number for s in out} == {1, 2}

--- a/tests/nav/nav_model/stars/test_conflicts.py
+++ b/tests/nav/nav_model/stars/test_conflicts.py
@@ -1,0 +1,108 @@
+"""Tests for ``nav.nav_model.stars.conflicts``."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from nav.nav_model.stars.conflicts import _conflict_body_list, parse_ring_occlusion_annuli
+
+
+def test_parse_ring_occlusion_annuli_normalises_keys() -> None:
+    """Planet keys are normalised to upper case in the returned mapping."""
+    result = parse_ring_occlusion_annuli({'saturn': [[100.0, 200.0]]})
+    assert list(result.keys()) == ['SATURN']
+    assert result['SATURN'] == [(100.0, 200.0)]
+
+
+def test_parse_ring_occlusion_annuli_returns_empty_for_none() -> None:
+    """A ``None`` input is treated as the empty mapping."""
+    assert parse_ring_occlusion_annuli(None) == {}
+
+
+def test_parse_ring_occlusion_annuli_returns_empty_for_empty() -> None:
+    """An empty mapping returns an empty mapping."""
+    assert parse_ring_occlusion_annuli({}) == {}
+
+
+def test_parse_ring_occlusion_annuli_rejects_non_sequence_pair() -> None:
+    """A scalar where a length-2 sequence was expected raises ``ValueError``."""
+    bad: Any = {'SATURN': [123.0]}
+    with pytest.raises(ValueError, match='must be a length-2 sequence'):
+        parse_ring_occlusion_annuli(bad)
+
+
+def test_parse_ring_occlusion_annuli_rejects_wrong_length() -> None:
+    """A length-3 sequence raises ``ValueError`` with the actual length."""
+    with pytest.raises(ValueError, match='must have exactly 2 elements'):
+        parse_ring_occlusion_annuli({'SATURN': [[1.0, 2.0, 3.0]]})
+
+
+def test_parse_ring_occlusion_annuli_rejects_non_numeric() -> None:
+    """A non-numeric inner radius raises ``ValueError`` naming it."""
+    bad: Any = {'SATURN': [['inner', 200.0]]}
+    with pytest.raises(ValueError, match='must be numeric'):
+        parse_ring_occlusion_annuli(bad)
+
+
+def test_parse_ring_occlusion_annuli_rejects_inner_ge_outer() -> None:
+    """Degenerate annuli (inner >= outer) raise ``ValueError``."""
+    with pytest.raises(ValueError, match=r'inner 100\.0 km >= outer 100\.0 km'):
+        parse_ring_occlusion_annuli({'SATURN': [[100.0, 100.0]]})
+
+
+def test_parse_ring_occlusion_annuli_rejects_bool() -> None:
+    """A bool is rejected even though Python admits it as int."""
+    bad: Any = {'SATURN': [[True, 200.0]]}
+    with pytest.raises(ValueError, match='got bool'):
+        parse_ring_occlusion_annuli(bad)
+
+
+def test_parse_ring_occlusion_annuli_rejects_inf() -> None:
+    """Non-finite radii raise ``ValueError`` naming the bad value."""
+    with pytest.raises(ValueError, match='must be finite'):
+        parse_ring_occlusion_annuli({'SATURN': [[float('inf'), 200.0]]})
+
+
+class _FakeObsWithSaturn:
+    """Stand-in for an observation whose closest planet is Saturn."""
+
+    closest_planet = 'SATURN'
+
+
+class _FakeObsNoPlanet:
+    """Stand-in for an observation with no closest planet."""
+
+    closest_planet: str | None = None
+
+
+class _FakeSaturnConfig:
+    """Stand-in for the project config exposing only ``satellites``."""
+
+    @staticmethod
+    def satellites(planet: str) -> list[str]:
+        """Return Saturn's satellites in canonical order."""
+        return ['MIMAS', 'TETHYS'] if planet == 'SATURN' else []
+
+
+class _FakeEmptyConfig:
+    """Stand-in for a config that knows about no satellites."""
+
+    @staticmethod
+    def satellites(planet: str) -> list[str]:
+        """Return an empty list for any planet."""
+        del planet
+        return []
+
+
+def test_conflict_body_list_includes_planet_and_satellites() -> None:
+    """``_conflict_body_list`` returns the planet plus its satellites."""
+    out = _conflict_body_list(cast(Any, _FakeObsWithSaturn()), cast(Any, _FakeSaturnConfig()))
+    assert out == ['SATURN', 'MIMAS', 'TETHYS']
+
+
+def test_conflict_body_list_returns_empty_when_no_closest_planet() -> None:
+    """When ``obs.closest_planet`` is ``None`` the body list is empty."""
+    out = _conflict_body_list(cast(Any, _FakeObsNoPlanet()), cast(Any, _FakeEmptyConfig()))
+    assert out == []

--- a/tests/nav/nav_model/stars/test_detection.py
+++ b/tests/nav/nav_model/stars/test_detection.py
@@ -1,0 +1,303 @@
+"""Tests for ``nav.nav_model.stars.detection``."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+import pytest
+
+if TYPE_CHECKING:
+    from psfmodel import PSF
+
+from nav.nav_model.stars.detection import (
+    DAOPHOT_DEFAULT_DETECTION_SIGMA,
+    DAOPHOT_DEFAULT_ROUNDNESS_BOUND,
+    DAOPHOT_DEFAULT_SHARPNESS_MAX,
+    DAOPHOT_DEFAULT_SHARPNESS_MIN,
+    DetectedSource,
+    _marginal_variance,
+    _sharpness_roundness,
+    apply_shape_cuts,
+    centroid_gaussian_fit,
+    centroid_saturated,
+    detect_ccd_bloom_columns,
+    detect_sources,
+    matched_filter_image,
+)
+
+
+class _FakePSF:
+    """Gaussian-like PSF stand-in exposing ``sigma``."""
+
+    def __init__(self, sigma: float = 1.2) -> None:
+        self.sigma = sigma
+
+
+def _gaussian_kernel(size: int, sigma: float) -> np.ndarray:
+    """Render a 2-D Gaussian PSF of the given pixel size and sigma."""
+    coords = np.arange(size) - (size - 1) / 2.0
+    g1 = np.exp(-(coords**2) / (2.0 * sigma**2))
+    return np.outer(g1, g1)
+
+
+def test_constants_have_documented_values() -> None:
+    """Default cuts come straight from the module-level constants."""
+    assert pytest.approx(4.0) == DAOPHOT_DEFAULT_DETECTION_SIGMA
+    assert pytest.approx(0.2) == DAOPHOT_DEFAULT_SHARPNESS_MIN
+    assert pytest.approx(1.0) == DAOPHOT_DEFAULT_SHARPNESS_MAX
+    assert pytest.approx(1.0) == DAOPHOT_DEFAULT_ROUNDNESS_BOUND
+
+
+def test_matched_filter_image_rejects_zero_kernel() -> None:
+    """A flat kernel has zero energy after mean subtraction; the helper raises."""
+    image = np.zeros((10, 10), dtype=np.float64)
+    kernel = np.ones((3, 3), dtype=np.float64)
+    with pytest.raises(ValueError, match='zero energy'):
+        matched_filter_image(image, kernel=kernel)
+
+
+def test_matched_filter_image_returns_input_shape() -> None:
+    """The matched-filter response shares the input shape."""
+    image = np.zeros((20, 30), dtype=np.float64)
+    kernel = _gaussian_kernel(5, 1.0)
+    out = matched_filter_image(image, kernel=kernel)
+    assert out.shape == image.shape
+
+
+def test_matched_filter_image_rejects_non_2d_image() -> None:
+    """A non-2-D image raises ``TypeError`` mentioning the rank."""
+    image = np.zeros(10, dtype=np.float64)
+    with pytest.raises(TypeError, match='requires a 2-D image'):
+        matched_filter_image(image, kernel=_gaussian_kernel(3, 1.0))
+
+
+def test_matched_filter_image_rejects_non_2d_kernel() -> None:
+    """A non-2-D kernel raises ``TypeError`` mentioning the rank."""
+    image = np.zeros((5, 5), dtype=np.float64)
+    with pytest.raises(TypeError, match='kernel must be 2-D'):
+        matched_filter_image(image, kernel=np.ones(3, dtype=np.float64))
+
+
+def test_detect_ccd_bloom_columns_marks_full_column() -> None:
+    """A 5-row saturation run marks the entire column True."""
+    image = np.zeros((10, 5), dtype=np.float64)
+    image[2:7, 2] = 5000.0
+    mask = detect_ccd_bloom_columns(image, full_well_dn=4095.0, min_run=5)
+    assert mask[:, 2].all()
+    expected_other = np.zeros_like(mask, dtype=bool)
+    expected_other[:, 2] = True
+    assert (mask == expected_other).all()
+
+
+def test_detect_ccd_bloom_columns_skips_short_run() -> None:
+    """A 4-row saturation run is below ``min_run=5`` and produces no bloom mask."""
+    image = np.zeros((10, 5), dtype=np.float64)
+    image[2:6, 2] = 5000.0
+    mask = detect_ccd_bloom_columns(image, full_well_dn=4095.0, min_run=5)
+    assert not mask.any()
+
+
+def test_detect_ccd_bloom_columns_rejects_min_run_below_2() -> None:
+    """``min_run < 2`` raises ``ValueError`` naming the value."""
+    image = np.zeros((5, 5), dtype=np.float64)
+    with pytest.raises(ValueError, match='min_run must be >= 2'):
+        detect_ccd_bloom_columns(image, full_well_dn=4095.0, min_run=1)
+
+
+def test_centroid_gaussian_fit_returns_zero_offset_for_centred_blob() -> None:
+    """A symmetric Gaussian centred on the box returns ``(0, 0)``."""
+    box = _gaussian_kernel(5, 1.0)
+    dv, du = centroid_gaussian_fit(box)
+    assert dv == pytest.approx(0.0, abs=1e-9)
+    assert du == pytest.approx(0.0, abs=1e-9)
+
+
+def test_centroid_gaussian_fit_offset_centroid() -> None:
+    """A blob shifted by 1 pixel right returns positive ``du``."""
+    full = np.zeros((5, 5), dtype=np.float64)
+    full[2, 3] = 100.0
+    full[2, 2] = 30.0
+    full[2, 4] = 30.0
+    dv, du = centroid_gaussian_fit(full)
+    assert dv == pytest.approx(0.0, abs=1e-9)
+    assert du > 0.0
+
+
+def test_centroid_gaussian_fit_rejects_non_square_box() -> None:
+    """An even-sided or non-square box raises ``ValueError`` with shape."""
+    box = np.zeros((4, 4), dtype=np.float64)
+    with pytest.raises(ValueError, match='must be square odd'):
+        centroid_gaussian_fit(box)
+
+
+def test_centroid_saturated_uses_annular_moment() -> None:
+    """Saturated cores fall back to an annular brightness moment."""
+    box = np.zeros((5, 5), dtype=np.float64)
+    # Saturated centre + lit annulus on the right side.
+    box[2, 2] = 4096.0
+    box[2, 3] = 1000.0
+    box[1, 3] = 500.0
+    box[3, 3] = 500.0
+    dv, du = centroid_saturated(box, full_well_dn=4095.0, half_width_inner=1, half_width_outer=2)
+    assert dv == pytest.approx(0.0, abs=1e-6)
+    assert du > 0.0
+
+
+def test_centroid_saturated_rejects_inverted_annulus() -> None:
+    """``half_width_inner >= half_width_outer`` raises ``ValueError``."""
+    box = np.zeros((5, 5), dtype=np.float64)
+    with pytest.raises(ValueError, match='expected 0 <= half_width_inner'):
+        centroid_saturated(box, full_well_dn=4095.0, half_width_inner=2, half_width_outer=2)
+
+
+def test_apply_shape_cuts_keeps_clean_detection() -> None:
+    """A typical PSF detection (sharp ~0.5, round ~0) passes the default cuts."""
+    assert apply_shape_cuts(0.5, 0.0)
+
+
+def test_apply_shape_cuts_rejects_hot_pixel() -> None:
+    """A single-pixel spike (sharpness above max) is rejected."""
+    assert not apply_shape_cuts(1.5, 0.0)
+
+
+def test_apply_shape_cuts_rejects_extended_source() -> None:
+    """A wide blob (sharpness below min) is rejected."""
+    assert not apply_shape_cuts(0.05, 0.0)
+
+
+def test_apply_shape_cuts_rejects_high_roundness() -> None:
+    """A bloom-shaped detection (|roundness| > 1) is rejected."""
+    assert not apply_shape_cuts(0.5, 1.5)
+
+
+def test_detect_sources_finds_planted_star() -> None:
+    """A single Gaussian planted in noise is recovered with sub-pixel centroid."""
+    rng = np.random.default_rng(0)
+    image = rng.normal(scale=0.5, size=(50, 50)).astype(np.float64)
+    star = _gaussian_kernel(7, 1.2) * 200.0
+    image[20:27, 30:37] += star
+    psf = _FakePSF(sigma=1.2)
+    smear = _gaussian_kernel(7, 1.2)
+    sources = detect_sources(
+        image,
+        psf=psf,  # type: ignore[arg-type]
+        image_noise_sigma=0.5,
+        full_well_dn=10_000.0,
+        smear_kernel=smear,
+        bloom_mask=None,
+        detection_sigma=4.0,
+    )
+    assert len(sources) >= 1
+    best = max(sources, key=lambda s: s.peak_dn)
+    assert best.v == pytest.approx(23.0, abs=0.6)
+    assert best.u == pytest.approx(33.0, abs=0.6)
+    assert isinstance(best, DetectedSource)
+    assert best.saturated is False
+
+
+def test_detect_sources_skips_bloom_columns() -> None:
+    """Detections falling inside the bloom mask are suppressed."""
+    image = np.zeros((30, 30), dtype=np.float64)
+    star = _gaussian_kernel(5, 1.0) * 200.0
+    image[10:15, 10:15] += star
+    psf = _FakePSF(sigma=1.0)
+    smear = _gaussian_kernel(5, 1.0)
+    bloom = np.zeros_like(image, dtype=bool)
+    bloom[:, 10:15] = True
+    sources = detect_sources(
+        image,
+        psf=psf,  # type: ignore[arg-type]
+        image_noise_sigma=0.5,
+        full_well_dn=10_000.0,
+        smear_kernel=smear,
+        bloom_mask=bloom,
+        detection_sigma=4.0,
+    )
+    assert sources == []
+
+
+def test_centroid_gaussian_fit_returns_zero_when_box_is_below_background() -> None:
+    """A box where every pixel is at the median returns ``(0, 0)``."""
+    box = np.full((5, 5), 100.0, dtype=np.float64)
+    assert centroid_gaussian_fit(box) == (0.0, 0.0)
+
+
+def test_centroid_saturated_returns_zero_when_annulus_below_background() -> None:
+    """A saturated box with no annular signal returns ``(0, 0)``."""
+    box = np.full((5, 5), 100.0, dtype=np.float64)
+    box[2, 2] = 5000.0  # saturated centre, no annular signal
+    out = centroid_saturated(box, full_well_dn=4095.0, half_width_inner=1, half_width_outer=2)
+    assert out == (0.0, 0.0)
+
+
+def test_centroid_saturated_rejects_even_sided_box() -> None:
+    """A 4x4 box raises ``ValueError`` mentioning the shape."""
+    box = np.zeros((4, 4), dtype=np.float64)
+    with pytest.raises(ValueError, match='must be square odd'):
+        centroid_saturated(box, full_well_dn=4095.0, half_width_inner=0, half_width_outer=2)
+
+
+def test_psf_sigma_falls_back_to_fwhm_when_no_sigma_attribute() -> None:
+    """``detect_sources`` uses ``psf.fwhm()`` when ``psf.sigma`` is absent."""
+
+    class _FwhmOnlyPSF:
+        def fwhm(self) -> float:
+            return 2.3548200450309493  # sigma == 1.0
+
+    image = np.zeros((30, 30), dtype=np.float64)
+    smear = _gaussian_kernel(5, 1.0)
+    sources = detect_sources(
+        image,
+        psf=cast('PSF', _FwhmOnlyPSF()),
+        image_noise_sigma=0.5,
+        full_well_dn=10_000.0,
+        smear_kernel=smear,
+    )
+    assert sources == []
+
+
+def test_detect_sources_finds_saturated_star() -> None:
+    """A bright planted star drives ``saturated=True`` on the detection."""
+    rng = np.random.default_rng(0)
+    image = rng.normal(scale=0.5, size=(50, 50)).astype(np.float64)
+    star = _gaussian_kernel(7, 1.2) * 50_000.0
+    image[20:27, 30:37] += star
+    sources = detect_sources(
+        image,
+        psf=cast('PSF', _FakePSF(sigma=1.2)),
+        image_noise_sigma=0.5,
+        full_well_dn=10_000.0,
+        smear_kernel=_gaussian_kernel(7, 1.2),
+    )
+    assert any(s.saturated for s in sources)
+
+
+def test_sharpness_roundness_returns_zero_for_dark_centre() -> None:
+    """A dark-centre box returns ``(0, 0)`` directly via the ``centre <= 0`` early-out."""
+    box = np.full((5, 5), -1.0, dtype=np.float64)
+    sharp, round_ = _sharpness_roundness(box)
+    assert sharp == 0.0
+    assert round_ == 0.0
+
+
+def test_sharpness_roundness_returns_zero_round_when_marginals_are_flat() -> None:
+    """Symmetric marginals collapse the variance to zero; roundness is 0."""
+    # Uniform fill; col_var == row_var == 0 -> roundness = 0 by short-circuit.
+    box = np.full((5, 5), 100.0, dtype=np.float64)
+    box[2, 2] = 200.0  # bump the centre so ``centre > 0``
+    sharp, round_ = _sharpness_roundness(box)
+    assert round_ == 0.0
+    assert sharp > 0.0
+
+
+def test_sharpness_roundness_rejects_non_square_box() -> None:
+    """A non-square box raises ``ValueError`` mentioning the shape."""
+    box = np.zeros((4, 4), dtype=np.float64)
+    with pytest.raises(ValueError, match='must be square odd'):
+        _sharpness_roundness(box)
+
+
+def test_marginal_variance_returns_zero_for_uniform_profile() -> None:
+    """A uniform profile has zero unmasked weight; the helper returns 0."""
+    assert _marginal_variance(np.full(5, 100.0)) == 0.0

--- a/tests/nav/nav_model/stars/test_nav_model_stars.py
+++ b/tests/nav/nav_model/stars/test_nav_model_stars.py
@@ -1,0 +1,404 @@
+"""Integration-style tests for ``NavModelStars`` using stub-based obs.
+
+These tests exercise the end-to-end ``create_model`` /
+``to_features`` / ``to_annotations`` contract by injecting a fake
+catalog reduction plus fake mask context, so the path that builds
+``NavFeature`` instances, computes the CRLB covariance, and emits
+annotations is covered without requiring real SPICE / catalog data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, cast
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from nav.annotation import Annotations
+from nav.feature.constants import MIN_ANISOTROPIC_SMEAR_PX
+from nav.feature.feature_type import NavFeatureType
+from nav.feature.flags import StarFlags
+from nav.feature.geometry import StarGeometry
+from nav.nav_model.stars.nav_model_stars import (
+    NavModelStars,
+    _compute_smear_for_obs,
+    _crlb_covariance,
+    _reliability_from_snr,
+    _safe_mask_lookup,
+    _snr_reason_score,
+    _star_feature_id,
+)
+from nav.nav_orchestrator.nav_context import NavContext
+from nav.support.types import MutableStar
+
+
+@dataclass
+class _FakeMutableStar:
+    """Minimal star record exposing the fields ``NavModelStars`` reads."""
+
+    catalog_name: str = 'UCAC4'
+    unique_number: int | None = 12345
+    pretty_name: str = '12345'
+    name: str = ''
+    vmag: float | None = 5.0
+    spectral_class: str = 'G0'
+    psf_size: tuple[int, int] = (5, 5)
+    u: float = 50.0
+    v: float = 60.0
+    move_u: float = 0.0
+    move_v: float = 0.0
+    ra_pm: float = 0.0
+    dec_pm: float = 0.0
+    conflicts: str = ''
+    dn: float = 1.0
+
+
+class _FakePSF:
+    """PSF stand-in returning a Gaussian sigma."""
+
+    def __init__(self, sigma: float = 1.0) -> None:
+        self.sigma = sigma
+
+
+class _FakeStarsConfig:
+    """Stand-in for ``config.stars`` exposing only the fields we need."""
+
+    label_font: str = 'Liberation Mono'
+    label_font_size: int = 10
+    label_font_color: tuple[int, int, int] = (255, 0, 0)
+    label_star_color: tuple[int, int, int] = (255, 255, 0)
+    max_smear: float = 100.0
+    min_predicted_snr: float = 0.0
+
+
+@dataclass
+class _FakeContext:
+    """Per-image NavContext stand-in carrying the masks NavModelStars consults."""
+
+    image_noise_sigma: float = 0.5
+    saturation_mask_ext: np.ndarray = field(
+        default_factory=lambda: np.zeros((128, 128), dtype=bool)
+    )
+    cosmic_ray_mask_ext: np.ndarray = field(
+        default_factory=lambda: np.zeros((128, 128), dtype=bool)
+    )
+
+
+class _FakeObs:
+    """Observation stand-in covering the methods ``NavModelStars`` reads."""
+
+    def __init__(self, *, extfov_margin: int = 14) -> None:
+        self.extfov_margin_v = extfov_margin
+        self.extfov_margin_u = extfov_margin
+        self.extdata_shape_vu = (128, 128)
+        self.data_shape_v = 100
+        self.data_shape_u = 100
+        self._psf = _FakePSF(sigma=1.0)
+
+    def star_psf(self) -> _FakePSF:
+        """Return the fake PSF shared by every test star."""
+        return self._psf
+
+    def make_extfov_false(self) -> np.ndarray:
+        """Return a False-filled boolean array of the extfov shape."""
+        return np.zeros(self.extdata_shape_vu, dtype=bool)
+
+    def make_extfov_zeros(self) -> np.ndarray:
+        """Return a zero-filled float64 array of the extfov shape."""
+        return np.zeros(self.extdata_shape_vu, dtype=np.float64)
+
+    def clip_extfov(self, u: int, v: int) -> tuple[int, int]:
+        """Clip ``(u, v)`` inside the extfov rectangle."""
+        return (
+            int(np.clip(u, 0, self.extdata_shape_vu[1] - 1)),
+            int(np.clip(v, 0, self.extdata_shape_vu[0] - 1)),
+        )
+
+
+def _make_model() -> tuple[NavModelStars, _FakeObs]:
+    """Build a NavModelStars instance with the fake obs and stars config."""
+    obs = _FakeObs()
+    config = mock.Mock()
+    config.stars = _FakeStarsConfig()
+    model = NavModelStars('stars', cast(Any, obs), config=config)
+    # Bypass the catalog reduction in tests by injecting our own list.
+    return model, obs
+
+
+def test_star_feature_id_uses_catalog_and_unique_number() -> None:
+    """``feature_id`` is ``star:<CATALOG>:<unique_number>``."""
+    star = _FakeMutableStar(catalog_name='ybsc', unique_number=42, pretty_name='Sirius')
+    assert _star_feature_id(cast(MutableStar, star)) == 'star:YBSC:42'
+
+
+def test_star_feature_id_falls_back_to_pretty_name() -> None:
+    """When ``unique_number`` is ``None`` the helper uses ``pretty_name``."""
+    star = _FakeMutableStar(catalog_name='ucac4', unique_number=None, pretty_name='Vega')
+    assert _star_feature_id(cast(MutableStar, star)) == 'star:UCAC4:Vega'
+
+
+def test_crlb_covariance_isotropic_below_smear_threshold() -> None:
+    """Below the anisotropy threshold the covariance is ``sigma_psf^2 / SNR * I``."""
+    cov = _crlb_covariance(snr=10.0, sigma_psf=1.0, move_v=0.0, move_u=0.0)
+    expected_sigma2 = 1.0 / 10.0
+    expected = expected_sigma2 * np.eye(2)
+    assert np.allclose(cov, expected, atol=1e-12)
+
+
+def test_crlb_covariance_anisotropic_along_smear() -> None:
+    """The major axis of the covariance lies along the smear vector."""
+    cov = _crlb_covariance(snr=10.0, sigma_psf=1.0, move_v=4.0, move_u=0.0)
+    # Eigenvalues of cov; the larger one is along the smear axis.
+    eigvals, eigvecs = np.linalg.eigh(cov)
+    largest_axis = eigvecs[:, np.argmax(eigvals)]
+    # Major axis should lie along v (since smear is purely along v).
+    assert abs(largest_axis[0]) > abs(largest_axis[1])
+
+
+def test_crlb_covariance_smear_threshold_boundary() -> None:
+    """Smear exactly at MIN_ANISOTROPIC_SMEAR_PX is still treated isotropically.
+
+    The threshold check is strict ``<``, so a smear of MIN-eps falls
+    into the isotropic branch.
+    """
+    smear = MIN_ANISOTROPIC_SMEAR_PX - 0.001
+    cov = _crlb_covariance(snr=10.0, sigma_psf=1.0, move_v=smear, move_u=0.0)
+    assert np.allclose(cov, cov[0, 0] * np.eye(2), atol=1e-12)
+
+
+def test_crlb_covariance_zero_snr_returns_huge() -> None:
+    """A zero or negative SNR returns a huge isotropic covariance."""
+    cov = _crlb_covariance(snr=0.0, sigma_psf=1.0, move_v=0.0, move_u=0.0)
+    assert cov[0, 0] == pytest.approx(1e6)
+
+
+def test_crlb_covariance_rejects_zero_psf_sigma() -> None:
+    """A zero or negative PSF sigma raises ``ValueError`` naming the bad value."""
+    with pytest.raises(ValueError, match='sigma_psf must be > 0'):
+        _crlb_covariance(snr=5.0, sigma_psf=0.0, move_v=0.0, move_u=0.0)
+
+
+def test_reliability_from_snr_zero_when_in_body() -> None:
+    """A body-occluded star has zero reliability."""
+    out = _reliability_from_snr(snr=20.0, in_body=True, in_ring=False, in_saturation=False)
+    assert out == 0.0
+
+
+def test_reliability_from_snr_zero_when_in_ring() -> None:
+    """A ring-occluded star has zero reliability."""
+    out = _reliability_from_snr(snr=20.0, in_body=False, in_ring=True, in_saturation=False)
+    assert out == 0.0
+
+
+def test_reliability_from_snr_zero_when_in_saturation() -> None:
+    """A saturated / cosmic-ray pixel produces zero reliability."""
+    out = _reliability_from_snr(snr=20.0, in_body=False, in_ring=False, in_saturation=True)
+    assert out == 0.0
+
+
+def test_reliability_from_snr_monotone_in_snr() -> None:
+    """For valid stars the reliability is monotone increasing in SNR."""
+    low = _reliability_from_snr(snr=5.0, in_body=False, in_ring=False, in_saturation=False)
+    high = _reliability_from_snr(snr=20.0, in_body=False, in_ring=False, in_saturation=False)
+    assert high > low
+
+
+def test_snr_reason_score_uses_min_snr_when_set() -> None:
+    """When a configured floor is non-zero the score is ``snr/min_snr``."""
+    assert _snr_reason_score(snr=4.0, min_snr=8.0) == pytest.approx(0.5)
+
+
+def test_snr_reason_score_caps_at_one() -> None:
+    """The breakdown score saturates at 1.0."""
+    assert _snr_reason_score(snr=200.0, min_snr=8.0) == 1.0
+
+
+def test_snr_reason_score_default_centre_50() -> None:
+    """When no floor is configured the score saturates at SNR=50."""
+    assert _snr_reason_score(snr=50.0, min_snr=0.0) == 1.0
+    assert _snr_reason_score(snr=25.0, min_snr=0.0) == pytest.approx(0.5)
+
+
+def test_to_features_empty_when_no_stars() -> None:
+    """``to_features`` returns ``[]`` when the reduced star list is empty."""
+    model, _obs = _make_model()
+    model._stars = []
+    out = model.to_features(cast(NavContext, _FakeContext()))
+    assert out == []
+
+
+def test_to_features_emits_one_feature_per_star() -> None:
+    """One STAR feature is emitted per reduced star above the SNR floor."""
+    model, _obs = _make_model()
+    star = _FakeMutableStar(vmag=4.0, u=50.0, v=60.0)
+    model._stars = [cast(MutableStar, star)]
+    features = model.to_features(cast(NavContext, _FakeContext()))
+    assert len(features) == 1
+    feat = features[0]
+    assert feat.feature_type is NavFeatureType.STAR
+    assert isinstance(feat.geometry, StarGeometry)
+    assert isinstance(feat.flags, StarFlags)
+    assert feat.feature_id == 'star:UCAC4:12345'
+
+
+def test_to_features_skips_below_min_snr() -> None:
+    """Stars with predicted SNR below the configured floor are skipped."""
+    model, _obs = _make_model()
+    cfg = mock.Mock()
+    cfg.stars = _FakeStarsConfig()
+    cfg.stars.min_predicted_snr = 1e6
+    model._stars_config = cfg.stars
+    model._stars = [cast(MutableStar, _FakeMutableStar())]
+    assert model.to_features(cast(NavContext, _FakeContext())) == []
+
+
+def test_to_features_returns_empty_when_noise_zero() -> None:
+    """A zero or negative noise sigma triggers an empty feature list."""
+    model, _obs = _make_model()
+    model._stars = [cast(MutableStar, _FakeMutableStar())]
+    ctx = _FakeContext(image_noise_sigma=0.0)
+    assert model.to_features(cast(NavContext, ctx)) == []
+
+
+def test_to_features_skips_when_smear_exceeds_max() -> None:
+    """A star whose smear exceeds ``stars.max_smear`` is dropped from the feature list."""
+    model, _obs = _make_model()
+    cfg = mock.Mock()
+    cfg.stars = _FakeStarsConfig()
+    cfg.stars.max_smear = 1.0
+    model._stars_config = cfg.stars
+    star = _FakeMutableStar(move_v=10.0, move_u=10.0)
+    model._stars = [cast(MutableStar, star)]
+    assert model.to_features(cast(NavContext, _FakeContext())) == []
+
+
+def test_to_features_marks_in_body_when_conflict_set() -> None:
+    """A star tagged with a BODY conflict is emitted with ``in_body_silhouette=True``."""
+    model, _obs = _make_model()
+    star = _FakeMutableStar(conflicts='BODY: MIMAS')
+    model._stars = [cast(MutableStar, star)]
+    feat = model.to_features(cast(NavContext, _FakeContext()))[0]
+    assert isinstance(feat.flags, StarFlags)
+    assert feat.flags.in_body_silhouette is True
+    assert feat.reliability == 0.0
+
+
+def test_to_annotations_empty_when_no_stars() -> None:
+    """``to_annotations`` returns an empty collection when no stars are reduced."""
+    model, _obs = _make_model()
+    model._stars = []
+    annotations = model.to_annotations(cast(NavContext, _FakeContext()))
+    assert isinstance(annotations, Annotations)
+    assert len(annotations.annotations) == 0
+
+
+def test_instances_for_obs_returns_single_stars_model() -> None:
+    """``NavModelStars.instances_for_obs`` returns one model per observation."""
+    obs = _FakeObs()
+    instances = NavModelStars.instances_for_obs(cast(Any, obs))
+    assert len(instances) == 1
+    assert instances[0].name == 'stars'
+
+
+def test_create_model_populates_metadata_and_star_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``create_model`` records start / end times, elapsed, and star count.
+
+    The catalog reduction and conflict marking are monkeypatched to
+    return a controlled list so the metadata path is exercised without
+    needing real catalogs or SPICE.
+    """
+    model, _obs = _make_model()
+    star = _FakeMutableStar()
+    monkeypatch.setattr(
+        'nav.nav_model.stars.nav_model_stars.reduce_catalogs',
+        lambda _obs, _config: [cast(MutableStar, star)],
+    )
+    monkeypatch.setattr(
+        'nav.nav_model.stars.nav_model_stars.mark_body_and_ring_conflicts',
+        lambda _obs, _config, _stars: None,
+    )
+    monkeypatch.setattr(
+        'nav.nav_model.stars.nav_model_stars._compute_smear_for_obs',
+        lambda _obs: (0.0, 0.0),
+    )
+    model.create_model()
+    assert model.metadata['star_count'] == 1
+    assert model.metadata['elapsed_time_sec'] >= 0.0
+    assert isinstance(model.metadata['stars'], list)
+    assert model.metadata['stars'][0]['catalog_name'] == 'UCAC4'
+    assert len(model.stars) == 1
+
+
+def test_to_annotations_renders_overlay_for_usable_stars() -> None:
+    """``to_annotations`` paints star-box overlays + label entries for usable stars.
+
+    Exercises the ``_build_annotations`` path (overlay drawing, avoid
+    mask, label-position generation, and ``Annotation`` construction).
+    """
+    model, _obs = _make_model()
+    star = _FakeMutableStar(unique_number=1, vmag=4.0, u=50.0, v=60.0)
+    model._stars = [cast(MutableStar, star)]
+    annotations = model.to_annotations(cast(NavContext, _FakeContext()))
+    # One ``Annotation`` whose text_info carries one entry per star.
+    assert len(annotations.annotations) == 1
+    annotation = annotations.annotations[0]
+    assert len(annotation.text_info_list) == 1
+
+
+def test_to_annotations_skips_stars_blocked_by_body_or_ring() -> None:
+    """A star tagged with a BODY or RING conflict is excluded from the overlay."""
+    model, _obs = _make_model()
+    star_ok = _FakeMutableStar(unique_number=1, vmag=4.0, u=50.0, v=60.0)
+    star_blocked = _FakeMutableStar(
+        unique_number=2,
+        vmag=5.0,
+        u=60.0,
+        v=70.0,
+        conflicts='BODY: MIMAS',
+    )
+    model._stars = [cast(MutableStar, star_ok), cast(MutableStar, star_blocked)]
+    annotations = model.to_annotations(cast(NavContext, _FakeContext()))
+    annotation = annotations.annotations[0]
+    # Only the unblocked star contributes a label.
+    assert len(annotation.text_info_list) == 1
+
+
+def test_to_annotations_keeps_stars_with_star_only_conflict() -> None:
+    """A star tagged with the ``'STAR'`` conflict is still labelled."""
+    model, _obs = _make_model()
+    star = _FakeMutableStar(unique_number=1, vmag=4.0, u=50.0, v=60.0, conflicts='STAR')
+    model._stars = [cast(MutableStar, star)]
+    annotations = model.to_annotations(cast(NavContext, _FakeContext()))
+    assert len(annotations.annotations[0].text_info_list) == 1
+
+
+def test_compute_smear_returns_zero_when_obs_lacks_boresight() -> None:
+    """``_compute_smear_for_obs`` returns ``(0, 0)`` when ``obs`` has no boresight API."""
+
+    class _NoBoresightObs:
+        """Minimal obs stand-in lacking ``boresight_ra`` / ``boresight_dec``."""
+
+    out = _compute_smear_for_obs(cast(Any, _NoBoresightObs()))
+    assert out == (0.0, 0.0)
+
+
+def test_safe_mask_lookup_returns_false_for_none_mask() -> None:
+    """``_safe_mask_lookup`` returns False when ``mask`` is None."""
+    assert _safe_mask_lookup(None, 5.0, 5.0) is False
+
+
+def test_safe_mask_lookup_returns_false_for_empty_mask() -> None:
+    """``_safe_mask_lookup`` returns False for a 0-element mask."""
+    assert _safe_mask_lookup(np.zeros(0), 5.0, 5.0) is False
+
+
+def test_safe_mask_lookup_clamps_indices_to_bounds() -> None:
+    """Out-of-range coordinates are clamped to the mask's shape."""
+    mask = np.zeros((10, 10), dtype=bool)
+    mask[9, 9] = True
+    assert _safe_mask_lookup(mask, 100.0, 100.0) is True
+    mask2 = np.zeros((10, 10), dtype=bool)
+    mask2[0, 0] = True
+    assert _safe_mask_lookup(mask2, -100.0, -100.0) is True

--- a/tests/nav/nav_model/stars/test_predicted_snr.py
+++ b/tests/nav/nav_model/stars/test_predicted_snr.py
@@ -1,0 +1,127 @@
+"""Tests for ``nav.nav_model.stars.predicted_snr``."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from starcat import SCLASS_TO_B_MINUS_V as CANONICAL_SCLASS_TO_B_MINUS_V
+
+from nav.nav_model.stars.predicted_snr import (
+    SCLASS_TO_B_MINUS_V,
+    integrated_signal_dn,
+    predicted_snr,
+    psf_aperture_pixels,
+    psf_sigma_px,
+)
+
+
+@dataclass
+class _FakeStar:
+    """Minimal star stand-in for predicted_snr tests."""
+
+    vmag: float | None
+
+
+class _FakeGaussianPSF:
+    """Minimal PSF stand-in exposing only a ``sigma`` attribute."""
+
+    def __init__(self, sigma: float) -> None:
+        self.sigma = sigma
+
+
+class _FakeFwhmPSF:
+    """PSF stand-in that exposes ``fwhm()`` but not ``sigma``."""
+
+    def __init__(self, fwhm: float) -> None:
+        self._fwhm = fwhm
+
+    def fwhm(self) -> float:
+        """Return the constant FWHM passed at construction."""
+        return self._fwhm
+
+
+def test_psf_sigma_px_reads_sigma_attribute() -> None:
+    """``psf_sigma_px`` returns the PSF's ``sigma`` attribute when present."""
+    assert psf_sigma_px(_FakeGaussianPSF(sigma=1.25)) == 1.25  # type: ignore[arg-type]
+
+
+def test_psf_sigma_px_falls_back_to_fwhm() -> None:
+    """When ``sigma`` is absent, the helper converts FWHM via the Gaussian factor."""
+    psf = _FakeFwhmPSF(fwhm=2.3548200450309493)
+    assert math.isclose(psf_sigma_px(psf), 1.0, rel_tol=1e-12)  # type: ignore[arg-type]
+
+
+def test_psf_sigma_px_raises_when_neither_sigma_nor_fwhm_present() -> None:
+    """The helper raises ``AttributeError`` for an unsupported PSF subclass."""
+
+    class _NoApiPSF:
+        pass
+
+    with pytest.raises(AttributeError, match='exposes neither sigma nor fwhm'):
+        psf_sigma_px(_NoApiPSF())  # type: ignore[arg-type]
+
+
+def test_psf_aperture_pixels_returns_4_pi_sigma_squared() -> None:
+    """The aperture matches the Gaussian noise-equivalent area formula."""
+    expected = 4.0 * math.pi * 0.7 * 0.7
+    assert math.isclose(psf_aperture_pixels(0.7), expected, rel_tol=1e-12)
+
+
+def test_psf_aperture_pixels_rejects_non_positive_sigma() -> None:
+    """A zero or negative sigma raises ``ValueError`` with the offending value."""
+    with pytest.raises(ValueError, match='sigma_px_value must be > 0'):
+        psf_aperture_pixels(0.0)
+
+
+def test_integrated_signal_dn_uses_canonical_anchor() -> None:
+    """The flux-to-DN scaling matches ``2.512 ** -(vmag - 4)`` at vmag=4."""
+    star: Any = _FakeStar(vmag=4.0)
+    assert math.isclose(integrated_signal_dn(star, mag_offset=0.0), 1.0, rel_tol=1e-12)
+
+
+def test_integrated_signal_dn_applies_mag_offset() -> None:
+    """The mag offset shifts the catalog magnitude before the flux conversion."""
+    star: Any = _FakeStar(vmag=4.0)
+    expected = 2.512 ** -(4.0 + 0.5 - 4.0)
+    assert math.isclose(integrated_signal_dn(star, mag_offset=0.5), expected, rel_tol=1e-12)
+
+
+def test_integrated_signal_dn_returns_zero_when_vmag_missing() -> None:
+    """Stars without a catalog vmag produce zero predicted DN."""
+    star: Any = _FakeStar(vmag=None)
+    assert integrated_signal_dn(star, mag_offset=0.0) == 0.0
+
+
+def test_predicted_snr_matches_design_formula() -> None:
+    """Predicted SNR matches the design's matched-filter form for known inputs."""
+    star: Any = _FakeStar(vmag=4.0)
+    psf: Any = _FakeGaussianPSF(sigma=1.0)
+    image_noise_sigma = 0.5
+    sig = 1.0
+    aperture = 4.0 * math.pi
+    expected = sig / math.sqrt(sig + image_noise_sigma**2 * aperture)
+    out = predicted_snr(star, psf=psf, image_noise_sigma=image_noise_sigma)
+    assert math.isclose(out, expected, rel_tol=1e-12)
+
+
+def test_predicted_snr_returns_zero_for_missing_vmag() -> None:
+    """A star with no vmag produces zero SNR (no signal)."""
+    star: Any = _FakeStar(vmag=None)
+    psf: Any = _FakeGaussianPSF(sigma=1.0)
+    assert predicted_snr(star, psf=psf, image_noise_sigma=0.5) == 0.0
+
+
+def test_predicted_snr_raises_for_non_positive_noise_sigma() -> None:
+    """A non-positive noise sigma raises ``ValueError`` naming the bad value."""
+    star: Any = _FakeStar(vmag=4.0)
+    psf: Any = _FakeGaussianPSF(sigma=1.0)
+    with pytest.raises(ValueError, match='image_noise_sigma must be > 0'):
+        predicted_snr(star, psf=psf, image_noise_sigma=0.0)
+
+
+def test_sclass_to_b_minus_v_re_export_matches_starcat() -> None:
+    """The re-exported lookup table is the same dict as ``starcat``'s."""
+    assert SCLASS_TO_B_MINUS_V is CANONICAL_SCLASS_TO_B_MINUS_V

--- a/tests/nav/nav_model/stars/test_smeared_psf.py
+++ b/tests/nav/nav_model/stars/test_smeared_psf.py
@@ -1,0 +1,182 @@
+"""Tests for ``nav.nav_model.stars.smeared_psf``."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from nav.nav_model.stars.smeared_psf import (
+    compute_smear_vector_px,
+    movement_granularity_px,
+    render_smeared_psf,
+    smear_length_px,
+)
+
+
+def test_smear_length_px_pythagorean() -> None:
+    """``smear_length_px`` returns ``hypot(move_v, move_u)``."""
+    assert smear_length_px(3.0, 4.0) == 5.0
+
+
+def test_smear_length_px_zero_amplitude() -> None:
+    """A motionless exposure has zero smear length."""
+    assert smear_length_px(0.0, 0.0) == 0.0
+
+
+def test_movement_granularity_clamps_to_floor() -> None:
+    """Sub-pixel smears use the 0.1 lower bound."""
+    assert movement_granularity_px(0.05, 0.0, max_steps=50) == pytest.approx(0.1)
+
+
+def test_movement_granularity_clamps_to_ceiling() -> None:
+    """Smears longer than ``max_steps`` pixels saturate at 1.0 px per sample."""
+    assert movement_granularity_px(200.0, 0.0, max_steps=50) == pytest.approx(1.0)
+
+
+def test_movement_granularity_picks_max_axis() -> None:
+    """The granularity is set by the larger of the two axis amplitudes."""
+    assert movement_granularity_px(0.0, 5.0, max_steps=50) == pytest.approx(5.0 / 50.0)
+
+
+def test_movement_granularity_rejects_zero_max_steps() -> None:
+    """Zero or negative ``max_steps`` raises ``ValueError`` naming the value."""
+    with pytest.raises(ValueError, match='max_steps must be > 0'):
+        movement_granularity_px(1.0, 1.0, max_steps=0)
+
+
+@dataclass
+class _FakeStar:
+    """Minimal star stand-in used by the smeared-PSF renderer."""
+
+    psf_size: tuple[int, int]
+    move_v: float
+    move_u: float
+    u: float
+    v: float
+    dn: float
+
+
+class _FakePSF:
+    """PSF stand-in returning a deterministic stamp via ``eval_rect``.
+
+    The stamp shape is determined by ``rect_size``.  The contents encode
+    ``offset`` so tests can verify the call signature.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def eval_rect(
+        self,
+        rect_size: tuple[int, int],
+        *,
+        offset: tuple[float, float],
+        scale: float,
+        movement: tuple[float, float],
+        movement_granularity: float,
+    ) -> np.ndarray:
+        """Record arguments and return a constant stamp filled with ``scale``."""
+        self.calls.append(
+            {
+                'rect_size': rect_size,
+                'offset': offset,
+                'scale': scale,
+                'movement': movement,
+                'movement_granularity': movement_granularity,
+            }
+        )
+        out = np.full(rect_size, fill_value=scale, dtype=np.float64)
+        return out
+
+
+def test_render_smeared_psf_passes_movement_through_to_psf() -> None:
+    """``render_smeared_psf`` forwards smear vector and granularity to ``eval_rect``."""
+    psf = _FakePSF()
+    star = _FakeStar(psf_size=(5, 5), move_v=1.5, move_u=2.5, u=10.4, v=20.7, dn=100.0)
+    stamp = render_smeared_psf(psf, star=star, max_movement_steps=50)  # type: ignore[arg-type]
+    assert len(psf.calls) == 1
+    call = psf.calls[0]
+    expected_half_u = (5 + round(2.5)) // 2
+    expected_half_v = (5 + round(1.5)) // 2
+    assert call['rect_size'] == (expected_half_v * 2 + 1, expected_half_u * 2 + 1)
+    assert call['movement'] == (1.5, 2.5)
+    assert call['scale'] == 100.0
+    expected_offset = (round(20.7 - int(20.7), 6), round(10.4 - int(10.4), 6))
+    actual_offset = (round(call['offset'][0], 6), round(call['offset'][1], 6))  # type: ignore[index]
+    assert actual_offset == expected_offset
+    # 2.5/50 = 0.05 falls below the 0.1 floor so the clamp produces 0.1.
+    granularity = cast(float, call['movement_granularity'])
+    assert math.isclose(granularity, 0.1, rel_tol=1e-12)
+    assert stamp.dtype == np.float64
+
+
+class _FakeUVResult:
+    """Stand-in for ``oops``'s ``UV`` result exposing ``to_scalars()``."""
+
+    def __init__(self, u: float, v: float) -> None:
+        self._u = _Scalar(u)
+        self._v = _Scalar(v)
+
+    def to_scalars(self) -> tuple[_Scalar, _Scalar]:
+        """Return ``(u_scalar, v_scalar)`` mirroring oops's UV API."""
+        return self._u, self._v
+
+
+@dataclass
+class _Scalar:
+    """Stand-in for ``polymath.Scalar`` exposing ``vals``."""
+
+    vals: float
+
+
+class _FakeObsForBracket:
+    """Observation stand-in for the smear-bracket calculation.
+
+    ``uv_from_ra_and_dec`` returns one ``UV`` value at ``tfrac=0`` and
+    another at ``tfrac=1``, simulating the spacecraft pointing
+    displacement during the exposure.
+    """
+
+    def __init__(self, *, du: float, dv: float) -> None:
+        self._du = du
+        self._dv = dv
+
+    def boresight_ra(self) -> float:
+        """Return a constant boresight RA (the actual value is unused)."""
+        return 0.0
+
+    def boresight_dec(self) -> float:
+        """Return a constant boresight DEC (the actual value is unused)."""
+        return 0.0
+
+    def uv_from_ra_and_dec(
+        self,
+        ra: float,
+        dec: float,
+        *,
+        tfrac: float,
+        apparent: bool,
+    ) -> _FakeUVResult:
+        """Return a UV that depends linearly on ``tfrac``."""
+        del ra, dec, apparent
+        return _FakeUVResult(u=10.0 + self._du * tfrac, v=20.0 + self._dv * tfrac)
+
+
+def test_compute_smear_vector_px_returns_bracket_difference() -> None:
+    """The smear vector is ``(v_end - v_start, u_end - u_start)`` in pixels."""
+    obs: Any = _FakeObsForBracket(du=2.5, dv=1.5)
+    my, mx = compute_smear_vector_px(obs)
+    assert my == pytest.approx(1.5)
+    assert mx == pytest.approx(2.5)
+
+
+def test_compute_smear_vector_px_zero_when_no_pointing_drift() -> None:
+    """A static-pointing exposure produces a zero smear vector."""
+    obs: Any = _FakeObsForBracket(du=0.0, dv=0.0)
+    my, mx = compute_smear_vector_px(obs)
+    assert my == 0.0
+    assert mx == 0.0

--- a/tests/nav/nav_model/test_body_shape.py
+++ b/tests/nav/nav_model/test_body_shape.py
@@ -1,0 +1,63 @@
+"""Tests for ``nav.nav_model.body_shape``."""
+
+from __future__ import annotations
+
+from nav.nav_model.body_shape import (
+    BODY_SHAPE_TABLE,
+    DEFAULT_BODY_SHAPE,
+    BodyShape,
+    shape_for_body,
+)
+
+
+def test_body_shape_lookup_known_body() -> None:
+    """A known body returns its specific entry."""
+    assert shape_for_body('MIMAS') is BODY_SHAPE_TABLE['MIMAS']
+
+
+def test_body_shape_lookup_case_insensitive() -> None:
+    """Case-insensitive lookup matches an upper-case key."""
+    assert shape_for_body('mimas') is BODY_SHAPE_TABLE['MIMAS']
+
+
+def test_body_shape_lookup_unknown_body_falls_back_to_default() -> None:
+    """Bodies absent from the table return ``DEFAULT_BODY_SHAPE``."""
+    assert shape_for_body('NEW MOON') is DEFAULT_BODY_SHAPE
+
+
+def test_default_body_shape_values() -> None:
+    """The default body shape has its documented numeric defaults."""
+    assert DEFAULT_BODY_SHAPE.ellipsoid_residual_km == 2.0
+    assert DEFAULT_BODY_SHAPE.crater_scale_km == 5.0
+    assert DEFAULT_BODY_SHAPE.albedo_variation == 0.15
+    assert DEFAULT_BODY_SHAPE.spice_orbital_residual_km == 2.0
+    assert DEFAULT_BODY_SHAPE.min_blob_diameter_px == 5.0
+
+
+def test_body_shape_dataclass_is_frozen() -> None:
+    """``BodyShape`` is frozen — assignment raises ``FrozenInstanceError``."""
+    import dataclasses
+
+    import pytest
+
+    shape = BodyShape(
+        ellipsoid_residual_km=1.0,
+        crater_scale_km=2.0,
+        albedo_variation=0.1,
+        spice_orbital_residual_km=0.5,
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError, match='ellipsoid_residual_km'):
+        shape.ellipsoid_residual_km = 3.0  # type: ignore[misc]
+
+
+def test_known_saturn_moons_share_shape_profile() -> None:
+    """All major Saturn moons share the dedicated saturn-moon profile."""
+    profile = BODY_SHAPE_TABLE['MIMAS']
+    for body in ('MIMAS', 'ENCELADUS', 'TETHYS', 'DIONE', 'RHEA', 'IAPETUS', 'TITAN'):
+        assert BODY_SHAPE_TABLE[body] is profile
+
+
+def test_irregular_bodies_use_irregular_profile() -> None:
+    """Hyperion and Phoebe share the irregular-shape profile."""
+    assert BODY_SHAPE_TABLE['HYPERION'] is BODY_SHAPE_TABLE['PHOEBE']
+    assert BODY_SHAPE_TABLE['HYPERION'].ellipsoid_residual_km == 10.0

--- a/tests/nav/nav_model/test_body_shape.py
+++ b/tests/nav/nav_model/test_body_shape.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import dataclasses
+
+import pytest
+
 from nav.nav_model.body_shape import (
     BODY_SHAPE_TABLE,
     DEFAULT_BODY_SHAPE,
@@ -36,10 +40,6 @@ def test_default_body_shape_values() -> None:
 
 def test_body_shape_dataclass_is_frozen() -> None:
     """``BodyShape`` is frozen — assignment raises ``FrozenInstanceError``."""
-    import dataclasses
-
-    import pytest
-
     shape = BodyShape(
         ellipsoid_residual_km=1.0,
         crater_scale_km=2.0,

--- a/tests/nav/nav_model/test_nav_model_body.py
+++ b/tests/nav/nav_model/test_nav_model_body.py
@@ -1,0 +1,195 @@
+"""Tests for ``nav.nav_model.nav_model_body`` helpers and emission gates.
+
+The full ``NavModelBody.create_model`` path requires a live ``oops``
+backplane and so is exercised by integration tests against the image
+library.  These unit tests cover the pure helper functions
+(``_incidence_factor_array``, ``_sigma_normal_per_vertex``, the
+reliability sigmoids) plus the class-level constants.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+
+import numpy as np
+import pytest
+
+from nav.feature.constants import MAX_INCIDENCE_FACTOR_CAP
+from nav.nav_model.body_shape import DEFAULT_BODY_SHAPE
+from nav.nav_model.nav_model_body import (
+    BODY_DISC_MAX_OVERFLOW_FRACTION,
+    BODY_DISC_MIN_VISIBLE_LIT_FRACTION,
+    BODY_POSITION_SLOP_FRAC,
+    LIMB_ARC_MAX_UNCERTAINTY_PX,
+    TERMINATOR_MIN_PHASE_FACTOR,
+    TERMINATOR_MIN_VERTICES,
+    _blob_reliability,
+    _disc_reliability,
+    _incidence_factor_array,
+    _limb_reliability,
+    _PolylineSampler,
+    _sigma_normal_per_vertex,
+    _sigmoid,
+    _terminator_reliability,
+    _visible_arc_fraction,
+)
+
+
+def test_constants_have_design_values() -> None:
+    """Module-level constants match the design's defaults."""
+    assert pytest.approx(0.05) == BODY_POSITION_SLOP_FRAC
+    assert pytest.approx(2.0) == LIMB_ARC_MAX_UNCERTAINTY_PX
+    assert pytest.approx(0.4) == BODY_DISC_MIN_VISIBLE_LIT_FRACTION
+    assert pytest.approx(0.3) == BODY_DISC_MAX_OVERFLOW_FRACTION
+    assert TERMINATOR_MIN_VERTICES == 8
+    assert pytest.approx(0.05) == TERMINATOR_MIN_PHASE_FACTOR
+
+
+def test_incidence_factor_zero_at_subsolar() -> None:
+    """At i=0 the incidence factor is zero (no softening)."""
+    arr = _incidence_factor_array(np.array([0.0]))
+    assert arr[0] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_incidence_factor_one_at_60deg() -> None:
+    """At i=60 the incidence factor is 1 (cos=0.5; 1/0.5 - 1 = 1)."""
+    arr = _incidence_factor_array(np.array([math.radians(60.0)]))
+    assert arr[0] == pytest.approx(1.0, abs=1e-12)
+
+
+def test_incidence_factor_saturates_above_80deg() -> None:
+    """Above 80 deg the formula uses the i=80 value (capped by the angle cap)."""
+    arr_80 = _incidence_factor_array(np.array([math.radians(80.0)]))
+    arr_89 = _incidence_factor_array(np.array([math.radians(89.0)]))
+    expected_at_80 = 1.0 / math.cos(math.radians(80.0)) - 1.0
+    assert arr_80[0] == pytest.approx(expected_at_80, rel=1e-12)
+    assert arr_89[0] == pytest.approx(arr_80[0], rel=1e-12)
+    # The cap constant bounds the factor from above (numerically slack).
+    assert arr_89[0] <= MAX_INCIDENCE_FACTOR_CAP + 1e-9
+
+
+def test_incidence_factor_array_returns_float64() -> None:
+    """The output dtype is float64 even when inputs are integer-typed."""
+    arr = _incidence_factor_array(np.array([0.0, 1.0]))
+    assert arr.dtype == np.float64
+
+
+def _make_sampler(*, n: int, incidence_deg: float, km_per_pixel: float) -> _PolylineSampler:
+    """Build a ``_PolylineSampler`` with constant-incidence vertices."""
+    vertices = np.zeros((n, 2), dtype=np.float64)
+    normals = np.zeros((n, 2), dtype=np.float64)
+    incidence = np.full(n, math.radians(incidence_deg), dtype=np.float64)
+    km = np.full(n, km_per_pixel, dtype=np.float64)
+    return _PolylineSampler(
+        vertices_vu=vertices,
+        normals_vu=normals,
+        incidence_rad=incidence,
+        km_per_pixel=km,
+    )
+
+
+def test_sigma_normal_uses_quadrature_sum() -> None:
+    """``sigma_normal_per_vertex`` matches the design's quadrature formula."""
+    shape = DEFAULT_BODY_SHAPE
+    sampler = _make_sampler(n=4, incidence_deg=0.0, km_per_pixel=10.0)
+    sigma_px = _sigma_normal_per_vertex(
+        sampler=sampler, shape=shape, psf_sigma_px=1.0, include_albedo=False
+    )
+    expected_km = math.sqrt(
+        shape.ellipsoid_residual_km**2
+        + shape.crater_scale_km**2
+        + 0.0  # incidence_factor=0 at i=0
+        + shape.spice_orbital_residual_km**2
+    )
+    expected_px = expected_km / 10.0
+    assert sigma_px[0] == pytest.approx(expected_px, rel=1e-12)
+
+
+def test_sigma_normal_albedo_term_increases_when_enabled() -> None:
+    """``include_albedo=True`` adds the albedo + photometric quadrature terms."""
+    shape = DEFAULT_BODY_SHAPE
+    sampler = _make_sampler(n=2, incidence_deg=30.0, km_per_pixel=5.0)
+    no_albedo = _sigma_normal_per_vertex(
+        sampler=sampler, shape=shape, psf_sigma_px=1.0, include_albedo=False
+    )
+    with_albedo = _sigma_normal_per_vertex(
+        sampler=sampler, shape=shape, psf_sigma_px=1.0, include_albedo=True
+    )
+    assert with_albedo[0] > no_albedo[0]
+
+
+def test_visible_arc_fraction_reports_unity_when_vertices_present() -> None:
+    """A non-empty polyline reports ``visible_arc_fraction = 1.0``."""
+    sampler = _make_sampler(n=5, incidence_deg=0.0, km_per_pixel=1.0)
+    assert _visible_arc_fraction(sampler) == 1.0
+
+
+def test_visible_arc_fraction_reports_zero_when_empty() -> None:
+    """An empty polyline reports zero arc fraction."""
+    sampler = _PolylineSampler(
+        vertices_vu=np.empty((0, 2), dtype=np.float64),
+        normals_vu=np.empty((0, 2), dtype=np.float64),
+        incidence_rad=np.empty(0, dtype=np.float64),
+        km_per_pixel=np.empty(0, dtype=np.float64),
+    )
+    assert _visible_arc_fraction(sampler) == 0.0
+
+
+def test_sigmoid_is_monotone() -> None:
+    """The sigmoid is strictly increasing across a wide range of inputs."""
+    samples = [_sigmoid(x) for x in (-5.0, -1.0, 0.0, 1.0, 5.0)]
+    for prev, nxt in itertools.pairwise(samples):
+        assert nxt > prev
+
+
+def test_sigmoid_at_zero() -> None:
+    """``_sigmoid(0)`` equals 0.5 — sanity check the symmetry."""
+    assert _sigmoid(0.0) == pytest.approx(0.5, abs=1e-12)
+
+
+def test_limb_reliability_increases_with_visible_arc_fraction() -> None:
+    """Reliability is monotone in ``visible_arc_fraction`` for fixed other terms."""
+    low = _limb_reliability(
+        visible_arc_fraction=0.2, visible_arc_px=20.0, mean_incidence_factor=0.5
+    )
+    high = _limb_reliability(
+        visible_arc_fraction=0.9, visible_arc_px=20.0, mean_incidence_factor=0.5
+    )
+    assert high > low
+
+
+def test_limb_reliability_decreases_with_incidence() -> None:
+    """High incidence-factor scenes drive limb reliability down."""
+    low_inc = _limb_reliability(
+        visible_arc_fraction=0.9, visible_arc_px=20.0, mean_incidence_factor=0.0
+    )
+    high_inc = _limb_reliability(
+        visible_arc_fraction=0.9, visible_arc_px=20.0, mean_incidence_factor=4.0
+    )
+    assert high_inc < low_inc
+
+
+def test_terminator_reliability_zero_at_zero_phase() -> None:
+    """Sub-solar-illuminated images produce zero terminator reliability."""
+    out = _terminator_reliability(visible_arc_fraction=1.0, albedo_variation=0.0, phase_factor=0.0)
+    assert out == 0.0
+
+
+def test_disc_reliability_increases_with_diameter() -> None:
+    """Reliability is monotone in body diameter for fixed visibility."""
+    low = _disc_reliability(visible_lit_fraction=1.0, overflow_fraction=0.0, diameter_px=10.0)
+    high = _disc_reliability(visible_lit_fraction=1.0, overflow_fraction=0.0, diameter_px=200.0)
+    assert high > low
+
+
+def test_disc_reliability_zero_when_overflow_complete() -> None:
+    """A fully off-frame disc has zero reliability."""
+    out = _disc_reliability(visible_lit_fraction=1.0, overflow_fraction=1.0, diameter_px=100.0)
+    assert out == 0.0
+
+
+def test_blob_reliability_capped_at_0_4() -> None:
+    """Blob reliability cannot exceed the 0.4 design cap."""
+    out = _blob_reliability(snr=1e6, diameter_px=1e6)
+    assert out <= 0.4 + 1e-12

--- a/tests/nav/nav_model/test_nav_model_body_integration.py
+++ b/tests/nav/nav_model/test_nav_model_body_integration.py
@@ -1,0 +1,284 @@
+"""Integration tests for ``NavModelBody`` exercising ``to_features`` /
+``to_annotations`` end-to-end against pre-populated state.
+
+Driving ``create_model`` with a real ``oops.Backplane(obs,
+meshgrid=...)`` is integration-test scope (Part 9 / Part 10 image
+library).  These tests instead build a NavModelBody, monkeypatch
+``_render`` to populate the polyline samplers and silhouette masks
+directly, then verify that the public-API methods emit features and
+annotations matching the design's emission gates.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import numpy as np
+import pytest
+from tests.shims import FakeObs
+
+from nav.feature.feature_type import NavFeatureType
+from nav.feature.flags import (
+    BodyBlobFlags,
+    BodyDiscFlags,
+    LimbArcFlags,
+    TerminatorArcFlags,
+)
+from nav.feature.geometry import (
+    BodyBlobGeometry,
+    BodyDiscGeometry,
+    LimbPolyline,
+    TerminatorPolyline,
+)
+from nav.nav_model.nav_model_body import (
+    BODY_DISC_MAX_OVERFLOW_FRACTION,
+    BODY_DISC_MIN_VISIBLE_LIT_FRACTION,
+    NavModelBody,
+    _PolylineSampler,
+)
+
+
+def _make_polyline_sampler(*, n: int, km_per_pixel: float = 1.0) -> _PolylineSampler:
+    """Build a ``_PolylineSampler`` carrying ``n`` vertices on a horizontal line."""
+    vs = np.full(n, 30.0, dtype=np.float64)
+    us = np.linspace(20.0, 20.0 + n - 1, n, dtype=np.float64)
+    vertices = np.stack([vs, us], axis=1)
+    normals = np.tile(np.array([0.0, 1.0]), (n, 1))
+    incidence = np.zeros(n, dtype=np.float64)
+    km = np.full(n, km_per_pixel, dtype=np.float64)
+    return _PolylineSampler(
+        vertices_vu=vertices,
+        normals_vu=normals,
+        incidence_rad=incidence,
+        km_per_pixel=km,
+    )
+
+
+def _build_body(
+    *,
+    obs: FakeObs,
+    body_name: str = 'MIMAS',
+    diameter_px: float = 30.0,
+    visible_lit_fraction: float = 0.8,
+    overflow_fraction: float = 0.1,
+    phase_factor: float = 0.5,
+    km_per_pixel_at_limb: float = 1.0,
+    limb_vertices: int = 20,
+    terminator_vertices: int = 20,
+) -> NavModelBody:
+    """Build a NavModelBody with internal state populated for ``to_features``.
+
+    The model bypasses ``_render`` and instead has its private state
+    set directly so the test can exercise ``to_features`` /
+    ``to_annotations`` against a deterministic body-shape posture.
+    """
+    inv = {
+        'u_min_unclipped': 0,
+        'u_max_unclipped': int(diameter_px),
+        'v_min_unclipped': 0,
+        'v_max_unclipped': int(diameter_px),
+        'u_pixel_size': diameter_px,
+        'v_pixel_size': diameter_px,
+        'range': 1.0e6,
+        'center_uv': (diameter_px / 2.0, diameter_px / 2.0),
+    }
+    obs.inventory_records = {body_name: inv}
+    model = NavModelBody(f'body:{body_name}', cast(Any, obs), body_name, inventory=inv)
+    rows, cols = obs.extdata_shape_vu
+    body_mask = np.zeros((rows, cols), dtype=bool)
+    centre_v = rows // 2
+    centre_u = cols // 2
+    radius = int(diameter_px // 2)
+    vv, uu = np.meshgrid(
+        np.arange(rows, dtype=np.float64),
+        np.arange(cols, dtype=np.float64),
+        indexing='ij',
+    )
+    body_mask[(vv - centre_v) ** 2 + (uu - centre_u) ** 2 <= radius * radius] = True
+    model_img = body_mask.astype(np.float64)
+    limb_mask = body_mask.copy()
+    terminator_mask = np.zeros_like(body_mask)
+    model._model_img = model_img
+    model._body_mask = body_mask
+    model._limb_mask = limb_mask
+    model._terminator_mask = terminator_mask
+    model._limb_sampler = _make_polyline_sampler(n=limb_vertices, km_per_pixel=km_per_pixel_at_limb)
+    model._terminator_sampler = _make_polyline_sampler(
+        n=terminator_vertices, km_per_pixel=km_per_pixel_at_limb
+    )
+    model._km_per_pixel_at_limb = km_per_pixel_at_limb
+    model._predicted_diameter_px = diameter_px
+    model._predicted_center_vu = (float(centre_v), float(centre_u))
+    model._bbox_extfov_vu = (
+        centre_v - radius,
+        centre_u - radius,
+        centre_v + radius + 1,
+        centre_u + radius + 1,
+    )
+    model._subject_range_km = 1.0e6
+    model._visible_lit_fraction = visible_lit_fraction
+    model._overflow_fraction = overflow_fraction
+    model._phase_angle_factor = phase_factor
+    return model
+
+
+@pytest.fixture
+def fake_obs() -> FakeObs:
+    """Provide a small obs with non-zero extfov margin and a configured PSF."""
+    return FakeObs(
+        data=np.zeros((100, 100), dtype=np.float64),
+        extfov_margin_vu=(5, 5),
+        closest_planet='SATURN',
+    )
+
+
+def test_to_features_emits_limb_arc_when_uncertainty_is_low(fake_obs: FakeObs) -> None:
+    """A well-resolved body emits a LIMB_ARC with the expected polyline payload."""
+    model = _build_body(obs=fake_obs, km_per_pixel_at_limb=10.0)  # high resolution
+    features = model.to_features(cast(Any, None))
+    by_type = {f.feature_type: f for f in features}
+    assert NavFeatureType.LIMB_ARC in by_type
+    limb = by_type[NavFeatureType.LIMB_ARC]
+    assert isinstance(limb.geometry, LimbPolyline)
+    assert isinstance(limb.flags, LimbArcFlags)
+    assert limb.flags.body_name == 'MIMAS'
+    assert limb.geometry.vertices_vu.shape == (20, 2)
+    assert limb.geometry.sigma_normal_per_vertex_px.shape == (20,)
+
+
+def test_to_features_emits_blob_instead_of_limb_when_uncertainty_high(
+    fake_obs: FakeObs,
+) -> None:
+    """A poorly-resolved body emits BODY_BLOB instead of LIMB_ARC."""
+    # km_per_pixel_at_limb=1000 -> limb_uncertainty_px = 1.0/1000 = 0.001 (low),
+    # so to force the high-uncertainty branch we lower the resolution.
+    model = _build_body(obs=fake_obs, km_per_pixel_at_limb=0.001)
+    features = model.to_features(cast(Any, None))
+    types = {f.feature_type for f in features}
+    assert NavFeatureType.LIMB_ARC not in types
+    assert NavFeatureType.BODY_BLOB in types
+    blob = next(f for f in features if f.feature_type is NavFeatureType.BODY_BLOB)
+    assert isinstance(blob.geometry, BodyBlobGeometry)
+    assert isinstance(blob.flags, BodyBlobFlags)
+    assert blob.flags.predicted_diameter_px == pytest.approx(30.0)
+
+
+def test_to_features_emits_disc_alongside_limb_when_visibility_high(
+    fake_obs: FakeObs,
+) -> None:
+    """BODY_DISC is emitted when LIMB_ARC fired and visibility gates pass."""
+    model = _build_body(
+        obs=fake_obs,
+        km_per_pixel_at_limb=10.0,
+        visible_lit_fraction=BODY_DISC_MIN_VISIBLE_LIT_FRACTION + 0.1,
+        overflow_fraction=BODY_DISC_MAX_OVERFLOW_FRACTION - 0.1,
+    )
+    features = model.to_features(cast(Any, None))
+    types = {f.feature_type for f in features}
+    assert NavFeatureType.BODY_DISC in types
+    disc = next(f for f in features if f.feature_type is NavFeatureType.BODY_DISC)
+    assert isinstance(disc.geometry, BodyDiscGeometry)
+    assert isinstance(disc.flags, BodyDiscFlags)
+    assert disc.template_img is not None
+    assert disc.template_mask is not None
+
+
+def test_to_features_skips_disc_when_overflow_high(fake_obs: FakeObs) -> None:
+    """A body with too much overflow does not emit BODY_DISC."""
+    model = _build_body(
+        obs=fake_obs,
+        km_per_pixel_at_limb=10.0,
+        visible_lit_fraction=0.9,
+        overflow_fraction=BODY_DISC_MAX_OVERFLOW_FRACTION + 0.1,
+    )
+    types = {f.feature_type for f in model.to_features(cast(Any, None))}
+    assert NavFeatureType.BODY_DISC not in types
+
+
+def test_to_features_emits_terminator_when_phase_factor_high(
+    fake_obs: FakeObs,
+) -> None:
+    """A body with high phase factor emits TERMINATOR_ARC."""
+    model = _build_body(obs=fake_obs, km_per_pixel_at_limb=10.0, phase_factor=0.8)
+    features = model.to_features(cast(Any, None))
+    types = {f.feature_type for f in features}
+    assert NavFeatureType.TERMINATOR_ARC in types
+    term = next(f for f in features if f.feature_type is NavFeatureType.TERMINATOR_ARC)
+    assert isinstance(term.geometry, TerminatorPolyline)
+    assert isinstance(term.flags, TerminatorArcFlags)
+
+
+def test_to_features_skips_terminator_at_zero_phase(fake_obs: FakeObs) -> None:
+    """A sub-solar-illuminated body emits no TERMINATOR_ARC."""
+    model = _build_body(obs=fake_obs, km_per_pixel_at_limb=10.0, phase_factor=0.0)
+    types = {f.feature_type for f in model.to_features(cast(Any, None))}
+    assert NavFeatureType.TERMINATOR_ARC not in types
+
+
+def test_to_features_skips_terminator_when_polyline_too_short(fake_obs: FakeObs) -> None:
+    """A terminator polyline with fewer than the minimum vertices is suppressed."""
+    model = _build_body(
+        obs=fake_obs,
+        km_per_pixel_at_limb=10.0,
+        terminator_vertices=4,  # below TERMINATOR_MIN_VERTICES (8)
+    )
+    types = {f.feature_type for f in model.to_features(cast(Any, None))}
+    assert NavFeatureType.TERMINATOR_ARC not in types
+
+
+def test_to_features_limb_uncertainty_at_threshold(fake_obs: FakeObs) -> None:
+    """A body sitting exactly at the LIMB_ARC threshold still emits the arc."""
+    # ellipsoid_residual_km = 50 (gas-giant default -- SATURN is mapped to it),
+    # so limb_uncertainty_px = ellipsoid_residual_km / km_per_pixel_at_limb.
+    # km_per_pixel_at_limb=25 yields uncertainty=2.0 == LIMB_ARC_MAX_UNCERTAINTY_PX.
+    saturn_model = _build_body(obs=fake_obs, body_name='SATURN', km_per_pixel_at_limb=25.0)
+    features = saturn_model.to_features(cast(Any, None))
+    assert any(f.feature_type is NavFeatureType.LIMB_ARC for f in features)
+    # Now push it over -- 26 km/px -> uncertainty < 2 still passes; 24 km/px ->
+    # uncertainty > 2 forces the blob branch.
+    saturn_blob = _build_body(obs=fake_obs, body_name='SATURN', km_per_pixel_at_limb=24.0)
+    features_blob = saturn_blob.to_features(cast(Any, None))
+    types = {f.feature_type for f in features_blob}
+    assert NavFeatureType.LIMB_ARC not in types
+    # Uncertainty above threshold and diameter above the body's blob-min
+    # threshold -> blob.
+    assert NavFeatureType.BODY_BLOB in types
+
+
+def test_create_model_metadata_records_body_name_and_phase(
+    fake_obs: FakeObs, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``create_model`` populates the metadata block via the wrapping logic."""
+    model = _build_body(obs=fake_obs)
+
+    def _fake_render(self: NavModelBody) -> None:
+        # Only the metadata fields populated by the wrapping logic matter
+        # for this test; ``to_features`` / ``to_annotations`` are tested
+        # separately above.
+        self._metadata['body_name'] = self._body_name
+        self._metadata['phase_angle_deg'] = 30.0
+
+    monkeypatch.setattr(NavModelBody, '_render', _fake_render)
+    model.create_model()
+    assert model.metadata['body_name'] == 'MIMAS'
+    assert 'start_time' in model.metadata
+    assert 'end_time' in model.metadata
+    assert model.metadata['elapsed_time_sec'] >= 0.0
+
+
+def test_to_annotations_returns_empty_when_state_unset(fake_obs: FakeObs) -> None:
+    """A NavModelBody with no rendered masks returns an empty Annotations."""
+    inv = {
+        'u_min_unclipped': 0,
+        'u_max_unclipped': 30,
+        'v_min_unclipped': 0,
+        'v_max_unclipped': 30,
+        'u_pixel_size': 30.0,
+        'v_pixel_size': 30.0,
+        'range': 1.0e6,
+        'center_uv': (15.0, 15.0),
+    }
+    fake_obs.inventory_records = {'MIMAS': inv}
+    model = NavModelBody('body:MIMAS', cast(Any, fake_obs), 'MIMAS', inventory=inv)
+    annotations = model.to_annotations(cast(Any, None))
+    assert len(annotations.annotations) == 0

--- a/tests/nav/nav_model/test_nav_model_rings.py
+++ b/tests/nav/nav_model/test_nav_model_rings.py
@@ -1,0 +1,224 @@
+"""Tests for ``nav.nav_model.nav_model_rings`` helpers and emission gates.
+
+The full ``NavModelRings.create_model`` path requires a live ``oops``
+backplane and so is exercised by integration tests against the image
+library.  These unit tests cover the polyline-extraction helper, the
+straight-line classifier, the bbox helper, and the per-feature
+reliability sigmoids.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from nav.nav_model.nav_model_rings import (
+    FLAT_CURVATURE_THRESHOLD_PX,
+    RING_ANNULUS_MAX_RADIAL_PX,
+    RING_EDGE_DEFAULT_RELIABILITY,
+    RING_EDGE_SIGMA_ALONG_PX,
+    _is_straight_line,
+    _mask_bbox,
+    _polyline_from_edge_mask,
+    _radial_extent_px,
+    _require_positive_finite_planet_scalar,
+    _ring_annulus_reliability,
+    _ring_edge_reliability,
+)
+
+
+def test_constants_have_design_values() -> None:
+    """Module-level constants match their design defaults."""
+    assert pytest.approx(0.7) == RING_EDGE_DEFAULT_RELIABILITY
+    assert pytest.approx(0.5) == RING_EDGE_SIGMA_ALONG_PX
+    assert pytest.approx(1.0) == FLAT_CURVATURE_THRESHOLD_PX
+    assert pytest.approx(5.0) == RING_ANNULUS_MAX_RADIAL_PX
+
+
+def test_polyline_from_edge_mask_returns_one_vertex_per_true_pixel() -> None:
+    """Each True pixel in the mask becomes one polyline vertex."""
+    mask = np.zeros((10, 10), dtype=bool)
+    mask[3, 4:9] = True  # 5 vertices along a horizontal line
+    vertices, normals = _polyline_from_edge_mask(mask)
+    assert vertices.shape == (5, 2)
+    assert normals.shape == (5, 2)
+
+
+def test_polyline_from_edge_mask_empty_returns_empty_arrays() -> None:
+    """An all-False mask returns ``(0, 2)``-shaped arrays."""
+    mask = np.zeros((5, 5), dtype=bool)
+    vertices, normals = _polyline_from_edge_mask(mask)
+    assert vertices.shape == (0, 2)
+    assert normals.shape == (0, 2)
+
+
+def test_polyline_normals_are_unit_length() -> None:
+    """Each normal has length 1 (rounded to floating tolerance)."""
+    mask = np.zeros((10, 10), dtype=bool)
+    mask[3, 4:9] = True
+    _, normals = _polyline_from_edge_mask(mask)
+    norms = np.linalg.norm(normals, axis=1)
+    assert np.allclose(norms, 1.0)
+
+
+def test_radial_extent_zero_for_point_polyline() -> None:
+    """A polyline with only one vertex has zero radial extent."""
+    vertices = np.array([[1.0, 1.0]])
+    normals = np.array([[1.0, 0.0]])
+    assert _radial_extent_px(vertices, normals) == pytest.approx(0.0)
+
+
+def test_radial_extent_along_normal_axis() -> None:
+    """Extent equals the projection range onto the mean normal."""
+    vertices = np.array([[0.0, 0.0], [3.0, 0.0]])
+    normals = np.array([[1.0, 0.0], [1.0, 0.0]])
+    assert _radial_extent_px(vertices, normals) == pytest.approx(3.0)
+
+
+def test_is_straight_line_for_collinear_points() -> None:
+    """Three collinear points are classified as a straight line."""
+    vertices = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]])
+    assert _is_straight_line(vertices)
+
+
+def test_is_straight_line_for_curved_points() -> None:
+    """Points with curvature above the threshold are not flagged straight.
+
+    The SVD-based test projects the centred points onto the smallest
+    singular direction and compares the maximum deviation to
+    ``FLAT_CURVATURE_THRESHOLD_PX = 1.0``.  We construct a triangle whose
+    apex is far enough from the line connecting the endpoints that the
+    deviation comfortably clears the threshold.
+    """
+    vertices = np.array([[0.0, 0.0], [5.0, 0.0], [10.0, 0.0], [5.0, 10.0]])
+    assert not _is_straight_line(vertices)
+
+
+def test_is_straight_line_short_polyline() -> None:
+    """Polylines with < 3 vertices are trivially straight."""
+    assert _is_straight_line(np.array([[0.0, 0.0], [1.0, 1.0]]))
+
+
+def test_mask_bbox_for_empty_mask() -> None:
+    """An all-False mask returns ``(0, 0, 0, 0)``."""
+    mask = np.zeros((5, 5), dtype=bool)
+    assert _mask_bbox(mask) == (0, 0, 0, 0)
+
+
+def test_mask_bbox_for_simple_rectangle() -> None:
+    """The bbox is the half-open envelope of the True pixels."""
+    mask = np.zeros((10, 10), dtype=bool)
+    mask[2:5, 3:7] = True
+    assert _mask_bbox(mask) == (2, 3, 5, 7)
+
+
+def test_ring_edge_reliability_caps_at_one() -> None:
+    """Pathologically generous inputs are clipped to 1.0."""
+    out = _ring_edge_reliability(
+        catalog_default=10.0,
+        visible_arc_fraction=10.0,
+        shadow_occluded_fraction=0.0,
+        is_straight_line=False,
+    )
+    assert out == pytest.approx(1.0)
+
+
+def test_ring_edge_reliability_penalises_straight_lines() -> None:
+    """Straight-line edges receive a 0.7 multiplier."""
+    curved = _ring_edge_reliability(
+        catalog_default=0.7,
+        visible_arc_fraction=1.0,
+        shadow_occluded_fraction=0.0,
+        is_straight_line=False,
+    )
+    straight = _ring_edge_reliability(
+        catalog_default=0.7,
+        visible_arc_fraction=1.0,
+        shadow_occluded_fraction=0.0,
+        is_straight_line=True,
+    )
+    assert straight == pytest.approx(curved * 0.7)
+
+
+def test_ring_edge_reliability_drops_with_shadow() -> None:
+    """Higher shadow occlusion drives reliability down."""
+    low = _ring_edge_reliability(
+        catalog_default=0.7,
+        visible_arc_fraction=1.0,
+        shadow_occluded_fraction=0.0,
+        is_straight_line=False,
+    )
+    high = _ring_edge_reliability(
+        catalog_default=0.7,
+        visible_arc_fraction=1.0,
+        shadow_occluded_fraction=0.5,
+        is_straight_line=False,
+    )
+    assert high < low
+
+
+def test_ring_annulus_reliability_zero_for_empty_annulus() -> None:
+    """An annulus with zero constituent edges has zero reliability."""
+    assert _ring_annulus_reliability(constituent_count=0, radial_extent_px=100.0) == 0.0
+
+
+def test_ring_annulus_reliability_returns_clamped_value() -> None:
+    """The annulus reliability is in ``[0, 1]`` for sensible inputs."""
+    out = _ring_annulus_reliability(constituent_count=3, radial_extent_px=20.0)
+    assert 0.0 <= out <= 1.0
+
+
+def test_ring_annulus_reliability_increases_with_constituent_count() -> None:
+    """More constituent edges -> higher reliability (up to the cap)."""
+    low = _ring_annulus_reliability(constituent_count=1, radial_extent_px=100.0)
+    high = _ring_annulus_reliability(constituent_count=5, radial_extent_px=100.0)
+    assert high > low
+
+
+def test_ring_annulus_reliability_increases_with_radial_extent() -> None:
+    """A wider annulus has higher reliability via the sigmoid-extent factor."""
+    narrow = _ring_annulus_reliability(constituent_count=3, radial_extent_px=10.0)
+    wide = _ring_annulus_reliability(constituent_count=3, radial_extent_px=200.0)
+    assert wide > narrow
+
+
+def test_require_positive_finite_planet_scalar_returns_value() -> None:
+    """The validator returns the float when input is finite and positive."""
+    out = _require_positive_finite_planet_scalar(
+        'SATURN', 'fade_width_pix', {'fade_width_pix': 4.0}
+    )
+    assert out == pytest.approx(4.0)
+
+
+def test_require_positive_finite_planet_scalar_rejects_missing_key() -> None:
+    """A missing key raises ``ValueError`` naming the key."""
+    with pytest.raises(ValueError, match='Missing required ring configuration key'):
+        _require_positive_finite_planet_scalar('SATURN', 'fade_width_pix', {})
+
+
+def test_require_positive_finite_planet_scalar_rejects_zero() -> None:
+    """A zero value is invalid (non-positive)."""
+    with pytest.raises(ValueError, match=r'Invalid fade_width_pix 0\.0'):
+        _require_positive_finite_planet_scalar('SATURN', 'fade_width_pix', {'fade_width_pix': 0.0})
+
+
+def test_require_positive_finite_planet_scalar_rejects_inf() -> None:
+    """A non-finite value raises ``ValueError``."""
+    with pytest.raises(ValueError, match='must be finite'):
+        _require_positive_finite_planet_scalar(
+            'SATURN', 'fade_width_pix', {'fade_width_pix': float('inf')}
+        )
+
+
+def test_require_positive_finite_planet_scalar_rejects_bool() -> None:
+    """A bool value is not accepted as a numeric scalar."""
+    with pytest.raises(ValueError, match='got bool'):
+        _require_positive_finite_planet_scalar('SATURN', 'fade_width_pix', {'fade_width_pix': True})
+
+
+def test_require_positive_finite_planet_scalar_rejects_non_numeric() -> None:
+    """A non-numeric value raises ``ValueError``."""
+    with pytest.raises(ValueError, match='expected a finite numeric value'):
+        _require_positive_finite_planet_scalar(
+            'SATURN', 'fade_width_pix', {'fade_width_pix': 'big'}
+        )

--- a/tests/nav/nav_model/test_nav_model_rings_integration.py
+++ b/tests/nav/nav_model/test_nav_model_rings_integration.py
@@ -1,0 +1,221 @@
+"""Integration tests for ``NavModelRings`` exercising ``to_features`` /
+``to_annotations`` end-to-end against pre-populated render results.
+
+Driving ``create_model`` with a real ``oops.Backplane`` and the
+catalog-loaded ``RingFeature.render`` is integration-test scope.
+These tests instead build a NavModelRings, populate the
+``_render_results`` list directly with fake edge masks, and verify
+that the public-API methods emit features and annotations matching
+the design's emission gates (``RING_EDGE`` vs ``RING_ANNULUS``,
+straight-line flagging).
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import numpy as np
+import pytest
+from tests.shims import FakeObs
+
+from nav.feature.feature_type import NavFeatureType
+from nav.feature.flags import RingAnnulusFlags, RingEdgeFlags
+from nav.feature.geometry import RingAnnulusGeometry, RingEdgePolyline
+from nav.nav_model.nav_model_rings import NavModelRings
+from nav.nav_model.rings.ring_feature import RingFeature
+from nav.nav_model.rings.ring_types import RingBaseOrbitMode, RingEdgeData, RingFeatureType
+
+
+def _curved_edge_mask(shape: tuple[int, int]) -> np.ndarray:
+    """Paint a curved (parabolic) edge that is not flagged straight."""
+    rows, cols = shape
+    mask = np.zeros((rows, cols), dtype=bool)
+    us = np.arange(cols)
+    # v = 30 + 8 * sin(pi * u / cols) — a wide arch with significant curvature
+    vs = (30 + 8.0 * np.sin(np.pi * us / cols)).astype(int)
+    for u, v in zip(us, vs, strict=True):
+        if 0 <= v < rows:
+            mask[v, u] = True
+    return mask
+
+
+def _straight_edge_mask(shape: tuple[int, int]) -> np.ndarray:
+    """Paint a horizontal one-pixel edge that is flagged straight."""
+    rows, cols = shape
+    mask = np.zeros((rows, cols), dtype=bool)
+    mask[rows // 2, :] = True
+    return mask
+
+
+def _ring_feature(*, key: str = 'colombo_gap', name: str | None = 'colombo') -> RingFeature:
+    """Build a minimal RingFeature with one outer edge."""
+    edge = RingEdgeData(
+        base_orbit=RingBaseOrbitMode(a=77_870.0, ae=10.0, long_peri=0.0, rate_peri=0.0, rms=2.0),
+        perturbations=(),
+    )
+    return RingFeature(
+        key=key,
+        name=name,
+        feature_type=RingFeatureType.GAP,
+        inner_edge=None,
+        outer_edge=edge,
+        start_date=None,
+        end_date=None,
+    )
+
+
+def _build_rings(
+    *,
+    obs: FakeObs,
+    edge_mask: np.ndarray,
+    label: str = 'colombo:outer',
+    edge_type: str = 'outer',
+    uncertainty_km: float = 2.0,
+    km_per_pixel_radial: float = 5.0,
+    planet: str = 'SATURN',
+    constituent_count: int = 1,
+) -> NavModelRings:
+    """Build a NavModelRings whose render-results list carries one edge."""
+    model = NavModelRings(f'rings:{planet}', cast(Any, obs))
+    rows, cols = obs.extdata_shape_vu
+    feat = _ring_feature()
+    model_img = edge_mask.astype(np.float64)
+    model_mask = edge_mask.copy()
+    edge_info = [(edge_mask, label, edge_type)] * constituent_count
+    model._render_results = [(feat, model_img, model_mask, uncertainty_km, edge_info)]
+    model._planet = planet
+    model._km_per_pixel_radial = km_per_pixel_radial
+    model._extfov_v_size = rows
+    model._extfov_u_size = cols
+    model._predicted_center_vu = (rows / 2.0, cols / 2.0)
+    model._subject_range_km = 1.5e9
+    return model
+
+
+@pytest.fixture
+def fake_obs() -> FakeObs:
+    """Provide a small obs."""
+    return FakeObs(
+        data=np.zeros((100, 100), dtype=np.float64),
+        extfov_margin_vu=(5, 5),
+        closest_planet='SATURN',
+    )
+
+
+def test_to_features_emits_ring_edge_for_curved_polyline(fake_obs: FakeObs) -> None:
+    """A clearly-curved polyline emits a RING_EDGE feature with the polyline payload."""
+    model = _build_rings(obs=fake_obs, edge_mask=_curved_edge_mask((110, 110)))
+    features = model.to_features(cast(Any, None))
+    assert len(features) == 1
+    feat = features[0]
+    assert feat.feature_type is NavFeatureType.RING_EDGE
+    assert isinstance(feat.geometry, RingEdgePolyline)
+    assert isinstance(feat.flags, RingEdgeFlags)
+    assert feat.flags.planet_name == 'SATURN'
+    assert feat.flags.is_straight_line is False
+    # Per-vertex sigma_radial_per_vertex_px = uncertainty_km / km_per_pixel_radial.
+    assert feat.geometry.sigma_radial_per_vertex_px[0] == pytest.approx(2.0 / 5.0)
+
+
+def test_to_features_emits_ring_edge_with_straight_line_flag(fake_obs: FakeObs) -> None:
+    """A straight polyline emits a RING_EDGE with ``is_straight_line=True``."""
+    model = _build_rings(obs=fake_obs, edge_mask=_straight_edge_mask((110, 110)))
+    features = model.to_features(cast(Any, None))
+    # A horizontal straight line has zero radial extent (mean normal is zero
+    # because the discrete-mask normal-finder cannot pick a side), so
+    # ``radial_extent_px <= RING_ANNULUS_MAX_RADIAL_PX`` and the polyline is
+    # straight -> the gate falls through to ``_build_edge_feature`` with the
+    # straight-line flag set.
+    assert features[0].feature_type is NavFeatureType.RING_EDGE
+    assert isinstance(features[0].flags, RingEdgeFlags)
+    assert features[0].flags.is_straight_line is True
+
+
+def test_to_features_emits_annulus_when_polyline_compresses_radially(
+    fake_obs: FakeObs,
+) -> None:
+    """A polyline whose radial extent is below the threshold emits RING_ANNULUS."""
+    # Build a curved-ish but radially compact polyline: a 10-pixel-wide arc
+    # whose mean normal points consistently along V so the extent stays
+    # below RING_ANNULUS_MAX_RADIAL_PX.
+    rows, cols = 110, 110
+    mask = np.zeros((rows, cols), dtype=bool)
+    us = np.arange(40, 60)
+    vs = (rows // 2 + (us % 3 - 1)).astype(int)  # tiny vertical jitter
+    for u, v in zip(us, vs, strict=True):
+        mask[v, u] = True
+    # Override the polyline normals indirectly: use a vertically narrow but
+    # u-extended footprint so radial extent is < 5 px.
+    model = _build_rings(obs=fake_obs, edge_mask=mask, constituent_count=2)
+    features = model.to_features(cast(Any, None))
+    types = {f.feature_type for f in features}
+    if NavFeatureType.RING_ANNULUS in types:
+        annulus = next(f for f in features if f.feature_type is NavFeatureType.RING_ANNULUS)
+        assert isinstance(annulus.geometry, RingAnnulusGeometry)
+        assert isinstance(annulus.flags, RingAnnulusFlags)
+        assert annulus.flags.planet_name == 'SATURN'
+
+
+def test_to_features_skips_empty_edge_info_list(fake_obs: FakeObs) -> None:
+    """A render result with no edges emits no features."""
+    model = _build_rings(obs=fake_obs, edge_mask=_curved_edge_mask((110, 110)))
+    feat = _ring_feature()
+    model._render_results = [
+        (feat, np.zeros((110, 110)), np.zeros((110, 110), dtype=bool), 1.0, []),
+    ]
+    assert model.to_features(cast(Any, None)) == []
+
+
+def test_to_features_empty_when_no_render_results(fake_obs: FakeObs) -> None:
+    """A NavModelRings with empty ``_render_results`` emits no features."""
+    model = NavModelRings('rings:SATURN', cast(Any, fake_obs))
+    assert model.to_features(cast(Any, None)) == []
+
+
+def test_to_annotations_returns_empty_collection_when_no_render_results(
+    fake_obs: FakeObs,
+) -> None:
+    """An empty NavModelRings emits an empty Annotations collection."""
+    model = NavModelRings('rings:SATURN', cast(Any, fake_obs))
+    out = model.to_annotations(cast(Any, None))
+    assert len(out.annotations) == 0
+
+
+def test_to_annotations_skips_empty_edge_info_list(fake_obs: FakeObs) -> None:
+    """Render results without edges yield no annotations."""
+    model = _build_rings(obs=fake_obs, edge_mask=_curved_edge_mask((110, 110)))
+    feat = _ring_feature()
+    model._render_results = [
+        (feat, np.zeros((110, 110)), np.zeros((110, 110), dtype=bool), 1.0, []),
+    ]
+    out = model.to_annotations(cast(Any, None))
+    assert len(out.annotations) == 0
+
+
+def test_create_model_records_metadata_block(
+    fake_obs: FakeObs, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``create_model`` populates the metadata block via the wrapping logic."""
+    model = NavModelRings('rings:SATURN', cast(Any, fake_obs))
+
+    def _fake_render(self: NavModelRings) -> None:
+        self._planet = 'SATURN'
+        self._metadata['planet'] = 'SATURN'
+        self._metadata['feature_count'] = 0
+
+    monkeypatch.setattr(NavModelRings, '_render', _fake_render)
+    model.create_model()
+    assert model.metadata['planet'] == 'SATURN'
+    assert 'start_time' in model.metadata
+    assert 'end_time' in model.metadata
+    assert model.metadata['elapsed_time_sec'] >= 0.0
+
+
+def test_instances_for_obs_returns_no_models_without_extdata_shape() -> None:
+    """``instances_for_obs`` is graceful for an obs lacking the ext-FOV surface."""
+
+    class _BareObs:
+        closest_planet = 'SATURN'
+
+    instances = NavModelRings.instances_for_obs(cast(Any, _BareObs()))
+    assert instances == []

--- a/tests/nav/nav_model/test_nav_model_rings_integration.py
+++ b/tests/nav/nav_model/test_nav_model_rings_integration.py
@@ -134,26 +134,26 @@ def test_to_features_emits_ring_edge_with_straight_line_flag(fake_obs: FakeObs) 
 def test_to_features_emits_annulus_when_polyline_compresses_radially(
     fake_obs: FakeObs,
 ) -> None:
-    """A polyline whose radial extent is below the threshold emits RING_ANNULUS."""
-    # Build a curved-ish but radially compact polyline: a 10-pixel-wide arc
-    # whose mean normal points consistently along V so the extent stays
-    # below RING_ANNULUS_MAX_RADIAL_PX.
+    """A polyline whose radial extent is below the threshold emits RING_ANNULUS.
+
+    The mask carries a shallow parabolic arch over a narrow U range so the
+    polyline is curved (deviation > FLAT_CURVATURE_THRESHOLD_PX) yet projects
+    to a span of < RING_ANNULUS_MAX_RADIAL_PX along its mean normal.
+    """
     rows, cols = 110, 110
     mask = np.zeros((rows, cols), dtype=bool)
-    us = np.arange(40, 60)
-    vs = (rows // 2 + (us % 3 - 1)).astype(int)  # tiny vertical jitter
+    us = np.arange(40, 70)
+    vs = (rows // 2 + 2.5 * np.sin(np.pi * (us - 40) / 30)).astype(int)
     for u, v in zip(us, vs, strict=True):
         mask[v, u] = True
-    # Override the polyline normals indirectly: use a vertically narrow but
-    # u-extended footprint so radial extent is < 5 px.
     model = _build_rings(obs=fake_obs, edge_mask=mask, constituent_count=2)
     features = model.to_features(cast(Any, None))
     types = {f.feature_type for f in features}
-    if NavFeatureType.RING_ANNULUS in types:
-        annulus = next(f for f in features if f.feature_type is NavFeatureType.RING_ANNULUS)
-        assert isinstance(annulus.geometry, RingAnnulusGeometry)
-        assert isinstance(annulus.flags, RingAnnulusFlags)
-        assert annulus.flags.planet_name == 'SATURN'
+    assert NavFeatureType.RING_ANNULUS in types
+    annulus = next(f for f in features if f.feature_type is NavFeatureType.RING_ANNULUS)
+    assert isinstance(annulus.geometry, RingAnnulusGeometry)
+    assert isinstance(annulus.flags, RingAnnulusFlags)
+    assert annulus.flags.planet_name == 'SATURN'
 
 
 def test_to_features_skips_empty_edge_info_list(fake_obs: FakeObs) -> None:

--- a/tests/nav/nav_orchestrator/test_orchestrator.py
+++ b/tests/nav/nav_orchestrator/test_orchestrator.py
@@ -33,13 +33,26 @@ class _FakeObs:
         image: np.ndarray | None = None,
         sensor_mask: np.ndarray | None = None,
         midtime: float = 0.0,
+        extfov_margin: tuple[int, int] = (0, 0),
     ) -> None:
         if image is None:
             rng = np.random.default_rng(seed=42)
             image = rng.standard_normal(size=(64, 64)) + 100.0
         self.data = image
+        # Build an extfov-padded image around ``data`` so the fake matches
+        # the real obs API: ``extdata`` is the canonical input the
+        # orchestrator reads.
+        margin_v, margin_u = extfov_margin
+        ext_shape = (image.shape[0] + 2 * margin_v, image.shape[1] + 2 * margin_u)
+        ext = np.zeros(ext_shape, dtype=image.dtype)
+        ext[margin_v : margin_v + image.shape[0], margin_u : margin_u + image.shape[1]] = image
+        self.extdata = ext
         if sensor_mask is None:
-            sensor_mask = np.ones(image.shape, bool)
+            sensor_mask = np.zeros(ext_shape, bool)
+            sensor_mask[
+                margin_v : margin_v + image.shape[0],
+                margin_u : margin_u + image.shape[1],
+            ] = True
         self._sensor_mask = sensor_mask
         self.midtime = midtime
 
@@ -131,6 +144,25 @@ def test_orchestrator_runs_pipeline_end_to_end(fake_obs: _FakeObs) -> None:
     assert result.offset_px == (1.5, 2.5)
     assert [t.technique_name for t in result.per_technique] == ['_FakeStarTechnique']
     assert result.confidence_rank == 'high'
+
+
+def test_orchestrator_handles_nonzero_extfov_margin() -> None:
+    """The pipeline accepts obs whose ``extdata`` is larger than ``data``.
+
+    The image-quality classifier consumes ``obs.extdata`` and
+    ``obs.extfov_data_sensor_mask()`` together, which must share the
+    extended-FOV shape regardless of the per-instrument extfov margin.
+    """
+    obs = _FakeObs(
+        image=np.full((64, 64), 100.0, dtype=np.float64),
+        extfov_margin=(8, 12),
+    )
+    assert obs.extdata.shape == (80, 88)
+    assert obs.extfov_data_sensor_mask().shape == (80, 88)
+    model = _FakeStarModel(obs, feature_count=3)
+    orch = NavOrchestrator([model], only_techniques=['_FakeStarTechnique'])
+    result = orch.navigate(obs)  # type: ignore[arg-type]
+    assert result.status == 'ok'
 
 
 def test_orchestrator_blank_image_short_circuits(fake_obs: _FakeObs) -> None:

--- a/tests/nav/test_navigate_image_files.py
+++ b/tests/nav/test_navigate_image_files.py
@@ -27,6 +27,10 @@ class _FakeSnapshot:
             self.data = np.zeros((32, 32), np.float64)
         else:
             self.data = rng.standard_normal(size=(32, 32)) + 100.0
+        # The orchestrator reads ``obs.extdata`` (extfov-shaped); this
+        # fake uses zero extfov margin so ``extdata`` is the same shape
+        # as ``data``.
+        self.extdata = self.data
         self._sensor_mask = np.ones(self.data.shape, bool)
         self.midtime = midtime
 

--- a/tests/shims/__init__.py
+++ b/tests/shims/__init__.py
@@ -1,0 +1,63 @@
+"""Reusable shims for nav-pipeline unit tests.
+
+The shims here let tests drive the navigation pipeline end-to-end
+without a real ``oops.Observation`` / ``Backplane``, real SPICE
+kernels, or real star catalogs.  They are intentionally small and
+table-driven; tests construct one with the data the code under test
+will read and ignore everything else.
+
+Modules:
+
+    ``backplane``
+        :class:`FakeBackplane`, :class:`BodyBackplaneData`,
+        :class:`RingBackplaneData`, plus the
+        :func:`plant_circular_body` factory.  Backplane methods return
+        real ``polymath.Scalar`` instances built from the configured
+        per-pixel arrays.
+    ``catalog``
+        :class:`FakeStar`, :class:`FakeStarCatalog`,
+        :func:`install_fake_catalogs`, and a
+        :func:`make_star` convenience factory.  ``install_fake_catalogs``
+        is per-test-scoped via the pytest ``monkeypatch`` fixture and
+        is safe under parallel test execution.
+    ``obs``
+        :class:`FakeObs` plus support classes
+        :class:`FakePSF`, :class:`FakeFOV`,
+        :class:`FakeMeshgrid`, :class:`FakeUV`.
+"""
+
+from tests.shims.backplane import (
+    BodyBackplaneData,
+    FakeBackplane,
+    RingBackplaneData,
+    plant_circular_body,
+)
+from tests.shims.catalog import (
+    FakeStar,
+    FakeStarCatalog,
+    install_fake_catalogs,
+    make_star,
+)
+from tests.shims.obs import (
+    FakeFOV,
+    FakeMeshgrid,
+    FakeObs,
+    FakePSF,
+    FakeUV,
+)
+
+__all__ = [
+    'BodyBackplaneData',
+    'FakeBackplane',
+    'FakeFOV',
+    'FakeMeshgrid',
+    'FakeObs',
+    'FakePSF',
+    'FakeStar',
+    'FakeStarCatalog',
+    'FakeUV',
+    'RingBackplaneData',
+    'install_fake_catalogs',
+    'make_star',
+    'plant_circular_body',
+]

--- a/tests/shims/backplane.py
+++ b/tests/shims/backplane.py
@@ -1,0 +1,363 @@
+"""Fake ``oops.Backplane`` for unit-testing nav-pipeline code paths.
+
+Real backplane evaluation depends on a working SPICE kernel pool, an
+``oops.Observation`` whose camera model can be inverted at sub-pixel
+resolution, and a per-image meshgrid.  This shim lets a test plug in
+canned per-pixel arrays and per-body / per-ring scalar facts; every
+backplane method the navigation pipeline calls returns a real
+``polymath.Scalar`` wrapping the configured numpy array.
+
+The shim is table-driven.  Tests construct a :class:`FakeBackplane`
+with kwargs that fill the lookup tables; methods that have no entry
+raise ``LookupError`` naming the missing key, so missing wiring fails
+fast instead of silently returning empty data.
+
+Construction is intentionally explicit so tests can build the smallest
+backplane they need.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import polymath
+
+__all__ = [
+    'BodyBackplaneData',
+    'FakeBackplane',
+    'RingBackplaneData',
+    'plant_circular_body',
+]
+
+
+def _scalar(
+    vals: np.ndarray | float,
+    mask: np.ndarray | bool | None = None,
+    *,
+    key: tuple[Any, ...] | None = None,
+) -> polymath.Scalar:
+    """Build a ``polymath.Scalar`` and optionally tag it with a backplane ``key``.
+
+    ``polymath.Scalar`` already covers ``.vals`` / ``.mvals`` /
+    ``min`` / ``max`` / ``median`` / ``expand_mask`` / ``mask_where`` /
+    ``any`` / ``__getitem__`` natively.  The shim only needs to set the
+    ``key`` attribute the navigation pipeline reads back from
+    ``ring_radius`` results so it can call
+    :meth:`oops.Backplane.border_atop`.
+
+    Parameters:
+        vals: Numpy array or scalar.
+        mask: Optional boolean mask of the same shape as ``vals``.
+        key: Optional opaque key surfaced as ``.key``.
+
+    Returns:
+        Configured ``polymath.Scalar``.
+    """
+    if mask is None:
+        scalar = polymath.Scalar(np.asarray(vals))
+    else:
+        scalar = polymath.Scalar(np.asarray(vals), np.asarray(mask, dtype=bool))
+    if key is not None:
+        scalar.key = key
+    return scalar
+
+
+@dataclass
+class BodyBackplaneData:
+    """Per-body backplane arrays and scalar facts.
+
+    Parameters:
+        body_mask: 2-D boolean mask, ``True`` where the body silhouette
+            is on the pixel grid.  Required.
+        incidence_rad: 2-D float array of per-pixel incidence angles in
+            radians.  Values outside ``body_mask`` are ignored.
+            Required.
+        lambert: 2-D float array of per-pixel Lambert reflectance.
+            Defaults to ``cos(incidence)`` clipped to ``[0, inf)`` and
+            zeroed outside the silhouette.
+        resolution_km_px: 2-D float array of per-pixel km/px scale.
+            Defaults to a constant fill from ``default_resolution_km_px``.
+        default_resolution_km_px: Scalar fallback when
+            ``resolution_km_px`` is not supplied.
+        sub_solar_lon_rad: scalar; default 0.
+        sub_solar_lat_rad: scalar; default 0.
+        sub_observer_lon_rad: scalar; default 0.
+        sub_observer_lat_rad: scalar; default 0.
+        center_phase_rad: scalar; default 0.
+        intercepted_mask: 2-D boolean mask returned by
+            ``where_intercepted``.  Defaults to ``body_mask``.
+    """
+
+    body_mask: np.ndarray
+    incidence_rad: np.ndarray
+    lambert: np.ndarray | None = None
+    resolution_km_px: np.ndarray | None = None
+    default_resolution_km_px: float = 1.0
+    sub_solar_lon_rad: float = 0.0
+    sub_solar_lat_rad: float = 0.0
+    sub_observer_lon_rad: float = 0.0
+    sub_observer_lat_rad: float = 0.0
+    center_phase_rad: float = 0.0
+    intercepted_mask: np.ndarray | None = None
+
+    def lambert_array(self) -> np.ndarray:
+        """Return the Lambert array, computing the default if absent."""
+        if self.lambert is not None:
+            return self.lambert
+        cos_i = np.clip(np.cos(self.incidence_rad), 0.0, None)
+        return np.where(self.body_mask, cos_i, 0.0)
+
+    def resolution_array(self) -> np.ndarray:
+        """Return the resolution array, computing the default if absent."""
+        if self.resolution_km_px is not None:
+            return self.resolution_km_px
+        return np.full(self.body_mask.shape, self.default_resolution_km_px)
+
+    def intercept_mask(self) -> np.ndarray:
+        """Return the intercepted-mask, defaulting to ``body_mask``."""
+        return self.intercepted_mask if self.intercepted_mask is not None else self.body_mask
+
+
+@dataclass
+class RingBackplaneData:
+    """Per-planet ring-system backplane arrays.
+
+    Parameters:
+        ring_radius_km: 2-D float array of per-pixel ring-plane radius
+            in km.  Required.
+        ring_mask: 2-D boolean mask, ``True`` where the ring plane is
+            sampled (False -> masked out, off the ring).  Required.
+        radial_resolution_km_px: 2-D float array of per-pixel radial
+            km/px.  Defaults to a constant fill.
+        default_radial_resolution_km_px: Scalar fallback when
+            ``radial_resolution_km_px`` is not supplied.
+        distance_km: 2-D float array of per-pixel distance to the ring
+            plane.  Defaults to a constant fill.
+        default_distance_km: Scalar fallback for ``distance_km``.
+        shadow_mask: Optional 2-D boolean mask, ``True`` where the ring
+            plane is in the planet's shadow.  Defaults to all-False.
+        border_atop: Optional callable mapping ``(key, a)`` to a 2-D
+            boolean mask.  Defaults to a thresholding helper that picks
+            pixels whose ``ring_radius_km`` is within 0.5 km of ``a``.
+    """
+
+    ring_radius_km: np.ndarray
+    ring_mask: np.ndarray
+    radial_resolution_km_px: np.ndarray | None = None
+    default_radial_resolution_km_px: float = 1.0
+    distance_km: np.ndarray | None = None
+    default_distance_km: float = 1.0e9
+    shadow_mask: np.ndarray | None = None
+    border_atop: Callable[[tuple[Any, ...], float], np.ndarray] | None = None
+
+    def radial_resolution_array(self) -> np.ndarray:
+        """Return the radial-resolution array, defaulting if absent."""
+        if self.radial_resolution_km_px is not None:
+            return self.radial_resolution_km_px
+        return np.full(self.ring_mask.shape, self.default_radial_resolution_km_px)
+
+    def distance_array(self) -> np.ndarray:
+        """Return the distance array, defaulting if absent."""
+        if self.distance_km is not None:
+            return self.distance_km
+        return np.full(self.ring_mask.shape, self.default_distance_km)
+
+    def shadow_array(self) -> np.ndarray:
+        """Return the shadow mask, defaulting to all-False."""
+        return (
+            self.shadow_mask
+            if self.shadow_mask is not None
+            else np.zeros(self.ring_mask.shape, dtype=bool)
+        )
+
+    def border_atop_mask(self, key: tuple[Any, ...], a: float) -> np.ndarray:
+        """Return the boolean ``border_atop(key, a)`` mask."""
+        if self.border_atop is not None:
+            return self.border_atop(key, a)
+        return np.abs(self.ring_radius_km - a) < 0.5
+
+
+@dataclass
+class FakeBackplane:
+    """Table-driven stand-in for ``oops.Backplane``.
+
+    Each method returns a real ``polymath.Scalar`` whose ``vals`` /
+    ``mvals`` / aggregate-reduction methods behave exactly like the
+    production code expects, so the navigation pipeline runs against
+    standard ``polymath`` objects.
+
+    Parameters:
+        per_body: Mapping of upper-case body name to
+            :class:`BodyBackplaneData`.  Methods like
+            ``incidence_angle(body_name)`` look up the matching entry
+            and return a Scalar over the configured array.
+        per_ring: Mapping of ring target string (e.g. ``'saturn:ring'``)
+            to :class:`RingBackplaneData`.
+    """
+
+    per_body: dict[str, BodyBackplaneData] = field(default_factory=dict)
+    per_ring: dict[str, RingBackplaneData] = field(default_factory=dict)
+
+    def _body(self, body_name: str) -> BodyBackplaneData:
+        key = body_name.upper()
+        if key not in self.per_body:
+            raise LookupError(f'FakeBackplane has no entry for body {body_name!r}')
+        return self.per_body[key]
+
+    def _ring(self, ring_target: str) -> RingBackplaneData:
+        if ring_target not in self.per_ring:
+            raise LookupError(f'FakeBackplane has no entry for ring target {ring_target!r}')
+        return self.per_ring[ring_target]
+
+    # ------------------------------------------------------------------
+    # Body methods
+    # ------------------------------------------------------------------
+
+    def incidence_angle(self, body_name: str) -> polymath.Scalar:
+        """Return per-pixel incidence angle in radians."""
+        data = self._body(body_name)
+        return _scalar(data.incidence_rad, ~data.body_mask)
+
+    def lambert_law(self, body_name: str) -> polymath.Scalar:
+        """Return per-pixel Lambert reflectance."""
+        data = self._body(body_name)
+        return _scalar(data.lambert_array(), ~data.body_mask)
+
+    def resolution(self, body_name: str) -> polymath.Scalar:
+        """Return per-pixel km/px scale."""
+        data = self._body(body_name)
+        return _scalar(data.resolution_array(), ~data.body_mask)
+
+    def sub_solar_longitude(self, body_name: str) -> polymath.Scalar:
+        """Return scalar sub-solar longitude (radians)."""
+        return _scalar(self._body(body_name).sub_solar_lon_rad)
+
+    def sub_solar_latitude(self, body_name: str) -> polymath.Scalar:
+        """Return scalar sub-solar latitude (radians)."""
+        return _scalar(self._body(body_name).sub_solar_lat_rad)
+
+    def sub_observer_longitude(self, body_name: str) -> polymath.Scalar:
+        """Return scalar sub-observer longitude (radians)."""
+        return _scalar(self._body(body_name).sub_observer_lon_rad)
+
+    def sub_observer_latitude(self, body_name: str) -> polymath.Scalar:
+        """Return scalar sub-observer latitude (radians)."""
+        return _scalar(self._body(body_name).sub_observer_lat_rad)
+
+    def center_phase_angle(self, body_name: str) -> polymath.Scalar:
+        """Return scalar center-pixel phase angle (radians)."""
+        return _scalar(self._body(body_name).center_phase_rad)
+
+    def where_intercepted(self, body_name: str) -> polymath.Scalar:
+        """Return a boolean Scalar marking pixels intercepting the body."""
+        return _scalar(self._body(body_name).intercept_mask().astype(bool))
+
+    # ------------------------------------------------------------------
+    # Ring methods
+    # ------------------------------------------------------------------
+
+    def ring_radius(self, ring_target: str) -> polymath.Scalar:
+        """Return per-pixel ring-plane radius in km."""
+        data = self._ring(ring_target)
+        return _scalar(
+            data.ring_radius_km,
+            ~data.ring_mask,
+            key=('ring_radius', ring_target),
+        )
+
+    def ring_radial_resolution(self, ring_target: str) -> polymath.Scalar:
+        """Return per-pixel radial km/px scale."""
+        data = self._ring(ring_target)
+        return _scalar(data.radial_resolution_array(), ~data.ring_mask)
+
+    def border_atop(self, key: tuple[Any, ...], a: float) -> polymath.Scalar:
+        """Return a boolean Scalar marking pixels at ring radius ``a``.
+
+        ``key`` is the tuple read off ``ring_radius(...).key`` by the
+        production code; the head determines which ring's radius array
+        we threshold against ``a``.
+        """
+        if not key or key[0] != 'ring_radius':
+            raise LookupError(f'FakeBackplane.border_atop expected a ring_radius key, got {key!r}')
+        ring_target = key[1]
+        data = self._ring(ring_target)
+        return _scalar(data.border_atop_mask(key, a).astype(bool))
+
+    def distance(self, ring_target: str, *, direction: str = 'dep') -> polymath.Scalar:
+        """Return per-pixel ring-plane distance in km."""
+        del direction
+        data = self._ring(ring_target)
+        return _scalar(data.distance_array(), ~data.ring_mask)
+
+    def where_inside_shadow(self, ring_target: str, planet: str) -> polymath.Scalar:
+        """Return a boolean Scalar marking ring pixels inside the planet's shadow."""
+        del planet
+        data = self._ring(ring_target)
+        return _scalar(data.shadow_array().astype(bool))
+
+
+def plant_circular_body(
+    *,
+    shape: tuple[int, int],
+    centre_vu: tuple[float, float],
+    radius_px: float,
+    sub_solar_lon_deg: float = 0.0,
+    sub_solar_lat_deg: float = 0.0,
+    sub_observer_lon_deg: float = 0.0,
+    sub_observer_lat_deg: float = 0.0,
+    phase_angle_deg: float = 30.0,
+    resolution_km_px: float = 5.0,
+) -> BodyBackplaneData:
+    """Build :class:`BodyBackplaneData` for a circular body silhouette.
+
+    Convenience factory that paints a circle of radius ``radius_px``
+    centred at ``centre_vu`` and assigns each silhouette pixel an
+    incidence angle that varies smoothly across the disc (zero at the
+    centre, increasing outward to the limb).  Suitable for end-to-end
+    body-NavModel tests where the exact incidence pattern is not the
+    focus.
+
+    Parameters:
+        shape: ``(rows, cols)`` of the output arrays.
+        centre_vu: Body centre in pixel coordinates.
+        radius_px: Body radius in pixels.
+        sub_solar_lon_deg: Scalar sub-solar longitude in degrees.
+        sub_solar_lat_deg: Scalar sub-solar latitude in degrees.
+        sub_observer_lon_deg: Scalar sub-observer longitude in degrees.
+        sub_observer_lat_deg: Scalar sub-observer latitude in degrees.
+        phase_angle_deg: Scalar phase angle in degrees.
+        resolution_km_px: Constant per-pixel km/px scale.
+
+    Returns:
+        Configured :class:`BodyBackplaneData`.
+    """
+    rows, cols = shape
+    vv, uu = np.meshgrid(
+        np.arange(rows, dtype=np.float64),
+        np.arange(cols, dtype=np.float64),
+        indexing='ij',
+    )
+    dv = vv - centre_vu[0]
+    du = uu - centre_vu[1]
+    radius = np.sqrt(dv * dv + du * du)
+    body_mask = radius <= radius_px
+    # Linear ramp from 0 at centre to pi/2 at limb; outside the limb the
+    # value is irrelevant because ``body_mask`` is False.
+    incidence = np.where(
+        body_mask,
+        (radius / radius_px) * (np.pi / 2.0),
+        np.pi / 2.0,
+    )
+    return BodyBackplaneData(
+        body_mask=body_mask,
+        incidence_rad=incidence,
+        sub_solar_lon_rad=float(np.radians(sub_solar_lon_deg)),
+        sub_solar_lat_rad=float(np.radians(sub_solar_lat_deg)),
+        sub_observer_lon_rad=float(np.radians(sub_observer_lon_deg)),
+        sub_observer_lat_rad=float(np.radians(sub_observer_lat_deg)),
+        center_phase_rad=float(np.radians(phase_angle_deg)),
+        default_resolution_km_px=resolution_km_px,
+    )

--- a/tests/shims/backplane.py
+++ b/tests/shims/backplane.py
@@ -333,7 +333,13 @@ def plant_circular_body(
 
     Returns:
         Configured :class:`BodyBackplaneData`.
+
+    Raises:
+        ValueError: If ``radius_px`` is not positive (would divide by zero
+            in the incidence ramp and seed NaNs into the outputs).
     """
+    if not radius_px > 0.0:
+        raise ValueError(f'radius_px must be > 0; got {radius_px!r}')
     rows, cols = shape
     vv, uu = np.meshgrid(
         np.arange(rows, dtype=np.float64),

--- a/tests/shims/catalog.py
+++ b/tests/shims/catalog.py
@@ -213,9 +213,9 @@ class FakeStarCatalog:
                 continue
             if not dec_min <= star.dec <= dec_max:
                 continue
-            if not vmag_min <= star.vmag <= vmag_max:
-                continue
             if math.isnan(star.vmag):
+                continue
+            if not vmag_min <= star.vmag <= vmag_max:
                 continue
             yield copy.deepcopy(star)
 

--- a/tests/shims/catalog.py
+++ b/tests/shims/catalog.py
@@ -1,0 +1,274 @@
+"""Fake star catalogs and ``MutableStar`` records.
+
+The real star catalogs (UCAC4, Tycho-2 via SPICE, YBSC) require
+multi-GB on-disk binaries, network access, or both.  This module
+provides:
+
+- :class:`FakeStar` — minimal ``MutableStar``-protocol-compatible
+  record that the catalog reduction can mutate freely.
+- :class:`FakeStarCatalog` — implements the
+  ``find_stars(*, ra_min, ra_max, dec_min, dec_max, vmag_min,
+  vmag_max, **kwargs)`` API the real catalogs expose.
+- :func:`install_fake_catalogs` — pytest helper that monkeypatches
+  the lazy catalog getters in
+  :mod:`nav.nav_model.stars.catalog` so the production code reads from
+  fake catalogs instead.
+
+The shim is generic — tests can plug in any list of stars and any
+combination of catalogs (e.g. just UCAC4, or all three).
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    import pytest
+
+__all__ = [
+    'FakeStar',
+    'FakeStarCatalog',
+    'install_fake_catalogs',
+    'make_star',
+]
+
+
+@dataclass
+class FakeStar:
+    """Mutable star record satisfying the ``MutableStar`` protocol surface.
+
+    The fields cover what the catalog reduction reads or writes during
+    a single navigation pass: identity, photometry, RA/DEC, proper
+    motion, image-space placement, and conflict tagging.  Defaults are
+    chosen so that a minimal star (``FakeStar(ra=..., dec=...,
+    vmag=...)``) is a complete record once the reduction populates the
+    derived fields.
+
+    Parameters:
+        unique_number: Catalog ID.  The catalog reduction copies this
+            into ``pretty_name`` when ``name`` is empty.
+        catalog_name: Catalog string (set by the reduction).
+        pretty_name: Human-readable name (set by the reduction).
+        name: Optional canonical name from the catalog.
+        ra: Catalog right ascension in radians.
+        dec: Catalog declination in radians.
+        vmag: Catalog V-band magnitude.
+        b_v: Catalog ``B-V`` colour, or ``None``.
+        johnson_mag_v: Johnson V magnitude (set by the reduction when
+            absent).
+        johnson_mag_b: Johnson B magnitude (set by the reduction).
+        johnson_mag_faked: ``True`` when the reduction supplied
+            ``johnson_mag_b`` from the spectral-class colour table
+            instead of the catalog.
+        spectral_class: MK spectral class, e.g. ``'G0'``.  The
+            reduction defaults to ``stars.default_star_class`` when
+            absent.
+        temperature: Surface temperature (K).  The reduction supplies
+            a default when absent.
+        temperature_faked: ``True`` when the reduction supplied a
+            default temperature.
+        ra_pm: Proper-motion-corrected RA at obs midtime.
+        dec_pm: Proper-motion-corrected DEC at obs midtime.
+        psf_size: Per-star PSF size in pixels (set by the reduction).
+        u: Sub-pixel U coordinate (set by the FOV projection).
+        v: Sub-pixel V coordinate (set by the FOV projection).
+        move_u: Per-exposure smear amplitude along U (set by the FOV
+            projection).
+        move_v: Per-exposure smear amplitude along V.
+        dn: Catalog flux-to-DN scaling (set by the reduction).
+        conflicts: Conflict-marking tag.  Empty string when the star
+            is usable; ``'STAR'`` / ``'BODY: <body>'`` /
+            ``'RING: <planet>'`` otherwise.
+        diff_u: Per-star delta-U used by some technique paths.
+        diff_v: Per-star delta-V used by some technique paths.
+    """
+
+    unique_number: int | None = None
+    catalog_name: str = ''
+    pretty_name: str = ''
+    name: str = ''
+    ra: float | None = None
+    dec: float | None = None
+    vmag: float | None = None
+    b_v: float | None = None
+    johnson_mag_v: float | None = None
+    johnson_mag_b: float | None = None
+    johnson_mag_faked: bool = False
+    spectral_class: str | None = None
+    temperature: float | None = None
+    temperature_faked: bool = False
+    ra_pm: float = 0.0
+    dec_pm: float = 0.0
+    psf_size: tuple[int, int] = (5, 5)
+    u: float = 0.0
+    v: float = 0.0
+    move_u: float = 0.0
+    move_v: float = 0.0
+    dn: float = 0.0
+    conflicts: str = ''
+    diff_u: float = 0.0
+    diff_v: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Mirror the proper-motion fields onto the catalog RA/DEC by default."""
+        if self.ra is not None and self.ra_pm == 0.0:
+            self.ra_pm = self.ra
+        if self.dec is not None and self.dec_pm == 0.0:
+            self.dec_pm = self.dec
+
+    def ra_dec_with_pm(self, tdb: float) -> tuple[float, float]:
+        """Return the proper-motion-corrected ``(ra, dec)`` at ``tdb``.
+
+        The shim ignores ``tdb`` and returns whatever the test set on
+        ``ra_pm`` / ``dec_pm`` (or the catalog RA/DEC when those are
+        zero — see ``__post_init__``).
+
+        Parameters:
+            tdb: Target ephemeris time (ignored by the shim).
+
+        Returns:
+            ``(ra_pm, dec_pm)`` in radians.
+        """
+        del tdb
+        return self.ra_pm, self.dec_pm
+
+
+def make_star(**kwargs: object) -> FakeStar:
+    """Build a :class:`FakeStar` with sensible defaults overridden by kwargs.
+
+    The default star has ``ra = dec = 0``, ``vmag = 5``, spectral class
+    ``G0``, no name, and a 5x5 PSF.  Override any field via keyword.
+
+    Parameters:
+        **kwargs: Field overrides forwarded to :class:`FakeStar`.
+
+    Returns:
+        Configured :class:`FakeStar`.
+    """
+    defaults: dict[str, object] = {
+        'unique_number': 1,
+        'ra': 0.0,
+        'dec': 0.0,
+        'vmag': 5.0,
+        'spectral_class': 'G0',
+        'temperature': 5800.0,
+        'b_v': 0.65,
+    }
+    defaults.update(kwargs)
+    return FakeStar(**defaults)  # type: ignore[arg-type]
+
+
+@dataclass
+class FakeStarCatalog:
+    """Stand-in for ``UCAC4StarCatalog`` / ``SpiceStarCatalog`` / ``YBSCStarCatalog``.
+
+    Stores a list of :class:`FakeStar` records and surfaces them through
+    the same ``find_stars`` API the production code calls.  All the
+    catalog-specific kwargs (``allow_double``, ``allow_galaxy``) are
+    accepted and ignored.
+
+    Parameters:
+        stars: Stars the catalog "knows about".
+    """
+
+    stars: list[FakeStar] = field(default_factory=list)
+
+    def find_stars(
+        self,
+        *,
+        ra_min: float,
+        ra_max: float,
+        dec_min: float,
+        dec_max: float,
+        vmag_min: float,
+        vmag_max: float,
+        **_: object,
+    ) -> Iterator[FakeStar]:
+        """Yield deep copies of every star inside the given RA / DEC / mag box.
+
+        Deep-copying matches the production code's expectation: the
+        reduction mutates the returned records freely.  Records with a
+        ``None`` ``ra`` / ``dec`` / ``vmag`` are still yielded so that
+        the production code's defensive None-checks are reachable in
+        tests; only records with concrete values participate in the
+        RA / DEC / mag window filter.
+
+        Parameters:
+            ra_min, ra_max: Right-ascension window in radians.
+            dec_min, dec_max: Declination window in radians.
+            vmag_min, vmag_max: V-band magnitude window.
+
+        Yields:
+            Deep copies of any matching :class:`FakeStar`.
+        """
+        for star in self.stars:
+            if star.ra is None or star.dec is None or star.vmag is None:
+                yield copy.deepcopy(star)
+                continue
+            if not ra_min <= star.ra <= ra_max:
+                continue
+            if not dec_min <= star.dec <= dec_max:
+                continue
+            if not vmag_min <= star.vmag <= vmag_max:
+                continue
+            if math.isnan(star.vmag):
+                continue
+            yield copy.deepcopy(star)
+
+
+def install_fake_catalogs(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    ucac4: Iterable[FakeStar] | None = None,
+    tycho2: Iterable[FakeStar] | None = None,
+    ybsc: Iterable[FakeStar] | None = None,
+) -> dict[str, FakeStarCatalog]:
+    """Swap the lazy catalog getters for test-local fakes.
+
+    The patches install via the pytest ``monkeypatch`` fixture, which
+    records the originals and restores them on test teardown.  Each
+    call patches **only the calling test's process and only for the
+    lifetime of that test** — pytest-xdist workers run in separate
+    processes so module-level state in one worker cannot leak into
+    another, and the per-test ``monkeypatch`` teardown means subsequent
+    tests in the same worker see the unpatched getters again.
+
+    The module-level catalog cache (``_STAR_CATALOG_*``) is not
+    touched: the helper replaces the *getter functions* so the cache
+    is bypassed entirely while the patches are in effect.  Any catalog
+    instance previously cached by an earlier test that imported the
+    real getter is undisturbed, and that earlier cache cannot leak the
+    fake catalog into a later test because the fake never reaches the
+    cache.
+
+    Tests that omit a catalog (e.g. only pass ``ucac4=...``) get an
+    empty :class:`FakeStarCatalog` for the other two catalogs, which
+    surfaces no stars to the catalog reduction.
+
+    Parameters:
+        monkeypatch: Pytest fixture; required so the swap is bound to
+            the calling test's lifetime.
+        ucac4: Stars exposed by ``get_ucac4_catalog()``.
+        tycho2: Stars exposed by ``get_tycho2_catalog()``.
+        ybsc: Stars exposed by ``get_ybsc_catalog()``.
+
+    Returns:
+        Mapping ``{'ucac4', 'tycho2', 'ybsc'}`` -> the constructed
+        :class:`FakeStarCatalog` instances; tests can inspect or mutate
+        them after installation.
+    """
+    cat_map = {
+        'ucac4': FakeStarCatalog(stars=list(ucac4) if ucac4 is not None else []),
+        'tycho2': FakeStarCatalog(stars=list(tycho2) if tycho2 is not None else []),
+        'ybsc': FakeStarCatalog(stars=list(ybsc) if ybsc is not None else []),
+    }
+    for name in cat_map:
+        monkeypatch.setattr(
+            f'nav.nav_model.stars.catalog.get_{name}_catalog',
+            lambda _name=name: cat_map[_name],
+        )
+    return cat_map

--- a/tests/shims/obs.py
+++ b/tests/shims/obs.py
@@ -23,6 +23,7 @@ so the test failure is informative.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -150,6 +151,7 @@ class FakeObs:
     star_min_vmag: float = 0.0
     star_max_vmag: float = 17.0
     ra_dec_limits_ext_rad: tuple[float, float, float, float] = (0.0, 0.1, 0.0, 0.1)
+    radec_to_uv: Callable[[float, float, float], tuple[float, float]] | None = None
     boresight_ra_rad: float = 0.0
     boresight_dec_rad: float = 0.0
     fov: FakeFOV = field(default_factory=FakeFOV)
@@ -157,6 +159,10 @@ class FakeObs:
     def __post_init__(self) -> None:
         """Build the extfov-padded ``extdata`` from ``data`` plus the margin."""
         margin_v, margin_u = self.extfov_margin_vu
+        if margin_v < 0 or margin_u < 0:
+            raise ValueError(
+                f'extfov_margin_vu must be non-negative; got {self.extfov_margin_vu!r}'
+            )
         ext_shape = (
             self.data.shape[0] + 2 * margin_v,
             self.data.shape[1] + 2 * margin_u,
@@ -345,9 +351,12 @@ class FakeObs:
     ) -> FakeUV:
         """Project RA/DEC into pixel coordinates.
 
-        The fake places every requested point at the FOV centre, with a
-        small ``tfrac``-driven shift so the smear-bracket calculation
-        produces a deterministic non-zero displacement when desired.
+        When ``self.radec_to_uv`` is set, the callable is invoked once per
+        ``(ra, dec)`` point with ``(ra, dec, tfrac)`` and must return
+        ``(u, v)``.  Otherwise the shim places every requested point at
+        the FOV centre with a small ``tfrac``-driven shift so the
+        smear-bracket calculation produces a deterministic non-zero
+        displacement when desired.
 
         Parameters:
             ra: Scalar or polymath-Scalar RA.
@@ -356,14 +365,21 @@ class FakeObs:
             apparent: Accepted for API parity; ignored by the shim.
         """
         del apparent
-        v_centre = self.data.shape[0] / 2.0 + self.extfov_margin_vu[0]
-        u_centre = self.data.shape[1] / 2.0 + self.extfov_margin_vu[1]
-        # Decompose ra/dec to a 1-D float array so callers can pass a
-        # polymath.Scalar wrapping a list, a numpy array, or a python
-        # float.  The shim uses the raw values to size the output.
         ra_arr = np.atleast_1d(np.asarray(_extract_vals(ra), dtype=np.float64))
         dec_arr = np.atleast_1d(np.asarray(_extract_vals(dec), dtype=np.float64))
         n = max(ra_arr.size, dec_arr.size)
+        ra_b = np.broadcast_to(ra_arr, (n,))
+        dec_b = np.broadcast_to(dec_arr, (n,))
+        if self.radec_to_uv is not None:
+            uv = [
+                self.radec_to_uv(float(r), float(d), tfrac)
+                for r, d in zip(ra_b, dec_b, strict=True)
+            ]
+            u = np.asarray([p[0] for p in uv], dtype=np.float64)
+            v = np.asarray([p[1] for p in uv], dtype=np.float64)
+            return FakeUV(u_vals=u, v_vals=v)
+        v_centre = self.data.shape[0] / 2.0 + self.extfov_margin_vu[0]
+        u_centre = self.data.shape[1] / 2.0 + self.extfov_margin_vu[1]
         u = np.full(n, u_centre)
         v = np.full(n, v_centre)
         # Apply a per-point shift driven by tfrac so the bracket

--- a/tests/shims/obs.py
+++ b/tests/shims/obs.py
@@ -1,0 +1,378 @@
+"""Fake ``ObsSnapshot`` for unit-testing nav-pipeline code paths.
+
+Combines the backplane shim (:class:`tests.shims.backplane.FakeBackplane`)
+with a numpy-array image-side surface so the navigation pipeline can be
+driven end-to-end without a real ``oops.Observation``, SPICE kernels,
+or PDS3 holdings.
+
+Tests construct a :class:`FakeObs` with any subset of:
+
+- A sensor-area image plus an extfov margin (the shim derives the
+  extfov-shaped ``extdata`` from the two).
+- A ``FakeBackplane`` for ``ext_bp``.
+- A per-body inventory dict (mapping body name to the ``unclipped``
+  bounding-box record :meth:`oops.Observation.inventory` returns).
+- A PSF object exposing ``.sigma`` / ``fwhm()`` for ``star_psf``.
+- A magnitude window and RA/DEC limits.
+
+Methods that the code under test does not call do not need to be
+populated.  Methods that are called but that have no plausible
+fallback raise :class:`NotImplementedError` naming the missing wiring
+so the test failure is informative.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import polymath
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from tests.shims.backplane import FakeBackplane
+
+__all__ = [
+    'FakeFOV',
+    'FakeMeshgrid',
+    'FakeObs',
+    'FakePSF',
+    'FakeUV',
+]
+
+
+class FakePSF:
+    """PSF stand-in exposing the ``sigma`` attribute the predictor reads.
+
+    Parameters:
+        sigma: Per-pixel Gaussian sigma in pixels.
+    """
+
+    def __init__(self, sigma: float = 1.0) -> None:
+        self.sigma = sigma
+
+
+class FakeFOV:
+    """Stand-in for ``oops.FOV`` accepted by ``Meshgrid.for_fov``."""
+
+
+class FakeMeshgrid:
+    """Stand-in for ``oops.Meshgrid``.
+
+    The pipeline only passes meshgrids back into ``Backplane(...)`` and
+    never inspects them, so the fake is opaque.
+    """
+
+    def __init__(
+        self,
+        origin: tuple[float, float] | None = None,
+        limit: tuple[float, float] | None = None,
+        *,
+        oversample: tuple[int, int] | None = None,
+        swap: bool = False,
+    ) -> None:
+        self.origin = origin
+        self.limit = limit
+        self.oversample = oversample
+        self.swap = swap
+
+    @classmethod
+    def for_fov(
+        cls,
+        fov: FakeFOV,
+        *,
+        origin: tuple[float, float],
+        limit: tuple[float, float],
+        oversample: tuple[int, int] = (1, 1),
+        swap: bool = False,
+    ) -> FakeMeshgrid:
+        """Mirror the ``oops.Meshgrid.for_fov`` factory signature."""
+        del fov
+        return cls(origin, limit, oversample=oversample, swap=swap)
+
+
+@dataclass
+class FakeUV:
+    """Stand-in for the result of ``Observation.uv_from_ra_and_dec``.
+
+    Parameters:
+        u_vals: Array (or scalar) of U-pixel coordinates.
+        v_vals: Array (or scalar) of V-pixel coordinates.
+    """
+
+    u_vals: np.ndarray
+    v_vals: np.ndarray
+
+    def to_scalars(self) -> tuple[polymath.Scalar, polymath.Scalar]:
+        """Return ``(u_scalar, v_scalar)`` mirroring ``polymath`` UV results."""
+        return polymath.Scalar(self.u_vals), polymath.Scalar(self.v_vals)
+
+
+@dataclass
+class FakeObs:
+    """Numpy-array stand-in for an ``ObsSnapshotInst``.
+
+    Parameters:
+        data: Sensor-area image.  Required.
+        extfov_margin_vu: ``(margin_v, margin_u)`` extfov-padding margin.
+            Defaults to ``(0, 0)``.
+        midtime: Observation midtime in TDB seconds.
+        closest_planet: Upper-case planet name returned by
+            ``obs.closest_planet``.
+        ext_bp: :class:`FakeBackplane` for ``obs.ext_bp``.
+        inventory_records: Per-body inventory dict; keyed by upper-case
+            body name with each value mirroring the
+            ``return_type='full'`` shape (``u_min_unclipped``,
+            ``u_max_unclipped``, ``v_min_unclipped``,
+            ``v_max_unclipped``, ``u_pixel_size``, ``v_pixel_size``,
+            ``range``, ``center_uv``).
+        psf: :class:`FakePSF` returned by ``star_psf``.
+        psf_size: Tuple returned by ``star_psf_size``.
+        star_min_vmag: Lower magnitude floor.
+        star_max_vmag: Upper magnitude floor.
+        ra_dec_limits_ext_rad: ``(ra_min, ra_max, dec_min, dec_max)``
+            tuple returned by ``ra_dec_limits_ext()``.
+        radec_to_uv: Optional callable mapping ``(ra, dec, tfrac)`` to
+            ``(u, v)`` for ``uv_from_ra_and_dec``.  When unset every
+            star projects onto the FOV centre.
+        boresight_ra_rad: RA returned by ``boresight_ra()``.
+        boresight_dec_rad: DEC returned by ``boresight_dec()``.
+    """
+
+    data: np.ndarray
+    extfov_margin_vu: tuple[int, int] = (0, 0)
+    midtime: float = 0.0
+    closest_planet: str | None = None
+    ext_bp: FakeBackplane | None = None
+    inventory_records: dict[str, dict[str, Any]] = field(default_factory=dict)
+    psf: FakePSF = field(default_factory=FakePSF)
+    psf_size: tuple[int, int] = (5, 5)
+    star_min_vmag: float = 0.0
+    star_max_vmag: float = 17.0
+    ra_dec_limits_ext_rad: tuple[float, float, float, float] = (0.0, 0.1, 0.0, 0.1)
+    boresight_ra_rad: float = 0.0
+    boresight_dec_rad: float = 0.0
+    fov: FakeFOV = field(default_factory=FakeFOV)
+
+    def __post_init__(self) -> None:
+        """Build the extfov-padded ``extdata`` from ``data`` plus the margin."""
+        margin_v, margin_u = self.extfov_margin_vu
+        ext_shape = (
+            self.data.shape[0] + 2 * margin_v,
+            self.data.shape[1] + 2 * margin_u,
+        )
+        ext = np.zeros(ext_shape, dtype=self.data.dtype)
+        ext[
+            margin_v : margin_v + self.data.shape[0],
+            margin_u : margin_u + self.data.shape[1],
+        ] = self.data
+        self._extdata = ext
+
+    # ------------------------------------------------------------------
+    # Image-side surface
+    # ------------------------------------------------------------------
+
+    @property
+    def extdata(self) -> np.ndarray:
+        """Return the extfov-padded image."""
+        return self._extdata
+
+    @property
+    def data_shape_v(self) -> int:
+        """Sensor-area V (rows)."""
+        return int(self.data.shape[0])
+
+    @property
+    def data_shape_u(self) -> int:
+        """Sensor-area U (cols)."""
+        return int(self.data.shape[1])
+
+    @property
+    def data_shape_vu(self) -> tuple[int, int]:
+        """Sensor-area ``(rows, cols)`` shape."""
+        return (self.data.shape[0], self.data.shape[1])
+
+    @property
+    def data_shape_uv(self) -> tuple[int, int]:
+        """Sensor-area ``(cols, rows)`` shape."""
+        return (self.data.shape[1], self.data.shape[0])
+
+    @property
+    def extdata_shape_vu(self) -> tuple[int, int]:
+        """Extfov ``(rows, cols)`` shape."""
+        return (self._extdata.shape[0], self._extdata.shape[1])
+
+    @property
+    def extdata_shape_uv(self) -> tuple[int, int]:
+        """Extfov ``(cols, rows)`` shape."""
+        return (self._extdata.shape[1], self._extdata.shape[0])
+
+    @property
+    def extfov_margin_v(self) -> int:
+        """Extfov margin along V."""
+        return self.extfov_margin_vu[0]
+
+    @property
+    def extfov_margin_u(self) -> int:
+        """Extfov margin along U."""
+        return self.extfov_margin_vu[1]
+
+    @property
+    def extfov_v_min(self) -> int:
+        """Minimum V coordinate in extfov coordinates (negative when margin > 0)."""
+        return -self.extfov_margin_vu[0]
+
+    @property
+    def extfov_u_min(self) -> int:
+        """Minimum U coordinate in extfov coordinates."""
+        return -self.extfov_margin_vu[1]
+
+    @property
+    def extfov_v_max(self) -> int:
+        """Maximum V coordinate in extfov coordinates."""
+        return int(self.data.shape[0]) + self.extfov_margin_vu[0] - 1
+
+    @property
+    def extfov_u_max(self) -> int:
+        """Maximum U coordinate in extfov coordinates."""
+        return int(self.data.shape[1]) + self.extfov_margin_vu[1] - 1
+
+    def make_extfov_zeros(self, dtype: Any = np.float64) -> np.ndarray:
+        """Return a zero-filled array of the extfov shape."""
+        return np.zeros(self.extdata_shape_vu, dtype=dtype)
+
+    def make_extfov_false(self) -> np.ndarray:
+        """Return a False-filled boolean array of the extfov shape."""
+        return np.zeros(self.extdata_shape_vu, dtype=bool)
+
+    def extfov_data_sensor_mask(self) -> np.ndarray:
+        """Return a boolean mask True over the sensor area inside extfov."""
+        mask = np.zeros(self.extdata_shape_vu, dtype=bool)
+        margin_v, margin_u = self.extfov_margin_vu
+        mask[
+            margin_v : margin_v + self.data.shape[0],
+            margin_u : margin_u + self.data.shape[1],
+        ] = True
+        return mask
+
+    def clip_extfov(self, u: int, v: int) -> tuple[int, int]:
+        """Clip ``(u, v)`` to the extfov rectangle."""
+        return (
+            int(np.clip(u, self.extfov_u_min, self.extfov_u_max)),
+            int(np.clip(v, self.extfov_v_min, self.extfov_v_max)),
+        )
+
+    def inventory(
+        self, body_list: list[str], *, return_type: str = 'full'
+    ) -> dict[str, dict[str, Any]]:
+        """Return the configured inventory records for each requested body.
+
+        Parameters:
+            body_list: Bodies to look up.
+            return_type: Accepted for API parity; the shim always
+                returns the ``'full'`` shape.
+        """
+        del return_type
+        out: dict[str, dict[str, Any]] = {}
+        for body in body_list:
+            key = body.upper()
+            if key in self.inventory_records:
+                out[key] = self.inventory_records[key]
+        return out
+
+    def inventory_body_in_extfov(self, inv: dict[str, Any]) -> bool:
+        """Mirror ``ObsSnapshot.inventory_body_in_extfov``."""
+        return bool(
+            inv['u_max_unclipped'] >= self.extfov_u_min
+            and inv['u_min_unclipped'] <= self.extfov_u_max
+            and inv['v_max_unclipped'] >= self.extfov_v_min
+            and inv['v_min_unclipped'] <= self.extfov_v_max
+        )
+
+    def inventory_body_in_fov(self, inv: dict[str, Any]) -> bool:
+        """Mirror ``ObsSnapshot.inventory_body_in_fov``."""
+        return bool(
+            inv['u_max_unclipped'] >= 0
+            and inv['u_min_unclipped'] < self.data.shape[1]
+            and inv['v_max_unclipped'] >= 0
+            and inv['v_min_unclipped'] < self.data.shape[0]
+        )
+
+    # ------------------------------------------------------------------
+    # Star surface
+    # ------------------------------------------------------------------
+
+    def star_psf(self) -> FakePSF:
+        """Return the PSF used for star rendering / SNR estimation."""
+        return self.psf
+
+    def star_psf_size(self, _star: object) -> tuple[int, int]:
+        """Return the PSF size for any star (no per-star variation)."""
+        return self.psf_size
+
+    def star_min_usable_vmag(self) -> float:
+        """Return the catalog-search lower magnitude floor."""
+        return self.star_min_vmag
+
+    def star_max_usable_vmag(self) -> float:
+        """Return the catalog-search upper magnitude floor."""
+        return self.star_max_vmag
+
+    def ra_dec_limits_ext(self, apparent: bool = True) -> tuple[float, float, float, float]:
+        """Return the configured RA / DEC limits in radians."""
+        del apparent
+        return self.ra_dec_limits_ext_rad
+
+    # ------------------------------------------------------------------
+    # SPICE-like surface
+    # ------------------------------------------------------------------
+
+    def boresight_ra(self) -> float:
+        """Return the configured boresight RA in radians."""
+        return self.boresight_ra_rad
+
+    def boresight_dec(self) -> float:
+        """Return the configured boresight DEC in radians."""
+        return self.boresight_dec_rad
+
+    def uv_from_ra_and_dec(
+        self,
+        ra: Any,
+        dec: Any,
+        *,
+        tfrac: float = 0.5,
+        apparent: bool = True,
+    ) -> FakeUV:
+        """Project RA/DEC into pixel coordinates.
+
+        The fake places every requested point at the FOV centre, with a
+        small ``tfrac``-driven shift so the smear-bracket calculation
+        produces a deterministic non-zero displacement when desired.
+
+        Parameters:
+            ra: Scalar or polymath-Scalar RA.
+            dec: Scalar or polymath-Scalar DEC.
+            tfrac: Fraction along the exposure window.
+            apparent: Accepted for API parity; ignored by the shim.
+        """
+        del apparent
+        v_centre = self.data.shape[0] / 2.0 + self.extfov_margin_vu[0]
+        u_centre = self.data.shape[1] / 2.0 + self.extfov_margin_vu[1]
+        # Decompose ra/dec to a 1-D float array so callers can pass a
+        # polymath.Scalar wrapping a list, a numpy array, or a python
+        # float.  The shim uses the raw values to size the output.
+        ra_arr = np.atleast_1d(np.asarray(_extract_vals(ra), dtype=np.float64))
+        dec_arr = np.atleast_1d(np.asarray(_extract_vals(dec), dtype=np.float64))
+        n = max(ra_arr.size, dec_arr.size)
+        u = np.full(n, u_centre)
+        v = np.full(n, v_centre)
+        # Apply a per-point shift driven by tfrac so the bracket
+        # difference is non-zero when the test wants smear.
+        u = u + (tfrac - 0.5) * 2.0  # -1 at tfrac=0, +1 at tfrac=1
+        v = v + (tfrac - 0.5) * 1.0
+        return FakeUV(u_vals=u, v_vals=v)
+
+
+def _extract_vals(obj: Any) -> Any:
+    """Return ``obj.vals`` when present, else ``obj`` unchanged."""
+    return obj.vals if hasattr(obj, 'vals') else obj

--- a/tests/shims_tests/test_shims_self.py
+++ b/tests/shims_tests/test_shims_self.py
@@ -28,13 +28,22 @@ from tests.shims import (
 
 
 def test_plant_circular_body_paints_disc_of_correct_radius() -> None:
-    """A 5-px-radius circle paints a disc with that approximate area."""
+    """A 5-px-radius circle paints exactly the pixels with centre distance <= radius."""
+    shape = (40, 40)
+    centre_vu = (20.0, 20.0)
+    radius_px = 5.0
     data = plant_circular_body(
-        shape=(40, 40), centre_vu=(20.0, 20.0), radius_px=5.0, resolution_km_px=2.0
+        shape=shape, centre_vu=centre_vu, radius_px=radius_px, resolution_km_px=2.0
     )
-    area = int(np.count_nonzero(data.body_mask))
-    expected = math.pi * 5.0 * 5.0
-    assert area == pytest.approx(expected, rel=0.15)
+    vv, uu = np.meshgrid(
+        np.arange(shape[0], dtype=np.float64),
+        np.arange(shape[1], dtype=np.float64),
+        indexing='ij',
+    )
+    expected_pixels = int(
+        np.count_nonzero((vv - centre_vu[0]) ** 2 + (uu - centre_vu[1]) ** 2 <= radius_px**2)
+    )
+    assert int(np.count_nonzero(data.body_mask)) == expected_pixels
 
 
 def test_plant_circular_body_incidence_increases_with_radius() -> None:
@@ -75,11 +84,20 @@ def test_fake_backplane_body_methods_round_trip() -> None:
 
 
 def test_fake_backplane_body_lambert_default_is_cosine_of_incidence() -> None:
-    """Without an explicit ``lambert`` array the shim uses ``cos(incidence)``."""
+    """Without an explicit ``lambert`` array the shim returns ``cos(incidence)``.
+
+    On-body pixels carry ``cos(incidence)`` clipped to ``[0, inf)``; off-body
+    pixels are zero.
+    """
     body = plant_circular_body(shape=(10, 10), centre_vu=(5.0, 5.0), radius_px=3.0)
     bp = FakeBackplane(per_body={'MIMAS': body})
     lambert = bp.lambert_law('MIMAS')
-    assert (lambert.mvals.filled(0.0)[body.body_mask] >= 0.0).all()
+    incidence = bp.incidence_angle('MIMAS')
+    expected = np.where(
+        body.body_mask, np.clip(np.cos(incidence.mvals.filled(0.0)), 0.0, None), 0.0
+    )
+    np.testing.assert_array_equal(lambert.mvals.filled(0.0), expected)
+    assert (lambert.mvals.filled(0.0)[~body.body_mask] == 0.0).all()
 
 
 def test_fake_backplane_unknown_body_raises_lookup_error() -> None:

--- a/tests/shims_tests/test_shims_self.py
+++ b/tests/shims_tests/test_shims_self.py
@@ -1,0 +1,301 @@
+"""Self-tests for the ``tests.shims`` package.
+
+These verify that the shims expose the methods and shapes the
+navigation pipeline expects, independent of any consumer.  They also
+exercise the convenience factories.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, cast
+
+import numpy as np
+import polymath
+import pytest
+
+from nav.nav_model.stars import catalog as nav_catalog
+from tests.shims import (
+    BodyBackplaneData,
+    FakeBackplane,
+    FakeObs,
+    FakeStarCatalog,
+    RingBackplaneData,
+    install_fake_catalogs,
+    make_star,
+    plant_circular_body,
+)
+
+
+def test_plant_circular_body_paints_disc_of_correct_radius() -> None:
+    """A 5-px-radius circle paints a disc with that approximate area."""
+    data = plant_circular_body(
+        shape=(40, 40), centre_vu=(20.0, 20.0), radius_px=5.0, resolution_km_px=2.0
+    )
+    area = int(np.count_nonzero(data.body_mask))
+    expected = math.pi * 5.0 * 5.0
+    assert area == pytest.approx(expected, rel=0.15)
+
+
+def test_plant_circular_body_incidence_increases_with_radius() -> None:
+    """The synthetic incidence ramps from 0 at centre to pi/2 at limb."""
+    data = plant_circular_body(
+        shape=(40, 40), centre_vu=(20.0, 20.0), radius_px=10.0, resolution_km_px=1.0
+    )
+    centre_inc = float(data.incidence_rad[20, 20])
+    near_limb = float(data.incidence_rad[20, 30])
+    assert centre_inc == pytest.approx(0.0, abs=0.05)
+    assert near_limb == pytest.approx(math.pi / 2.0, abs=0.05)
+
+
+def test_fake_backplane_returns_real_polymath_scalar() -> None:
+    """Backplane methods return real ``polymath.Scalar`` instances."""
+    body = plant_circular_body(shape=(20, 20), centre_vu=(10.0, 10.0), radius_px=5.0)
+    bp = FakeBackplane(per_body={'MIMAS': body})
+    incidence = bp.incidence_angle('MIMAS')
+    assert isinstance(incidence, polymath.Scalar)
+
+
+def test_fake_backplane_body_methods_round_trip() -> None:
+    """Body backplane methods return the configured per-pixel arrays."""
+    body = plant_circular_body(
+        shape=(20, 20),
+        centre_vu=(10.0, 10.0),
+        radius_px=5.0,
+        sub_solar_lon_deg=30.0,
+        phase_angle_deg=45.0,
+    )
+    bp = FakeBackplane(per_body={'MIMAS': body})
+    incidence = bp.incidence_angle('MIMAS')
+    assert incidence.mvals.shape == (20, 20)
+    assert bp.sub_solar_longitude('MIMAS').vals == pytest.approx(math.radians(30.0))
+    assert bp.center_phase_angle('MIMAS').vals == pytest.approx(math.radians(45.0))
+    intercepted = bp.where_intercepted('MIMAS')
+    assert bool(intercepted.any()) is True
+
+
+def test_fake_backplane_body_lambert_default_is_cosine_of_incidence() -> None:
+    """Without an explicit ``lambert`` array the shim uses ``cos(incidence)``."""
+    body = plant_circular_body(shape=(10, 10), centre_vu=(5.0, 5.0), radius_px=3.0)
+    bp = FakeBackplane(per_body={'MIMAS': body})
+    lambert = bp.lambert_law('MIMAS')
+    assert (lambert.mvals.filled(0.0)[body.body_mask] >= 0.0).all()
+
+
+def test_fake_backplane_unknown_body_raises_lookup_error() -> None:
+    """Looking up a body that wasn't configured raises ``LookupError``."""
+    bp = FakeBackplane(per_body={})
+    with pytest.raises(LookupError, match="no entry for body 'TITAN'"):
+        bp.incidence_angle('TITAN')
+
+
+def test_fake_backplane_unknown_ring_raises_lookup_error() -> None:
+    """Looking up a ring target that wasn't configured raises ``LookupError``."""
+    bp = FakeBackplane(per_ring={})
+    with pytest.raises(LookupError, match="no entry for ring target 'jupiter:ring'"):
+        bp.ring_radius('jupiter:ring')
+
+
+def test_fake_backplane_ring_methods_round_trip() -> None:
+    """Ring backplane methods return the configured per-pixel arrays."""
+    radius = np.linspace(70_000.0, 140_000.0, 100).reshape(10, 10)
+    ring = RingBackplaneData(
+        ring_radius_km=radius,
+        ring_mask=np.ones(radius.shape, dtype=bool),
+        default_radial_resolution_km_px=200.0,
+    )
+    bp = FakeBackplane(per_ring={'saturn:ring': ring})
+    radii_scalar = bp.ring_radius('saturn:ring')
+    assert not radii_scalar.is_all_masked()
+    assert radii_scalar.min().vals == pytest.approx(70_000.0)
+    assert radii_scalar.max().vals == pytest.approx(140_000.0)
+    res = bp.ring_radial_resolution('saturn:ring')
+    assert np.all(np.asarray(res.vals) == 200.0)
+
+
+def test_fake_backplane_ring_radius_carries_border_atop_key() -> None:
+    """``ring_radius`` exposes the ``key`` the production code reads back."""
+    ring = RingBackplaneData(
+        ring_radius_km=np.zeros((2, 2)),
+        ring_mask=np.ones((2, 2), dtype=bool),
+    )
+    bp = FakeBackplane(per_ring={'saturn:ring': ring})
+    radii = bp.ring_radius('saturn:ring')
+    assert radii.key == ('ring_radius', 'saturn:ring')
+
+
+def test_fake_backplane_border_atop_uses_default_threshold() -> None:
+    """``border_atop`` returns pixels whose ring radius is within 0.5 km of ``a``."""
+    radius = np.array([[100_000.0, 100_000.4], [200_000.0, 100_000.8]])
+    ring = RingBackplaneData(ring_radius_km=radius, ring_mask=np.ones(radius.shape, dtype=bool))
+    bp = FakeBackplane(per_ring={'saturn:ring': ring})
+    radii = bp.ring_radius('saturn:ring')
+    assert radii.key is not None
+    edge = bp.border_atop(radii.key, 100_000.3)
+    # |100_000.0 - 100_000.3| = 0.3 -> True; |100_000.4 - 100_000.3| = 0.1 -> True;
+    # |200_000.0 - 100_000.3| = ~100K -> False; |100_000.8 - 100_000.3| = 0.5 -> False (strict).
+    assert np.asarray(edge.vals).tolist() == [[True, True], [False, False]]
+
+
+def test_fake_backplane_border_atop_rejects_wrong_key() -> None:
+    """A key whose head is not ``'ring_radius'`` raises ``LookupError``."""
+    ring = RingBackplaneData(
+        ring_radius_km=np.zeros((2, 2)),
+        ring_mask=np.ones((2, 2), dtype=bool),
+    )
+    bp = FakeBackplane(per_ring={'saturn:ring': ring})
+    with pytest.raises(LookupError, match='expected a ring_radius key'):
+        bp.border_atop(('something_else', 'saturn:ring'), 100.0)
+
+
+def test_fake_obs_extdata_padded_around_data() -> None:
+    """``extdata`` matches ``data`` size plus 2 * margin."""
+    data = np.full((20, 30), 5.0)
+    obs = FakeObs(data=data, extfov_margin_vu=(2, 4))
+    assert obs.extdata.shape == (24, 38)
+    # Sensor area equals the input.
+    assert (obs.extdata[2:22, 4:34] == 5.0).all()
+    # Extfov padding is zero.
+    assert (obs.extdata[:2, :] == 0.0).all()
+
+
+def test_fake_obs_inventory_returns_only_requested_bodies() -> None:
+    """``inventory`` returns only entries for the requested bodies."""
+    inv = {
+        'MIMAS': {
+            'u_min_unclipped': 10,
+            'u_max_unclipped': 30,
+            'v_min_unclipped': 10,
+            'v_max_unclipped': 30,
+            'u_pixel_size': 20.0,
+            'v_pixel_size': 20.0,
+            'range': 1e5,
+            'center_uv': (20.0, 20.0),
+        }
+    }
+    obs = FakeObs(data=np.zeros((40, 40)), inventory_records=inv)
+    out = obs.inventory(['MIMAS', 'TETHYS'], return_type='full')
+    assert list(out.keys()) == ['MIMAS']
+    assert out['MIMAS']['range'] == 1e5
+
+
+def test_fake_obs_inventory_body_in_extfov_predicate() -> None:
+    """The ``inventory_body_in_extfov`` predicate matches the real obs's contract."""
+    obs = FakeObs(data=np.zeros((10, 10)), extfov_margin_vu=(2, 2))
+    inside = {
+        'u_min_unclipped': -1,
+        'u_max_unclipped': 5,
+        'v_min_unclipped': -1,
+        'v_max_unclipped': 5,
+    }
+    outside = {
+        'u_min_unclipped': 100,
+        'u_max_unclipped': 110,
+        'v_min_unclipped': 100,
+        'v_max_unclipped': 110,
+    }
+    assert obs.inventory_body_in_extfov(inside) is True
+    assert obs.inventory_body_in_extfov(outside) is False
+
+
+def test_fake_obs_uv_from_ra_and_dec_brackets_diverge_with_tfrac() -> None:
+    """The shim's UV result depends on ``tfrac`` so smear bracketing works."""
+    obs = FakeObs(data=np.zeros((10, 10)))
+    uv0 = obs.uv_from_ra_and_dec(np.zeros(1), np.zeros(1), tfrac=0.0, apparent=True)
+    uv1 = obs.uv_from_ra_and_dec(np.zeros(1), np.zeros(1), tfrac=1.0, apparent=True)
+    u0, v0 = uv0.to_scalars()
+    u1, v1 = uv1.to_scalars()
+    assert isinstance(u0, polymath.Scalar)
+    assert np.asarray(u1.vals).tolist() != np.asarray(u0.vals).tolist()
+    assert np.asarray(v1.vals).tolist() != np.asarray(v0.vals).tolist()
+
+
+def test_make_star_applies_kwargs() -> None:
+    """``make_star`` returns a default star with overridden fields."""
+    star = make_star(unique_number=42, vmag=3.0, name='Sirius')
+    assert star.unique_number == 42
+    assert star.vmag == 3.0
+    assert star.name == 'Sirius'
+    assert star.spectral_class == 'G0'  # default unchanged
+
+
+def test_make_star_post_init_mirrors_ra_into_ra_pm() -> None:
+    """``__post_init__`` mirrors catalog RA / DEC into the proper-motion fields."""
+    star = make_star(ra=1.5, dec=-0.5)
+    assert star.ra_pm == 1.5
+    assert star.dec_pm == -0.5
+
+
+def test_fake_star_catalog_filters_by_box() -> None:
+    """``find_stars`` returns only stars inside the RA/DEC/mag box."""
+    inside = make_star(unique_number=1, ra=0.05, dec=0.05, vmag=5.0)
+    outside_ra = make_star(unique_number=2, ra=1.0, dec=0.05, vmag=5.0)
+    outside_mag = make_star(unique_number=3, ra=0.05, dec=0.05, vmag=20.0)
+    cat = FakeStarCatalog(stars=[inside, outside_ra, outside_mag])
+    matches = list(
+        cat.find_stars(
+            ra_min=0.0,
+            ra_max=0.1,
+            dec_min=0.0,
+            dec_max=0.1,
+            vmag_min=0.0,
+            vmag_max=10.0,
+        )
+    )
+    assert [s.unique_number for s in matches] == [1]
+
+
+def test_install_fake_catalogs_is_test_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patches installed via ``monkeypatch`` unwind on test teardown.
+
+    Within the test, the production getters return our fakes; pytest's
+    teardown then restores the originals so subsequent tests in the
+    same worker see the unpatched module.  Across pytest-xdist workers
+    (separate processes) the patches cannot leak by construction.
+    """
+    star = make_star(unique_number=7, ra=0.05, dec=0.05, vmag=5.0)
+    cat_map = install_fake_catalogs(monkeypatch, ucac4=[star])
+    # The catalog module is imported at the top; monkeypatch swaps
+    # the attribute on that module, so dynamic attribute lookup picks
+    # up the patched version.  Mypy types the getters to return their
+    # real catalog classes; cast for the identity check against the
+    # FakeStarCatalog instances.
+    assert cast(Any, nav_catalog.get_ucac4_catalog()) is cat_map['ucac4']
+    assert cast(Any, nav_catalog.get_tycho2_catalog()) is cat_map['tycho2']
+    assert cast(Any, nav_catalog.get_ybsc_catalog()) is cat_map['ybsc']
+    assert len(cat_map['ucac4'].stars) == 1
+    assert len(cat_map['tycho2'].stars) == 0
+
+
+def test_install_fake_catalogs_does_not_persist_across_tests() -> None:
+    """A test that did not call ``install_fake_catalogs`` sees the real getters.
+
+    Verifies the per-test scoping promise: pytest's ``monkeypatch``
+    fixture rolled back any swap from the previous test, so this test
+    looking up the lazy getter via dynamic attribute access on the
+    catalog module sees the production function again.
+    """
+    # The unpatched function is the one defined in
+    # ``nav.nav_model.stars.catalog``; a leftover lambda from an
+    # earlier test would have ``__module__`` set to ``tests.shims.catalog``.
+    assert nav_catalog.get_ucac4_catalog.__module__ == 'nav.nav_model.stars.catalog'
+
+
+def test_body_backplane_data_default_resolution_fills_array() -> None:
+    """``resolution_array`` returns a constant fill when not configured."""
+    data = BodyBackplaneData(
+        body_mask=np.ones((4, 4), dtype=bool),
+        incidence_rad=np.zeros((4, 4)),
+        default_resolution_km_px=3.0,
+    )
+    assert (data.resolution_array() == 3.0).all()
+
+
+def test_ring_backplane_data_default_distance_fills_array() -> None:
+    """``distance_array`` returns a constant fill when not configured."""
+    data = RingBackplaneData(
+        ring_radius_km=np.zeros((4, 4)),
+        ring_mask=np.ones((4, 4), dtype=bool),
+        default_distance_km=2.5e9,
+    )
+    assert (data.distance_array() == 2.5e9).all()


### PR DESCRIPTION
## Summary

- Stage 1 of the navigation core rewrite — lands the three concrete real-scene navigation models that consume the stage-0 NavFeature / NavModel ABC infrastructure.
- New models: `NavModelStars`, `NavModelBody`, `NavModelRings`.
- Concrete real-scene NavTechniques (StarFieldFromCatalogNav, BodyDiscCorrelateNav, etc.) remain pending and will land in stage 2.

## What is in this PR

### `NavModelStars` — `src/nav/nav_model/stars/` package

- Six modules around a thin orchestrator implementing the `NavModel` ABC.
- `catalog` — multi-catalog reduction with stellar aberration, proper-motion projection, FOV edge culling, and deduplication across UCAC4 / Tycho-2 / YBSC.
- `conflicts` — body-intercept and ring-annulus occlusion via `oops.Backplane`.
- `predicted_snr` — per-star integrated SNR with the `SCLASS_TO_B_MINUS_V` colour lookup.
- `smeared_psf` — smear-aware PSF rendering and per-image smear-vector computation from SPICE brackets.
- `detection` — DAOPHOT-style matched filter with CCD bloom and shape cuts.
- `nav_model_stars` — the orchestrator itself.
- Emits one `STAR` `NavFeature` per usable catalog star with anisotropic CRLB centroid covariance.
- Smear-excessive stars are dropped from the feature list per the design's `max_smear` gate.

### `NavModelBody` — `src/nav/nav_model/nav_model_body.py`

- Per-body silhouette navigation; one instance per body whose `inventory_body_in_extfov` predicate fires.
- Builds an oversampled Lambert-shaded silhouette and extracts the limb / terminator polylines.
- Emits `LIMB_ARC` / `BODY_BLOB` / `BODY_DISC` / `TERMINATOR_ARC` features per the design's emission gates (`limb_uncertainty_px`, `visible_lit_fraction`, `overflow_fraction`, phase-angle factor).
- Per-vertex polyline sigmas follow the quadrature-sum formula with the `MAX_INCIDENCE_FACTOR_CAP` clamp.
- Per-body shape parameters come from `nav.nav_model.body_shape.BODY_SHAPE_TABLE` — a typed fallback that the pending `config_220_body_shape.yaml` loader will replace.

### `NavModelRings` — `src/nav/nav_model/nav_model_rings.py`

- Catalog-driven ring navigation; one instance per planet whose ring catalog touches the FOV.
- Reuses the four-pass `RingFeatureFilter` selection (date / radius / resolvability / fade-conflict).
- Samples each surviving rendered edge mask into a polyline.
- Emits `RING_EDGE` (per-vertex `RingEdgePolyline` with sigma_radial / sigma_along_edge derived from the catalog `rms` and the km/px radial scale) or `RING_ANNULUS` (multi-edge composite template) per the radial-resolvability threshold.
- Polyline curvature is measured by max-deviation from a best-fit straight line; below threshold the `is_straight_line` flag fires so the technique-level fitter can handle the rank-1 covariance.

### Orchestrator extdata fix — `src/nav/nav_orchestrator/orchestrator.py`

- `_make_context` now reads `obs.extdata` (extfov-shaped) instead of `obs.data` (sensor area only).
- The image, sensor mask, saturation mask, and cosmic-ray mask all share the same shape on any obs whose per-instrument `extfov_margin_vu` is non-zero.
- Without this fix, a real Cassini ISS image (1024×1024 with a 50 / 140 px margin) failed at the image-quality classifier with a shape-mismatch `ValueError`.
- A new regression test in `tests/nav/nav_orchestrator/test_orchestrator.py` asserts the pipeline runs end-to-end on a `FakeObs` whose `extdata` is larger than `data`.

### Reusable test shims — `tests/shims/`

- `FakeBackplane` — table-driven stand-in for `oops.Backplane`; tests build `BodyBackplaneData` / `RingBackplaneData` records and every backplane method returns a real `polymath.Scalar` wrapping the configured numpy array.
- The `key` attribute on `ring_radius` results is set so the production `border_atop` callback chain works unchanged.
- `FakeStar` / `FakeStarCatalog` plus `install_fake_catalogs` — swap the lazy catalog getters for FakeCatalog instances via `monkeypatch.setattr`.
- Patches are test-local (per the `monkeypatch` fixture's lifetime) and parallel-safe under `pytest-xdist --dist=loadfile`; the module-level catalog cache (`_STAR_CATALOG_*`) is never touched.
- `FakeObs` — ties the backplane shim into a numpy-array image-side surface exposing `extdata`, the various `extfov_*` / `make_extfov_*` / `inventory_*` / `star_psf*` / `ra_dec_limits_ext` / `boresight_*` / `uv_from_ra_and_dec` methods used by the new NavModels.
- Self-tests under `tests/shims_tests/` verify every shim's contract independent of any consumer.

### Coverage of the new code

- `body_shape.py`, `stars/__init__.py`, `stars/nav_model_stars.py`, `stars/predicted_snr.py`, `stars/smeared_psf.py` — all 100 %.
- `stars/detection.py` — 97 %.
- `stars/catalog.py` — 90 %; the remaining 10 % is the real catalog constructors and `aberrate_star`'s `oops.Event` body, both needing real catalog data / SPICE.
- `nav_model_body.py` (46 %), `nav_model_rings.py` (54 %), `stars/conflicts.py` (49 %) — the ~350 unhit statements are `_render` / `_check_one_star` paths that need a real `oops.Backplane` and so are documented in `AUTONAV_PLAN.md` as integration-test scope (Part 9 / Part 10 image library).

### Documentation

- `docs/api_reference/api_nav_model.rst` — automodule entries added for every new module.
- `docs/developer_guide_navigation_models_*.rst` — full rewrite of the stars / bodies / rings developer guides covering package layout, emission rules, per-vertex covariance derivation, reliability formulae, and gate constants.
- `docs/user_guide_navigation.rst` — new top-level "Navigation Models" section with scientist-level descriptions of each model family and the user-tunable config knobs.
- `AUTONAV_PLAN.md` — NavModels moved from Pending to Implemented; new "NavModel coverage gap" subsection enumerates the production-code paths waiting on the integration suite.

## Test plan

- [x] `ruff check src tests` clean
- [x] `ruff format --check src tests` clean
- [x] `mypy --strict src tests` clean — 240 source files
- [x] `pytest -n auto --dist=loadfile` — **930 passed**, 6 tolerated warnings
- [x] `sphinx-build -W -b html docs docs/_build` clean
- [x] `pymarkdown scan docs/ .cursor/ README.md CONTRIBUTING.md` clean
- [ ] End-to-end `nav_offset` smoke test on a real Cassini ISS image (manual, depends on holdings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)