### PR TITLE
Stage 2: DT-based NavTechniques + DT fitting infrastructure

### DIFF
--- a/.cursor/rules/logging_best_practices.mdc
+++ b/.cursor/rules/logging_best_practices.mdc
@@ -59,8 +59,8 @@ with IMAGE_LOGGER.open(str(image_url), handler=local_handlers):
 
 ## 3. Logging Calls
 
-Use `%`-style format strings (never f-strings) so the interpolation is deferred
-until the message is actually emitted:
+Use `%`-style format strings (never f-strings) in logging calls so the
+interpolation is deferred until the message is actually emitted:
 
 ```python
 # ✅ GOOD
@@ -77,6 +77,9 @@ self._logger.info(f'Writing metadata to {public_metadata_file}')
 Available levels: `debug`, `info`, `warning`, `error`, `exception`, `fatal`.
 Use `exception` (not `error`) when inside an `except` block so the traceback is
 captured automatically.
+
+Note: f-strings are OK in the logger.open() call.
+
 
 ## 4. Setting Up Handlers
 
@@ -115,10 +118,6 @@ never call `mkdir` on the log directory — `PdsLogger` handles directory creati
 via `FileCache` internally.
 
 ```python
-# ✅ GOOD
-log_dir = FCPath(nav_results_root_str) / 'logs' / 'nav_offset'
-MAIN_LOGGER.add_handler(pdslogger.file_handler(log_dir / 'nav_offset.log', rotation='ymdhms'))
-
 # ❌ BAD - do not mkdir the log directory
 log_dir.mkdir(parents=True, exist_ok=True)
 ```
@@ -130,8 +129,7 @@ log_dir.mkdir(parents=True, exist_ok=True)
 | Import loggers | `from nav.config import MAIN_LOGGER, IMAGE_LOGGER` |
 | Top-level events | `MAIN_LOGGER.info(...)` |
 | Per-image events | `self._logger.info(...)` (`self._logger` is `IMAGE_LOGGER`) |
-| Named section | `with logger.open('SECTION HEADER'):` |
-| Named section + level | `with logger.open('HEADER', level='DEBUG'):` |
-| Per-image file + console | `with IMAGE_LOGGER.open(url, handler=local_handlers):` |
+| Named section | `with self._logger.open('SECTION HEADER'):` |
+| Named section + level | `with self._logger.open('HEADER', level='DEBUG'):` |
 | Exception in except block | `logger.exception('msg: %s', detail)` |
 | Standard library logging | Only for type annotations in low-level plumbing |

--- a/.cursor/rules/logging_best_practices.mdc
+++ b/.cursor/rules/logging_best_practices.mdc
@@ -88,8 +88,10 @@ attaches a stdout stream handler and a rotating timestamped file handler to
 from nav.config import setup_logging, MAIN_LOGGER
 
 setup_logging(arguments, config, nav_results_root_str)
-MAIN_LOGGER.add_handler(pdslogger.stream_handler(level='INFO'))
-# file handler written under {nav_results_root}/logs/nav_offset/
+# `setup_logging` attaches both the stdout stream handler and the
+# timestamped file handler under {nav_results_root}/logs/nav_offset/
+# to MAIN_LOGGER; do not call `MAIN_LOGGER.add_handler` again or the
+# stdout console will see every line twice.
 ```
 
 For `IMAGE_LOGGER`, create per-image handlers with `image_log_handlers()` and pass
@@ -132,4 +134,4 @@ log_dir.mkdir(parents=True, exist_ok=True)
 | Named section + level | `with logger.open('HEADER', level='DEBUG'):` |
 | Per-image file + console | `with IMAGE_LOGGER.open(url, handler=local_handlers):` |
 | Exception in except block | `logger.exception('msg: %s', detail)` |
-| Standard library logging | Only for `NullHandler` and type annotations |
+| Standard library logging | Only for type annotations in low-level plumbing |

--- a/.cursor/rules/logging_best_practices.mdc
+++ b/.cursor/rules/logging_best_practices.mdc
@@ -6,14 +6,10 @@ description: Best practices for using PdsLogger (rms-pdslogger) throughout this 
 # Logging Best Practices
 
 This project uses `pdslogger.PdsLogger` exclusively. **Never** use the standard Python
-`logging` module to emit log messages. The only legitimate uses of `import logging` are:
-
-- Adding a `NullHandler` in library modules so unhandled records are silenced:
-  ```python
-  import logging
-  logging.getLogger(__name__).addHandler(logging.NullHandler())
-  ```
-- Type annotations (`logging.Handler`, `logging.FileHandler`) in signatures.
+`logging` module to emit log messages. The only legitimate use of `import logging` is
+for type annotations in low-level plumbing code (e.g. `logging.Handler`,
+`logging.FileHandler` in `nav.config.logger`) where `pdslogger` factory functions
+return standard handler objects. Do not add `import logging` to new files.
 
 ## 1. The Two Module-Level Loggers
 

--- a/.cursor/rules/logging_best_practices.mdc
+++ b/.cursor/rules/logging_best_practices.mdc
@@ -1,0 +1,139 @@
+---
+alwaysApply: true
+description: Best practices for using PdsLogger (rms-pdslogger) throughout this project.
+---
+
+# Logging Best Practices
+
+This project uses `pdslogger.PdsLogger` exclusively. **Never** use the standard Python
+`logging` module to emit log messages. The only legitimate uses of `import logging` are:
+
+- Adding a `NullHandler` in library modules so unhandled records are silenced:
+  ```python
+  import logging
+  logging.getLogger(__name__).addHandler(logging.NullHandler())
+  ```
+- Type annotations (`logging.Handler`, `logging.FileHandler`) in signatures.
+
+## 1. The Two Module-Level Loggers
+
+`nav.config.logger` defines two singleton loggers imported from `nav.config`:
+
+```python
+from nav.config import MAIN_LOGGER, IMAGE_LOGGER
+```
+
+| Logger | Name | Purpose |
+|--------|------|---------|
+| `MAIN_LOGGER` | `"nav_offset"` | Top-level program events; stdout + timestamped file handler attached at startup via `setup_logging()` |
+| `IMAGE_LOGGER` | `"nav_image"` | Per-image events; handlers are attached only inside an `IMAGE_LOGGER.open()` context via `image_log_handlers()` |
+
+Navigation components (subclasses of `NavBase`) receive `IMAGE_LOGGER` via `self._logger`.
+The main driver modules use `MAIN_LOGGER` directly.
+
+## 2. Structuring Output with `logger.open()`
+
+Use `with logger.open(header)` to group related log lines under a named section header.
+This creates a visual block in both the console and log files.
+
+```python
+# ✅ GOOD - wrap a logical unit of work in a named section
+with self._logger.open(f'CREATE BODY MODEL FOR: {self._body_name}'):
+    self._render()
+
+# ✅ GOOD - optional level= to control visibility
+with self._logger.open('CREATE RINGS MODEL', level=log_level):
+    ...
+
+# ✅ GOOD - attach per-image handlers (stdout + file) for IMAGE_LOGGER contexts
+with logger.open(str(image_url), handler=local_handlers):
+    ...
+```
+
+Sections can be nested. The outermost `open()` at the image level carries
+`handler=local_handlers` so that per-image console and file handlers are
+active only for that image's processing window:
+
+```python
+local_handlers = image_log_handlers(image_log_path, log_arguments, DEFAULT_CONFIG)
+with IMAGE_LOGGER.open(str(image_url), handler=local_handlers):
+    log_run_environment(IMAGE_LOGGER, sys.argv[1:])
+    # ... process image ...
+```
+
+## 3. Logging Calls
+
+Use `%`-style format strings (never f-strings) so the interpolation is deferred
+until the message is actually emitted:
+
+```python
+# ✅ GOOD
+self._logger.info('No rings visible in observation')
+self._logger.info('Writing metadata to %s', public_metadata_file)
+self._logger.warning('No closest planet found -- cannot create ring model')
+self._logger.debug('Navigation failed; metadata keys: %s', sorted(metadata.keys()))
+self._logger.exception('Error reading image "%s": %s', image_path, message)
+
+# ❌ BAD - f-string is always evaluated, even when the level is suppressed
+self._logger.info(f'Writing metadata to {public_metadata_file}')
+```
+
+Available levels: `debug`, `info`, `warning`, `error`, `exception`, `fatal`.
+Use `exception` (not `error`) when inside an `except` block so the traceback is
+captured automatically.
+
+## 4. Setting Up Handlers
+
+Call `setup_logging()` once from `main()` after resolving the results root. It
+attaches a stdout stream handler and a rotating timestamped file handler to
+`MAIN_LOGGER`:
+
+```python
+from nav.config import setup_logging, MAIN_LOGGER
+
+setup_logging(arguments, config, nav_results_root_str)
+MAIN_LOGGER.add_handler(pdslogger.stream_handler(level='INFO'))
+# file handler written under {nav_results_root}/logs/nav_offset/
+```
+
+For `IMAGE_LOGGER`, create per-image handlers with `image_log_handlers()` and pass
+them to `logger.open()` — never attach them permanently to the logger:
+
+```python
+from nav.config import IMAGE_LOGGER, image_log_handlers
+
+local_handlers = image_log_handlers(image_log_path, arguments, config)
+with IMAGE_LOGGER.open(str(image_url), handler=local_handlers):
+    ...
+```
+
+`image_log_handlers()` returns one `stream_handler` and one `file_handler`. Their
+levels are resolved from CLI args → config → `"INFO"`.
+
+## 5. Log File Paths
+
+Log file paths are `FCPath` objects. Follow the `filecache_best_practices` rule:
+never call `mkdir` on the log directory — `PdsLogger` handles directory creation
+via `FileCache` internally.
+
+```python
+# ✅ GOOD
+log_dir = FCPath(nav_results_root_str) / 'logs' / 'nav_offset'
+MAIN_LOGGER.add_handler(pdslogger.file_handler(log_dir / 'nav_offset.log', rotation='ymdhms'))
+
+# ❌ BAD - do not mkdir the log directory
+log_dir.mkdir(parents=True, exist_ok=True)
+```
+
+## 6. Quick Reference
+
+| Task | Pattern |
+|------|---------|
+| Import loggers | `from nav.config import MAIN_LOGGER, IMAGE_LOGGER` |
+| Top-level events | `MAIN_LOGGER.info(...)` |
+| Per-image events | `self._logger.info(...)` (`self._logger` is `IMAGE_LOGGER`) |
+| Named section | `with logger.open('SECTION HEADER'):` |
+| Named section + level | `with logger.open('HEADER', level='DEBUG'):` |
+| Per-image file + console | `with IMAGE_LOGGER.open(url, handler=local_handlers):` |
+| Exception in except block | `logger.exception('msg: %s', detail)` |
+| Standard library logging | Only for `NullHandler` and type annotations |

--- a/AUTONAV_PLAN.md
+++ b/AUTONAV_PLAN.md
@@ -1012,6 +1012,44 @@ this section is the operational checklist.
 - `NavTechniqueManual` — interactive technique opted out of the
   auto-discovery registry.
 
+**DT-based techniques (Part 3)**
+
+- `nav.nav_technique.dt_fitting` — shared distance-transform fitting
+  machinery: `coarse_ncc_search` (binary-mask cross-correlation),
+  `polarity_filter` (per-vertex polarity test), `tukey_biweight_weights`
+  (Holland-Welsch redescender), `lm_subpixel_refine` (translation, and
+  optional rotation, Levenberg-Marquardt with IRLS Tukey weights), and
+  `information_matrix_to_covariance` (M-estimator information matrix →
+  covariance via ``scipy.linalg.pinvh`` with the same ``rtol`` the
+  ensemble uses).  All five helpers are pure functions over numpy
+  arrays, called by the three DT techniques.
+- `nav.nav_technique.BodyLimbNav` — joint-translation fit on
+  ``LIMB_ARC`` polylines.  Concatenates every body's limb vertices,
+  weights by ``1 / sigma_normal_per_vertex_px**2``, runs the shared
+  coarse-search + LM pipeline with polarity filtering enabled, and
+  emits a ``BodyLimbDiagnostics`` populated with the per-image
+  visible-arc fraction, total visible arc length, DT RMS, LM iteration
+  count, and Tukey inlier count.  Feasibility threshold is at least
+  one limb arc with ``visible_arc_px >= LIMB_MIN_ARC_PX = 30``.
+- `nav.nav_technique.BodyTerminatorNav` — same shape as
+  ``BodyLimbNav`` with the design's per-body uniform weighting (each
+  body's vertices share the body's mean ``sigma_normal_per_vertex_px``)
+  and a confidence spec carrying albedo-penalty and phase-angle-factor
+  terms.
+- `nav.nav_technique.RingEdgeNav` — ``RING_EDGE`` polyline fit.
+  Polarity is intentionally disabled (per the deferred polarity-aware
+  ring matching item) and the technique reports ``is_rank_1=True``
+  whenever every input edge is straight-line, propagating an honest
+  rank-deficient covariance into the ensemble.
+- Shared image-side derivatives on ``NavContext``:
+  ``image_gradient_ext`` (Sobel-of-Gaussian magnitude),
+  ``image_gradient_vu_ext`` (per-pixel ``(g_v, g_u)`` vector consumed
+  by the polarity filter), and ``image_edge_dt_ext`` (signed distance
+  transform of the Canny-style thinned gradient image).  Computed once
+  per navigation by ``nav.nav_orchestrator.image_derivatives.build_image_edge_dt``
+  + ``compute_image_gradient_vu``; the orchestrator's ``_make_context``
+  populates both fields.
+
 **NavModel infrastructure (Part 1, Part 8)**
 
 - `nav.nav_model.NavModel` ABC + `__init_subclass__` registry +
@@ -1136,6 +1174,12 @@ this section is the operational checklist.
   under "Concrete NavModels (Part 1, Part 8)" above. The
   `rings/` data-model subpackage and the simulated variants
   survive unchanged.
+- ``CartographicDiagnostics`` — deleted from
+  ``nav.nav_technique.diagnostics`` until ``CartographicNav``
+  itself ships (the dataclass had no producer in the cutover-tier
+  source tree).  The class returns alongside the technique when
+  ``CARTOGRAPHIC_MODEL`` emission and ``CartographicNav`` land
+  together (deferred per Part 13b §2); recover from git history.
 
 ### Pending
 
@@ -1156,20 +1200,28 @@ this section is the operational checklist.
 
 **Concrete NavTechniques (Part 3)**
 
-- `BodyDiscCorrelateNav`, `BodyLimbNav`, `BodyTerminatorNav`,
-  `BodyBlobNav`, `RingEdgeNav`, `RingAnnulusNav`,
+- `BodyDiscCorrelateNav`, `BodyBlobNav`, `RingAnnulusNav`,
   `StarFieldFromCatalogNav`, `StarUniqueMatchNav`, `StarRefineNav`,
-  `CartographicNav`, `TitanNav`.
+  `CartographicNav`, `TitanNav`.  ``BodyLimbNav``,
+  ``BodyTerminatorNav``, and ``RingEdgeNav`` are implemented (see
+  "DT-based techniques" under Implemented).
 
 **NavContext shared derivatives**
 
-- `image_gradient_ext`, `image_edge_dt_ext`, source-image
-  `BANDPASS_DOG` pre-filter — fields are present on `NavContext`
-  but the orchestrator does not yet populate them.
+- Source-image ``BANDPASS_DOG`` pre-filter — field is present on
+  `NavContext` but the orchestrator does not yet apply it.
 - Per-instrument saturation DN read from `config_4N0_inst_*.yaml`
   (the orchestrator currently returns the named module-level
   ``DEFAULT_FULL_WELL_DN_12_BIT = 4095.0`` constant from
   ``_instrument_full_well_dn``; replace with a config loader).
+- Per-instrument ``ImageQualityThresholds`` from
+  ``config_4N0_inst_*.yaml``.  The classifier today carries raw-DN
+  defaults (``blank_max_dn = 5.0``, ``saturation_threshold_dn = 4095``,
+  ``noisy_threshold = 10.0``) which mis-classify CALIB I/F-unit
+  Cassini products as ``blank`` (max value < 1.0) and short-circuit
+  before any model or technique runs.  Phase-1 manual artifact per
+  Part 13 line 4424; Phase-2 consumer per the orchestrator's
+  ``_make_context``.
 
 **Provenance population**
 
@@ -1218,9 +1270,22 @@ this section is the operational checklist.
 **INFO logging cadence (Part 12.7)**
 
 - `STATUS_REASON_INFO_TEMPLATE` exists; the orchestrator does not
-  yet emit those INFO lines for each status_reason.
+  yet emit those INFO lines for each status_reason.  In particular,
+  hard-failure short-circuits (``no_signal_in_image``,
+  ``image_overexposed``, ``mostly_missing_data``, ``image_corrupt``)
+  return immediately from ``NavOrchestrator.navigate`` without
+  emitting any per-image INFO line, so the operator log shows the
+  ``HEADER`` opening of the per-image section followed by metadata
+  write with no model/technique lines in between.  Wire the template
+  through every ``NavResult.failed`` site so the failure reason
+  appears in the log alongside the section header.
 - Per-technique 1-line summary + per-feature reliability score
-  breakdown at DEBUG level.
+  breakdown at DEBUG level (the three DT techniques already emit
+  summary INFO lines under their ``with self.logger.open(...)``
+  sections; the missing piece is the ``no_features_extracted`` /
+  ``all_features_gated`` / ``no_feasible_techniques`` /
+  ``final_confidence_below_threshold`` orchestrator-level INFO
+  cadence).
 
 **Image-quality classifier completeness**
 
@@ -1557,26 +1622,343 @@ work can construct any of these and trust the inputs are checked.
   (not just those targeting ``main``); the matrix covers Python
   3.11 / 3.12 / 3.13 / 3.14.  ``codecov-action@v6``.
 
-### Stage 1 entry points (NavModels — complete)
+### Stage 1 forward reference
 
-The three concrete NavModels (`NavModelStars`, `NavModelBody`,
-`NavModelRings`) are landed under
-``src/nav/nav_model/{stars,nav_model_body.py,nav_model_rings.py}``.
-The "Pending" subsection of "Implementation status (snapshot)" is
-the canonical follow-up list.  The next stage of work is the
-concrete `NavTechniques` that consume the emitted features
-(`StarFieldFromCatalogNav`, `BodyDiscCorrelateNav`, `RingEdgeNav`,
-etc.).
-
-After NavModels land, stage 2 should bring up the concrete
-NavTechniques (``BodyDiscCorrelateNav``, ``BodyLimbNav``,
-``BodyTerminatorNav``, ``BodyBlobNav``, ``RingEdgeNav``,
-``RingAnnulusNav``, ``StarFieldFromCatalogNav``,
-``StarUniqueMatchNav``, ``StarRefineNav``, ``CartographicNav``).
-The technique-class registration mechanism is already in place;
-each new subclass auto-registers via ``__init_subclass__``.
+Stage 1 (real-scene NavModels) is described in its own top-level
+section, "Stage 1 status (NavModels — complete)", below.
 
 End of "Foundation cleanup status (stage 0)" section.
+
+---
+
+## Stage 1 status (NavModels — complete)
+
+Stage 1 ("real-scene NavModels" PR
+[#112](https://github.com/SETI/rms-nav/pull/112),
+branch ``core_rewrite_models`` → ``rf_core_rewrite``) is **complete**.
+The three concrete NavModels listed in Part 1 / Part 8 — `NavModelStars`,
+`NavModelBody`, `NavModelRings` — now exist on the new `NavModel` ABC
+contract, together with the per-body shape table and the helper
+modules each model composes.  Inline review findings on the PR have
+been triaged and either landed or explicitly declined with a recorded
+reason (see ``a4e70ab``).
+
+### Final stage-1 check matrix
+
+```
+$ ruff check src tests           — clean
+$ ruff format --check src tests  — 239 files already formatted
+$ mypy --strict src tests        — 240 source files, no issues
+$ pytest -n auto --dist=loadfile — 930 passed (6 tolerated warnings)
+$ sphinx-build -W -b html docs docs/_build  — clean
+```
+
+### Stage-1 commit lineage (most recent first)
+
+- ``a4e70ab`` fix: address inline review findings on stage-1 NavModels
+- ``6e04b83`` test: silence astropy XDG_CONFIG_HOME warning during collection
+- ``709d109`` feat: stage 1 real-scene NavModels
+
+### Real-scene NavModels shipped in stage 1
+
+Each NavModel below conforms to the ABC: ``create_model`` builds the
+internal state, ``to_features(context)`` emits one or more
+``NavFeature`` instances, ``to_annotations(context)`` emits an
+``Annotations`` collection, and ``instances_for_obs(obs)`` is the
+factory the orchestrator's registry walks at construction.
+
+- ``nav.nav_model.stars`` package — ``NavModelStars`` orchestrator
+  plus five helper modules:
+  - ``catalog`` — multi-catalog reduction (UCAC4 → Tycho-2 → YBSC
+    by default), incremental magnitude-bin walk, stellar aberration
+    via ``oops.Event``, proper-motion update at ``obs.midtime``,
+    FOV projection with smear-aware edge culling, dedup +
+    visual-overlap tagging.  Lazy catalog construction is now
+    ``functools.lru_cache``-backed (thread-safe first call).
+  - ``conflicts`` — per-star body / ring occlusion via tiny
+    ``Meshgrid.for_fov`` + ``Backplane.where_intercepted`` /
+    ``ring_radius`` queries; produces ``BODY: <name>`` /
+    ``RING: <planet>`` strings on ``MutableStar.conflicts``.
+  - ``predicted_snr`` — per-star integrated SNR using
+    ``SCLASS_TO_B_MINUS_V`` and the per-instrument flux-to-DN
+    constants; re-exported from the package root.
+  - ``smeared_psf`` — smear-aware PSF rendering (``smeared_psf``,
+    ``smear_length_px``) and per-image smear-vector computation
+    (``compute_smear_vector_px``) from the SPICE bracket
+    ``obs.uv_from_ra_and_dec(boresight, tfrac=0/1)``.
+  - ``detection`` — DAOPHOT-style matched-filter detector
+    (``detect_sources`` + ``apply_shape_cuts`` +
+    ``centroid_gaussian_fit`` / ``centroid_saturated``) with the
+    ``_psf_sigma`` helper that raises rather than silently
+    inventing a sigma.
+
+  ``NavModelStars`` itself emits one ``STAR`` ``NavFeature`` per
+  usable catalog star with anisotropic CRLB centroid covariance
+  rotated to the per-image smear vector, isotropic short-smear
+  fallback below ``MIN_ANISOTROPIC_SMEAR_PX``, and ``StarFlags``
+  carrying ``saturated`` (saturation mask only) and
+  ``in_saturation_or_cosmic_mask`` (saturation OR cosmic-ray) as
+  separately-sourced fields.
+
+- ``nav.nav_model.NavModelBody`` — catalog-driven per-body
+  silhouette navigation; one instance per body inside the extfov
+  (filtered by ``inventory_body_in_extfov``).  Builds an
+  oversampled Lambert-shaded silhouette via
+  ``Meshgrid.for_fov(oversample=...)`` + ``Backplane(obs,
+  meshgrid=...)`` + ``filter_downsample``, extracts limb /
+  terminator polylines, and emits the four feature types per the
+  design's emission gates: ``LIMB_ARC`` / ``BODY_BLOB`` /
+  ``BODY_DISC`` / ``TERMINATOR_ARC``.  Per-vertex polyline sigmas
+  follow the quadrature-sum formula with the
+  ``MAX_INCIDENCE_FACTOR_CAP`` clamp.  Per-body shape parameters
+  are read from ``nav.nav_model.body_shape.BODY_SHAPE_TABLE``;
+  the pending ``config_220_body_shape.yaml`` loader is the
+  successor.
+
+- ``nav.nav_model.NavModelRings`` — catalog-driven ring navigation;
+  one instance per planet whose ring catalog touches the FOV.
+  Reuses the four-pass ``RingFeatureFilter`` that already shipped
+  in stage 0, samples each surviving rendered edge mask into a
+  polyline, and emits ``RING_EDGE`` (per-vertex
+  ``RingEdgePolyline`` with σ_radial / σ_along_edge) or
+  ``RING_ANNULUS`` (multi-edge composite template) depending on
+  the radial extent + straightness gates
+  (``RING_ANNULUS_MAX_RADIAL_PX`` and ``FLAT_CURVATURE_THRESHOLD_PX``).
+
+- ``nav.nav_model.body_shape`` — ``BodyShape`` frozen dataclass
+  plus ``BODY_SHAPE_TABLE`` covering Saturn moons (``MIMAS``,
+  ``ENCELADUS``, ``TETHYS``, ``DIONE``, ``RHEA``, ``IAPETUS``,
+  ``TITAN``), irregulars (``HYPERION``, ``PHOEBE``), gas / ice
+  giants (``SATURN``, ``JUPITER``, ``URANUS``, ``NEPTUNE``), and
+  the major Galilean satellites; ``shape_for_body`` is the
+  case-insensitive lookup with ``DEFAULT_BODY_SHAPE`` fallback.
+
+### Test shims established in stage 1 (binding)
+
+The shims under ``tests/shims/`` are the canonical way to drive
+nav code paths that depend on ``oops.Backplane``,
+``oops.Observation``, or production star catalogs without paying
+the SPICE-kernel / multi-GB-binary price.  Stage 2 should reuse
+them; if a NavTechnique surfaces a missing surface, extend the
+shim rather than spinning up a parallel fake.
+
+- ``tests/shims/backplane.py`` — ``FakeBackplane`` returning real
+  ``polymath.Scalar`` instances over ``BodyBackplaneData`` /
+  ``RingBackplaneData`` records; convenience factory
+  ``plant_circular_body`` validates ``radius_px > 0`` and paints a
+  disc whose pixel-count test asserts exactly.
+- ``tests/shims/catalog.py`` — ``FakeStar`` /
+  ``FakeStarCatalog`` mutable star records satisfying the
+  ``MutableStar`` protocol surface; ``install_fake_catalogs``
+  uses ``monkeypatch.setattr`` so the swap is **per-test scoped**
+  (no inter-test or inter-worker leakage under
+  ``pytest -n auto --dist=loadfile``).
+- ``tests/shims/obs.py`` — ``FakeObs`` numpy-array stand-in for
+  ``ObsSnapshotInst``: required ``data`` plus optional extfov
+  margin (validated non-negative), inventory dict, RA/DEC limits,
+  PSF stub, optional per-call ``radec_to_uv`` callable for
+  custom projection, and bracket-driven default
+  ``uv_from_ra_and_dec`` for smear-vector tests.
+
+### Test coverage achieved in stage 1
+
+```
+nav_model_stars                100%
+stars/nav_model_stars          100%
+stars/predicted_snr            100%
+stars/smeared_psf              100%
+body_shape                     100%
+stars/detection                 97%
+stars/catalog                   94%
+stars/conflicts                 49%   (rest needs real Backplane)
+nav_model_rings                 55%   (rest needs real Backplane)
+nav_model_body                  46%   (rest needs real Backplane)
+```
+
+The < 50 % coverage on the body / rings / conflicts modules is
+the ``_render`` / ``_build_backplane_model`` / ``_check_one_star``
+chain that constructs an ``oops.Backplane`` over a real obs
+camera model.  These paths run end-to-end against synthetic
+fixtures in the stage-1 integration tests but the
+``Meshgrid.for_fov`` + ``Backplane(obs, meshgrid=...)`` line
+itself can only be exercised by integration tests against the
+image library (Part 9 / Part 10), which is the next gating piece
+of work.  The list of specific functions that need image-library
+coverage is enumerated under "NavModel coverage gap" in the
+"Implementation status (snapshot) → Pending" section above.
+
+### Conventions established in stage 1 (binding)
+
+- **Test shims under ``tests/shims/``** are the canonical way to
+  drive nav code paths that depend on ``oops.Backplane``,
+  ``oops.Observation``, or production star catalogs without
+  paying the SPICE-kernel / multi-GB-binary price.  Stage 2
+  reuses them.
+- **Pytest ``monkeypatch`` is per-test scoped.**
+  ``install_fake_catalogs`` swaps the lazy getter functions
+  using ``monkeypatch.setattr``; the swap is bound to the
+  calling test's lifetime and ``pytest-xdist`` workers run in
+  separate processes, so module-level state in one worker
+  cannot leak into another.
+- **Real ``polymath.Scalar`` over fakes.**  The backplane shim
+  wraps real ``polymath.Scalar`` masked arrays rather than
+  reimplementing a parallel ``FakeScalar`` surface.  Tests
+  assert against the actual ``mvals`` / ``vals`` API.
+- **Inline imports remain forbidden.**  Every test imports at
+  the module top — including small one-off ``dataclasses`` /
+  ``pytest`` references; the per-function-import shortcut is
+  not acceptable.
+- **Star-catalog factory caching.**  The three star catalog
+  getters (``get_ucac4_catalog`` / ``get_tycho2_catalog`` /
+  ``get_ybsc_catalog``) use ``functools.lru_cache(maxsize=1)``
+  rather than module-level mutable globals; first-call
+  construction is thread-safe and the cache is bypassed when
+  ``install_fake_catalogs`` patches the getters.
+- **Saturation vs cosmic-ray separation.**  ``StarFlags.saturated``
+  reflects the saturation mask only.  ``StarFlags.in_saturation_or_cosmic_mask``
+  and the reliability gate input both carry the OR.  Mixing
+  the two on the ``saturated`` field was rejected during the
+  stage-1 review; the split is binding for any new flag in any
+  feature type.
+
+### CI / collection robustness
+
+- ``pyproject.toml [tool.pytest.ini_options].filterwarnings``
+  carries an explicit ``"default:XDG_CONFIG_HOME is set to:UserWarning"``
+  entry to keep astropy's import-time XDG / ``~/.astropy/config``
+  precedence warning from being elevated to a collection error
+  on the GitHub-hosted runner image.  The matching xdist
+  collection-mismatch was a downstream symptom that disappears
+  when the warning is allowed through.
+
+End of "Stage 1 status" section.
+
+---
+
+## Stage 2 status (NavTechniques — partial; DT techniques landed)
+
+Stage 2 brings up the concrete ``NavTechnique`` subclasses that consume
+the features the stage-1 NavModels emit.  The first wave (the three
+DT-based techniques plus their shared infrastructure) has shipped; the
+remaining techniques (full-disc NCC, blob centroid, ring-annulus NCC,
+all star techniques) are still pending.
+
+### DT-based techniques shipped
+
+- ``BodyLimbNav`` — joint translation fit on every ``LIMB_ARC`` feature
+  via the shared coarse-NCC + Levenberg-Marquardt pipeline with
+  polarity filtering and Tukey biweight reweighting.
+- ``BodyTerminatorNav`` — same shape with terminator-specific
+  per-body uniform weighting and an albedo / phase-angle confidence
+  spec.
+- ``RingEdgeNav`` — DT fit on every ``RING_EDGE`` feature; reports
+  honest rank-1 covariance when every input edge is straight-line.
+  Polarity prediction is intentionally disabled (deferred per
+  Part 13b §1).
+
+### Shared infrastructure shipped alongside the techniques
+
+- ``nav.nav_technique.dt_fitting`` — pure-numerical helpers shared by
+  every DT technique:
+  - ``coarse_ncc_search`` — binary-mask cross-correlation with
+    Manhattan-distance tie-breaking.
+  - ``polarity_filter`` — strict ``dot(model_normal, image_gradient) > 0``.
+  - ``tukey_biweight_weights`` — Holland-Welsch redescender at
+    ``c = 4.685``.
+  - ``lm_subpixel_refine`` — translation (or translation + rotation)
+    LM with IRLS Tukey reweighting; ``lambda = 1e-3`` start, max 30
+    iterations, step-norm tolerance ``1e-3 px``.
+  - ``information_matrix_to_covariance`` — Hessian to covariance via
+    ``scipy.linalg.pinvh(rtol=1e-9)`` (matches the ensemble combine).
+- ``nav.nav_orchestrator.image_derivatives`` — shared
+  Sobel-of-Gaussian gradient + Canny-style directional NMS + truncated
+  distance transform.  ``build_image_edge_dt`` returns
+  ``(image_gradient_ext, image_edge_dt_ext)`` and
+  ``compute_image_gradient_vu`` returns the per-pixel ``(g_v, g_u)``
+  vector consumed by the polarity filter.  The orchestrator's
+  ``_make_context`` populates all three fields on every NavContext
+  before any technique runs.
+- ``tests/nav/nav_technique/conftest.py`` — shared factory fixtures
+  (``disc_image``, ``horizontal_step_image``, ``circle_polyline``,
+  ``arc_polyline``, ``flat_polyline``, ``make_nav_context``,
+  ``make_limb_feature``, ``make_terminator_feature``,
+  ``make_ring_feature``, plus the ``FakeObs`` stand-in and the
+  ``DiscImageFactory`` / ``ArcPolylineFactory`` / etc. type aliases) so
+  the three technique end-to-end test files share their scaffolding
+  rather than duplicating it.
+
+### Logging convention shipped with the DT techniques
+
+The codebase does **not** use the stdlib ``logging`` module anywhere in
+the cutover-tier source tree.  Pdslogger via
+``nav.config.logger.IMAGE_LOGGER`` is the only logger; ``NavBase`` exposes
+it as ``self.logger``.  Every ``NavTechnique.navigate`` body opens a
+section via ``with self.logger.open(f'TECHNIQUE: {self.name}'):`` so per-
+image logs delimit each technique's contribution.  Tests capture log
+output via ``capsys``, never ``caplog`` (pdslogger writes through its
+own stream handler).
+
+### Final stage-2-DT check matrix
+
+```
+$ ruff check src tests           — clean
+$ ruff format --check src tests  — 250 files already formatted
+$ mypy --strict src tests        — 251 source files, no issues
+$ pytest -n auto --dist=loadfile — 1009 passed (6 tolerated warnings)
+$ sphinx-build -W -b html docs docs/_build  — clean
+$ pymarkdown scan docs/ .cursor/ README.md CONTRIBUTING.md  — clean
+```
+
+### Coverage of the new DT-stage modules
+
+```
+nav_orchestrator/image_derivatives                 100%
+nav_technique/dt_fitting                            93%
+nav_technique/nav_technique_body_limb               90%
+nav_technique/nav_technique_body_terminator         90%
+nav_technique/nav_technique_ring_edge               89%
+```
+
+Per-module coverage on the new DT-tier code is 89-100 %.  Whole-tree
+coverage stays at ~39 % because the GUI / mosaic-viewer / sim / pds4
+packages are intentionally out of scope.
+
+### What stage 2 still owes
+
+Concrete NavTechniques not yet landed:
+
+- ``BodyDiscCorrelateNav`` (BODY_DISC NCC)
+- ``BodyBlobNav`` (BODY_BLOB centroid)
+- ``RingAnnulusNav`` (RING_ANNULUS NCC)
+- ``StarFieldFromCatalogNav`` (multi-star RANSAC)
+- ``StarUniqueMatchNav`` (single-star unique match)
+- ``StarRefineNav`` (single-star refine pass)
+- ``CartographicNav`` (CARTOGRAPHIC_MODEL NCC, deferred per Part 13b)
+- ``TitanNav`` (atmospheric-body, deferred per Part 13b)
+
+Per Part 13b §2 the ``CartographicDiagnostics`` dataclass is **deleted**
+from the cutover-tier source tree until ``CartographicNav`` itself
+lands; the diagnostics class returns alongside the technique (kept in
+git history until then).
+
+Production wiring still pending (see "Pending" subsection):
+
+- Static-data YAML files (``config_220_body_shape.yaml`` plus four
+  orchestration tier files plus per-camera ``noise:`` / ``mag_offset:``
+  blocks).
+- Per-instrument ``ImageQualityThresholds`` from ``config_4N0_inst_*.yaml``
+  (today the orchestrator uses raw-DN-unit defaults, which mis-classify
+  CALIB I/F-unit images as ``blank``).
+- ``STATUS_REASON_INFO_TEMPLATE`` wiring so every hard-failure
+  short-circuit emits an operator-readable INFO line.
+- Per-camera saturation DN, mag-offset table consumer, source-image
+  ``BANDPASS_DOG`` pre-filter.
+- Provenance population (SPICE kernels, static-data hashes, git SHA).
+- Annotations + summary-PNG renderer.
+- Real-image integration suite (Parts 9 / 10).
+- Confidence-formula calibration against the integration library.
+
+End of "Stage 2 status" section.
 
 ---
 
@@ -4505,6 +4887,41 @@ codebase regresses to its previous shape.
   in vNext" comments.  When something is replaced, the old form is
   deleted; the new form is the only form.
 
+### Logging — pdslogger only, never the stdlib ``logging`` module
+
+The codebase has its own logging infrastructure built on the
+``pdslogger`` package.  Two ``pdslogger.PdsLogger`` instances live in
+``nav.config.logger``:
+
+- ``MAIN_LOGGER`` (``nav_offset``) — top-level program events.
+- ``IMAGE_LOGGER`` (``nav_image``) — per-image processing events;
+  per-image stdout and file handlers are attached as **local
+  handlers** inside each ``IMAGE_LOGGER.open(...)`` context (see
+  ``nav.config.logger.image_log_handlers`` and
+  ``navigate_image_files``).
+
+The ``NavBase`` superclass exposes ``self.logger`` returning
+``IMAGE_LOGGER`` so every NavModel / NavFeatureExtractor / NavTechnique
+subclass logs through pdslogger automatically.  Binding rules:
+
+- **No ``import logging``** anywhere in the new core code (``nav.feature``,
+  ``nav.nav_model``, ``nav.nav_orchestrator``, ``nav.nav_technique``,
+  ``nav.support``).  The historical ``logging.getLogger(__name__).addHandler(logging.NullHandler())``
+  module-bootstrap line is removed everywhere.
+- **No ``logging.getLogger`` calls** — pdslogger is the only logger
+  factory.
+- **Every ``NavTechnique.navigate`` body opens a logger section** via
+  ``with self.logger.open(f'TECHNIQUE: {self.name}'):`` so the
+  per-image log clearly delimits each technique's contribution.
+  ``NavModel`` and ``NavFeatureExtractor`` may follow the same pattern
+  when they have multi-step bodies worth structuring; otherwise they
+  log directly to ``self.logger``.
+- **Logging output is captured with ``capsys``, not ``caplog``.**
+  Pdslogger writes through its own stream handler that does not feed
+  the standard ``logging`` propagation.  Tests that need to verify a
+  WARNING / ERROR / EXCEPTION emission read from
+  ``capsys.readouterr().out``.
+
 ### Git as the source of preserved-but-deleted code
 
 Several modules were deleted during the cutover whose internal
@@ -4627,11 +5044,30 @@ scratch.
   ``mypy --strict`` is clean.  Remove the ignore once oops ships
   type stubs.
 
+### DT-based fitting machinery lives in ``nav.nav_technique.dt_fitting``
+
+The shared DT pipeline that the body-limb, body-terminator, and
+ring-edge techniques compose lives in
+``src/nav/nav_technique/dt_fitting.py``.  Future DT-using techniques
+(e.g. a polarity-aware ring matcher) should reuse the same five
+helpers — ``coarse_ncc_search``, ``polarity_filter``,
+``tukey_biweight_weights``, ``lm_subpixel_refine``,
+``information_matrix_to_covariance`` — rather than rolling their own
+LM loops.  Image-side derivatives are produced by
+``nav.nav_orchestrator.image_derivatives.build_image_edge_dt`` (Canny-
+style directional non-maximum suppression on the Sobel-of-Gaussian
+gradient, then a truncated DT) and
+``compute_image_gradient_vu`` (the per-pixel gradient vector consumed
+by the polarity filter).  The orchestrator's ``_make_context``
+populates ``image_gradient_ext``, ``image_gradient_vu_ext``, and
+``image_edge_dt_ext`` on every ``NavContext``; techniques must not
+recompute them.
+
 ### Things that already work and should not be re-litigated
 
-- The 700-test suite is green.  Adding code that breaks existing tests
-  is a regression; either fix the regression or delete the obsolete
-  test (with justification).
+- The full test suite is green.  Adding code that breaks existing
+  tests is a regression; either fix the regression or delete the
+  obsolete test (with justification).
 - `ruff check`, `ruff format --check`, and `mypy --strict` are clean
   on every committed file.  CI must stay clean.
 - The `nav.nav_model.rings/` data-model subpackage is preserved

--- a/AUTONAV_PLAN.md
+++ b/AUTONAV_PLAN.md
@@ -1002,7 +1002,9 @@ this section is the operational checklist.
   `BodyTerminatorDiagnostics`, `BodyBlobDiagnostics`,
   `RingEdgeDiagnostics`, `RingAnnulusDiagnostics`,
   `StarFieldDiagnostics`, `StarUniqueMatchDiagnostics`,
-  `StarRefineDiagnostics`, `CartographicDiagnostics`.
+  `StarRefineDiagnostics`.  ``CartographicDiagnostics`` is **not** in
+  the cutover-tier source tree until ``CartographicNav`` itself
+  ships — see "Removed without direct replacement" below.
 - `nav.nav_technique.confidence` — `evaluate_sigmoid_combination`
   with `ConfidenceSpec` / `ConfidenceTerm`.  Both dataclasses
   validate types, finite numerics, and range invariants in

--- a/AUTONAV_PLAN.md
+++ b/AUTONAV_PLAN.md
@@ -1,5 +1,63 @@
 # Autonomous Navigation Overhaul — Design Plan
 
+## Reading order for an AI picking this up cold
+
+Read in this order; later items reference earlier ones, not the
+other way round:
+
+1. **This subsection** (you are here) — orientation.
+2. **Part 0 — Audit corrections** — binding overrides; supersedes
+   any conflicting text further down in Parts 1–16.
+3. **Implementation phases — overview** — the action plan. Phase
+   table, "Per-phase definition of done" (lint / type / pytest /
+   sphinx / pymarkdown checks + six-file critique folder + executive
+   summary), and "Tooling and conventions binding for every phase".
+4. **Phase 0 / Phase 1 / Phase 2 — status sections** — historical
+   record of what has already shipped (foundation, real-scene
+   NavModels, DT-based NavTechniques). Read these to know what
+   already exists in the codebase.
+5. **Phase 3 → Phase 12+** — the per-phase work specifications you
+   will execute next. Each phase is self-contained (Goal / Why now /
+   Prerequisites / Scope (in) / Scope (out) / Design references /
+   Tests / Documentation / Definition of done). **Do exactly one
+   phase per fresh context.**
+6. **Implementation status (snapshot)** — historical flat checklist
+   (Implemented / Removed / Pending) preserved as a comprehensive
+   index. **Not the action plan**; the per-phase sections above
+   are. Where this list and a phase's Scope (in) disagree, the
+   phase wins.
+7. **Parts 1–16** — design source-of-truth. Per-phase Scope (in) lines
+   point here ("Design references: Part 1 §X / Part 5 §Y"); read
+   only the cited subsections, not the full body. Anything in
+   Parts 1–16 that conflicts with Part 0 loses.
+8. **Resumption notes + Continuation notes for the implementation
+   (binding)** — at the very bottom of the file. Read once for
+   user-style preferences, hallucination history, and the
+   "things that already work" list before starting any work.
+
+**Phase-numbering caveat.** "Phase N" appears throughout this file
+in two distinct numberings:
+
+- The **new** per-phase plan at the top of this file uses
+  Phase 0–11 (plus 12+ for Part 13b deferred items). This is what
+  you are executing.
+- Parts 1–16 (the design body) and parts of Part 0 occasionally
+  reference the **legacy** phase numbering (legacy Phase 1 ↔ new
+  Phase 0; legacy Phase 5 ↔ new Phase 10; legacy Phase 7 ↔ new
+  Phase 11). Where this matters, the legacy reference is annotated
+  inline with "(Legacy wording said …)" so you can disambiguate.
+  Part 13 carries the full legacy → new mapping.
+
+If you read a "Phase N" reference and aren't sure which numbering
+it uses, check the surrounding sentence for a "(Legacy wording …)"
+annotation; if present, the new numbering is canonical and the
+legacy reference is preserved only for traceability to old
+discussions. If you find a "Phase N" reference that is genuinely
+ambiguous and not covered by an annotation, treat that as a bug in
+this plan and fix it.
+
+---
+
 ## Part 0 — Audit corrections (2026-04-26)
 
 These supersede any conflicting text below. Where a Part 1–16 section
@@ -65,10 +123,13 @@ Same naming convention applies inside `NavResult`: `status_reason: NavStatusReas
    Update the JSON schema, `tier_thresholds` YAML, and the rank-derivation
    table accordingly.
 
-5. **Phase-5 placeholder constants get inline comments.** Each placeholder
-   value in Phase-1 YAML carries a `# PLACEHOLDER — calibrate in Phase 5`
-   comment; PR review enforces that no `PLACEHOLDER` markers ship to
-   production. No CI gate is added.
+5. **Calibration-phase placeholder constants get inline comments.** Each
+   placeholder value in YAML written before calibration carries a
+   `# PLACEHOLDER — calibrate in Phase 10` comment; PR review enforces
+   that no `PLACEHOLDER` markers ship to production. No CI gate is
+   added. (Original wording referenced "Phase 1 YAML" / "Phase 5
+   calibration" under the legacy phasing; Phase 1 ↔ new Phase 0 + 3
+   shipped placeholders, Phase 5 ↔ new Phase 10 calibrates them.)
 
 6. **`LimbRefineNav` is dropped.** Remove from Part 8 file list.
    `BodyLimbNav` does its own subpixel refinement after the coarse DT
@@ -154,7 +215,9 @@ Same naming convention applies inside `NavResult`: `status_reason: NavStatusReas
   Part 4 is true at the read interface; just reword for accuracy.
 - `pyproject.toml` `[tool.pytest.ini_options]` has no `testpaths`,
   `markers`, `--strict-markers`, or `filterwarnings = ["error"]` today.
-  Phase 1 must add all four (per `critique-test-suite` §19, §22).
+  All four were added in Phase 0 (per `critique-test-suite` §19, §22);
+  the binding is preserved in the "Tooling and conventions binding for
+  every phase" subsection. (Legacy wording said "Phase 1".)
 - "Three rules" in Part 0 (Cardinal Principles) is actually four; the
   fourth is angles in degrees / radians. Reread Cardinal Principles with
   that count.
@@ -268,12 +331,18 @@ plan-body section conflicts, this list wins.
 #### Internal-inconsistency fixes
 
 20. **Cutover gating timing (B3).** The 500-image breadth comparison vs
-    legacy is a **pre-merge** gate of the Phase 4 change-set, not a
-    Phase 7 step. While the change-set is on a feature branch, both
-    pipelines coexist; the comparison runs there. After Phase 4 merges,
-    legacy is gone and there's nothing to compare against. Phase 7
-    cutover-gating is verification (grep sweeps + coverage + docs)
-    only.
+    legacy is a **pre-merge** gate of the cutover change-set (the
+    change-set that deletes the legacy code; in the new phase plan
+    this is the Phase 11 cutover, but in the codebase this *already
+    happened* during the Phase 0/1/2 cutover branch — the breadth
+    comparison must therefore be re-run on a comparison branch that
+    re-instates legacy or against a pinned pre-cutover commit hash).
+    The comparison cannot run after the legacy delete merges because
+    legacy is gone. Phase 11 cutover-gating is verification (grep
+    sweeps + coverage + docs) plus the breadth comparison itself.
+    (Legacy wording referenced "Phase 4 change-set" / "Phase 7 step";
+    legacy Phase 4 = orchestrator + cutover, legacy Phase 7 =
+    cleanup, both rolled into new Phase 11.)
 
 21. **`'corrupt'` row in image-classifier table (B15).** Add a row:
     `corrupt | image file failed to parse / read; raises in obs construction
@@ -493,9 +562,9 @@ plan-body section conflicts, this list wins.
     `INCIDENCE_FACTOR_CLIP_DEG = 85.0`, `AGREEMENT_FACTOR_CAP = 1.5`,
     `COMBINED_CONFIDENCE_CAP = 0.99`, `JSON_INF_SENTINEL = 1e9`,
     `MIN_ANISOTROPIC_SMEAR_PX = 0.5`, etc. Each carries a one-line
-    docstring with units + intent. Phase 1 implementation populates
-    this module; pseudocode in this plan referencing the inline numbers
-    is updated to reference the constant name.
+    docstring with units + intent. Phase 0 shipped this module;
+    pseudocode in this plan referencing the inline numbers is updated
+    to reference the constant name. (Legacy wording said "Phase 1".)
 
 45. **Typing aliases (D6).** Add `src/nav/support/types.py` containing
     `NDArrayFloat = np.ndarray  # cast of NDArray[np.floating[Any]]`,
@@ -536,7 +605,9 @@ plan-body section conflicts, this list wins.
     - `nav.support.status_reason.__all__ = ['NavStatusReason']`.
 
 47. **Pre-emptive module splits (D10).** Three packages get split before
-    Phase 4 ships, avoiding > 1000-line files:
+    the orchestrator phase ships, avoiding > 1000-line files (the
+    orchestrator-tier work shipped in Phase 0; the splits below are
+    binding for any later additions to those modules):
     - `nav.nav_orchestrator` already split (`orchestrator.py`,
       `ensemble.py`, `nav_result.py`); also split `nav_result.py` into
       `nav_result.py` (the dataclass), `feature_summary.py`
@@ -577,7 +648,9 @@ plan-body section conflicts, this list wins.
 
 49. **Module index (E4).** Update `docs/index.rst` (the Sphinx
     top-level toctree) to list every new module, sorted by package and
-    name. Add to Phase 6 work list.
+    name. The toctree must be kept in sync as each phase ships its
+    docs; the final audit is part of Phase 11. (Legacy wording said
+    "Phase 6 work list".)
 
 #### Testing additions (Section F)
 
@@ -725,18 +798,20 @@ plan-body section conflicts, this list wins.
 
 65. **"Future need" sentences swept into Part 13b (H3).** Every "if a
     future need arises" / "tracked in Part 13b" / "to be designed and
-    added later" sentence in Parts 1–12 either points to one of the 5
-    existing Part 13b items or its referenced item is added. Reading
-    pass during Phase 1 catches the rest; for now, the 5 items in
-    Part 13b are the canonical deferred-work list.
+    added later" sentence in Parts 1–12 either points to one of the
+    Part 13b items or its referenced item is added. Reading pass
+    during Phase 0 caught the rest; for now, the 6 items in Part 13b
+    are the canonical deferred-work list. (Legacy wording said "5
+    items" / "Phase 1".)
 
 66. **UI per-technique-result panel layout (H13).** Out of scope for
     the cutover. Filed as a 6th Part 13b item: "UI per-technique panel
     redesign — replace the manual-nav 'Auto' button with a per-technique
     side-by-side panel; ergonomics + interaction TBD; tracker only."
-    Phase 4 keeps the existing manual-nav UI working with the new
-    `NavResult` (one technique surfaced per the orchestrator's choice);
-    the panel redesign happens later.
+    The cutover (Phases 0–11) keeps the existing manual-nav UI working
+    with the new `NavResult` (one technique surfaced per the
+    orchestrator's choice); the panel redesign happens later.
+    (Legacy wording said "Phase 4".)
 
 #### Section I: missing material
 
@@ -752,18 +827,18 @@ plan-body section conflicts, this list wins.
     - VGISS NA, `fit_camera_rotation=True`: ≤ 3× legacy.
     - Memory ceiling per worker: 800 MB resident set for any of the
       four supported missions at native resolution.
-    Phase 5 calibration validates against the library; CI smoke test
+    Phase 10 calibration validates against the library; CI smoke test
     measures one COISS NAC frame and fails if runtime > 5× a stored
     baseline (loose; for catching catastrophic regressions, not
-    fine tuning).
+    fine tuning). (Legacy wording said "Phase 5".)
 
-69. **CI grep step for deleted symbols (I3).** Phase 7 adds a
+69. **CI grep step for deleted symbols (I3).** Phase 11 adds a
     `.github/workflows/ci.yml` step:
     `grep -rE 'NavTechniqueCorrelateAll|NavModelCombined|NavModelResult|NavMaster|weighted_mask|blur_amount|final_offset|final_confidence|use_legacy_pipeline' src tests docs README.md CLAUDE.md && exit 1 || exit 0`
     fails the build if any leftover reference appears. Single sweep;
-    run on every PR.
+    run on every PR. (Legacy wording said "Phase 7".)
 
-70. **Empty tests directories (I5).** Phase 1 creates
+70. **Empty tests directories (I5).** Phase 0 created
     `tests/nav/feature/__init__.py` (empty),
     `tests/nav/nav_orchestrator/__init__.py` (empty),
     `tests/integration/__init__.py` (empty),
@@ -857,8 +932,7 @@ plan-body section conflicts, this list wins.
       <document_id> v<version>, §<section>, Table <N>` — the document
       ID matches the PDS3/PDS4 holdings.
     - **IAU report**: `IAU WGCCRE <year> report, §<section>`.
-    - **Mission-team technical memo**: `<Author or Team> (Year),
-      <Title>, <Identifier or URL>` — URL only when no DOI exists.
+    - **Mission-team technical memo**: `<Author or Team> (Year), <Title>, <Identifier or URL>` — URL only when no DOI exists.
 
     **Anti-hallucination procedure.** AI agents that draft body-shape
     entries:
@@ -867,9 +941,10 @@ plan-body section conflicts, this list wins.
        session. Citing from training-data memory is not allowed.
     2. If a value cannot be sourced from a fetched document, the value
        is left as `null` and the `_sources` entry reads
-       `'PLACEHOLDER — no source found, calibrate in Phase 5'`. The
+       `'PLACEHOLDER — no source found, calibrate in Phase 10'`. The
        loader fallback (Part 5: 10% radius default, WARNING log,
-       reliability cap 0.3) handles `null` values at runtime.
+       reliability cap 0.3) handles `null` values at runtime. (Legacy
+       wording said "Phase 5".)
     3. DOIs and paper titles must verify against a real
        `https://doi.org/<DOI>` lookup; agents do not invent identifiers.
     4. The drafting prompt explicitly forbids fabrication: any draft
@@ -931,11 +1006,181 @@ implementation-time conventions. Their absence from this section means
 
 ---
 
+## Implementation phases — overview
+
+The implementation is split into context-sized phases. Each phase is small
+enough to fit in a single Claude Opus context (no context drift),
+self-contained (assume the agent picking it up has no memory of prior
+phases beyond what is in the codebase + the design content in Parts 1–16
++ this overview), and ends with full lint, type, pytest, and
+documentation checks plus a complete code review (see "Per-phase
+definition of done" below). Order is chosen so that **minimal
+end-to-end functionality lands as early as possible** — the first time
+a real image navigates is Phase 4 — and only then do additional
+techniques broaden coverage.
+
+| Phase | Goal | Status |
+|-------|------|--------|
+| **0** | Foundational support for the navigation core rewrite | **Complete** (PR #111) |
+| **1** | Real-scene NavModels (`NavModelStars`, `NavModelBody`, `NavModelRings`) | **Complete** (PR #112) |
+| **2** | DT-based NavTechniques (`BodyLimbNav`, `BodyTerminatorNav`, `RingEdgeNav`) | **Complete** (branch `core_rewrite_dt_techniques`) |
+| **3** | Foundation completion + per-instrument config wiring | Pending |
+| **4** | First navigable image (end-to-end DT-only) | Pending |
+| **5** | Body disc + body blob techniques | Pending |
+| **6** | Ring-annulus technique | Pending |
+| **7** | Star techniques part 1 (unique-match + refine) | Pending |
+| **8** | `StarFieldFromCatalogNav` (multi-star RANSAC) | Pending |
+| **9** | Camera rotation correction (per instrument) | Pending |
+| **10** | Image library expansion + confidence-formula calibration | Pending |
+| **11** | Cleanup + documentation finalization + breadth comparison | Pending |
+| **12+** | Deferred items (Part 13b) — each its own phase when scheduled | Tracked |
+
+**Detailed Phase 0–2 status sections** ("Phase 0 — Foundation
+(complete)" / "Phase 1 — Real-scene NavModels (complete)" / "Phase 2
+— DT-based NavTechniques (partial)") follow this overview and the
+operational checklist. They preserve the check matrix, commit lineage,
+shipped components, conventions, and remaining gaps recorded during
+each phase.
+
+**Detailed Phase 3+ specifications** (Goal / Why now / Prerequisites /
+Scope (in) / Scope (out) / Design references / Tests / Documentation /
+Definition of done) follow the Phase 0–2 sections.
+
+### Per-phase definition of done
+
+Every phase must end with all of the following clean before it is
+considered done:
+
+- `ruff check src tests` — clean.
+- `ruff format --check src tests` — clean.
+- `mypy --strict src tests` — clean (`MYPYPATH=src` from `pyproject.toml`).
+- `pytest -n auto --dist=loadfile` — all passing (`--dist=loadfile`
+  matches CI; default scheduling crashes PyQt6 workers).
+- `pytest --cov` — coverage ≥ 90 % on the cutover-tier modules
+  (`nav.feature/`, `nav.nav_orchestrator/`, `nav.nav_technique/`,
+  `nav.nav_model/`); whole-tree percentage gated by per-package
+  thresholds (the GUI / mosaic-viewer / sim packages pre-date the
+  cutover and are below 90 % by design).
+- `sphinx-build -W -b html docs docs/_build` — clean.
+- `pymarkdown scan docs/ .cursor/ README.md CONTRIBUTING.md` — clean.
+- `./scripts/run-all-checks.sh` — green end-to-end.
+
+Plus a **complete code review** written to a per-phase folder
+`phase_NN_review/` at the repo root (committed alongside the phase
+work as the historical record of its quality bar — the existing
+stage-0 critique reports at the repo root are the precedent for this
+convention). The folder contains the following files:
+
+- `CRITIQUE_PYTHON.md` — review against `.cursor/rules/python_best_practices.mdc`.
+- `CRITIQUE_DOCS.md` — review against `.cursor/rules/documentation.mdc`.
+- `CRITIQUE_FILECACHE.md` — review against `.cursor/rules/filecache_best_practices.mdc`.
+- `CRITIQUE_LOGGING.md` — review against `.cursor/rules/logging_best_practices.mdc`.
+- `CRITIQUE_TESTS.md` — review using `.cursor/skills/critique-test-suite/SKILL.md`.
+- `CRITIQUE_CODEBASE.md` — review using `.cursor/skills/python-codebase-analysis/SKILL.md`.
+- `CRITIQUE_SUMMARY.md` — **executive summary** aggregating every
+  finding from the six files above with importance
+  (Critical / High / Medium / Low) and a ready-to-run AI prompt to
+  execute the fix for each finding. Every Critical and High
+  finding **must** be addressed before the phase closes.
+
+Doc files unique to the phase (e.g. `developer_guide_<topic>.rst`,
+`user_guide_<topic>.rst`) ship alongside the code in the phase. There
+is no separate documentation phase; doc finalization (index audit,
+README + CLAUDE.md + CHANGELOG, `.cursor/rules/*.mdc` files) folds
+into Phase 11.
+
+### Tooling and conventions binding for every phase
+
+Cross-phase bindings established during Phases 0–2. An AI continuing
+the work must respect every item below; regressing any of them is a
+phase-blocker.
+
+- **Python floor** is 3.11. `NavStatusReason` uses `StrEnum`; do not
+  regress to a `(str, Enum)` mixin without bumping `requires-python`
+  first. CI matrix covers 3.11 / 3.12 / 3.13 / 3.14.
+- **No backwards-compatibility shims** anywhere (Cardinal Principle #1).
+  When something is replaced, the old form is deleted; the new form
+  is the only form. No "DEPRECATED: removed in vNext" comments.
+- **Stub honesty.** Code that is not yet implemented either logs the
+  deferral and returns an inert value (the summary-PNG path before
+  Phase 4) or raises `NotImplementedError` naming the deferred work.
+  No silent placeholder values, ever.
+- **Magic constants live in module-level `ALL_CAPS` constants** with a
+  one-line docstring stating units and intent (e.g.
+  `DEFAULT_FULL_WELL_DN_12_BIT` was the canonical example before
+  Phase 3 replaced it with config-driven values). No hard-coded
+  saturation thresholds, magic factors, or sentinels in function
+  bodies.
+- **Broad `except Exception:` is reserved for the orchestrator's
+  plugin-sandbox sites** (per-NavModel `create_model` /
+  `to_features` / `to_annotations`, per-NavTechnique `navigate`).
+  Each site carries a docstring explaining why and a per-line
+  justification comment. Other broad catches are not acceptable.
+- **Pdslogger output is captured with `capsys`, not `caplog`.**
+  Pdslogger writes through its own stream handler that does not feed
+  the standard `logging` propagation. Tests that need to verify a
+  WARNING / ERROR / EXCEPTION emission read from
+  `capsys.readouterr().out`.
+- **Frozen dataclasses validate on construction.** Public dataclasses
+  use `__post_init__` to enforce documented invariants;
+  `object.__setattr__` is the standard escape hatch for normalising
+  inputs in a frozen dataclass.
+- **Sphinx `automodule` for re-exporting packages uses `:no-index:`**
+  to avoid duplicate cross-references with the submodule pages
+  (see `docs/api_reference/api_feature.rst`).
+- **`pyproject.toml [tool.pytest.ini_options]`** has
+  `filterwarnings = ["error"]` plus a single tolerated rule for the
+  third-party `PytestUnraisableExceptionWarning` raised by astropy's
+  FITS reader on integration tests.
+- **CI.** `.github/workflows/run-tests.yml` runs on every PR (not
+  just those targeting `main`); the Python matrix covers 3.11 /
+  3.12 / 3.13 / 3.14; `codecov-action@v6`.
+- **Source-tree code, comments, docstrings, and tests must not
+  mention the plan.** No "Per Part X §Y", no "Phase N", no "Cardinal
+  Principle #N", no "AUTONAV_PLAN". The implementation reads as if
+  written from scratch with the design in mind.
+- **No `import logging`** anywhere in the new core code
+  (`nav.feature`, `nav.nav_model`, `nav.nav_orchestrator`,
+  `nav.nav_technique`, `nav.support`). Pdslogger via
+  `nav.config.logger.IMAGE_LOGGER` is the only logger; `NavBase`
+  exposes it as `self.logger`.
+- **Every `NavTechnique.navigate` body opens a logger section** via
+  `with self.logger.open(f'TECHNIQUE: {self.name}'):` so the
+  per-image log clearly delimits each technique's contribution.
+- **Test shims under `tests/shims/`** are the canonical way to drive
+  nav code paths that depend on `oops.Backplane`, `oops.Observation`,
+  or production star catalogs without paying the SPICE-kernel /
+  multi-GB-binary price. Extend the shim rather than spinning up a
+  parallel fake.
+- **Inline imports remain forbidden** — every test imports at the
+  module top.
+- **`@pytest.fixture(autouse=True)`** is reserved for genuinely
+  cross-cutting setup (e.g., DB cleanup if it existed). Per-test
+  data injection should be requested explicitly.
+- **`pytest-xdist` must run with `--dist=loadfile`**; default
+  scheduling crashes PyQt6 workers when tests from one file split
+  across processes.
+
+---
+
 ## Implementation status (snapshot)
+
+> **Future-AI orientation note.** This section is the **historical
+> operational checklist** built up during Phases 0–2; it lists what
+> shipped, what was removed without direct replacement, and what is
+> still pending. **It is not the action plan.** The action plan is
+> the per-phase sections at the top of this file (Phase 0 → Phase
+> 12+). Where this checklist's "Pending" subsection and a per-phase
+> "Scope (in)" disagree, the **per-phase section wins** — it has been
+> reorganised for context-friendly delivery, while the checklist
+> below is preserved as a flat, comprehensive index of every
+> outstanding item. Read this section to *survey* what is left;
+> read the per-phase sections to *do* the next phase.
 
 This section tracks what has shipped vs. what still needs to be built.
 The remainder of the plan (Parts 1–16) describes the *target* design;
-this section is the operational checklist.
+this section is the operational checklist that the per-phase sections
+above operationalise.
 
 ### Implemented
 
@@ -1376,7 +1621,7 @@ image library lands.
 - README + CLAUDE.md + CHANGELOG.md updates.
 - The three new `.cursor/rules/*.mdc` files.
 
-**Cleanup (Phase 7)**
+**Cleanup (new Phase 11; legacy Phase 7)**
 
 - ``sphinx-build -W`` is clean as of stage 0; CI must keep it that
   way.
@@ -1411,11 +1656,14 @@ image library lands.
 
 ---
 
-## Foundation cleanup status (stage 0 — complete)
+## Phase 0 — Foundation (complete)
 
-Stage 0 ("foundational support" PR
+Phase 0 ("foundational support" PR
 [#111](https://github.com/SETI/rms-nav/pull/111),
 branch ``core_rewrite_foundation`` → ``rf_core_rewrite``) is **complete**.
+The internal label "stage 0" survives in commit messages and the body
+of this section as historical record; treat it as synonymous with
+Phase 0.
 The 2026-04-27 foundation critique surfaced four severity-tagged
 domains of work; every blocking and important item has been resolved.
 The original critique reports (`CRITIQUE_PYTHON.md`,
@@ -1469,7 +1717,7 @@ The simulated body / rings NavModels emit on the new contract; the
 ``NavModelTitan`` stub is registered.  ``NavTechniqueManual`` is
 abstract-opted-out of the auto-discovery registry but available for
 the GUI driver.  Real-scene NavModels and concrete NavTechniques are
-the next stage's work — see "Stage 1 entry points" below.
+the next phase's work — see "Phase 1 forward reference" below.
 
 ### Hardening landed in stage 0
 
@@ -1586,6 +1834,14 @@ work can construct any of these and trust the inputs are checked.
 
 ### Tooling and conventions established in stage 0 (binding)
 
+> The canonical cross-phase binding lives in the **"Tooling and
+> conventions binding for every phase"** subsection inside the
+> "Implementation phases — overview" section at the top of this
+> file. The list below is the original Phase-0-era version, kept
+> verbatim as the historical record. The two lists are
+> intentionally aligned — if they ever drift, the top-of-file
+> "binding for every phase" subsection wins.
+
 - **Python floor** is 3.11.  ``NavStatusReason`` uses ``StrEnum``;
   do not regress to the ``(str, Enum)`` mixin without bumping
   ``requires-python`` first.
@@ -1624,20 +1880,23 @@ work can construct any of these and trust the inputs are checked.
   (not just those targeting ``main``); the matrix covers Python
   3.11 / 3.12 / 3.13 / 3.14.  ``codecov-action@v6``.
 
-### Stage 1 forward reference
+### Phase 1 forward reference
 
-Stage 1 (real-scene NavModels) is described in its own top-level
-section, "Stage 1 status (NavModels — complete)", below.
+Phase 1 (real-scene NavModels) is described in its own top-level
+section, "Phase 1 — Real-scene NavModels (complete)", below.
 
-End of "Foundation cleanup status (stage 0)" section.
+End of "Phase 0 — Foundation" section.
 
 ---
 
-## Stage 1 status (NavModels — complete)
+## Phase 1 — Real-scene NavModels (complete)
 
-Stage 1 ("real-scene NavModels" PR
+Phase 1 ("real-scene NavModels" PR
 [#112](https://github.com/SETI/rms-nav/pull/112),
 branch ``core_rewrite_models`` → ``rf_core_rewrite``) is **complete**.
+The internal label "stage 1" survives in commit messages and the body
+of this section as historical record; treat it as synonymous with
+Phase 1.
 The three concrete NavModels listed in Part 1 / Part 8 — `NavModelStars`,
 `NavModelBody`, `NavModelRings` — now exist on the new `NavModel` ABC
 contract, together with the per-body shape table and the helper
@@ -1740,9 +1999,9 @@ factory the orchestrator's registry walks at construction.
 The shims under ``tests/shims/`` are the canonical way to drive
 nav code paths that depend on ``oops.Backplane``,
 ``oops.Observation``, or production star catalogs without paying
-the SPICE-kernel / multi-GB-binary price.  Stage 2 should reuse
-them; if a NavTechnique surfaces a missing surface, extend the
-shim rather than spinning up a parallel fake.
+the SPICE-kernel / multi-GB-binary price.  Phase 2 and every later
+phase should reuse them; if a NavTechnique surfaces a missing
+surface, extend the shim rather than spinning up a parallel fake.
 
 - ``tests/shims/backplane.py`` — ``FakeBackplane`` returning real
   ``polymath.Scalar`` instances over ``BodyBackplaneData`` /
@@ -1794,8 +2053,8 @@ coverage is enumerated under "NavModel coverage gap" in the
 - **Test shims under ``tests/shims/``** are the canonical way to
   drive nav code paths that depend on ``oops.Backplane``,
   ``oops.Observation``, or production star catalogs without
-  paying the SPICE-kernel / multi-GB-binary price.  Stage 2
-  reuses them.
+  paying the SPICE-kernel / multi-GB-binary price.  Phase 2 and
+  every later phase reuse them.
 - **Pytest ``monkeypatch`` is per-test scoped.**
   ``install_fake_catalogs`` swaps the lazy getter functions
   using ``monkeypatch.setattr``; the swap is bound to the
@@ -1833,17 +2092,34 @@ coverage is enumerated under "NavModel coverage gap" in the
   collection-mismatch was a downstream symptom that disappears
   when the warning is allowed through.
 
-End of "Stage 1 status" section.
+End of "Phase 1 — Real-scene NavModels" section.
 
 ---
 
-## Stage 2 status (NavTechniques — partial; DT techniques landed)
+## Phase 2 — DT-based NavTechniques (partial — DT subset complete)
 
-Stage 2 brings up the concrete ``NavTechnique`` subclasses that consume
-the features the stage-1 NavModels emit.  The first wave (the three
-DT-based techniques plus their shared infrastructure) has shipped; the
-remaining techniques (full-disc NCC, blob centroid, ring-annulus NCC,
-all star techniques) are still pending.
+Phase 2 brings up the concrete ``NavTechnique`` subclasses that consume
+the features the Phase-1 NavModels emit.  The first wave (the three
+DT-based techniques plus their shared infrastructure) has shipped under
+this phase; the remaining techniques (full-disc NCC, blob centroid,
+ring-annulus NCC, all star techniques) are scheduled into separate
+later phases — see the table below. The internal label "stage 2"
+survives in commit messages and the body of this section as historical
+record; treat it as synonymous with Phase 2 in this plan.
+
+The remaining technique work originally bundled into "stage 2" has
+been re-cut into context-friendly later phases:
+
+| Technique | Phase |
+|---|---|
+| `BodyDiscCorrelateNav` | 5 |
+| `BodyBlobNav` | 5 |
+| `RingAnnulusNav` | 6 |
+| `StarUniqueMatchNav` | 7 |
+| `StarRefineNav` | 7 |
+| `StarFieldFromCatalogNav` | 8 |
+| `CartographicNav` | 12+ (deferred per Part 13b §2) |
+| `TitanNav` (real algorithm) | 12+ (deferred per Part 13b §3) |
 
 ### DT-based techniques shipped
 
@@ -1900,7 +2176,7 @@ image logs delimit each technique's contribution.  Tests capture log
 output via ``capsys``, never ``caplog`` (pdslogger writes through its
 own stream handler).
 
-### Final stage-2-DT check matrix
+### Final Phase-2-DT check matrix
 
 ```
 $ ruff check src tests           — clean
@@ -1925,42 +2201,807 @@ Per-module coverage on the new DT-tier code is 89-100 %.  Whole-tree
 coverage stays at ~39 % because the GUI / mosaic-viewer / sim / pds4
 packages are intentionally out of scope.
 
-### What stage 2 still owes
+### What Phase 2 owes downstream
 
-Concrete NavTechniques not yet landed:
+The remaining technique implementations and the production-wiring
+gaps that surfaced during Phase 2 are scheduled into the later
+phases below. Each is **not** a Phase 2 deliverable; they are tracked
+here only as forward references so an agent reading this section
+sees where the work went.
 
-- ``BodyDiscCorrelateNav`` (BODY_DISC NCC)
-- ``BodyBlobNav`` (BODY_BLOB centroid)
-- ``RingAnnulusNav`` (RING_ANNULUS NCC)
-- ``StarFieldFromCatalogNav`` (multi-star RANSAC)
-- ``StarUniqueMatchNav`` (single-star unique match)
-- ``StarRefineNav`` (single-star refine pass)
-- ``CartographicNav`` (CARTOGRAPHIC_MODEL NCC, deferred per Part 13b)
-- ``TitanNav`` (atmospheric-body, deferred per Part 13b)
+Concrete NavTechniques scheduled into later phases (see the table at
+the top of this section):
+
+- ``BodyDiscCorrelateNav`` / ``BodyBlobNav`` — Phase 5.
+- ``RingAnnulusNav`` — Phase 6.
+- ``StarUniqueMatchNav`` / ``StarRefineNav`` — Phase 7.
+- ``StarFieldFromCatalogNav`` — Phase 8.
+- ``CartographicNav`` / ``TitanNav`` — Phase 12+ (deferred per
+  Part 13b §2 / §3).
 
 Per Part 13b §2 the ``CartographicDiagnostics`` dataclass is **deleted**
 from the cutover-tier source tree until ``CartographicNav`` itself
 lands; the diagnostics class returns alongside the technique (kept in
 git history until then).
 
-Production wiring still pending (see "Pending" subsection):
+Production wiring scheduled into later phases:
 
 - Static-data YAML files (``config_220_body_shape.yaml`` plus four
   orchestration tier files plus per-camera ``noise:`` / ``mag_offset:``
-  blocks).
+  blocks) — initial bodies + per-instrument blocks land in Phase 3;
+  full ~55-body coverage in Phase 10.
 - Per-instrument ``ImageQualityThresholds`` from ``config_4N0_inst_*.yaml``
   (today the orchestrator uses raw-DN-unit defaults, which mis-classify
-  CALIB I/F-unit images as ``blank``).
+  CALIB I/F-unit images as ``blank``) — Phase 3.
 - ``STATUS_REASON_INFO_TEMPLATE`` wiring so every hard-failure
-  short-circuit emits an operator-readable INFO line.
+  short-circuit emits an operator-readable INFO line — Phase 3.
 - Per-camera saturation DN, mag-offset table consumer, source-image
-  ``BANDPASS_DOG`` pre-filter.
-- Provenance population (SPICE kernels, static-data hashes, git SHA).
-- Annotations + summary-PNG renderer.
-- Real-image integration suite (Parts 9 / 10).
-- Confidence-formula calibration against the integration library.
+  ``BANDPASS_DOG`` pre-filter — Phase 3.
+- Provenance population (SPICE kernels, static-data hashes, git SHA)
+  — Phase 3.
+- Annotations + summary-PNG renderer — Phase 4.
+- Real-image integration suite (Parts 9 / 10) — Phase 4 (initial 1-3
+  images), expanded incrementally each subsequent phase, full ~50
+  images in Phase 10.
+- Confidence-formula calibration against the integration library —
+  Phase 10.
 
-End of "Stage 2 status" section.
+End of "Phase 2 — DT-based NavTechniques" section.
+
+---
+
+## Phase 3 — Foundation completion + per-instrument config wiring
+
+**Goal:** Close the foundational gaps that should have shipped in
+Phases 0–2 but didn't, and wire enough static data + per-instrument
+config so a real image can run through the pipeline without
+hard-coded defaults misclassifying it.
+
+**Why now:** The orchestrator currently hard-codes a 12-bit
+saturation default and uses raw-DN-unit classifier defaults that
+mis-classify Cassini CALIB I/F products as `blank` (max value < 1.0).
+Without per-instrument config wiring, no real image navigates
+correctly. INFO logging cadence is missing for hard-failure
+short-circuits, so failed images log only the section header with no
+reason. Provenance is unpopulated. The source-image pre-filter is
+unwired. These are foundational pieces that block every downstream
+phase, so they go first.
+
+**Prerequisites:** Phase 0, 1, 2 (complete).
+
+**Scope (in):**
+
+A. **Config file infrastructure.**
+   - Renumber `config_NN_*.yaml` → `config_NNN_*.yaml` (3-digit
+     prefix per the binding file numbering convention in the
+     resumption notes / active style conventions). Update the
+     loader's filename-order merge contract to match.
+   - Convert any radian-based fields in existing configs (notably
+     `config_07_bootstrap.yaml`, which becomes
+     `config_070_bootstrap.yaml`) to degrees per Cardinal Principle
+     #4. Loader converts at load time; metadata curator already
+     converts back at write time. No backwards compatibility.
+   - **Config-load validation** (per Part 0 §16): `Config`
+     initialization runs `evaluate_sigmoid_combination` on every
+     shipped technique YAML against its `NavTechniqueDiagnostics`
+     field set; unknown fields raise `ValueError` with full
+     diagnostic at startup. Add a config-load test asserting every
+     shipped YAML resolves cleanly.
+
+B. **Per-instrument `config_4N0_inst_*.yaml` — real wiring** (replaces
+   stage-0 hard-coded defaults).
+   - Each instrument config gains `data_units: 'raw_dn' |
+     'calibrated_if'` at the camera section root (required field).
+     Loader rejects any instrument config without it.
+   - For raw instruments, `noise.{saturation_dn, full_well_dn,
+     expected_noise_dn, marker_value, read_noise_dn}` and
+     `image_quality_thresholds.{blank_max_dn,
+     saturation_threshold_dn, noisy_threshold_dn,
+     max_missing_frac_clean, max_overexposed_frac_clean}` are all
+     required. **Each raw observation type carries its own max DN
+     — no global default; an 8-bit instrument's `saturation_dn`
+     is 255, 12-bit is 4095, 14-bit is 16383, etc.**
+   - For calibrated-IF instruments, the DN-keyed fields are
+     omitted/null; the I/F-keyed counterparts (`blank_max_if`,
+     `saturation_threshold_if`, `noisy_threshold_if`,
+     `marker_value: NaN`) are required instead. The orchestrator's
+     saturation-mask path keys off `data_units` and either reads
+     raw DN against `saturation_dn` or reads preserved
+     raw-saturation flags off the calibrated obs (or short-circuits
+     with a one-line WARNING when neither is available).
+   - Each camera section gains a `mag_offset:` block with
+     `fallback_combo` and per-filter-combo `mag_offset_table` keyed
+     by B-V color bin (per Part 1 "Filter-aware photometry"). Per
+     Part 0 §74, every numeric field carries a sibling `_sources`
+     entry with DOI / URL evidence. Citations for the filter
+     transformations come from the per-mission calibration reports
+     (CISS Calibration Report, GOSSI calibration documentation,
+     VGISS / NHLORRI PDS calibration archives).
+   - Each camera section gains a `source_image_filter:` block
+     (`kind`, `lo_sigma_px`, `hi_sigma_px`, `enabled`) per
+     Part 2 §"Source-image filters".
+   - Each camera section gains `fit_camera_rotation: false` (default;
+     Phase 9 flips this on per camera) and `max_rotation_deg: 5.0`.
+
+C. **Orchestrator wiring.**
+   - Replace `_instrument_full_well_dn` returning the named
+     module-level `DEFAULT_FULL_WELL_DN_12_BIT` constant with a
+     real config consumer that reads
+     `config.<camera>.noise.saturation_dn`. Returns `None` for
+     `data_units == 'calibrated_if'` instruments; downstream
+     gradient/star paths handle `None` by producing an empty
+     saturation mask.
+   - Wire `ImageQualityThresholds` from
+     `config_4N0_inst_*.yaml.image_quality_thresholds`. The
+     classifier today carries raw-DN defaults
+     (`blank_max_dn = 5.0`, `saturation_threshold_dn = 4095`,
+     `noisy_threshold = 10.0`) that mis-classify CALIB I/F-unit
+     Cassini products as `blank` and short-circuit before any model
+     or technique runs.
+   - Apply the source-image `BANDPASS_DOG` pre-filter to
+     `NavContext.image_ext` when the per-instrument config enables
+     it. The field is already on `NavContext`; only the application
+     step is missing.
+   - Wire `STATUS_REASON_INFO_TEMPLATE` through every
+     `NavResult.failed` site (orchestrator hard-failure
+     short-circuits, classifier short-circuits, plugin sandbox
+     sites). Hard-failure short-circuits
+     (`no_signal_in_image`, `image_overexposed`,
+     `mostly_missing_data`, `image_corrupt`) currently return
+     immediately from `NavOrchestrator.navigate` without emitting
+     any per-image INFO line; wire the template through every
+     `NavResult.failed` site so the failure reason appears in the
+     log alongside the per-image section header. Add per-stage
+     INFO lines for the four orchestrator-level failure status
+     reasons (`no_features_extracted`, `all_features_gated`,
+     `no_feasible_techniques`, `final_confidence_below_threshold`).
+
+D. **Provenance population.**
+   - Populate `Provenance.spice_kernels` from `spice.ktotal` /
+     `spice.kdata` at navigation time; `static_data_hashes` with
+     sha256 of raw YAML bytes for every `config_*.yaml` that
+     contributes to the run (per Part 0 §18; comments + whitespace
+     are part of the hash so comment-only edits invalidate
+     baselines); `rms_nav_git_sha` from `git rev-parse HEAD` at
+     process start.
+   - Test that two consecutive identical-input runs produce
+     byte-identical Provenance except `pipeline_run_iso8601` (per
+     Part 0 §11).
+
+E. **`NavModelStars` per-camera mag-offset wiring.**
+   - `nav.nav_model.stars.NavModelStars.to_features` reads
+     `config.<camera>.mag_offset.filter_combos[<combo>]` per star,
+     falling back to `config.<camera>.mag_offset.fallback_combo`
+     when the in-image combo has no entry. The `mag_offset`
+     parameter accepted by `predicted_snr` is no longer hard-coded
+     to `0.0`.
+
+F. **Image-quality classifier completeness.**
+   - Add detection paths and `flags` / classes for
+     `partial_data_dropout`, `alternating_lines`,
+     `truncated_readout`, `ccd_bloom_dominant`. Each detection is
+     a global statistic on the full sensor area (Cardinal
+     Principle #2). The `ImageClass` Literal grows to include
+     these.
+
+G. **Static data — `config_220_body_shape.yaml` (initial).**
+   - Populate the bodies needed for the Phase 4 first integration
+     image plus immediate neighbours (~10 bodies; full ~55-body
+     coverage lands in Phase 10). Per-body schema in Part 5;
+     AI-drafted citations per Part 0 §74; PR limit ≤ 10 bodies.
+   - Add the schema validator test (`test_body_shape_citations.py`
+     per Part 9). Per Part 0 §74: every body has a `_sources`
+     mapping; every non-`null` numeric/list field has a non-empty
+     `_sources` entry; no `TODO` / `FIXME` / `XXX`; `PLACEHOLDER`
+     allowed only as a matched pair with a `null` value.
+
+**Scope (out):**
+- Full ~55-body `config_220_body_shape.yaml` — Phase 10.
+- New techniques (BodyDisc / Blob / RingAnnulus / Stars) — Phases 5–8.
+- Camera rotation math — Phase 9.
+- Annotations + summary-PNG renderer — Phase 4.
+- Per-image integration tests — Phase 4.
+
+**Design references:** Part 1 §"Image-quality preprocessing" /
+§"Image-quality classification (quick-fail before techniques)" /
+§"Filter-aware photometry"; Part 2 §"Source-image filters";
+Part 5 §"Static-data sources" §"Extensions to existing
+`config_4N0_inst_*.yaml`"; Part 12.7 §"Observability and logging
+conventions".
+
+**Tests:**
+- Unit tests for every new config consumer (under `tests/nav/config/`).
+- Config-load test asserting every shipped YAML resolves cleanly
+  (every technique YAML's `confidence_terms` map cleanly to its
+  `NavTechniqueDiagnostics` field set).
+- Provenance round-trip test: two consecutive runs produce identical
+  Provenance ex `pipeline_run_iso8601`.
+- Tests for the new classifier branches using the FakeObs shim
+  (synthetic inputs for each new class).
+- Tests for the radian → degree conversion in the renumbered
+  `config_070_bootstrap.yaml`.
+- Tests for the data_units field rejection and the I/F-fallback
+  saturation path.
+
+**Documentation:**
+- New developer guide pages: `developer_guide_static_data.rst`
+  (initial), `developer_guide_logging.rst` (initial). Existing
+  pages updated to reference the new config blocks.
+- Update README and `CLAUDE.md` if any new env var or CLI flag
+  is added (none expected for this phase).
+
+**Definition of done:** see "Per-phase definition of done" in the
+overview at the top of the file.
+
+---
+
+## Phase 4 — First navigable image (end-to-end)
+
+**Goal:** A real Cassini ISS image (or similar) navigates
+end-to-end through the orchestrator using the existing DT
+techniques (`BodyLimbNav`, `BodyTerminatorNav`, `RingEdgeNav`),
+producing a `NavResult` with offset / confidence and a non-trivial
+summary PNG. This is the **minimal-functionality milestone** — the
+first time the new pipeline does real work on a real image.
+
+**Why now:** All foundational infra is in place after Phase 3. The
+DT techniques shipped in Phase 2. Only the test-image-library
+scaffolding + annotation rendering + a few curated images stand
+between the codebase and a working end-to-end run.
+
+**Prerequisites:** Phase 3.
+
+**Scope (in):**
+
+A. **Test image library scaffolding.**
+   - `tests/integration/image_library/<class>/<image_id>/` directory
+     layout per Part 10 §"Library structure".
+   - Per-image sidecar schema (`schema_version: 1`) per Part 10
+     §"Per-image sidecar schema": operator-supplied ground-truth
+     offset, expected confidence tier, expected status,
+     scene-class tags, provenance.
+   - `tests/integration/test_image_library.py` — structural
+     invariants: every directory has a sidecar; every sidecar
+     validates against the schema; every cited image_id resolves
+     through the holdings layout; sidecars do not duplicate
+     scene-class tags. Runs without the holdings env vars.
+
+B. **Initial library entries (DT-friendly scenes).**
+   - 1–3 operator-curated images covering scenes where the DT
+     techniques are expected to succeed: e.g. a Cassini Mimas scene
+     with a long visible limb, a Cassini Saturn ring scene with a
+     sharp ring edge, optionally a Cassini terminator-only scene
+     for `BodyTerminatorNav`. Operator hand-picks via the
+     manual-nav UI (per Part 10 §"Per-class selection criteria").
+     Ground truth via the manual-nav dialog.
+   - **Save-as-library-entry button** on the manual-nav dialog
+     (originally a Phase 5 work item in the old plan; pulled
+     forward to enable library curation now). Writes a sidecar
+     with provenance pre-filled.
+
+C. **Annotations + summary-PNG renderer.**
+   - Replace the honest INFO-level no-op in
+     `nav.navigate_image_files._write_summary_png` with the real
+     annotation-compositing renderer that turns
+     `NavResult.annotations` plus the source image into a
+     `_summary.png`. The orchestrator's `_collect_annotations`
+     already merges every NavModel's `to_annotations(context)` —
+     only the renderer is missing.
+   - The renderer composites annotation overlays + text labels
+     over the source image; the existing `Annotations` collection
+     class owns the rendering logic, so this is a thin driver.
+     **No new annotation classes; no new styling config.**
+
+D. **Per-image integration regression test.**
+   - `tests/integration/test_autonomous_nav.py` — for each library
+     entry: run `navigate_image_files` end-to-end against the real
+     holdings; assert `NavResult.status == sidecar.expected.status`,
+     `NavResult.confidence_rank == sidecar.expected.confidence_tier`,
+     `offset_px` within `offset_uncertainty_px + 0.5 px` slack of
+     the operator-supplied ground truth.
+   - Tests run under the `integration` mark (require
+     `PDS3_HOLDINGS_DIR` etc. env vars per the existing CI workflow;
+     fast suite skips them).
+
+E. **Regression baseline scaffolding.**
+   - `tests/integration/baselines/<image_id>.json` per Part 0 §17:
+     `offset_px` rounded to 4 decimals, `confidence` to 3 decimals;
+     comparison is exact-equal on rounded values. Populated for
+     the 1–3 initial images; gated by the citations test.
+
+**Scope (out):**
+- BodyDiscCorrelateNav / BodyBlobNav / RingAnnulusNav / Star
+  techniques — Phases 5–8.
+- ~50-image library + confidence calibration — Phase 10.
+- Per-technique side-by-side panel (Part 13b §6) — deferred.
+- Annotation styling for gated-out features (Part 13b §4) —
+  deferred.
+
+**Design references:** Part 1 §"Annotations: reuse existing
+infrastructure, no new classes" (annotation reuse); Part 4
+(orchestrator); Part 9 §"Methodology — TDD throughout"; Part 10
+(test image library).
+
+**Tests:**
+- Structural-invariants test (no external dependencies; runs in
+  the fast suite).
+- Per-image regression test (under the `integration` mark; runs in
+  the slow / integration CI step).
+- Annotation renderer unit tests against synthetic annotations + a
+  synthetic image.
+
+**Documentation:**
+- `developer_guide_orchestrator.rst` — describes the end-to-end
+  flow; cite the integration test as the worked example.
+- `user_guide_image_library.rst` — describes the library layout,
+  sidecar schema, and how operators add new entries.
+- Manual-nav dialog "Save as library entry" button workflow added
+  to `developer_guide_extending.rst` (or the manual-nav dev page).
+
+**Definition of done:** see "Per-phase definition of done".
+
+---
+
+## Phase 5 — Body disc + body blob techniques
+
+**Goal:** Ship `BodyDiscCorrelateNav` (full-disc NCC) and
+`BodyBlobNav` (blob centroid) — the two body-side techniques that
+don't fit the DT shape. After this phase, body-fills-FOV,
+body-mostly-off-frame-with-irregular-shape, and unresolved-body
+scenes navigate.
+
+**Why now:** Body-disc correlation is the foundation of the existing
+pipeline; porting it forward is well-understood and adds large
+coverage. Body-blob is cheap and fills the irregular-body /
+under-resolution gap. Together they extend the per-image
+integration suite with broad real-world coverage.
+
+**Prerequisites:** Phase 4 (so the integration test harness exists
+for the new techniques).
+
+**Scope (in):**
+
+A. **`BodyDiscCorrelateNav`.**
+   - NCC pyramid against the per-body `BODY_DISC` template, using
+     the existing 4-level pyramid structure as in
+     `navigate_with_pyramid_kpeaks`. `use_gradient='auto'` mode
+     picks raw vs gradient per Part 3 §"Correlation type — RAW vs
+     GRADIENT vs AUTO".
+   - Multi-body handling per Part 0 §2: Z-buffer paint by
+     `subject_range_km` ascending; closer body's nonzero pixels
+     overwrite farther body's; combined mask = OR of per-body
+     masks. This produces a single fused `BODY_DISC` template the
+     technique correlates against.
+   - Diagnostics via the existing `BodyDiscDiagnostics` dataclass
+     in `nav.nav_technique.diagnostics`.
+   - Confidence formula per `config_510_techniques.yaml` carries
+     placeholder coefficients with the
+     `# PLACEHOLDER — calibrate in Phase 10` marker (per Part 0 §5).
+
+B. **`BodyBlobNav`.**
+   - Brightness-weighted-moment centroid fit on the per-body
+     `BODY_BLOB` payload (predicted bounding box in image; centroid
+     intensity-weighted over predicted-lit pixels per Part 1
+     §"BODY_BLOB" position-covariance derivation).
+   - Confidence intrinsically capped at 0.4 per
+     `config_510_techniques.yaml`.
+   - Diagnostics via the existing `BodyBlobDiagnostics` dataclass.
+   - **Body extractor emission rule** per Part 5: emit `LIMB_ARC`
+     if `limb_uncertainty_px ≤ limb_uncertainty_px_max_for_arc`
+     (default 3 px); else emit `BODY_BLOB` if body diameter
+     ≥ `body_blob_min_px` (default 8 px); else emit nothing.
+     Wire the gate based on per-image computed
+     `limb_uncertainty_px = ellipsoid_residual_km / km_per_px_at_limb`
+     using `config_220_body_shape.yaml`.
+
+C. **Cartographic-model emission deferral.**
+   - `CartographicNav` and `CARTOGRAPHIC_MODEL` emission stay
+     deferred per Part 13b §2; restore the deleted
+     `CartographicDiagnostics` dataclass when its producer ships
+     (Phase 12+). No work in Phase 5.
+
+D. **Library expansion.**
+   - 2–4 operator-curated library images covering: body fills FOV
+     with small overflow; body 80 % off-frame with regular shape
+     (Moon-class); body at low resolution (~10 px) where blob-only
+     applies; multi-body scene where Z-buffer paint matters.
+     Sidecars + ground truth + baselines.
+
+E. **`_filter_models` glob-negation extension.**
+   - Per Part 0 §9: extend the existing `_filter_models` in
+     `src/nav/nav_technique/nav_technique.py` to parse leading `!`
+     as gitignore-style exclusion. Existing technique callers pass
+     non-negation patterns unchanged. Tests assert mixed
+     include/exclude patterns work in both `nav_models` and
+     `nav_techniques` orchestrator filters.
+
+**Scope (out):** Ring-annulus technique — Phase 6. Star techniques —
+Phases 7–8. Camera rotation — Phase 9. Confidence calibration —
+Phase 10.
+
+**Design references:** Part 1 §"BODY_BLOB" + §"BODY_DISC";
+Part 3 §"Techniques" + §"Correlation type — RAW vs GRADIENT vs
+AUTO"; Part 5 §"New: `config_220_body_shape.yaml`" extractor rules.
+
+**Tests:** Unit tests recover planted offsets on synthetic inputs
+per technique; report appropriate confidence at boundary cases
+(low signal, partial overlap); detect infeasibility cleanly; raise
+on invalid input with assert-on-message. Integration tests against
+the new library entries.
+
+**Documentation:** `developer_guide_techniques.rst` gains
+`BodyDiscCorrelateNav` and `BodyBlobNav` sections (formula source,
+diagnostics fields, infeasibility cases). Per-technique docstrings
+link to the confidence formula source-of-truth
+(`config_510_techniques.yaml.<technique_key>`).
+
+**Definition of done:** see "Per-phase definition of done".
+
+---
+
+## Phase 6 — Ring-annulus technique
+
+**Goal:** Ship `RingAnnulusNav` for low-resolution ring scenes
+where individual edges compress into a small image area. After
+this phase all ring scenes navigate (sharp edges via `RingEdgeNav`,
+low-res annulus via `RingAnnulusNav`).
+
+**Why now:** Ring-annulus is a small, focused technique that
+completes ring coverage. It has a smaller surface area than the
+star techniques and unblocks low-res Saturn / Uranus ring scenes
+that are currently un-navigable.
+
+**Prerequisites:** Phase 5.
+
+**Scope (in):**
+
+A. **`RingAnnulusNav`.**
+   - NCC against the multi-ring composite template carried on the
+     `RING_ANNULUS` feature.
+   - Per Part 0 §13, one feature per detectable ring system per
+     scene; multi-planet scenes (rare but real) emit one
+     `RING_ANNULUS` per planet; `is_feasible` handles
+     `len(features) > 1`.
+   - Confidence formula per `config_510_techniques.yaml`
+     (placeholder coefficients).
+   - Diagnostics via the existing `RingAnnulusDiagnostics` dataclass.
+
+B. **Library expansion.**
+   - 1–2 low-res-ring library images. Distant Cassini ring views;
+     possibly NHLORRI Pluto/Charon if the geometry yields a
+     useful annulus. Sidecars + ground truth + baselines.
+
+**Scope (out):** Star techniques — Phases 7–8. Calibration —
+Phase 10.
+
+**Design references:** Part 1 §"RING_ANNULUS"; Part 2 (filter for
+ring-annulus); Part 3 (technique).
+
+**Tests / Documentation / Definition of done:** standard.
+
+---
+
+## Phase 7 — Star techniques part 1 (unique-match + refine)
+
+**Goal:** Ship `StarUniqueMatchNav` and `StarRefineNav` — the two
+simpler star techniques that do not require multi-star pattern
+matching.
+
+**Why now:** Star navigation is the long pole, but
+`StarUniqueMatchNav` (1–2 stars; exploits catalog uniqueness) and
+`StarRefineNav` (refine pass given a prior) are well-defined and
+unblock star-only and star-supplemented scenes that the
+orchestrator can't currently handle. `StarFieldFromCatalogNav`
+(the big triplet-hash RANSAC pattern matcher) gets its own phase.
+
+**Prerequisites:** Phase 6.
+
+**Scope (in):**
+
+A. **`StarUniqueMatchNav`.**
+   - 1-star path: catalog reduction yields the unique brightest
+     predictable star (per `brightness_margin_to_next_catalog_star_mag`,
+     ≥ 1.5 mag default); brightest detection matched to it; offset
+     = detection − prediction. Confidence capped at 0.7.
+   - 2-star path: tries both detection-to-catalog assignments,
+     picks smaller-residual fit; confidence ~0.8 because the
+     residual cross-checks the assignment.
+   - On `fit_camera_rotation = True` instruments the 3×3
+     covariance is rank-2 in the 1-star case (translation
+     observable, rotation unobservable); ensemble combine handles
+     via `pinvh`.
+   - Diagnostics via the existing `StarUniqueMatchDiagnostics`
+     dataclass.
+
+B. **`StarRefineNav`.**
+   - Port the existing star-refinement pass forward; consumes a
+     prior offset (typically the pass-1 ensemble result) and
+     refines via local PSF fit on detected stars near each
+     predicted catalog star. Confidence per the refinement formula.
+   - Diagnostics via `StarRefineDiagnostics`.
+
+C. **Library expansion.**
+   - 2–3 star-rich library images: 1 Cassini star-cal frame, 1
+     NHLORRI scene with detectable stars, 1 multi-feature scene
+     with stars + body where the refine pass matters. Sidecars +
+     ground truth + baselines.
+
+**Scope (out):** `StarFieldFromCatalogNav` — Phase 8. Camera
+rotation — Phase 9.
+
+**Design references:** Part 1 §"Star magnitudes by filter" /
+§"Per-instrument star PSF" / §"Star-poor missions"; Part 3
+§"Techniques" star sections; Part 6 scenarios.
+
+---
+
+## Phase 8 — `StarFieldFromCatalogNav`
+
+**Goal:** Ship the multi-star RANSAC pattern matcher — the long
+pole of the star side. After this phase all star scenes navigate
+(unique-match + refine + multi-star pattern matching).
+
+**Why now:** Largest single technique; benefits from being last on
+the technique side so the rest of the pipeline is in production by
+then. Each sub-piece is TDD'd separately per the existing Part 13
+guidance.
+
+**Prerequisites:** Phase 7.
+
+**Scope (in):**
+
+A. **Sub-piece 1 — source detection.** Reuse the DAOPHOT-style
+   matched-filter detector from `nav.nav_model.stars.detection`
+   (already shipped in Phase 1). Phase 8 wires the technique-side
+   consumer.
+
+B. **Sub-piece 2 — triplet hashing.** Spatial-hash table keyed by
+   triplet relative geometry (angles + log-ratio of side lengths).
+   Built once per image from catalog stars; queried with detection
+   triplets.
+
+C. **Sub-piece 3 — RANSAC.** Deterministic seeding (seed from
+   `obs.midtime` ET as integer ns per Part 3 §"Determinism in
+   RANSAC"). Inlier count + median residual reported in
+   `StarFieldDiagnostics`.
+
+D. **Sub-piece 4 — verification.** Procrustes fit
+   (translation + rotation when `fit_camera_rotation` is true;
+   translation-only otherwise). Tukey biweight reweighting
+   (reuse `nav.nav_technique.dt_fitting.tukey_biweight_weights`).
+   Diagnostics via `StarFieldDiagnostics`.
+
+E. **Library expansion.** 2–3 dense star fields: Cassini star
+   calibration scenes, NHLORRI deep sky. Sidecars + ground truth +
+   baselines.
+
+**Scope (out):** Camera rotation full enablement — Phase 9.
+Calibration — Phase 10.
+
+**Design references:** Part 3 §"Techniques" star sections;
+Part 5 §"Backplane query reference"; Appendix A.
+
+**Tests:** Each sub-piece has its own TDD red→green→refactor
+cycle; integration test on each library star field. Determinism
+test: seeded RANSAC runs are bit-identical across two
+back-to-back invocations on the same obs.
+
+---
+
+## Phase 9 — Camera rotation correction (per instrument)
+
+**Goal:** Enable camera rotation fitting on instruments where
+attitude rotation residuals are observable per-image (VGISS,
+GOSSI). Cassini ISS and NHLORRI stay 2-DoF.
+
+**Why now:** Phases 4–8 produce a 2-DoF baseline. Once every
+technique is in place, the rotation knob can be flipped without
+churn — every technique can populate its 3×3 covariance correctly
+and the ensemble combine logic only needs one round of changes.
+
+**Prerequisites:** Phase 8.
+
+**Scope (in):**
+
+A. **Per-technique 3-DoF math.** Per Part 5b, each technique's
+   cost function gains a third parameter `dθ` (radians; bounded
+   by `±deg_to_rad(max_rotation_deg)`). Per-technique pivot rules
+   (body center, planet center, point-set centroid, etc.) per
+   Part 5b. Implementations populate the `rotation_rad` /
+   `sigma_rotation_rad` fields on `NavTechniqueResult`.
+   - DT-based techniques run rotation as a third LM parameter
+     (no outer search; LM converges from 2-D coarse-search basin
+     in <15 iters; compute overhead < 50 %).
+   - `BodyDiscCorrelateNav` runs the 3-D NCC pyramid sample
+     schedule per Part 5b §"Sub-decisions / pessimism".
+   - `BodyBlobNav` carries zero rotation information (centroid is
+     rotation-invariant); reports rank-deficient 3×3 covariance.
+   - `RingEdgeNav` on flat rings is doubly-rank-deficient;
+     ensemble's `pinvh` handles correctly without special cases.
+
+B. **Rotation-aware ensemble combine.** 3-D agreement /
+   precision-weighted combine. Mahalanobis check in 3-D.
+   Rank-deficient handling extends naturally — `pinvh` already
+   handles it. 3×3 covariance flows through to `NavResult`.
+
+C. **Per-instrument flag flip.** VGISS / GOSSI
+   `fit_camera_rotation: true`. Cassini / NHLORRI stays false.
+   Per-instrument `max_rotation_deg` tuned from observed residuals
+   (initial 5° default).
+
+D. **Metadata curator.** Convert `rotation_rad` →
+   `rotation_deg` and `sigma_rotation_rad` → `sigma_rotation_deg`
+   for the JSON; omit both fields entirely when
+   `fit_camera_rotation` is False (cleaner than serializing nulls).
+
+E. **Library expansion.** 2–3 VGISS / GOSSI images where rotation
+   fit is observably non-zero. Sidecars carry expected rotation
+   tier.
+
+**Scope (out):** Calibration — Phase 10.
+
+**Design references:** Part 5b (camera rotation correction in full).
+
+---
+
+## Phase 10 — Image library expansion + confidence calibration
+
+**Goal:** Expand the curated library to ~50 images covering every
+scene class per Part 10 §"Coverage matrix"; one-time fit of
+confidence-formula α coefficients in `config_510_techniques.yaml`
+against the library.
+
+**Why now:** Calibration is the last gate before legacy delete (the
+breadth comparison in Phase 11 depends on calibrated confidences).
+Cannot be done sooner because all techniques must be in place for
+their formulas to be tunable against ground truth.
+
+**Prerequisites:** Phase 9.
+
+**Scope (in):**
+
+A. **Library expansion to ~50 images.** Per Part 10 §"Per-class
+   selection criteria"; operator-curated. Coverage matrix asserts
+   every technique exercises on ≥ 1 image. Test library
+   intentionally over-samples star-only Cassini / NHLORRI scenes
+   and star-absent Galileo / Voyager science scenes per Part 1
+   §"Star-poor missions".
+
+B. **Full ~55-body `config_220_body_shape.yaml` population** per
+   Part 0 §74 + Part 5 source-citation rules. Bodies populated in
+   PRs of ≤ 10 each for human reviewer spot-check.
+
+C. **Confidence-formula calibration.** `confidence = sigmoid(α₀ +
+   Σ αᵢ × xᵢ)`; fit via `scipy.optimize.curve_fit` against
+   `target_tier_midpoint` per image (`0.9` for `high`, `0.65` for
+   `medium`, `0.35` for `low`, `0.1` for `failed`). One-time fit;
+   check `config_510_techniques.yaml` in afterward; never updated
+   by per-image runs. The placeholder coefficients in
+   `config_510_techniques.yaml` are arithmetically illustrative
+   only — they are not claimed to produce the example confidence
+   values stated alongside them; calibration replaces them.
+   PR review enforces no `PLACEHOLDER` markers ship to production
+   (per Part 0 §5).
+
+D. **Regression baselines for every library image.**
+   `tests/integration/baselines/<image_id>.json` populated per
+   Part 0 §17.
+
+E. **Manual-nav UI polish.** Save-as-library-entry button shipped
+   in Phase 4; finalize any remaining workflow rough edges
+   discovered during the bulk library curation.
+
+**Scope (out):** Cleanup — Phase 11. Deferred items — Phase 12+.
+
+**Design references:** Part 9 (test strategy); Part 10 (library);
+Part 11 (manual research vs AI-automated research) for
+attribution / human-vs-AI split.
+
+---
+
+## Phase 11 — Cleanup + documentation finalization + breadth comparison
+
+**Goal:** Final residual-reference grep, coverage gate enforcement,
+module-size split, doc index audit, README / `CLAUDE.md` /
+`CHANGELOG` updates, three new `.cursor/rules/*.mdc` files, and the
+500-image breadth comparison vs legacy that gates the cutover.
+
+**Why now:** Legacy code is already deleted (the cutover branch
+deleted `NavTechniqueCorrelateAll`, `NavModelCombined`, `NavMaster`,
+etc.). Phase 11 is verification + final polish. **The breadth
+comparison is the load-bearing gate**: per Part 13 (legacy
+phasing) §"Cutover gating", the new pipeline must be equal-or-
+better than the legacy pipeline on every per-class aggregate
+metric (% ok, P50 / P95 offset error, % conflicted, % failed).
+
+**Prerequisites:** Phase 10.
+
+**Scope (in):**
+
+A. **CI grep step.** Single-line CI step that fails the build on
+   any leftover reference to deleted symbols:
+   `NavTechniqueCorrelateAll`, `NavModelCombined`,
+   `NavModelResult`, `NavMaster`, `weighted_mask`, `blur_amount`,
+   `final_offset`, `final_confidence`, `use_legacy_pipeline`. Per
+   Part 0 §69.
+
+B. **Coverage gate in CI.** Cutover-tier modules
+   (`nav.feature/`, `nav.nav_orchestrator/`, `nav.nav_technique/`,
+   `nav.nav_model/`) at ≥ 90 %; whole-tree percentage gated by
+   per-package thresholds (the GUI / mosaic-viewer / sim packages
+   pre-date the cutover and are below 90 % by design).
+
+C. **Module size cap.** Split
+   `src/nav/ui/manual_nav_dialog.py` (1058 lines) into a
+   `nav.ui.manual_nav/` subpackage in a dedicated PR with GUI-test
+   infrastructure to verify the manual workflow still works.
+   1000-line ceiling per Cardinal Principle / Part 16.
+
+D. **Doc index / toctree audit.** Per Part 0 §49: verify every
+   new page is wired into `docs/index.rst` sorted by package and
+   name. All cross-references resolve. `sphinx-build -W -b html
+   docs docs/_build` clean. Verify `sphinx-build -W` has been
+   clean every phase.
+
+E. **README + `CLAUDE.md` + `CHANGELOG.md`.** Summarize the
+   autonomy cutover: new architecture overview, updated
+   install / usage instructions, PyPI / ReadTheDocs badges still
+   valid. CHANGELOG entries for each phase's release.
+
+F. **Three new `.cursor/rules/*.mdc` files.**
+   - Autonomy conventions (per the cutover discoveries — pdslogger
+     only, no `import logging`, frozen-dataclass validation,
+     plugin-sandbox try/except, etc.).
+   - Feature/extractor patterns (binding for any future technique
+     addition).
+   - Ensemble/orchestrator conventions
+     (precision-weighted combine, rank-deficient handling, INFO
+     cadence).
+
+G. **500-image breadth comparison vs legacy.** Per Part 13 (legacy)
+   §"Cutover gating": run `nav_offset` over a curated 500-image
+   selection (5 missions × 100 images covering scene diversity)
+   and measure % `ok`, per-tier offset-error distribution
+   (median, P95), % `conflicted`, % `failed`. Compare to the
+   legacy baseline (re-run on a comparison branch that re-instates
+   the legacy pipeline, or pin the comparison to a pre-cutover
+   commit hash); gate on **"new pipeline ≥ legacy on every
+   per-class metric"**. A regression on one scene class is a
+   blocker even when overall metrics improve. If a class regresses,
+   the response is **fix the new pipeline**, not retain the legacy
+   as a fallback (Cardinal Principle #1).
+
+**Scope (out):** Deferred items — Phase 12+.
+
+**Design references:** Part 0 §20 (cutover gating); Part 0 §69
+(grep CI step); Part 12 §"Cutover (no backwards compatibility)";
+Part 13 (legacy phasing) §"Cutover gating" preserved below.
+
+---
+
+## Phase 12+ — Deferred items (Part 13b)
+
+Each deferred item is its own phase when scheduled. The full
+descriptions live in Part 13b (kept verbatim below); each item
+inherits the standard "Per-phase definition of done" plus a code
+review folder `phase_NN_review/`.
+
+| Phase | Deferred item | Source |
+|-------|----------------|--------|
+| 12 | Ring-edge polarity-aware matching | Part 13b §1 |
+| 13 | Cartographic-model technique testing | Part 13b §2 |
+| 14 | Atmospheric-body navigation algorithm (real `TitanNav`) | Part 13b §3 |
+| 15 | Annotation styling for gated-out features | Part 13b §4 |
+| 16 | Mixed-instrument batch SPICE-kernel hot path | Part 13b §5 |
+| 17 | UI per-technique-result panel redesign | Part 13b §6 |
+
+For Phase 13 (cartographic), the deleted `CartographicDiagnostics`
+dataclass is restored from git history alongside the technique;
+recover with `git log --diff-filter=D -- src/nav/nav_technique/diagnostics.py`
+and pull from the appropriate commit. The `CARTOGRAPHIC_MODEL`
+feature emission from `NavModelBody` via
+`nav.reproj.cartographic_model.create_cartographic_model` lands in
+the same phase.
 
 ---
 
@@ -2237,7 +3278,7 @@ The orchestrator additionally emits its own `Annotations` for items that have no
 
 Three image-level checks happen in the orchestrator before any technique runs. All operate on the full image — Cardinal Principle #2 — and produce masks / statistics that go on `NavContext` for every downstream consumer:
 
-- **Saturation map.** Pixels at or near full-well DN (per-instrument value from the `noise:` block of the matching `config_4N0_inst_*.yaml`) are marked. The global gradient computation excludes them; the star detector treats saturated peaks specially (truncated PSF, unreliable centroid — either reject if isolated or use moments instead of fit).
+- **Saturation map.** Pixels at or near full-well DN (per-instrument value from the `noise:` block of the matching `config_4N0_inst_*.yaml`) are marked. The global gradient computation excludes them; the star detector treats saturated peaks specially (truncated PSF, unreliable centroid — either reject if isolated or use moments instead of fit). **Raw vs calibrated:** the saturation map is built from the per-instrument `noise.saturation_dn` value only when the instrument config declares `data_units: 'raw_dn'`. For instruments declaring `data_units: 'calibrated_if'` (e.g. Cassini ISS CALIB I/F products), the per-image DN is no longer a meaningful unit (typical CALIB I/F values are < 1.0); the saturation map is instead built from the calibration pipeline's preserved raw-saturation flags carried in the metadata when available, or — if the calibration product carries no preserved flags — left empty with a one-line WARNING noting that overexposure cannot be detected for calibrated inputs. Each *raw* observation type carries its own per-camera `saturation_dn` (e.g. 8-bit = 255, 12-bit = 4095, 14-bit = 16383); there is no global default.
 - **Cosmic-ray / hot-pixel rejection.** Single-pixel spikes 5+σ above their immediate neighbors (median 3×3 vs raw) are masked. This step is global and pre-detection; without it a single hot pixel produces a fake "star" detection that derails pattern matching. Existing GOSSI / Voyager / Cassini pipelines all need this; their archives have many cosmic ray hits per long-exposure image.
 - **Smear-aware PSF via the `eval_rect(movement=...)` parameter.** Long exposures with non-zero spacecraft attitude rate smear stars into trails. The existing `psfmodel.GaussianPSF` provides smear support directly: `eval_rect(rect_size, offset, *, movement=(my, mx), movement_granularity=0.1, ...)` integrates the PSF along a line segment of length `sqrt(my² + mx²)` in the `(Y, X)` direction. The internal `_eval_rect_smeared` (PSF base) does the integration; `movement_granularity` is the step size in pixels for the smear-line sampling.
 
@@ -2252,7 +3293,7 @@ Three image-level checks happen in the orchestrator before any technique runs. A
   Mission applicability:
   - **Cassini**: SPICE-bracket geometry is well-tested elsewhere and the brackets reliably represent the true relative rotation. Enabled by default.
   - **Voyager / Galileo / NHLORRI**: same approach is theoretically applicable but **untested in this project**. Implementation parameterizes uniformly (the smear math doesn't care which mission), but ships with a config flag (`stars.smear_from_spice_brackets: bool`, default `true` for Cassini, `false` for the others until validated). Galileo and Voyager are mostly star-blind anyway.
-  - The existing `stars.max_smear: 100` config in `config_110_stars.yaml` is currently dead code (no consumer in today's tree). The new pipeline becomes its first consumer: smear lengths beyond `max_smear` cause the star to be rejected from the star feature list (PSF too elongated to fit reliably even with the smear-aware template). The 100 px value is liberal: it's a "reject above this" hard gate, not a "trust below this" gate. Empirically, smear < 5 px is "minor", 5–20 px is "significant but well-fittable", 20–100 px is "extreme but worth trying once with reduced reliability". Tighten in Phase 5 if the relaxed gate generates too many low-confidence star features.
+  - The existing `stars.max_smear: 100` config in `config_110_stars.yaml` is currently dead code (no consumer in today's tree). The new pipeline becomes its first consumer: smear lengths beyond `max_smear` cause the star to be rejected from the star feature list (PSF too elongated to fit reliably even with the smear-aware template). The 100 px value is liberal: it's a "reject above this" hard gate, not a "trust below this" gate. Empirically, smear < 5 px is "minor", 5–20 px is "significant but well-fittable", 20–100 px is "extreme but worth trying once with reduced reliability". Tighten in Phase 10 calibration if the relaxed gate generates too many low-confidence star features. (Legacy wording said "Phase 5".)
 
 ### Image-quality classification (quick-fail before techniques)
 
@@ -2271,7 +3312,7 @@ Before any extractor runs, the orchestrator assigns the image to one of these cl
 | `corrupt` | image file failed to parse / read; `obs.from_file(...)` or `obs.data` access raised an exception | `status='failed', status_reason='image_corrupt'`. No technique runs. (Per Part 0 §21.) |
 | (`noisy` is **not** a class; see Part 0 §7) | high read noise = `noise_sigma > per-instrument threshold` | Pipeline runs as `image_class='clean', flags=['noisy']`; per-feature reliability gates use the elevated noise so faint stars are correctly rejected. |
 
-Per-instrument detection thresholds (saturation_dn, marker_value, expected_noise_dn) live in the `noise:` block of each `config_4N0_inst_*.yaml`. The classifier's decision goes into `NavResult.feature_inventory` as a top-level diagnostic so operators can see which images failed for which reason.
+Per-instrument detection thresholds (saturation_dn, marker_value, expected_noise_dn) live in the `noise:` block of each `config_4N0_inst_*.yaml`. The classifier's decision goes into `NavResult.feature_inventory` as a top-level diagnostic so operators can see which images failed for which reason. **The DN-based branches (`fully_overexposed`, `blank` against an absolute DN floor) are conditional on `inst.data_units == 'raw_dn'`.** For instruments declaring `data_units: 'calibrated_if'`, those branches use the per-camera `image_quality_thresholds.saturation_threshold_if` and `blank_max_if` values instead (typical CISS CALIB cap is around 10 I/F; blank floor around 1e-3 I/F). Each *raw* observation type carries its own `saturation_dn` and `full_well_dn` keyed by camera bit depth (8-bit = 255, 12-bit = 4095, 14-bit = 16383, etc.); there is no global default. Misconfiguring the data-units flag is the canonical way to mis-classify CALIB Cassini products as `blank` (max I/F < 1.0 against a `blank_max_dn = 5.0` raw-DN default).
 
 ### Filter-aware photometry
 
@@ -2336,7 +3377,7 @@ Occlusion / shadow handled at extraction by vertex cropping (no `range` field on
 
 where:
 - `L` is the smear length in pixels (scalar `sqrt(my² + mx²)`).
-- `L² / 12` is the variance of a uniform distribution of length L. **Assumption**: spacecraft attitude rate is approximately constant during the exposure (uniform smear). This holds for almost all imaging — attitude jerk events are rare and typically excluded from imaging campaigns. If the rate is non-uniform during the exposure (e.g., a thruster fired mid-exposure), the smear distribution is non-uniform and `L²/12` is wrong; the practical effect is a wider smear than predicted, which manifests as `position_cov_px` being a *lower bound* rather than the true covariance. Phase 5 calibration flags any library image showing attitude-jerk-during-exposure behavior.
+- `L² / 12` is the variance of a uniform distribution of length L. **Assumption**: spacecraft attitude rate is approximately constant during the exposure (uniform smear). This holds for almost all imaging — attitude jerk events are rare and typically excluded from imaging campaigns. If the rate is non-uniform during the exposure (e.g., a thruster fired mid-exposure), the smear distribution is non-uniform and `L²/12` is wrong; the practical effect is a wider smear than predicted, which manifests as `position_cov_px` being a *lower bound* rather than the true covariance. Phase 10 calibration flags any library image showing attitude-jerk-during-exposure behavior. (Legacy wording said "Phase 5".)
 - `σ_PSF` is the per-pixel PSF Gaussian σ.
 - `SNR_predicted` is the **integrated** SNR across the full PSF support, computed as `total_signal_DN / sqrt(total_signal_DN + read_noise_DN² × N_pixels_in_aperture)` where the aperture is the smeared-PSF box. *Not* per-pixel SNR. (The denominator under the square root is the variance from shot noise + read noise; the numerator is the total expected signal in DN.)
 
@@ -2375,7 +3416,7 @@ Reliability is a [0, 1] scalar on every emitted `NavFeature`, computed at extrac
 
 **Distinction from confidence**: reliability lives on a `NavFeature` and answers "how trustworthy is this *as input data*". Confidence lives on a `NavTechniqueResult` and answers "how trustworthy is this *as an offset*". Different objects, different stages.
 
-**Per-type formulas** (sigmoid-of-linear-combination form; α coefficients calibrated in Phase 5):
+**Per-type formulas** (sigmoid-of-linear-combination form; α coefficients calibrated in Phase 10; legacy wording said "Phase 5"):
 
 ```
 STAR:          sigmoid(α₀ + α₁·(predicted_snr − threshold_snr))
@@ -2395,7 +3436,7 @@ BODY_BLOB:     sigmoid(snr_in_bbox) × sigmoid(extent_px / 8 − 1) × 0.4   # h
 CARTOGRAPHIC:  same shape as BODY_DISC with higher ceiling
 ```
 
-**Gate threshold** in `config_520_features.yaml`, per-type, with per-instrument overrides. Default placeholders, calibrated in Phase 5 from image library.
+**Gate threshold** in `config_520_features.yaml`, per-type, with per-instrument overrides. Default placeholders, calibrated in Phase 10 from image library. (Legacy wording said "Phase 5".)
 
 **Gated-out features**:
 1. Not passed to any technique (excluded from technique input lists).
@@ -2500,7 +3541,7 @@ inst:
 
 Rule: `lo_sigma_px >= 50 × hi_sigma_px` so the bandpass is a true high-pass-with-noise-cap, not a narrow band.
 
-Per-instrument concrete values (placeholders for Phase 5 retuning):
+Per-instrument concrete values (placeholders for Phase 10 retuning; legacy wording said "Phase 5"):
 
 | Instrument | kind | `lo_sigma_px` | `hi_sigma_px` | rationale |
 |---|---|---|---|---|
@@ -2764,7 +3805,7 @@ If RANSAC fails (no transform with enough inliers), the technique reports infeas
   - *Unsaturated* (`peak_DN < saturation_threshold_dn`): 2-D Gaussian fit on a `2.5 × psf_fwhm` box; cuts `fitted_fwhm ∈ [0.7, 1.5] × instrument_psf_fwhm`, `roundness < 0.25` (skipped for smeared images), `sharpness > 0.4`. Hot-pixel sanity: reject if `peak_DN > 5 × max(8 surrounding pixels)`.
   - *Saturated* (`peak_DN ≥ saturation_threshold_dn`): annular brightness-weighted moment centroid over `r ∈ [0.5, 1.5] × psf_fwhm`, excluding `cosmic_ray_mask_ext`, `saturation_mask_ext`, bloom columns, missing-data pixels. Reject if fewer than 8 valid annulus pixels remain. σ_centroid floor 0.2 px; `saturated=True` tag downweights triplet weight.
 - **Bloom detection**: vertical (per `bloom_orientation`) saturated runs > 1.5 × psf_fwhm at a saturated peak mark a bloom column; column + 1 px each side merged into `saturation_mask_ext`. Parent star kept (centroided via annulus).
-- **Implementation choice**: DAOPHOT-style sharpness/roundness cuts are hand-rolled in numpy / scipy (already in deps). Modern alternatives (`photutils.detection.StarFinder`, `sep`, `scikit-image.feature`) cost extra dependencies; `photutils` would be the cheapest fallback if the hand-roll proves troublesome in Phase 3.
+- **Implementation choice**: DAOPHOT-style sharpness/roundness cuts are hand-rolled in numpy / scipy (already in deps). Modern alternatives (`photutils.detection.StarFinder`, `sep`, `scikit-image.feature`) cost extra dependencies; `photutils` would be the cheapest fallback if the hand-roll proves troublesome in Phase 7 / 8 (the star-technique phases). (Legacy wording said "Phase 3".)
 
 **Single-bright-star scenes** are a **primary navigation mode** via `StarUniqueMatchNav`, not a failure. When `stars_list_for_obs()` predicts 1–2 catalog stars in extended FOV and the brightest is ≥ `unique_match_brightness_margin_mag` (default 1.5 mag) brighter than the next-brightest predictable source, the catalog itself supplies uniqueness — no triplet hash needed. The brightest detection assigns to the unique catalog star; offset = detection − prediction; sanity check is that the detection lies within `extfov_margin` of predicted position (otherwise the brightest detection is an asteroid / surviving cosmic ray / rare transient, and the technique reports infeasibility). 2-star case fits a translation (or translation + rotation) via two-assignment trial. `StarFieldFromCatalogNav` and `StarUniqueMatchNav` are mutually exclusive at feasibility time: ≥3 unambiguous catalog stars → triplet matcher runs, unique matcher returns `'enough_stars_for_triplet_match'`; 1–2 → unique matcher runs, triplet returns `'fewer_than_3_detected_sources'`. The single-star STAR feature is also still consumed by `StarRefineNav` in pass 2 when a body / ring prior exists — multiple paths benefit from the lone bright star.
 
@@ -2947,7 +3988,7 @@ Every `NavTechniqueResult.confidence` is a calibrated 0..1 score derived **from 
 confidence = sigmoid(α₀ + Σᵢ αᵢ * normalized_feature_iᵢ)
 ```
 
-with `sigmoid(x) = 1 / (1 + exp(-x))`. Starting constants — to be retuned in Phase 5 against the library; what matters now is that they're *concrete* enough to implement and calibrate against. **The example confidence values listed alongside each formula below are illustrative targets, not arithmetic outputs of the listed coefficients** — coefficients are calibrated in Phase 5 to produce those targets, not the other way round. Implementations should not assert on the example values; they should evaluate the formula as written and accept whatever confidence emerges.
+with `sigmoid(x) = 1 / (1 + exp(-x))`. Starting constants — to be retuned in Phase 10 against the library; what matters now is that they're *concrete* enough to implement and calibrate against. **The example confidence values listed alongside each formula below are illustrative targets, not arithmetic outputs of the listed coefficients** — coefficients are calibrated in Phase 10 to produce those targets, not the other way round. Implementations should not assert on the example values; they should evaluate the formula as written and accept whatever confidence emerges. (Legacy wording said "Phase 5".)
 
 - **StarFieldFromCatalogNav**: `α₀ = -2`, `α(n_inliers, capped at 12) = 0.6`, `α(median_residual_px) = -2.5`. With 6 inliers and 0.4 px median residual, confidence ≈ 0.85.
 - **StarUniqueMatchNav (1-star)**: `α₀ = -1.5`, `α(predicted_snr_capped_at_50) = 0.06`, `α(brightness_margin_mag − 1.5, capped at 3) = 0.5`. With SNR=20 and 2-mag margin, confidence ≈ 0.6. Hard-capped at 0.7 (no internal cross-check is possible from one star).
@@ -3498,6 +4539,52 @@ So Prometheus at approach is a `BODY_BLOB` (maybe with confidence-cap 0.3); Prom
 
 **3. Extensions to existing `config_4N0_inst_*.yaml`** — per-camera `noise:` and `mag_offset:` blocks added under each existing camera section. The instrument noise data, mag-offset tables, and image-quality classifier thresholds all live here, alongside the existing `extfov_margin_vu` / `star_psf_sigma` fields. Schema in the proposal section below; no new file. Loaded by the existing `Config` machinery — accessed as `config.cassini_iss.nac.noise.read_noise_dn` and `config.cassini_iss.nac.mag_offset.filter_combos['CL1+CL2']`.
 
+Each instrument additionally declares **`data_units: 'raw_dn' | 'calibrated_if'`** at the camera section root (required field). This determines which DN-based vs I/F-based fields the classifier and saturation pipeline read:
+
+```yaml
+cassini_iss:
+  nac:
+    data_units: raw_dn          # COISS NAC RAW products
+    noise:
+      saturation_dn: 4095       # 12-bit; required when data_units == 'raw_dn'
+      full_well_dn: 4095
+      expected_noise_dn: 4.0
+      marker_value: 0           # per-instrument missing-data sentinel
+      read_noise_dn: 4.0
+    image_quality_thresholds:
+      blank_max_dn: 5.0
+      saturation_threshold_dn: 4095
+      noisy_threshold_dn: 10.0
+      max_missing_frac_clean: 0.05
+      max_overexposed_frac_clean: 0.80
+    # ...
+
+cassini_iss_calib:
+  nac:
+    data_units: calibrated_if   # COISS NAC CALIB I/F products
+    noise:
+      # saturation_dn / full_well_dn / expected_noise_dn omitted — DN-based
+      # checks short-circuit. Saturation mask is built from preserved raw-
+      # saturation flags carried by the calibration pipeline when available;
+      # otherwise empty + WARNING.
+      marker_value: NaN          # CALIB pipeline marks missing pixels with NaN
+    image_quality_thresholds:
+      blank_max_if: 1.0e-3       # used in place of blank_max_dn
+      saturation_threshold_if: 10.0   # used in place of saturation_threshold_dn
+      noisy_threshold_if: 0.005       # used in place of noisy_threshold_dn
+      max_missing_frac_clean: 0.05
+      max_overexposed_frac_clean: 0.80
+    # ...
+```
+
+Rules:
+
+- `data_units` is required; loader rejects an instrument config without it.
+- For `data_units == 'raw_dn'`: `noise.saturation_dn`, `noise.full_well_dn`, `noise.expected_noise_dn`, and `image_quality_thresholds.{blank_max_dn, saturation_threshold_dn, noisy_threshold_dn}` are all required. **Each raw observation type carries its own max DN — no global default; an 8-bit instrument's saturation_dn is 255, 12-bit is 4095, 14-bit is 16383, etc.**
+- For `data_units == 'calibrated_if'`: those DN-keyed fields are omitted/null; the I/F-keyed counterparts (`blank_max_if`, `saturation_threshold_if`, `noisy_threshold_if`) are required instead. The orchestrator's saturation-mask path keys off `data_units` and either reads raw DN against `saturation_dn` or reads preserved raw-saturation flags off the calibrated obs (or short-circuits with a WARNING when neither is available).
+
+The **`mag_offset:`** block schema is unchanged by `data_units` (color transforms apply equally to raw and calibrated photometry; the difference is only in absolute scale, which the catalog flux-to-DN computation already handles per-image). Same for the `source_image_filter:` and `fit_camera_rotation:` blocks.
+
 Each entry is loaded once at config init and cached. Missing body entries fall back to `shape_class_hint: unknown` with conservative defaults (residual ≈ 10% of mean radius). Missing instrument-noise blocks log a warning and force stars to `reliability ≤ 0.3`.
 
 ### How these substitute for cross-image statistics
@@ -3546,7 +4633,7 @@ inst:
   max_rotation_deg: 5.0           # applies when fit_camera_rotation = true
 ```
 
-Stored in `config_4N0_inst_*.yaml`. Default `false`; flip on for VGISS / GOSSI based on observed residuals during Phase 5 calibration.
+Stored in `config_4N0_inst_*.yaml`. Default `false`; flip on for VGISS / GOSSI in Phase 9 (camera rotation correction) based on observed residuals; final tuning during Phase 10 calibration. (Legacy wording said "Phase 5 calibration".)
 
 **Behavior when enabled:**
 
@@ -3586,7 +4673,7 @@ The metadata curator converts to `rotation_deg` and `sigma_rotation_deg` for the
 
   For DT-based techniques (BodyLimbNav, BodyTerminatorNav, RingEdgeNav), rotation is a third optimizer parameter rather than an outer-loop search — Levenberg-Marquardt converges from the 2-D coarse-search basin in < 15 iterations including rotation. Compute overhead < 50%.
 - **Rotation ambiguity on partial-overlap geometry.** A short visible limb arc + free rotation has correlated (rotation, translation) ambiguity — covariance becomes ill-conditioned. The 3×3 covariance reflects this directly; orchestrator's rank-deficient handling produces low-confidence results without needing special cases.
-- **`max_rotation_deg` is a knob.** Default 5° per the user's "<5°" guidance; per-instrument tuning in Phase 5.
+- **`max_rotation_deg` is a knob.** Default 5° per the user's "<5°" guidance; per-instrument tuning in Phase 9 / 10. (Legacy wording said "Phase 5".)
 
 ## Part 6 — Scenario handling
 
@@ -4365,7 +5452,7 @@ CI test tolerance = `offset_uncertainty_px + 0.5 px` slack. Slack absorbs algori
 
 **No `manifest.yaml`** — the directory tree IS the registry. Adding a library image = creating a sidecar in the right class directory; CI picks it up automatically. Removing a sidecar stops its test. Drift between manifest and disk is impossible because no manifest exists.
 
-**Regression baselines** (per Part 9) live in a separate `tests/integration/baselines/<image_id>.json` per image and run as a third test layer; baseline updates require explicit PR review (Phase 5 work).
+**Regression baselines** (per Part 9) live in a separate `tests/integration/baselines/<image_id>.json` per image and run as a third test layer; baseline updates require explicit PR review (initial seed during Phase 4; full set populated in Phase 10; legacy wording said "Phase 5").
 
 ### Library curation policy
 
@@ -4534,77 +5621,76 @@ If an image shows a body that's not in `config_220_body_shape.yaml`, extractor u
 
 ---
 
-## Part 13 — Phasing (implementation order)
+## Part 13 — Phasing (legacy phase plan — superseded; preserved for cutover gating)
 
-Order matters — each phase is self-contained, follows TDD throughout (Part 9), and leaves the tree green. Each phase ends with `ruff check && ruff format --check && mypy && pytest -n auto --dist=loadfile` clean before merging.
+The original phase plan that this section once contained has been
+**reorganised** into the per-phase sections at the top of this file
+("Phase 0" through "Phase 12+"). Those sections are now the source
+of truth. The legacy phase numbering (legacy Phase 1 ↔ Foundation,
+legacy Phase 2 ↔ Extractors, legacy Phase 3 ↔ Techniques,
+legacy Phase 4 ↔ Orchestrator, legacy Phase 5 ↔ Library +
+calibration, legacy Phase 6 ↔ Documentation, legacy Phase 7 ↔
+Cleanup) split unevenly across context windows; the new per-phase
+plan above is context-sized and ordered so that minimal end-to-end
+functionality lands as early as possible.
 
-**Phase 1: Foundations (~1 week).** Types and plumbing only; no behavior change.
-- *Tests first* for: `NavFeature` invariants, `NavFilterSpec` construction, `NavTechniqueResult` round-trip, `NavContext` field requirements, static-data loader for missing-body fallback and missing-instrument warning. Use parametrize for the per-type variants.
-- Implement: `NavFeature`, `NavFilterSpec`, `NavTechniqueResult`, `NavContext`, `NavResult`, `NavFeatureExtractor` ABC + registry. Static-data loader. Implement payload sum-type in `src/nav/feature/geometry.py` (`NavFeatureGeometry` per Part 0).
-- **`pyproject.toml` `[tool.pytest.ini_options]` updates (mandatory)**: add `testpaths = ["tests"]`, `--strict-markers` and `--strict-config` to `addopts`, register `markers = ["integration: requires PDS3_HOLDINGS_DIR", "slow: per-image library regression"]`, and set `filterwarnings = ["error"]` so unexpected warnings fail the build (per `critique-test-suite` §19, §22; verified absent in baseline pyproject.toml).
-- **Manual artifacts needed at the start of Phase 1**: `config_220_body_shape.yaml`, the `noise:` / `mag_offset:` block additions to each `config_4N0_inst_*.yaml`, and the `default_reliability` / `sharpness` extensions to the existing ring catalogs. Without them the loader has nothing to load. Required scope: ~55 body entries (Part 5 list); all four mission instrument-noise blocks; `mag_offset:` populated for the dominant filter combos per camera, with `fallback_combo` for the long tail. **YAML population workflow (per Part 0 §74)**: an AI agent drafts entries from PDS calibration reports + Thomas et al. shape papers + IAU physical-parameters tables, **citing only documents fetched in-session via `WebFetch` / `WebSearch`** (never from training-data memory) — every numeric value carries a sibling `_sources` entry with DOI where available. PRs are split into ≤10 bodies each so the human reviewer can spot-check ≥5 citations per PR by opening the cited document and verifying the value appears at the cited location. Fabricated citations are a revert-in-full offense. The `test_body_shape_citations.py` validation test (Part 9) blocks merge on schema gaps; citation accuracy is human-verified.
-- No old code touched in this phase.
+The legacy material content from the old Part 13 has been preserved
+in the per-phase sections at the top of this file:
 
-**Phase 2: Image preprocessing + extractors (~1 week).**
-- *Tests first* for: cosmic-ray despeckle (planted hot pixels), saturation mask, smear-aware PSF size, global noise estimate convergence. Then per-extractor tests using synthetic obs fixtures (already covered in Part 9).
-- Implement: image-quality preprocessing, `StarFeatureExtractor`, body extractors, ring extractors, cartographic extractor. Reuse existing `RingFeatureFilter`.
-- New CLI `nav_feature_inspect` for visual eyeballing — useful for confirming what the extractors produce on real images without running navigation.
-- Old pipeline still the navigation path.
+- Old Phase 1 (Foundations) → new Phase 0 (already shipped).
+- Old Phase 2 (Image preprocessing + extractors) → new Phase 0 / 1
+  (already shipped) and the per-camera image-preprocessing wiring
+  in new Phase 3.
+- Old Phase 3 (Techniques) → new Phases 2 / 5 / 6 / 7 / 8
+  (DT subset already shipped; remainder split for context size).
+- Old Phase 4 (Orchestrator + ensemble + CLI cutover + legacy
+  delete) → new Phase 0 (orchestrator) plus new Phase 11
+  (residual-symbol grep + breadth comparison; legacy delete
+  already happened on the cutover branch).
+- Old Phase 5 (Image library + calibration) → new Phase 4 (initial
+  1-3 images, end-to-end milestone) and new Phase 10 (full ~50
+  images + α calibration).
+- Old Phase 6 (Documentation) → distributed across every new
+  phase (per-phase docs ship with the code) plus new Phase 11
+  (index audit + README + CHANGELOG + `.cursor/rules/*.mdc`).
+- Old Phase 7 (Cleanup) → new Phase 11.
 
-**Phase 3: Techniques (~3–4 weeks; pattern matching is the long pole).**
-- *Tests first* per technique. For each technique, write tests that: (a) recover a planted offset on a synthetic input; (b) report appropriate confidence at boundary cases (low signal, partial overlap, etc.); (c) detect infeasibility cleanly; (d) raise on invalid input with assert-on-message.
-- Implement in this order: `BodyDiscCorrelateNav` (port existing correlation; well-tested baseline), `BodyBlobNav` (cheap), `BodyLimbNav` (DT-based; new heavy algorithm), `BodyTerminatorNav` (small variant of limb), `RingEdgeNav`, `RingAnnulusNav`, `StarRefineNav` (port existing refinement), `CartographicNav` (port existing bootstrap), `TitanNav` (stub — registered but always reports infeasible; real algorithm is a separate future work item).
-- `StarFieldFromCatalogNav` (pattern matching from scratch) is its own sub-phase: source detection → triplet hashing → RANSAC → verification. Each piece TDD'd separately.
-- After each technique, run the codebase-analysis + critique-test-suite skills; revise before moving on.
+### Cutover gating — what blocks the legacy delete (per Part 0 §20)
 
-**Phase 4: Orchestrator + ensemble (~1 week).**
-- *Tests first* for: feasibility filtering, two-pass priority, agreement grouping, conflicted handling, rank-deficient combination. Use mocked `NavTechniqueResult`s so tests don't depend on technique implementations.
-- Implement `NavOrchestrator`, `ensemble()`, two-pass driver, `NavResult` JSON serialization (extending the existing `_metadata.json` additively).
-- **CLI cutover** (every script in `src/main/` that invokes navigation):
-  - `nav_offset.py` → `NavOrchestrator(...).navigate(obs)`.
-  - `nav_offset_cloud_tasks.py` → same; per-image task body unchanged in shape.
-  - `nav_backplanes.py` and `nav_backplanes_cloud_tasks.py` → read `offset` from the new metadata (already present in additive form).
-  - `nav_create_bundle.py` and `nav_create_bundle_cloud_tasks.py` → read `confidence_rank` and refuse to bundle `low` results unless `--include-low-confidence` is set.
-  - `nav_create_simulated_image.py` → no change (writes images, doesn't read nav metadata).
-  - `nav_mosaic_*.py` and `nav_mosaic_*_cloud_tasks.py` → read `offset` and `confidence_rank` per Part 12.6.
-- **CI workflow**: `.github/workflows/run-tests.yml` already sets `PDS3_HOLDINGS_DIR`, `PDS4_HOLDINGS_DIR`, `OOPS_RESOURCES`, `UCAC4_PATH`, `YBSC_PATH`. No new env vars. Add a new job step for `pytest tests/integration/test_image_library.py` (structural invariants — runs without holdings) and `pytest tests/integration/test_autonomous_nav.py -n auto` (per-image regression — runs with holdings).
-- Legacy `NavTechniqueCorrelateAll` / `NavModelCombined` / `NavModelResult` are **deleted** in this same change-set (Cardinal Principle #1).
+This subsection is **load-bearing** and applies to new Phase 11 (or
+to the moment when the cutover branch's legacy-deleting change-set
+merges, whichever is in flight). It is preserved verbatim from the
+legacy plan because nothing in the per-phase reorganisation
+supersedes the gating contract.
 
-**Phase 5: Image library + calibration (~2 weeks).** *This is when the manually-supplied test images are required.*
-- **UI work**: add a "Save as library entry" button to the manual-nav dialog that writes a sidecar with provenance pre-filled. Without it, hand-curating 50 sidecars is a 50-paste ceremony. Small but real Phase 5 work; sits alongside the per-technique-result panel work in Part 12.6.
-- **Manual artifact needed**: ~50 PDS3 image identifiers chosen by the operator covering all scene classes (Part 10), plus operator-verified ground-truth offsets via the manual-nav UI. Library cannot be drafted by an AI; ground truth must be a human eye matching the overlay.
-- Tune every confidence formula (Part 4) against library ground-truth. The model is `confidence = sigmoid(α₀ + Σ αᵢ × xᵢ)` (logistic in the αᵢ); fitting is via `scipy.optimize.curve_fit` with the sigmoid model, optimizing the αᵢ to minimize `Σ_image (predicted_confidence − target_tier_midpoint)²` where `target_tier_midpoint` is `0.9` for images expected to land in `high`, `0.65` for `medium`, `0.35` for `low`, `0.1` for `failed`. (Equivalent to a logistic regression with continuous targets; not strictly OLS because the model is nonlinear, hence `curve_fit` not `lstsq`.) The placeholder coefficients in Part 4 are arithmetically illustrative only — they are *not* claimed to produce the example confidence values stated alongside them; calibration replaces them. This is a one-time calibration; `config_510_techniques.yaml` is checked in afterward and never updated by per-image runs.
-- Set the regression baselines in `tests/integration/baselines/`.
+The legacy code is deleted in the cutover change-set per Cardinal
+Principle #1. **Pre-merge gates run on the feature branch while
+both pipelines coexist** — the breadth comparison cannot run after
+merge because legacy is gone by then. Gates that must be green
+before merging that change-set:
 
-**Phase 6: Documentation (~1 week).**
-- All new `.rst` pages (Part 8 file list). Existing `user_guide_*` and `introduction_overview` updated.
-- AI agent drafts pages from code docstrings + this plan; human edits for clarity and accuracy.
-- Per Part 0 §49: update `docs/index.rst` Sphinx toctree to list every new module sorted by package and name.
-- Per Part 0 §48: every new module/class/function carries a Google-style docstring (Parameters / Returns / Raises) detailed enough to write a black-box test from the docstring alone (per `documentation.mdc` §4). Each technique's docstring links to its confidence-formula source-of-truth (`config_510_techniques.yaml.<technique_key>`).
-- Per Part 0 §63: thread-safety section added to each extractor and the orchestrator docstrings ("Not safe for concurrent use on the same `obs`...").
-- Per Part 0 §54: `developer_guide_testing.rst` declares mocking conventions (`mock.patch` for spies; `monkeypatch` for env / module state) and lists canonical patch targets per shared utility.
-- Per Part 0 §57: `developer_guide_testing.rst` declares the `xfail` / `skipif` discipline.
+1. Every image in the new-Phase-10 library navigates to
+   `expected.status` and `expected.confidence_tier`, with offset
+   within `offset_uncertainty_px + 0.5 px` slack.
+2. The 500-image breadth comparison (Part 15) shows the new
+   pipeline equal-or-better than the legacy on every aggregate
+   metric (% ok, P50 / P95 offset error, % conflicted, % failed).
+   "Equal-or-better" is **per-class, not just overall** — a
+   regression on one scene class is a blocker even when overall
+   metrics improve.
+3. Coverage ≥ 90 % on the new code (cursor rule §7).
+4. Every doc page listed in Part 8 written and
+   `sphinx-build -W -b html` clean.
 
-**Phase 7: Cleanup (~3 days).** All deletions happen in Phase 4 (Cardinal Principle #1); Phase 7 is verification only. Per Part 0 §20, the breadth comparison vs legacy already ran pre-merge in Phase 4 — Phase 7 is post-merge cleanup, not gating.
-- `grep` sweeps to verify nothing references deleted symbols (`NavTechniqueCorrelateAll`, `NavModelCombined`, `NavModelResult`, `NavMaster`, `weighted_mask`, `blur_amount`, `final_offset`, `final_confidence`, `use_legacy_pipeline`). Per Part 0 §69: implemented as a single-line CI step that fails the build on any match.
-- Final regression run on the full library; the 500-image breadth comparison vs legacy already ran pre-merge in Phase 4 (Part 0 §20).
-- Coverage report ≥ 90% on the new code.
-- `sphinx-build -W -b html` clean.
-- Per Part 0 §69: new CI step (single grep line in `.github/workflows/ci.yml`) fails the build on any leftover reference to deleted symbols.
-- If the grep sweeps find any leftover references, fix in Phase 7 — but Phase 4 should have left no leftovers.
+If a library image regresses, the response is **fix the new
+pipeline**, not retain the legacy as a fallback. The image library
+plus the breadth comparison is the safety net. There is no
+rollback to the legacy pipeline post-merge (per Cardinal Principle
+#1); pre-merge, the change-set sits behind these gates.
 
-**Cutover gating — what blocks the legacy delete (per Part 0 §20):**
-
-The legacy code is deleted in Phase 4's change-set per Cardinal Principle #1. **Pre-merge gates run on the feature branch while both pipelines coexist** — the breadth comparison cannot run after merge because legacy is gone by then. Gates that must be green before merging that change-set:
-
-1. Every image in the Phase 5 library navigates to `expected.status` and `expected.confidence_tier`, with offset within `offset_uncertainty_px + 0.5 px` slack.
-2. The 500-image breadth comparison (Part 15) shows the new pipeline equal-or-better than the legacy on every aggregate metric (% ok, P50 / P95 offset error, % conflicted, % failed). "Equal-or-better" is per-class, not just overall — a regression on one scene class is a blocker even when overall metrics improve.
-3. Coverage ≥ 90% on the new code (cursor rule §7).
-4. Every doc page listed in Part 8 written and `sphinx-build -W -b html` clean.
-
-If a Phase 5 image regresses, the response is **fix the new pipeline**, not retain the legacy as a fallback. The image library plus the breadth comparison is the safety net. There is no rollback to the legacy pipeline post-merge (per Cardinal Principle #1); pre-merge, the change-set sits behind these gates.
-
-Total estimated: 2–3 months of focused work, including iteration. The design is structured so that each phase ships useful progress even if the overall project pauses.
+Total estimated effort across new Phases 3–11: 2–3 months of
+focused work, including iteration. Each phase ships useful progress
+even if the overall project pauses.
 
 ---
 
@@ -4627,12 +5713,12 @@ architecture leaves room for them.
 2. **Cartographic-model technique testing.** The architecture supports
    `CARTOGRAPHIC_MODEL` features and `CartographicNav` and the technique is
    implemented + unit-tested against synthetic mosaics in the cutover, but
-   the Phase 5 image library does not include cartographic-model test images
-   (no production cartographic mosaics exist for the supported missions
-   yet). Track: when production mosaics become available, add representative
-   cartographic test images to the library, recalibrate the
+   the Phase 10 image library does not include cartographic-model test
+   images (no production cartographic mosaics exist for the supported
+   missions yet). Track: when production mosaics become available, add
+   representative cartographic test images to the library, recalibrate the
    `CartographicNav` confidence formula against ground truth, and add the
-   technique to the regression baseline.
+   technique to the regression baseline. (Legacy wording said "Phase 5".)
 
 3. **Atmospheric-body navigation algorithm.** `TitanNav` ships as a stub
    that always returns infeasibility; bodies flagged `atmospheric: true` in
@@ -4668,10 +5754,10 @@ architecture leaves room for them.
    target end-state is a per-technique side-by-side panel showing each
    technique's proposal, confidence, and overlay (operator picks one or
    accepts the orchestrator's choice). Out of scope for the cutover;
-   Phase 4 keeps the existing UI working with the new `NavResult` (the
-   orchestrator's chosen offset is what gets surfaced). Track:
+   Phases 0–11 keep the existing UI working with the new `NavResult`
+   (the orchestrator's chosen offset is what gets surfaced). Track:
    ergonomics, interaction model, layout, color coding for confidence
-   tiers.
+   tiers. (Legacy wording said "Phase 4".)
 
 ## Part 14 — Open questions — operator decisions
 
@@ -4682,7 +5768,7 @@ Resolved during review:
 3. **Confidence tier thresholds** — 0.8 / 0.5 / 0.2 starting point accepted; re-tuned on the image library during calibration.
 4. **"Conflicted" strictness** — groups form at 2σ Mahalanobis (`agreement_sigma`); `conflicted` fires when ≥2 groups exist and the summed-confidence gap between best and runner-up is below `agreement_gap` (default 0.5). Both thresholds live in `config_540_orchestrator.yaml`. See Part 4.
 5. **Cloud-tasks parallelism** — the cloud-tasks environment is already multi-process; the navigation pipeline stays single-image-per-task and parallelism is the harness's job. No pipeline changes required.
-6. **Legacy retention** — none. `NavTechniqueCorrelateAll`, `NavModelCombined`, `NavModelResult`, `NavMaster` are deleted in the Phase 4 cutover change-set. No `use_legacy_pipeline` flag. Pre-merge gates (Phase 7) protect against regression; no post-merge rollback.
+6. **Legacy retention** — none. `NavTechniqueCorrelateAll`, `NavModelCombined`, `NavModelResult`, `NavMaster` are deleted in the cutover change-set (already shipped during the Phase 0/1/2 cutover branch). No `use_legacy_pipeline` flag. Pre-merge gates (Phase 11 verification + breadth comparison) protect against regression; no post-merge rollback. (Legacy wording said "Phase 4 cutover" / "Pre-merge gates (Phase 7)".)
 
 No questions outstanding — ready to implement when scheduled.
 
@@ -4774,9 +5860,16 @@ These apply uniformly across every section above; called out here so an implemen
 
 ---
 
-# Resumption notes — read these first when picking up the discussion
+# Resumption notes — read for user-style + load-bearing decisions
 
-This plan is the product of an extended interview-style design discussion. If you're picking it up in a fresh context, read this section before proposing changes — it preserves the working state, the user's communication style, and the load-bearing decisions that have already been settled.
+> The "Reading order for an AI picking this up cold" subsection at
+> the very top of this file is the **first** thing to read; this
+> section is **step 8** in that reading order. The original
+> "read these first" framing is preserved below for the moments
+> when this file is consumed standalone (e.g., grepped for the
+> "What this is" paragraph or the hallucination history).
+
+This plan is the product of an extended interview-style design discussion. If you're picking it up in a fresh context, read this section for the user's communication style and the load-bearing decisions that have already been settled — but do so **after** you have read the top-of-file reading-order subsection and the per-phase plan, not before.
 
 ## What this is
 
@@ -4826,6 +5919,15 @@ None outstanding from the operator (Part 14 records resolved decisions). The use
 
 ## What to do when continuing
 
+> The original guidance below was for **continuing the design
+> discussion**, written when the plan was being walked branch by
+> branch. The design walk is finished. The current activity is
+> **executing the per-phase implementation plan** (Phase 3 onward).
+> For implementation work, follow the top-of-file "Reading order"
+> subsection plus the per-phase Definition of done — not the steps
+> below. The steps below remain the canonical recipe if a fresh
+> design discussion ever resumes.
+
 1. Read this whole resumption-notes section, then read Cardinal Principles in the plan body, then skim the per-Part headings.
 2. Pick the next branch from "Still to walk" (or ask the user which one).
 3. Start with a focused proposal — concrete answer with reasoning, not options.
@@ -4857,6 +5959,7 @@ None outstanding from the operator (Part 14 records resolved decisions). The use
 - `range` field on `LimbPolyline` — wrong; occlusion is handled at extraction time by vertex cropping, just like ring shadows.
 - Treating `NavResult` as a direct JSON dump — wrong; a curator function builds a curated subset.
 - "One bright star, no body, can't navigate from scratch" — wrong; `StarUniqueMatchNav` exploits catalog uniqueness (when the brightest predicted catalog star is ≥1.5 mag brighter than the next-brightest predictable source, the catalog itself supplies the assignment, no triplet hash needed). 1-star and 2-star scenes are primary navigation modes, not failures.
+- "DN-based overexposure detection works for every image" — wrong; only **raw** instrument observations carry DN values that can be compared against a per-instrument saturation DN. Calibrated images (I/F units, radiance, reflectance) cannot be checked for overexposure with a DN threshold. Each per-instrument config carries an explicit `data_units: 'raw_dn' | 'calibrated_if'` field; the saturation / overexposure classifier branches are conditional on it. Each raw observation type carries its own `saturation_dn` / `full_well_dn` (8-bit = 255, 12-bit = 4095, 14-bit = 16383, etc.); there is no global default.
 
 ## Active style conventions
 

--- a/docs/api_reference/api_nav_orchestrator.rst
+++ b/docs/api_reference/api_nav_orchestrator.rst
@@ -31,6 +31,11 @@ nav.nav_orchestrator
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: nav.nav_orchestrator.image_derivatives
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: nav.nav_orchestrator.provenance
    :members:
    :undoc-members:

--- a/docs/api_reference/api_nav_technique.rst
+++ b/docs/api_reference/api_nav_technique.rst
@@ -26,6 +26,26 @@ nav.nav_technique
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: nav.nav_technique.dt_fitting
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: nav.nav_technique.nav_technique_body_limb
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: nav.nav_technique.nav_technique_body_terminator
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: nav.nav_technique.nav_technique_ring_edge
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: nav.nav_technique.nav_technique_manual
    :members:
    :undoc-members:

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -11,6 +11,8 @@ This guide is intended for developers who want to understand, modify, or extend 
    developer_guide_introduction
    developer_guide_class_hierarchy
    developer_guide_navigation_models
+   developer_guide_techniques
+   developer_guide_uncertainty
    developer_guide_reprojection
    developer_guide_extending
    developer_guide_configuration

--- a/docs/developer_guide_techniques.rst
+++ b/docs/developer_guide_techniques.rst
@@ -1,0 +1,183 @@
+=====================
+Navigation Techniques
+=====================
+
+A ``NavTechnique`` consumes a subset of the per-image ``NavFeature`` set
+plus a per-image ``NavContext`` and produces one
+``NavTechniqueResult`` carrying a calibrated translation offset, a
+``2x2`` covariance, a ``[0, 1]`` confidence, and a typed diagnostics
+dataclass.  The orchestrator's ensemble combine reconciles every
+technique's result into a single ``NavResult``.
+
+This page walks the *distance-transform* pipeline that three techniques
+share: ``BodyLimbNav``, ``BodyTerminatorNav``, and ``RingEdgeNav``.
+
+DT-based fitting
+================
+
+The three DT-based techniques follow the same five-step pipeline:
+
+.. code-block:: text
+
+    +---------------------------+
+    |  source image (extfov)    |
+    +---------------------------+
+                |
+                | Gaussian smooth + Sobel
+                v
+    +---------------------------+
+    |  gradient magnitude       |
+    |  + gradient (g_v, g_u)    |     <-- once per image, on NavContext
+    +---------------------------+
+                |
+                | threshold > k * noise_sigma
+                | + Canny-style directional NMS
+                v
+    +---------------------------+
+    |  thin edge mask           |
+    +---------------------------+
+                |
+                | distance_transform_edt
+                v
+    +---------------------------+
+    |  image_edge_dt_ext        |     <-- once per image, on NavContext
+    +---------------------------+
+                |
+    +-----------|---------------+
+    |  per-technique:           |
+    |    - render polyline mask |
+    |    - coarse_ncc_search    |
+    |    - polarity_filter      |
+    |    - lm_subpixel_refine   |
+    |      (Tukey-reweighted)   |
+    |    - information matrix   |
+    |      -> covariance        |
+    +---------------------------+
+
+Image-side derivatives
+----------------------
+
+``nav.nav_orchestrator.image_derivatives.build_image_edge_dt`` is the
+helper the orchestrator calls in ``_make_context``.  It Gaussian-smooths
+the source image at ``image_gradient_sigma_px`` (default 1.2 px),
+computes the Sobel-of-Gaussian gradient vector, takes the magnitude,
+thresholds at ``edge_threshold_k_sigma * image_noise_sigma`` (default
+``k = 4``), thins via Canny-style directional non-maximum suppression
+(comparing each candidate against its two neighbours along the local
+gradient direction), and finally takes the truncated distance
+transform.  ``compute_image_gradient_vu`` returns the per-pixel
+``(g_v, g_u)`` gradient vector image consumed by the polarity filter.
+
+The orchestrator caches all three products on the per-image
+``NavContext`` (``image_gradient_ext``, ``image_gradient_vu_ext``,
+``image_edge_dt_ext``) so every DT technique reads them rather than
+recomputing.
+
+Coarse search and LM refinement
+-------------------------------
+
+``nav.nav_technique.dt_fitting`` exposes the five shared helpers:
+
+``coarse_ncc_search``
+    Cross-correlates the polyline edge mask against the image edge mask
+    over a bounded integer ``(dv, du)`` search window and returns the
+    integer-pixel argmax.  Both inputs are binary, so this reduces to
+    overlap counting and is exact under the per-shift NCC normaliser.
+
+``polarity_filter``
+    Per-vertex gradient-direction agreement test.  At each vertex's
+    current position, samples the image gradient vector and dots it with
+    the model's polarity normal; vertices with ``dot <= 0`` are rejected
+    and assigned an effectively-infinite residual so the Tukey biweight
+    zeroes their contribution.  Strict inequality, per the design.
+
+``tukey_biweight_weights``
+    Holland-Welsch redescender.  ``w_i = (1 - (r_i / c)^2)^2`` for
+    ``|r_i| <= c``, else 0.  ``c = 4.685`` gives 95 % asymptotic
+    efficiency on Gaussian residuals when the residuals are scaled by
+    their robust scale.
+
+``lm_subpixel_refine``
+    Levenberg-Marquardt minimisation of
+    ``sum_i w_i * DT(R(theta) (vert_i - pivot) + pivot + (dv, du))^2``
+    with iteratively-reweighted Tukey weights.  Damping ``lambda=1e-3``,
+    multiplicative update on accept / reject, max 30 iterations,
+    termination when the combined step norm
+    ``sqrt(d_dv^2 + d_du^2 + (d_theta * pivot_dist)^2)`` drops below
+    ``1e-3`` px.  Translation-only by default; rotation enabled with
+    ``fit_rotation=True`` and a documented ``pivot_distance_px``.
+
+``information_matrix_to_covariance``
+    Returns ``pinvh(J^T diag(w) J, rtol=1e-9)`` so rank-deficient
+    Jacobians (from flat ring polylines or other unobservable axes)
+    propagate honestly into the per-technique covariance.  Same
+    ``rtol`` as the orchestrator's ensemble combine.
+
+Per-technique specifics
+=======================
+
+BodyLimbNav
+-----------
+
+Accepts ``LIMB_ARC`` features.  ``is_feasible`` returns True when at
+least one limb arc has ``visible_arc_px >= LIMB_MIN_ARC_PX`` (30).
+Per-vertex weight is ``1 / sigma_normal_per_vertex_px**2``.  Polarity
+filtering is enabled — the model's geometric outward normals are
+negated before being passed in (the typical bright-body case has the
+image gradient pointing into the silhouette, opposite the geometric
+outward).  Spurious detection fires when the converged DT RMS exceeds
+the larger of ``SPURIOUS_DT_FLOOR_PX = 3`` px and
+``5 * min(sigma_normal_per_vertex_px)`` or the Tukey inlier count
+drops below ``SPURIOUS_MIN_INLIERS = 6``.
+
+Confidence spec coefficients (placeholders, calibrated against the
+image library):
+
+- ``alpha0 = -1``
+- ``alpha(visible_limb_arc_fraction) = 3``
+- ``alpha(dt_fit_rms_px) = -1.5``
+- ``alpha(visible_arc_px / 100, capped at 1) = 0.4``
+- hard zero when ``at_edge`` is True
+
+BodyTerminatorNav
+-----------------
+
+Accepts ``TERMINATOR_ARC`` features.  Same algorithm as ``BodyLimbNav``
+with two terminator-specific changes: each body's per-vertex sigmas are
+collapsed to a single per-body scalar (the body's mean), and the
+confidence spec carries ``mean_phase_angle_factor`` and
+``mean_albedo_penalty`` terms so high-albedo / low-phase scenes
+collapse below the rank threshold.
+
+RingEdgeNav
+-----------
+
+Accepts ``RING_EDGE`` features.  Polarity is intentionally disabled
+because the ring catalog does not yet distinguish bright-ring vs
+dark-gap edges (deferred polarity work).  When every input edge has
+``is_straight_line=True`` the combined Jacobian is rank-deficient — the
+along-edge axis is unobservable — and the technique reports
+``is_rank_1=True`` on its diagnostics.  The returned 2x2 covariance is
+the M-estimator pseudoinverse, honestly rank-deficient on flat-only
+scenes; the ensemble combine fuses it with any orthogonal feature
+(star, body limb, body blob) before declaring a final answer.
+
+Logging
+=======
+
+Each technique's ``navigate`` body opens a pdslogger section
+(``with self.logger.open(f'TECHNIQUE: {self.name}'):``) so the
+per-image log file delimits each technique's contribution clearly.
+The section logs the consumed feature count, the coarse-search
+integer offset, and the converged offset / RMS / inlier count /
+confidence on a single INFO line.  The pdslogger
+``IMAGE_LOGGER`` is the only logger this codebase uses; the standard
+library ``logging`` module is not imported.
+
+See also
+========
+
+- :doc:`developer_guide_uncertainty` — derivation of the M-estimator
+  information-matrix to covariance step that turns the LM Jacobian at
+  convergence into the per-technique 2x2 (or 3x3) covariance reported
+  on every ``NavTechniqueResult``.

--- a/docs/developer_guide_uncertainty.rst
+++ b/docs/developer_guide_uncertainty.rst
@@ -1,0 +1,101 @@
+===========
+Uncertainty
+===========
+
+This page derives the M-estimator covariance returned by the DT-based
+techniques from first principles and shows where the project-wide
+``pinvh`` cutoff comes from.
+
+The cost function
+=================
+
+For a polyline of ``N`` vertices ``x_i`` with prior precision
+``w_i^prior = 1 / sigma_i^2`` and a parameter vector ``p`` that
+shifts and (optionally) rotates the polyline, the DT cost is
+
+.. math::
+
+    C(p) = \sum_i w_i \, r_i(p)^2
+
+where the residual ``r_i(p) = DT(R(theta)(x_i - x_p) + x_p + (dv, du))``
+is the bilinearly-sampled distance transform at the shifted vertex
+position and ``w_i = w_i^prior \cdot w_i^\mathrm{Tukey}`` combines the
+prior precision with the iteratively-reweighted Tukey biweight weight.
+
+At the converged estimate :math:`\hat p`, the gradient
+
+.. math::
+
+    \nabla C(\hat p) = 2 \sum_i w_i \, r_i(\hat p) \, \nabla r_i(\hat p)
+
+vanishes and the local Hessian reduces (under the Gauss-Newton
+approximation, dropping the second-order ``r_i \, \nabla^2 r_i``
+term that integrates to zero against zero-mean residuals) to
+
+.. math::
+
+    H \approx 2 \sum_i w_i \, \nabla r_i(\hat p) \, \nabla r_i(\hat p)^T
+        = 2 \, J^T \, W \, J
+
+with ``J`` the residual Jacobian (rows are
+:math:`\nabla r_i(\hat p)^T`) and ``W = diag(w_i)``.
+
+Under the M-estimator interpretation the parameter covariance is the
+inverse of the *information matrix* :math:`I = J^T W J` (the factor of
+2 cancels in the standard derivation against the residual variance
+that the Tukey weights have already absorbed); the dropped
+``2 r \nabla^2 r`` term is exactly the variance contribution that
+becomes negligible at convergence under low-residual conditions.
+
+The pseudoinverse cutoff
+========================
+
+When the model polyline is geometrically rank-deficient (e.g. every
+edge in a flat-ring scene is parallel and the along-ring axis is
+unobservable), :math:`I` is singular.  Replacing the inverse with the
+Hermitian pseudoinverse :math:`I^+` lets the unobservable direction
+remain unobservable in the returned covariance: the corresponding
+eigenvalue is zero, the marginal variance along that axis is also
+zero in :math:`I^+`, and the per-axis sigma reported by the ensemble
+correctly flags the rank deficiency rather than silently inverting
+floating-point noise.
+
+``scipy.linalg.pinvh(I, rtol=rcond)`` is the implementation.  The
+``rtol`` cutoff is set to ``1e-9`` project-wide — the same value the
+orchestrator's ensemble combine uses.  A tighter cutoff would silently
+treat near-rank-deficient matrices as full-rank, producing garbage
+inverse entries; a looser cutoff would prematurely zero observable
+directions.  ``1e-9`` is liberal enough to fold near-singular
+directions into the null space and conservative enough to preserve
+genuine 2-D / 3-D constraints typical of body-limb / ring-edge fits.
+
+Tukey biweight reweighting
+==========================
+
+The Holland-Welsch biweight assigns weight
+
+.. math::
+
+    w_i^\mathrm{Tukey} = \left(1 - (r_i / c)^2\right)^2 \quad |r_i| \le c
+
+and zero otherwise, with ``c = 4.685`` selected so the M-estimator
+attains 95 % asymptotic efficiency on Gaussian residuals once the
+residuals are pre-scaled by their robust scale (the per-vertex
+``sigma_i`` in our formulation).  Recomputing the weights after each
+accepted LM step (iteratively-reweighted least squares) makes the
+Tukey-rejected vertices truly drop out of the information matrix and
+keeps the converged covariance an honest expression of the surviving
+inliers' precision.
+
+Combining the M-estimator covariance with a prior
+=================================================
+
+The per-technique covariance returned to the orchestrator is the
+M-estimator pseudoinverse :math:`I^+`.  The orchestrator's ensemble
+combines per-technique results in *information form*: invert each
+covariance, sum, invert again.  ``scipy.linalg.pinvh`` is used at
+every inversion and the same ``rtol`` propagates throughout, so a
+single rank-1 ring constraint plus any other rank-2 result yields a
+fully-resolved 2-D answer; a single rank-1 ring constraint alone
+yields a rank-1 final covariance with the unobservable axis honestly
+flagged.

--- a/docs/user_guide_navigation.rst
+++ b/docs/user_guide_navigation.rst
@@ -130,10 +130,17 @@ Navigation options
   enable. Valid entries are ``stars``, ``rings``, and body-specific entries of
   the form ``body:NAME`` (glob patterns are allowed).
 
-* ``--nav-techniques LIST``: a comma-separated list of navigation techniques to
-  apply. Valid entries include ``correlate_all`` and ``manual``. Note: You
-  should typically use only one technique at a time, as they serve different
-  purposes.
+* ``--nav-techniques LIST``: a comma-separated glob-pattern list selecting
+  which registered ``NavTechnique`` subclasses run.  Implemented techniques
+  today are ``BodyLimbNav``, ``BodyTerminatorNav``, and ``RingEdgeNav``;
+  several more (``BodyDiscCorrelateNav``, ``BodyBlobNav``, ``RingAnnulusNav``,
+  ``StarFieldFromCatalogNav``, ``StarUniqueMatchNav``, ``StarRefineNav``)
+  are planned but not yet shipped.  Defaults to ``*`` (all registered
+  techniques run); a leading ``!`` excludes a pattern (e.g.
+  ``--nav-techniques '!RingEdgeNav'`` runs every technique except the
+  ring-edge fitter).  Multiple feasible techniques run in parallel and the
+  orchestrator combines their results via the ensemble; you do **not**
+  pick "one technique at a time" the way the legacy pipeline did.
 
 Output options
 ^^^^^^^^^^^^^^
@@ -200,11 +207,13 @@ To process Voyager images within a single PDS3 volume:
 
    nav_offset vgiss --volumes VGISS_5101
 
-To process a New Horizons image list found in a CSV from PDS using the correlate_all technique:
+To process a New Horizons image list found in a CSV from PDS, restricting the
+run to the body-limb and ring-edge DT techniques:
 
 .. code-block:: bash
 
-   nav_offset nhlorri --image-filespec-csv /path/to/nhlorri.csv --nav-techniques correlate_all
+   nav_offset nhlorri --image-filespec-csv /path/to/nhlorri.csv \
+       --nav-techniques 'BodyLimbNav,RingEdgeNav'
 
 To choose ten random Cassini images between two volumes and perform a dry run:
 
@@ -241,7 +250,7 @@ objects. Each task is:
             "dataset_name": "<dataset_name>",
             "arguments": {
                 "nav_models": ["body:*", "rings", "stars"],
-                "nav_techniques": ["correlate_all"]
+                "nav_techniques": ["*"]
             },
             "files": [
                 {
@@ -342,154 +351,119 @@ every supported field, see :doc:`user_guide_simulated_images`.
 Navigation Techniques
 =====================
 
-RMS-NAV supports two navigation techniques that can be selected using the ``--nav-techniques`` command-line option. You should typically use only one technique at a time, as they serve different purposes.
+The autonomous-navigation pipeline runs every registered ``NavTechnique``
+whose feasibility check passes on the surviving feature set, then combines
+the per-technique offsets via the orchestrator's precision-weighted
+ensemble.  Use ``--nav-techniques`` to restrict which techniques run; the
+default ``*`` runs all of them.
 
-correlate_all
--------------
+The algorithmic detail (DT pipeline, Levenberg-Marquardt refinement,
+information-matrix covariance) lives in
+:doc:`developer_guide_techniques` and :doc:`developer_guide_uncertainty`;
+this page summarises what each technique does and which scenes it
+applies to.
 
-The ``correlate_all`` technique performs automated navigation by correlating the observed image with a combined theoretical model. This is the primary automated navigation method.
+Implemented techniques
+----------------------
 
-**How it works:**
+``BodyLimbNav``
+^^^^^^^^^^^^^^^
 
-1. **Model Combination**: The technique first creates a combined model from all available navigation models (stars, bodies, rings, etc.). For each pixel, it selects the model element with the smallest range (closest to the observer), ensuring proper depth ordering.
+Translation fit on a body's lit limb.  Consumes every ``LIMB_ARC`` feature
+emitted by ``NavModelBody``, concatenates their per-vertex polylines, and
+runs a coarse-NCC plus Levenberg-Marquardt refinement against the image
+edge-distance transform.  Tukey biweight reweighting rejects outlier
+vertices; the M-estimator information matrix at the converged solution
+yields the result's covariance.  Multi-body inputs sharpen the fit by
+``sqrt(N_bodies)``.
 
-2. **Correlation**: It uses a pyramid-based correlation algorithm (KPeaks) to find the best match between the observed image and the combined model. The correlation searches for the offset that maximizes the match quality.
+Best for: scenes where one or more bodies show a visible limb arc
+(typical Cassini ISS Mimas / Enceladus / Tethys / Dione / Rhea encounter
+images).  Feasibility threshold: at least one limb arc with at least
+30 surviving polyline vertices.
 
-3. **Star Refinement** (optional): If star models are available and star refinement is enabled in the configuration, the technique performs a second pass to refine the offset by precisely locating individual stars in the image. This refinement:
-   - Searches for each star's position using the instrument's point spread function (PSF)
-   - Applies photometric gates to reject non-stellar signal (scale/noise, chi-squared, SNR, position error)
-   - Computes the median offset from all successfully located stars
-   - Removes outliers using a robust statistical method
-   - Updates the final offset with the refined value
+``BodyTerminatorNav``
+^^^^^^^^^^^^^^^^^^^^^
 
-4. **Validation**: The technique validates that the computed offset is within the extended field of view margins. If the offset is outside these bounds, the technique fails.
+Same shape as ``BodyLimbNav`` on ``TERMINATOR_ARC`` features, with two
+differences: each body's per-vertex sigmas collapse to one per-body scalar
+(the body's mean sigma), and the confidence formula carries
+phase-angle-factor and albedo-penalty terms.  Best for crescent
+geometries where the terminator runs through bright, nearly-uniform
+hemispheres.
 
-**Configuration Options:**
+``RingEdgeNav``
+^^^^^^^^^^^^^^^
 
-The following configuration options in ``config_02_offset.yaml`` control the behavior of ``correlate_all``:
+DT-based fit on every ``RING_EDGE`` feature.  Polarity prediction is
+intentionally disabled today (the ring catalog does not yet flag
+polarity_predictable, deferred work).  When every input edge is
+straight-line the technique reports ``is_rank_1=True`` and returns an
+honest rank-deficient covariance; the ensemble combine fuses it with any
+orthogonal-axis result (a star, body limb, body blob) before declaring a
+final answer.
 
-* ``offset.correlation_fft_upsample_factor`` (default: 128): The upsampling factor used in the FFT-based correlation. Higher values provide finer sub-pixel resolution but increase computation time.
+Best for: scenes containing bright ring edges (typical Cassini ISS
+Saturn-rings imagery).
 
-* ``offset.star_refinement_enabled`` (default: true): Whether to enable star-based refinement after the initial correlation.
+``NavTechniqueManual``
+^^^^^^^^^^^^^^^^^^^^^^
 
-* ``offset.star_refinement_nsigma`` (default: 3): The number of standard deviations used to identify outliers during star refinement.
+Interactive PyQt6 dialog that composes every template-bearing feature
+into a single ext-FOV overlay and lets the operator pick the offset by
+hand.  Not part of the autonomous registry; invoke it directly from a
+GUI driver when human judgement is required.
 
-* ``offset.star_refinement_search_limit`` (default: [2.5, 2.5]): The search radius in pixels (v, u) when locating individual stars.
+Pending techniques (not yet shipped)
+-------------------------------------
 
-* ``offset.star_refinement_max_reduced_chi2`` (default: 10.0): Reject PSF fits with reduced chi-squared above this threshold. A high chi-squared indicates the PSF model cannot describe the data, suggesting a non-stellar source.
+The following techniques are designed and have stub diagnostics in
+place; their concrete implementations are pending.
 
-* ``offset.star_refinement_min_reduced_chi2`` (default: 0.1): Reject PSF fits with reduced chi-squared below this threshold. A value near zero indicates the background polynomial has absorbed the signal (overfitting).
+* ``BodyDiscCorrelateNav`` -- full-disc NCC for fully-in-FOV bodies.
+* ``BodyBlobNav`` -- centroid fit for under-resolved or irregular bodies.
+* ``RingAnnulusNav`` -- multi-ring composite NCC for compressed ring
+  geometries.
+* ``StarFieldFromCatalogNav`` -- triplet-hash + RANSAC pattern match for
+  star-rich frames.
+* ``StarUniqueMatchNav`` -- direct catalog-uniqueness match for sparse
+  star fields with one or two bright stars.
+* ``StarRefineNav`` -- prior-refining single-star polish (pass-2).
 
-* ``offset.star_refinement_min_peak_snr`` (default: 5.0): Reject PSF fits with peak signal-to-noise ratio below this value. Low SNR indicates the fit may have locked onto noise or a non-stellar feature.
+Until these land, scenes whose only viable feature type is ``STAR``,
+``BODY_DISC``, ``BODY_BLOB``, or ``RING_ANNULUS`` will report
+``status_reason=no_feasible_techniques``.
 
-* ``offset.star_refinement_max_pos_err`` (default: 0.5 pixels): Reject PSF fits where the 1-sigma position uncertainty in either axis exceeds this limit.
+Filtering examples
+------------------
 
-* ``offset.log_star_refinement_detail`` (default: false): Log all fit metrics and gate thresholds per star at DEBUG level. Useful for diagnosing unexpected rejection behavior.
+Run only the ring-edge technique:
 
-* ``general.log_level_nav_correlate_all`` (default: ``INFO``, from ``config_01_general.yaml``): Logging level for this technique. Accepts ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, or ``CRITICAL``.
+.. code-block:: bash
 
-**Star conflict strings from refinement:**
+   nav_offset coiss N1234567890 --nav-techniques RingEdgeNav
 
-Stars that fail a gate receive one of the following ``conflicts`` strings and are excluded from offset statistics:
+Run every technique except ``BodyTerminatorNav``:
 
-* ``REFINEMENT EDGE``: Star is too close to the image edge for PSF fitting.
-* ``REFINEMENT FAILED``: PSF optimizer returned no result.
-* ``REFINEMENT NO STAR``: Fit scale at or below the noise floor; no real signal present.
-* ``REFINEMENT CHI2 LOW``: Reduced chi-squared below minimum; background polynomial overfit the signal.
-* ``REFINEMENT CHI2``: Reduced chi-squared above maximum; PSF model cannot describe the data.
-* ``REFINEMENT SNR``: Peak SNR below minimum.
-* ``REFINEMENT POS_ERR``: Position uncertainty exceeds the maximum.
-* ``REFINEMENT OUTLIER``: Passed all photometric gates but identified as a spatial outlier by the robust rejection step.
+.. code-block:: bash
 
-**Star ring-plane occlusion:**
+   nav_offset coiss N1234567890 --nav-techniques '!BodyTerminatorNav'
 
-Before entering the star model or refinement loop, each star is checked against the ring-plane backplane for the observation's closest planet. Stars whose predicted image position falls within a configured opaque ring annulus receive a ``RING: <PLANET>`` conflict string and are excluded from the star model and refinement. Body intercept (``BODY: <NAME>``) takes precedence: if a star is already behind a planet or moon the ring check is skipped.
+Run both DT body techniques together:
 
-The ring annuli are configured per planet under ``stars.ring_occlusion_radii_km``. Each planet maps to a list of ``[inner_km, outer_km]`` pairs. A star is occluded if the sampled ring-plane radius falls inside any pair for that planet. Planets not listed have no ring occlusion.
+.. code-block:: bash
 
-Example from ``config_03_stars.yaml``:
+   nav_offset coiss N1234567890 --nav-techniques 'BodyLimbNav,BodyTerminatorNav'
 
-.. code-block:: yaml
-
-   stars:
-     ring_occlusion_enabled: true
-     ring_occlusion_radii_km:
-       SATURN:
-         - [74490.0, 91980.0]    # C ring
-         - [91980.0, 117580.0]   # B ring
-         - [122170.0, 136780.0]  # A ring (Cassini Division excluded)
-       URANUS:
-         - [41837.0, 51149.0]
-       NEPTUNE:
-         - [40900.0, 62933.0]
-
-* ``stars.ring_occlusion_enabled`` (default: true): Master switch. Set to ``false`` to disable ring-plane occlusion for all planets.
-
-* ``stars.ring_occlusion_radii_km``: Dict mapping uppercase planet names to lists of ``[inner_km, outer_km]`` annulus pairs. Each pair defines a radial range that is treated as opaque. Multiple pairs per planet allow gaps (e.g., the Cassini Division) to remain transparent.
-
-**When to use:**
-
-* Use ``correlate_all`` for automated batch processing of images
-* Best for images with clear features (stars, planetary bodies, or rings)
-* Suitable for both starfield and body-dominated images
-* Works well when you need consistent, reproducible results
-
-**Output:**
-
-The technique produces:
-* A pixel offset (dv, du) indicating the correction needed
-* Uncertainty estimates (sigma_v, sigma_u) based on the correlation quality and star refinement
-* Confidence score (typically 1.0 for successful correlations)
-* Metadata including correlation quality metrics and star refinement statistics
-
-manual
+Output
 ------
 
-The ``manual`` technique provides an interactive graphical interface for manually adjusting the navigation offset. This is useful when automated techniques fail or when expert judgment is needed.
-
-**How it works:**
-
-1. **Model Combination**: Like ``correlate_all``, the manual technique first creates a combined model from all available navigation models.
-
-2. **Interactive Dialog**: A PyQt6-based dialog window opens showing:
-   * The observed image (science data)
-   * The combined model overlaid on the image
-   * Pan and zoom controls for detailed inspection
-   * Offset adjustment controls (dv, du spin boxes)
-   * An "Auto" button that runs the same correlation algorithm used by ``correlate_all``
-
-3. **User Interaction**: The user can:
-   * Pan and zoom to examine details
-   * Manually adjust the offset using spin boxes
-   * Click "Auto" to get an automated correlation result as a starting point
-   * Accept or cancel the navigation
-
-4. **Result**: If the user accepts, the manually specified offset is used. The confidence is set to 1.0, and uncertainty is set to None (since it's a manual determination).
-
-**Configuration Options:**
-
-The manual technique uses the same correlation settings as ``correlate_all`` when the "Auto" button is clicked:
-* ``offset.correlation_fft_upsample_factor``: Controls the precision of the auto-correlation
-
-**When to use:**
-
-* Use ``manual`` when automated techniques fail or produce questionable results
-* Useful for images with poor quality, unusual features, or edge cases
-* Helpful for expert review and validation of automated results
-* Required when running in an environment with a display (X11 or similar)
-
-**Requirements:**
-
-* Requires a graphical display (X11, Wayland, or similar)
-* Requires PyQt6 to be installed
-* Not suitable for headless batch processing environments
-
-**Output:**
-
-The technique produces:
-* A pixel offset (dv, du) as specified by the user
-* Confidence score of 1.0 (user-accepted result)
-* Uncertainty set to None (manual determination)
+Every technique that runs contributes one entry to
+``NavResult.per_technique`` carrying the per-technique offset, 2x2
+covariance, calibrated confidence, and a typed ``*Diagnostics``
+dataclass.  The orchestrator's ensemble combine reconciles those
+entries into a single ``NavResult.offset_px`` and ``confidence_rank``;
+both numbers land in the per-image ``_metadata.json``.
 
 Navigation Models
 =================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "numpy>=2.2.0",
   "PyQt6",
   "rms-cloud_tasks>=0.1.2",
+  "rms-cspyce>=2.3.5",
   "rms-filecache>=3.0.0",
   "rms-imgdisp",
   "rms-julian>=3.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,11 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
   "astropy>=6.0",
+  "cspyce>=2.3.5",
   "matplotlib",
   "numpy>=2.2.0",
   "PyQt6",
-  "rms-cloud_tasks>=0.1.2",
-  "rms-cspyce>=2.3.5",
+  "cspyce>=2.3.5",
   "rms-filecache>=3.0.0",
   "rms-imgdisp",
   "rms-julian>=3.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
   "matplotlib",
   "numpy>=2.2.0",
   "PyQt6",
-  "cspyce>=2.3.5",
   "rms-filecache>=3.0.0",
   "rms-imgdisp",
   "rms-julian>=3.0.1",

--- a/src/nav/feature/__init__.py
+++ b/src/nav/feature/__init__.py
@@ -27,8 +27,6 @@ as each thread holds its own ``ObsSnapshotInst`` (the underlying ``oops``
 ``Backplane`` queries mutate global precision state).
 """
 
-import logging
-
 from nav.feature.composition import compose_template_features
 from nav.feature.constants import (
     AGREEMENT_FACTOR_CAP,
@@ -68,8 +66,6 @@ from nav.feature.reliability import (
     FeatureReliabilityGate,
     GatedFeatureRecord,
 )
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     'AGREEMENT_FACTOR_CAP',

--- a/src/nav/feature/reliability.py
+++ b/src/nav/feature/reliability.py
@@ -10,14 +10,11 @@ optional per-instrument overrides.  Default values defined here are used
 when no override is supplied by the loader.
 """
 
-import logging
 from dataclasses import dataclass, field
 from typing import Final
 
 from nav.feature.feature import NavFeature
 from nav.feature.feature_type import NavFeatureType
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     'DEFAULT_RELIABILITY_THRESHOLDS',

--- a/src/nav/nav_model/__init__.py
+++ b/src/nav/nav_model/__init__.py
@@ -30,8 +30,6 @@ Modules:
         Catalog-driven star ``NavModel`` and supporting helpers.
 """
 
-import logging
-
 from nav.nav_model.nav_model import NavModel, build_models_for_obs
 from nav.nav_model.nav_model_body import NavModelBody
 from nav.nav_model.nav_model_body_base import NavModelBodyBase
@@ -41,8 +39,6 @@ from nav.nav_model.nav_model_rings_base import NavModelRingsBase
 from nav.nav_model.nav_model_rings_simulated import NavModelRingsSimulated
 from nav.nav_model.nav_model_titan import NavModelTitan
 from nav.nav_model.stars import NavModelStars
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     'NavModel',

--- a/src/nav/nav_model/stars/__init__.py
+++ b/src/nav/nav_model/stars/__init__.py
@@ -15,8 +15,6 @@ orchestrator class:
   ``NavModel`` ABC.
 """
 
-import logging
-
 from nav.nav_model.stars.catalog import (
     CATALOG_MAGNITUDE_BINS,
     aberrate_star,
@@ -55,8 +53,6 @@ from nav.nav_model.stars.smeared_psf import (
     render_smeared_psf,
     smear_length_px,
 )
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     'CATALOG_MAGNITUDE_BINS',

--- a/src/nav/nav_orchestrator/__init__.py
+++ b/src/nav/nav_orchestrator/__init__.py
@@ -15,8 +15,11 @@ Modules:
     ``image_classifier_result``
         ``NavImageClassifierResult`` — output of the classifier.
     ``image_derivatives``
-        ``build_image_edge_dt`` and ``ImageDerivativesConfig`` — shared
-        gradient and edge-distance-transform computation.
+        ``build_image_edge_dt``, ``compute_image_gradient_vu``,
+        ``compute_all_image_derivatives``, and ``ImageDerivativesConfig`` —
+        shared gradient / edge-DT / gradient-vector computation.  The
+        combined entry point (``compute_all_image_derivatives``) shares
+        the heavy gaussian + sobel pass between all three products.
     ``provenance``
         ``Provenance`` — reproducibility metadata.
     ``ensemble``
@@ -48,6 +51,8 @@ from nav.nav_orchestrator.image_classifier_result import NavImageClassifierResul
 from nav.nav_orchestrator.image_derivatives import (
     ImageDerivativesConfig,
     build_image_edge_dt,
+    compute_all_image_derivatives,
+    compute_image_gradient_vu,
 )
 from nav.nav_orchestrator.nav_context import NavContext
 from nav.nav_orchestrator.nav_result import NavResult
@@ -70,6 +75,8 @@ __all__ = [
     'assert_diagnostic_fields_present',
     'build_image_edge_dt',
     'build_metadata_dict',
+    'compute_all_image_derivatives',
+    'compute_image_gradient_vu',
     'derive_confidence_rank',
     'ensemble',
 ]

--- a/src/nav/nav_orchestrator/__init__.py
+++ b/src/nav/nav_orchestrator/__init__.py
@@ -14,6 +14,9 @@ Modules:
         ``NavImageClassifier`` — quick-fail image-quality classifier.
     ``image_classifier_result``
         ``NavImageClassifierResult`` — output of the classifier.
+    ``image_derivatives``
+        ``build_image_edge_dt`` and ``ImageDerivativesConfig`` — shared
+        gradient and edge-distance-transform computation.
     ``provenance``
         ``Provenance`` — reproducibility metadata.
     ``ensemble``
@@ -26,8 +29,6 @@ Modules:
         ``STATUS_REASON_INFO_TEMPLATE`` — per-``status_reason`` operator log
         templates.
 """
-
-import logging
 
 from nav.nav_orchestrator.curator import (
     assert_diagnostic_fields_present,
@@ -44,17 +45,20 @@ from nav.nav_orchestrator.image_classifier import (
     NavImageClassifier,
 )
 from nav.nav_orchestrator.image_classifier_result import NavImageClassifierResult
+from nav.nav_orchestrator.image_derivatives import (
+    ImageDerivativesConfig,
+    build_image_edge_dt,
+)
 from nav.nav_orchestrator.nav_context import NavContext
 from nav.nav_orchestrator.nav_result import NavResult
 from nav.nav_orchestrator.orchestrator import NavOrchestrator
 from nav.nav_orchestrator.provenance import Provenance
 from nav.nav_orchestrator.status_reason_info import STATUS_REASON_INFO_TEMPLATE
 
-logging.getLogger(__name__).addHandler(logging.NullHandler())
-
 __all__ = [
     'STATUS_REASON_INFO_TEMPLATE',
     'EnsembleConfig',
+    'ImageDerivativesConfig',
     'ImageQualityThresholds',
     'NavContext',
     'NavFeatureSummary',
@@ -64,6 +68,7 @@ __all__ = [
     'NavResult',
     'Provenance',
     'assert_diagnostic_fields_present',
+    'build_image_edge_dt',
     'build_metadata_dict',
     'derive_confidence_rank',
     'ensemble',

--- a/src/nav/nav_orchestrator/curator.py
+++ b/src/nav/nav_orchestrator/curator.py
@@ -11,7 +11,6 @@ fails CI if a new diagnostic field is added without updating the allow-list.
 """
 
 import dataclasses
-import logging
 import math
 from typing import Any
 
@@ -21,8 +20,6 @@ from nav.nav_orchestrator.image_classifier_result import NavImageClassifierResul
 from nav.nav_orchestrator.nav_result import NavResult
 from nav.nav_orchestrator.provenance import Provenance
 from nav.nav_technique.technique_result import NavTechniqueResult
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     'assert_diagnostic_fields_present',

--- a/src/nav/nav_orchestrator/ensemble.py
+++ b/src/nav/nav_orchestrator/ensemble.py
@@ -17,7 +17,6 @@ correctness here is what makes the rest of the pipeline trustworthy.
 """
 
 import copy
-import logging
 import math
 from dataclasses import dataclass, field
 from typing import Any, cast
@@ -38,8 +37,6 @@ from nav.nav_orchestrator.provenance import Provenance
 from nav.nav_technique.technique_result import NavTechniqueResult
 from nav.support.status_reason import NavStatusReason
 from nav.support.types import NDArrayFloatType
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     'EnsembleConfig',

--- a/src/nav/nav_orchestrator/image_classifier.py
+++ b/src/nav/nav_orchestrator/image_classifier.py
@@ -16,7 +16,6 @@ takes them as constructor parameters so it stays pure-Python and unit-
 testable without loading config.
 """
 
-import logging
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -27,8 +26,6 @@ from nav.nav_orchestrator.image_classifier_result import (
 )
 from nav.support.noise_estimate import estimate_image_noise_sigma
 from nav.support.types import NDArrayBoolType, NDArrayFloatType
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     'ImageQualityThresholds',

--- a/src/nav/nav_orchestrator/image_derivatives.py
+++ b/src/nav/nav_orchestrator/image_derivatives.py
@@ -49,6 +49,7 @@ __all__ = [
     'DEFAULT_IMAGE_GRADIENT_SIGMA_PX',
     'ImageDerivativesConfig',
     'build_image_edge_dt',
+    'compute_all_image_derivatives',
     'compute_image_gradient_vu',
 ]
 
@@ -123,6 +124,96 @@ class ImageDerivativesConfig:
             )
 
 
+def _smooth_and_compute_gradients(
+    image_ext: NDArrayFloatType,
+    sigma_px: float,
+) -> tuple[NDArrayFloatType, NDArrayFloatType]:
+    """Smooth ``image_ext`` and return ``(g_v, g_u)`` Sobel gradients.
+
+    Shared core of :func:`build_image_edge_dt`,
+    :func:`compute_image_gradient_vu`, and
+    :func:`compute_all_image_derivatives`.  Each public entry point
+    delegates the gaussian + sobel pass to this helper so the heavy
+    smoothing only runs once per image when the orchestrator uses the
+    combined entry point.
+
+    Parameters:
+        image_ext: Extended-FOV image array.  Must be 2-D and finite.
+        sigma_px: Gaussian sigma (pixels).  Must be strictly positive.
+
+    Returns:
+        Tuple ``(gv, gu)`` of float64 arrays shaped like ``image_ext``.
+
+    Raises:
+        TypeError: if ``image_ext`` is not 2-D.
+        ValueError: if ``image_ext`` contains NaN or +/-inf, or if
+            ``sigma_px`` is not strictly positive.
+    """
+    if image_ext.ndim != 2:
+        raise TypeError(f'image_ext must be 2-D; got ndim={image_ext.ndim}')
+    if not np.isfinite(image_ext).all():
+        raise ValueError(
+            'image_ext must contain only finite values; NaN or +/-inf would '
+            'propagate through gaussian_filter / sobel and poison every '
+            'derivative downstream'
+        )
+    if not (math.isfinite(sigma_px) and sigma_px > 0.0):
+        raise ValueError(f'sigma_px must be a finite positive number; got {sigma_px!r}')
+    smoothed = gaussian_filter(image_ext.astype(np.float64), sigma=(sigma_px, sigma_px))
+    gv = sobel(smoothed, axis=0, mode='constant', cval=0.0)
+    gu = sobel(smoothed, axis=1, mode='constant', cval=0.0)
+    return cast(NDArrayFloatType, gv.astype(np.float64, copy=False)), cast(
+        NDArrayFloatType, gu.astype(np.float64, copy=False)
+    )
+
+
+def _build_edge_dt_from_gradients(
+    gv: NDArrayFloatType,
+    gu: NDArrayFloatType,
+    *,
+    edge_threshold_k_sigma: float,
+    dt_half_width_px: float,
+    image_noise_sigma: float,
+) -> tuple[NDArrayFloatType, NDArrayFloatType]:
+    """Return ``(gradient_magnitude, edge_dt)`` from precomputed ``(gv, gu)``.
+
+    The thresholding intentionally treats *every* edge pixel as a
+    candidate; the per-technique polarity filter rejects matches that
+    disagree on the gradient direction.  Empty thresholded masks fall
+    back to a saturated DT so downstream consumers always see a
+    fully-defined array.
+
+    Parameters:
+        gv: Per-pixel ``g_v`` Sobel-of-Gaussian derivative.
+        gu: Per-pixel ``g_u`` Sobel-of-Gaussian derivative.
+        edge_threshold_k_sigma: Multiples of ``image_noise_sigma`` used as
+            the gradient-magnitude threshold.
+        dt_half_width_px: Cap on the truncated distance transform.
+        image_noise_sigma: MAD noise sigma for the threshold scaling.
+
+    Returns:
+        ``(gradient_magnitude, edge_dt)`` float64 arrays.
+    """
+    gradient = np.hypot(gv, gu).astype(np.float64)
+    threshold = edge_threshold_k_sigma * image_noise_sigma
+    # Thin the gradient ridge to a one-pixel-wide edge map via Canny-style
+    # non-maximum suppression along the local gradient direction.  A naive
+    # 3x3 NMS would discard most edge pixels along a smooth ridge; the
+    # directional check compares each candidate only against the two
+    # neighbours along its own gradient direction, leaving the full edge
+    # length intact and producing a usable input for both the
+    # cross-correlation coarse search and the distance transform.
+    edge_mask = _directional_nms(gradient, gv, gu, threshold)
+    edge_dt = apply_filter(
+        edge_mask.astype(np.float64, copy=False),
+        NavFilterSpec(
+            kind=NavFilterKind.DISTANCE_TRANSFORM,
+            dt_half_width_px=dt_half_width_px,
+        ),
+    )
+    return cast(NDArrayFloatType, gradient), edge_dt
+
+
 def build_image_edge_dt(
     image_ext: NDArrayFloatType,
     image_noise_sigma: float,
@@ -138,6 +229,10 @@ def build_image_edge_dt(
     2. The distance transform of the thresholded gradient image, where the
        threshold is ``config.edge_threshold_k_sigma * image_noise_sigma``
        and the result is truncated at ``config.dt_half_width_px``.
+
+    For callers (the orchestrator) that need *both* this product and the
+    gradient-vector product, prefer :func:`compute_all_image_derivatives`
+    so the heavy smoothing + Sobel pass runs once instead of twice.
 
     Parameters:
         image_ext: Extended-FOV image array (post any source-image filter).
@@ -156,39 +251,17 @@ def build_image_edge_dt(
         ValueError: if ``image_ext`` contains NaN or +/-inf, or if
             ``image_noise_sigma`` is negative or non-finite.
     """
-    if image_ext.ndim != 2:
-        raise TypeError(f'image_ext must be 2-D; got ndim={image_ext.ndim}')
-    if not np.isfinite(image_ext).all():
-        raise ValueError(
-            'image_ext must contain only finite values; NaN or +/-inf would '
-            'propagate through gaussian_filter / sobel and poison the '
-            'gradient and DT outputs'
-        )
     if not (math.isfinite(image_noise_sigma) and image_noise_sigma >= 0.0):
         raise ValueError(f'image_noise_sigma must be finite and >= 0; got {image_noise_sigma!r}')
     cfg = config if config is not None else ImageDerivativesConfig()
-    sigma = cfg.image_gradient_sigma_px
-    smoothed = gaussian_filter(image_ext.astype(np.float64), sigma=(sigma, sigma))
-    gv = sobel(smoothed, axis=0, mode='constant', cval=0.0)
-    gu = sobel(smoothed, axis=1, mode='constant', cval=0.0)
-    gradient = np.hypot(gv, gu).astype(np.float64)
-    threshold = cfg.edge_threshold_k_sigma * image_noise_sigma
-    # Thin the gradient ridge to a one-pixel-wide edge map via Canny-style
-    # non-maximum suppression along the local gradient direction.  A naive
-    # 3x3 NMS would discard most edge pixels along a smooth ridge; the
-    # directional check compares each candidate only against the two
-    # neighbours along its own gradient direction, leaving the full edge
-    # length intact and producing a usable input for both the
-    # cross-correlation coarse search and the distance transform.
-    edge_mask = _directional_nms(gradient, gv, gu, threshold)
-    edge_dt = apply_filter(
-        edge_mask.astype(np.float64, copy=False),
-        NavFilterSpec(
-            kind=NavFilterKind.DISTANCE_TRANSFORM,
-            dt_half_width_px=cfg.dt_half_width_px,
-        ),
+    gv, gu = _smooth_and_compute_gradients(image_ext, cfg.image_gradient_sigma_px)
+    return _build_edge_dt_from_gradients(
+        gv,
+        gu,
+        edge_threshold_k_sigma=cfg.edge_threshold_k_sigma,
+        dt_half_width_px=cfg.dt_half_width_px,
+        image_noise_sigma=image_noise_sigma,
     )
-    return cast(NDArrayFloatType, gradient), edge_dt
 
 
 def _directional_nms(
@@ -260,6 +333,10 @@ def compute_image_gradient_vu(
     polarity filter, which compares the image gradient direction to the
     model's outward normal.
 
+    For callers (the orchestrator) that need this product alongside the
+    gradient magnitude / DT, prefer :func:`compute_all_image_derivatives`
+    so the heavy smoothing + Sobel pass runs once instead of twice.
+
     Parameters:
         image_ext: Extended-FOV image array.  Must be 2-D.
         sigma_px: Gaussian sigma (pixels) used before the Sobel operator.
@@ -275,18 +352,59 @@ def compute_image_gradient_vu(
         ValueError: if ``image_ext`` contains NaN or +/-inf, or if
             ``sigma_px`` is not strictly positive.
     """
-    if image_ext.ndim != 2:
-        raise TypeError(f'image_ext must be 2-D; got ndim={image_ext.ndim}')
-    if not np.isfinite(image_ext).all():
-        raise ValueError(
-            'image_ext must contain only finite values; NaN or +/-inf would '
-            'propagate through gaussian_filter / sobel and poison the '
-            'gradient-vector output'
-        )
-    if not (math.isfinite(sigma_px) and sigma_px > 0.0):
-        raise ValueError(f'sigma_px must be a finite positive number; got {sigma_px!r}')
-    smoothed = gaussian_filter(image_ext.astype(np.float64), sigma=(sigma_px, sigma_px))
-    gv = sobel(smoothed, axis=0, mode='constant', cval=0.0)
-    gu = sobel(smoothed, axis=1, mode='constant', cval=0.0)
+    gv, gu = _smooth_and_compute_gradients(image_ext, sigma_px)
     out = np.stack([gv, gu], axis=-1).astype(np.float64)
     return cast(NDArrayFloatType, out)
+
+
+def compute_all_image_derivatives(
+    image_ext: NDArrayFloatType,
+    image_noise_sigma: float,
+    *,
+    config: ImageDerivativesConfig | None = None,
+) -> tuple[NDArrayFloatType, NDArrayFloatType, NDArrayFloatType]:
+    """Compute every image-side derivative the orchestrator needs in one pass.
+
+    Returns the same products that :func:`build_image_edge_dt` and
+    :func:`compute_image_gradient_vu` produce separately, but shares the
+    single gaussian + sobel pass between them.  The orchestrator's
+    per-image setup uses this entry point so the heavy smoothing only
+    runs once even though three derivative products end up on the
+    :class:`~nav.nav_orchestrator.nav_context.NavContext`.
+
+    Parameters:
+        image_ext: Extended-FOV image array (post any source-image
+            filter).  Must be 2-D.
+        image_noise_sigma: MAD-derived noise sigma (DN units) used to
+            scale the gradient threshold.  Must be finite and
+            non-negative.
+        config: Optional override; when ``None`` the documented defaults
+            apply.
+
+    Returns:
+        Tuple ``(gradient_ext, edge_dt_ext, gradient_vu_ext)``:
+
+        - ``gradient_ext`` — gradient magnitude shaped ``(H, W)``.
+        - ``edge_dt_ext`` — truncated distance transform of the
+          thresholded edge mask, shaped ``(H, W)``.
+        - ``gradient_vu_ext`` — signed ``(g_v, g_u)`` gradient vector
+          image, shaped ``(H, W, 2)``.
+
+    Raises:
+        TypeError: if ``image_ext`` is not 2-D.
+        ValueError: if ``image_ext`` contains NaN or +/-inf, or if
+            ``image_noise_sigma`` is negative or non-finite.
+    """
+    if not (math.isfinite(image_noise_sigma) and image_noise_sigma >= 0.0):
+        raise ValueError(f'image_noise_sigma must be finite and >= 0; got {image_noise_sigma!r}')
+    cfg = config if config is not None else ImageDerivativesConfig()
+    gv, gu = _smooth_and_compute_gradients(image_ext, cfg.image_gradient_sigma_px)
+    gradient, edge_dt = _build_edge_dt_from_gradients(
+        gv,
+        gu,
+        edge_threshold_k_sigma=cfg.edge_threshold_k_sigma,
+        dt_half_width_px=cfg.dt_half_width_px,
+        image_noise_sigma=image_noise_sigma,
+    )
+    gradient_vu = np.stack([gv, gu], axis=-1).astype(np.float64)
+    return gradient, edge_dt, cast(NDArrayFloatType, gradient_vu)

--- a/src/nav/nav_orchestrator/image_derivatives.py
+++ b/src/nav/nav_orchestrator/image_derivatives.py
@@ -153,10 +153,17 @@ def build_image_edge_dt(
 
     Raises:
         TypeError: if ``image_ext`` is not 2-D.
-        ValueError: if ``image_noise_sigma`` is negative or non-finite.
+        ValueError: if ``image_ext`` contains NaN or +/-inf, or if
+            ``image_noise_sigma`` is negative or non-finite.
     """
     if image_ext.ndim != 2:
         raise TypeError(f'image_ext must be 2-D; got ndim={image_ext.ndim}')
+    if not np.isfinite(image_ext).all():
+        raise ValueError(
+            'image_ext must contain only finite values; NaN or +/-inf would '
+            'propagate through gaussian_filter / sobel and poison the '
+            'gradient and DT outputs'
+        )
     if not (math.isfinite(image_noise_sigma) and image_noise_sigma >= 0.0):
         raise ValueError(f'image_noise_sigma must be finite and >= 0; got {image_noise_sigma!r}')
     cfg = config if config is not None else ImageDerivativesConfig()
@@ -265,10 +272,17 @@ def compute_image_gradient_vu(
 
     Raises:
         TypeError: if ``image_ext`` is not 2-D.
-        ValueError: if ``sigma_px`` is not strictly positive.
+        ValueError: if ``image_ext`` contains NaN or +/-inf, or if
+            ``sigma_px`` is not strictly positive.
     """
     if image_ext.ndim != 2:
         raise TypeError(f'image_ext must be 2-D; got ndim={image_ext.ndim}')
+    if not np.isfinite(image_ext).all():
+        raise ValueError(
+            'image_ext must contain only finite values; NaN or +/-inf would '
+            'propagate through gaussian_filter / sobel and poison the '
+            'gradient-vector output'
+        )
     if not (math.isfinite(sigma_px) and sigma_px > 0.0):
         raise ValueError(f'sigma_px must be a finite positive number; got {sigma_px!r}')
     smoothed = gaussian_filter(image_ext.astype(np.float64), sigma=(sigma_px, sigma_px))

--- a/src/nav/nav_orchestrator/image_derivatives.py
+++ b/src/nav/nav_orchestrator/image_derivatives.py
@@ -1,0 +1,268 @@
+"""Shared image-side derivatives consumed by every DT-based technique.
+
+The orchestrator computes one gradient-magnitude image, one gradient-vector
+image, and one signed distance-transform image per navigation; every limb /
+terminator / ring-edge technique then samples those products at its own
+model polylines.  Computing them once keeps the per-image cost bounded
+regardless of how many DT techniques run.
+
+Three quantities are produced and attached to the per-image
+:class:`~nav.nav_orchestrator.nav_context.NavContext`:
+
+``image_gradient_ext``
+    Gradient magnitude of the source image after a Gaussian blur at
+    :attr:`ImageDerivativesConfig.image_gradient_sigma_px`.  Used by the
+    technique-side polarity / gating logic when only a magnitude readout is
+    needed.
+
+``image_gradient_vu_ext``
+    Per-pixel ``(g_v, g_u)`` gradient vector after the same Gaussian blur.
+    Sampled by the polarity filter to compare the image's edge direction
+    with the model's outward normal at each polyline vertex.
+
+``image_edge_dt_ext``
+    Distance transform of the binarised gradient image, with the threshold
+    chosen as ``edge_threshold_k_sigma * image_noise_sigma``.  The DT is
+    truncated at :data:`DEFAULT_DT_HALF_WIDTH_PX` so the per-pixel cost is
+    bounded for the DT-based techniques' Levenberg-Marquardt step.
+
+The thresholding intentionally treats *every* edge pixel as a candidate; the
+per-technique polarity filter rejects matches that disagree on the gradient
+direction.  A non-empty gradient image always produces a fully-defined DT
+because :func:`build_image_edge_dt` falls back to a pure-saturation array
+when no pixel exceeds the threshold.
+"""
+
+from dataclasses import dataclass
+from typing import cast
+
+import numpy as np
+from scipy.ndimage import gaussian_filter, sobel
+
+from nav.support.filters import NavFilterKind, NavFilterSpec, apply_filter
+from nav.support.types import NDArrayFloatType
+
+__all__ = [
+    'DEFAULT_DT_HALF_WIDTH_PX',
+    'DEFAULT_EDGE_THRESHOLD_K_SIGMA',
+    'DEFAULT_IMAGE_GRADIENT_SIGMA_PX',
+    'ImageDerivativesConfig',
+    'build_image_edge_dt',
+    'compute_image_gradient_vu',
+]
+
+
+DEFAULT_IMAGE_GRADIENT_SIGMA_PX: float = 1.2
+"""Default Gaussian sigma (pixels) used to smooth before the gradient operator.
+
+A 1.2 pixel sigma matches the typical instrument PSF; below that the
+gradient is dominated by single-pixel noise, above it sharp limbs blur out
+and the DT loses contrast against the background.
+"""
+
+
+DEFAULT_EDGE_THRESHOLD_K_SIGMA: float = 4.0
+"""Default gradient-magnitude threshold expressed as multiples of MAD noise.
+
+Pixels whose smoothed-gradient magnitude exceeds
+``edge_threshold_k_sigma * image_noise_sigma`` are kept as edge candidates.
+A 4-sigma threshold keeps single-pixel noise excursions out of the DT
+input while letting limb / terminator / ring edges through with margin
+to spare.
+"""
+
+
+DEFAULT_DT_HALF_WIDTH_PX: float = 64.0
+"""Maximum distance returned by the truncated distance transform.
+
+Pixels farther than this from any thresholded gradient pixel saturate at
+``DEFAULT_DT_HALF_WIDTH_PX``.  The cap bounds the LM cost contribution from
+vertices that fall in completely-empty regions of the image and bounds the
+DT array's working range to a documented maximum.
+"""
+
+
+@dataclass(frozen=True)
+class ImageDerivativesConfig:
+    """Configuration for the shared gradient + DT computation.
+
+    Parameters:
+        image_gradient_sigma_px: Gaussian sigma (pixels) used before the
+            gradient operator.  Both axes share the same value;
+            anisotropic blur is intentionally not exposed here because the
+            image-side computation must be feature-agnostic.
+        edge_threshold_k_sigma: Multiples of ``image_noise_sigma`` used to
+            threshold the gradient magnitude into a binary edge mask.
+        dt_half_width_px: Cap on the DT distance.  Vertices farther than
+            this from any edge pixel see a constant cost.
+
+    Raises:
+        ValueError: if any field is not strictly positive.
+    """
+
+    image_gradient_sigma_px: float = DEFAULT_IMAGE_GRADIENT_SIGMA_PX
+    edge_threshold_k_sigma: float = DEFAULT_EDGE_THRESHOLD_K_SIGMA
+    dt_half_width_px: float = DEFAULT_DT_HALF_WIDTH_PX
+
+    def __post_init__(self) -> None:
+        """Validate the three positive-real parameters."""
+        if not (self.image_gradient_sigma_px > 0.0):
+            raise ValueError(
+                f'image_gradient_sigma_px must be > 0; got {self.image_gradient_sigma_px!r}'
+            )
+        if not (self.edge_threshold_k_sigma > 0.0):
+            raise ValueError(
+                f'edge_threshold_k_sigma must be > 0; got {self.edge_threshold_k_sigma!r}'
+            )
+        if not (self.dt_half_width_px > 0.0):
+            raise ValueError(f'dt_half_width_px must be > 0; got {self.dt_half_width_px!r}')
+
+
+def build_image_edge_dt(
+    image_ext: NDArrayFloatType,
+    image_noise_sigma: float,
+    *,
+    config: ImageDerivativesConfig | None = None,
+) -> tuple[NDArrayFloatType, NDArrayFloatType]:
+    """Compute the shared gradient and edge-distance-transform images.
+
+    Two independent products are returned, both aligned to ``image_ext``:
+
+    1. The gradient magnitude after a Gaussian smooth at
+       ``config.image_gradient_sigma_px``.
+    2. The distance transform of the thresholded gradient image, where the
+       threshold is ``config.edge_threshold_k_sigma * image_noise_sigma``
+       and the result is truncated at ``config.dt_half_width_px``.
+
+    Parameters:
+        image_ext: Extended-FOV image array (post any source-image filter).
+            Must be 2-D.
+        image_noise_sigma: MAD-derived noise sigma (DN units) used to scale
+            the gradient threshold.  Must be finite and non-negative.
+        config: Optional override; when ``None`` the documented defaults
+            apply.
+
+    Returns:
+        Tuple ``(gradient_ext, edge_dt_ext)`` of float64 arrays, each
+        shaped like ``image_ext``.
+
+    Raises:
+        TypeError: if ``image_ext`` is not 2-D.
+        ValueError: if ``image_noise_sigma`` is negative or non-finite.
+    """
+    if image_ext.ndim != 2:
+        raise TypeError(f'image_ext must be 2-D; got ndim={image_ext.ndim}')
+    if not (image_noise_sigma >= 0.0) or image_noise_sigma != image_noise_sigma:
+        raise ValueError(f'image_noise_sigma must be finite and >= 0; got {image_noise_sigma!r}')
+    cfg = config if config is not None else ImageDerivativesConfig()
+    sigma = cfg.image_gradient_sigma_px
+    smoothed = gaussian_filter(image_ext.astype(np.float64), sigma=(sigma, sigma))
+    gv = sobel(smoothed, axis=0, mode='constant', cval=0.0)
+    gu = sobel(smoothed, axis=1, mode='constant', cval=0.0)
+    gradient = np.hypot(gv, gu).astype(np.float64)
+    threshold = cfg.edge_threshold_k_sigma * image_noise_sigma
+    # Thin the gradient ridge to a one-pixel-wide edge map via Canny-style
+    # non-maximum suppression along the local gradient direction.  A naive
+    # 3x3 NMS would discard most edge pixels along a smooth ridge; the
+    # directional check compares each candidate only against the two
+    # neighbours along its own gradient direction, leaving the full edge
+    # length intact and producing a usable input for both the
+    # cross-correlation coarse search and the distance transform.
+    edge_mask = _directional_nms(gradient, gv, gu, threshold)
+    edge_dt = apply_filter(
+        edge_mask.astype(np.float64, copy=False),
+        NavFilterSpec(
+            kind=NavFilterKind.DISTANCE_TRANSFORM,
+            dt_half_width_px=cfg.dt_half_width_px,
+        ),
+    )
+    return cast(NDArrayFloatType, gradient), edge_dt
+
+
+def _directional_nms(
+    gradient_magnitude: NDArrayFloatType,
+    gv: NDArrayFloatType,
+    gu: NDArrayFloatType,
+    threshold: float,
+) -> NDArrayFloatType:
+    """Return a Canny-style thin edge mask in float form (0.0 / 1.0).
+
+    Each pixel above ``threshold`` is kept only if its magnitude is at
+    least as large as both of its neighbours along the local gradient
+    direction.  The gradient direction is quantised to four cardinal
+    sectors (0, 45, 90, 135 degrees from horizontal) so the lookup
+    reduces to a small fixed set of shifts.
+
+    Parameters:
+        gradient_magnitude: 2-D non-negative gradient magnitude image.
+        gv: 2-D Sobel-of-Gaussian derivative along v.
+        gu: 2-D Sobel-of-Gaussian derivative along u.
+        threshold: Magnitude threshold; pixels at or below this value
+            are discarded regardless of NMS outcome.
+
+    Returns:
+        2-D float64 mask with 1.0 at retained edge pixels and 0.0
+        elsewhere.
+    """
+    abs_gv = np.abs(gv)
+    abs_gu = np.abs(gu)
+    diag = abs_gv * 0.4142135623730951  # tan(22.5 deg) approximation
+    sector_horizontal = abs_gu >= abs_gv + diag
+    sector_vertical = abs_gv >= abs_gu + diag
+    sector_diag_pos = (~sector_horizontal) & (~sector_vertical) & (gv * gu >= 0)
+    sector_diag_neg = (~sector_horizontal) & (~sector_vertical) & (gv * gu < 0)
+    pad = np.pad(gradient_magnitude, 1, mode='constant', constant_values=-np.inf)
+    center = pad[1:-1, 1:-1]
+    left = pad[1:-1, :-2]
+    right = pad[1:-1, 2:]
+    up = pad[:-2, 1:-1]
+    down = pad[2:, 1:-1]
+    up_left = pad[:-2, :-2]
+    down_right = pad[2:, 2:]
+    up_right = pad[:-2, 2:]
+    down_left = pad[2:, :-2]
+    keep_horizontal = sector_horizontal & (center >= left) & (center >= right)
+    keep_vertical = sector_vertical & (center >= up) & (center >= down)
+    keep_diag_pos = sector_diag_pos & (center >= up_left) & (center >= down_right)
+    keep_diag_neg = sector_diag_neg & (center >= up_right) & (center >= down_left)
+    keep = keep_horizontal | keep_vertical | keep_diag_pos | keep_diag_neg
+    edge_mask = np.where(keep & (gradient_magnitude > threshold), 1.0, 0.0).astype(np.float64)
+    return cast(NDArrayFloatType, edge_mask)
+
+
+def compute_image_gradient_vu(
+    image_ext: NDArrayFloatType,
+    *,
+    sigma_px: float = DEFAULT_IMAGE_GRADIENT_SIGMA_PX,
+) -> NDArrayFloatType:
+    """Compute the per-pixel ``(g_v, g_u)`` gradient vector image.
+
+    The image is first smoothed with an isotropic Gaussian of standard
+    deviation ``sigma_px``; gradients are then computed by Sobel along each
+    axis.  The output preserves the sign of the gradient — required by the
+    polarity filter, which compares the image gradient direction to the
+    model's outward normal.
+
+    Parameters:
+        image_ext: Extended-FOV image array.  Must be 2-D.
+        sigma_px: Gaussian sigma (pixels) used before the Sobel operator.
+            Must be strictly positive.
+
+    Returns:
+        ``(H, W, 2)`` float64 array; the last axis stacks the v-component
+        and the u-component of the gradient (``out[..., 0]`` is ``g_v``,
+        ``out[..., 1]`` is ``g_u``).
+
+    Raises:
+        TypeError: if ``image_ext`` is not 2-D.
+        ValueError: if ``sigma_px`` is not strictly positive.
+    """
+    if image_ext.ndim != 2:
+        raise TypeError(f'image_ext must be 2-D; got ndim={image_ext.ndim}')
+    if not (sigma_px > 0.0):
+        raise ValueError(f'sigma_px must be > 0; got {sigma_px!r}')
+    smoothed = gaussian_filter(image_ext.astype(np.float64), sigma=(sigma_px, sigma_px))
+    gv = sobel(smoothed, axis=0, mode='constant', cval=0.0)
+    gu = sobel(smoothed, axis=1, mode='constant', cval=0.0)
+    out = np.stack([gv, gu], axis=-1).astype(np.float64)
+    return cast(NDArrayFloatType, out)

--- a/src/nav/nav_orchestrator/image_derivatives.py
+++ b/src/nav/nav_orchestrator/image_derivatives.py
@@ -33,6 +33,7 @@ because :func:`build_image_edge_dt` falls back to a pure-saturation array
 when no pixel exceeds the threshold.
 """
 
+import math
 from dataclasses import dataclass
 from typing import cast
 
@@ -106,16 +107,20 @@ class ImageDerivativesConfig:
 
     def __post_init__(self) -> None:
         """Validate the three positive-real parameters."""
-        if not (self.image_gradient_sigma_px > 0.0):
+        if not (math.isfinite(self.image_gradient_sigma_px) and self.image_gradient_sigma_px > 0.0):
             raise ValueError(
-                f'image_gradient_sigma_px must be > 0; got {self.image_gradient_sigma_px!r}'
+                'image_gradient_sigma_px must be a finite positive number; '
+                f'got {self.image_gradient_sigma_px!r}'
             )
-        if not (self.edge_threshold_k_sigma > 0.0):
+        if not (math.isfinite(self.edge_threshold_k_sigma) and self.edge_threshold_k_sigma > 0.0):
             raise ValueError(
-                f'edge_threshold_k_sigma must be > 0; got {self.edge_threshold_k_sigma!r}'
+                'edge_threshold_k_sigma must be a finite positive number; '
+                f'got {self.edge_threshold_k_sigma!r}'
             )
-        if not (self.dt_half_width_px > 0.0):
-            raise ValueError(f'dt_half_width_px must be > 0; got {self.dt_half_width_px!r}')
+        if not (math.isfinite(self.dt_half_width_px) and self.dt_half_width_px > 0.0):
+            raise ValueError(
+                f'dt_half_width_px must be a finite positive number; got {self.dt_half_width_px!r}'
+            )
 
 
 def build_image_edge_dt(
@@ -152,7 +157,7 @@ def build_image_edge_dt(
     """
     if image_ext.ndim != 2:
         raise TypeError(f'image_ext must be 2-D; got ndim={image_ext.ndim}')
-    if not (image_noise_sigma >= 0.0) or image_noise_sigma != image_noise_sigma:
+    if not (math.isfinite(image_noise_sigma) and image_noise_sigma >= 0.0):
         raise ValueError(f'image_noise_sigma must be finite and >= 0; got {image_noise_sigma!r}')
     cfg = config if config is not None else ImageDerivativesConfig()
     sigma = cfg.image_gradient_sigma_px
@@ -206,9 +211,14 @@ def _directional_nms(
     """
     abs_gv = np.abs(gv)
     abs_gu = np.abs(gu)
-    diag = abs_gv * 0.4142135623730951  # tan(22.5 deg) approximation
-    sector_horizontal = abs_gu >= abs_gv + diag
-    sector_vertical = abs_gv >= abs_gu + diag
+    # Standard Canny quantisation splits the half-circle of gradient
+    # directions into four 45-degree sectors with boundaries at 22.5,
+    # 67.5, 112.5, and 157.5 degrees from the u-axis.  A direction
+    # belongs to the horizontal sector when |angle| <= 22.5 deg, i.e.
+    # |gu| >= |gv| * cot(22.5 deg).  cot(22.5 deg) = 1 + sqrt(2).
+    cot_22_5 = 2.414213562373095
+    sector_horizontal = abs_gu >= abs_gv * cot_22_5
+    sector_vertical = abs_gv >= abs_gu * cot_22_5
     sector_diag_pos = (~sector_horizontal) & (~sector_vertical) & (gv * gu >= 0)
     sector_diag_neg = (~sector_horizontal) & (~sector_vertical) & (gv * gu < 0)
     pad = np.pad(gradient_magnitude, 1, mode='constant', constant_values=-np.inf)
@@ -259,8 +269,8 @@ def compute_image_gradient_vu(
     """
     if image_ext.ndim != 2:
         raise TypeError(f'image_ext must be 2-D; got ndim={image_ext.ndim}')
-    if not (sigma_px > 0.0):
-        raise ValueError(f'sigma_px must be > 0; got {sigma_px!r}')
+    if not (math.isfinite(sigma_px) and sigma_px > 0.0):
+        raise ValueError(f'sigma_px must be a finite positive number; got {sigma_px!r}')
     smoothed = gaussian_filter(image_ext.astype(np.float64), sigma=(sigma_px, sigma_px))
     gv = sobel(smoothed, axis=0, mode='constant', cval=0.0)
     gu = sobel(smoothed, axis=1, mode='constant', cval=0.0)

--- a/src/nav/nav_orchestrator/nav_context.py
+++ b/src/nav/nav_orchestrator/nav_context.py
@@ -47,6 +47,11 @@ class NavContext:
         image_classifier: The image-quality classifier's verdict.
         image_gradient_ext: Optional shared Sobel-of-Gaussian magnitude
             (computed once, reused by every DT-based technique).
+        image_gradient_vu_ext: Optional ``(H, W, 2)`` per-pixel
+            gradient-vector image (``[..., 0]`` is ``g_v``,
+            ``[..., 1]`` is ``g_u``).  Sampled by the polarity filter to
+            compare each model vertex's outward normal against the image's
+            edge direction.
         image_edge_dt_ext: Optional shared signed distance transform of the
             thresholded gradient image.
         prior_offset_px: Prior offset from pass 1, ``None`` on pass 1.
@@ -65,6 +70,7 @@ class NavContext:
     image_classifier: NavImageClassifierResult
     provenance: Provenance
     image_gradient_ext: NDArrayFloatType | None = None
+    image_gradient_vu_ext: NDArrayFloatType | None = None
     image_edge_dt_ext: NDArrayFloatType | None = None
     prior_offset_px: tuple[float, float] | None = None
     prior_covariance_px2: NDArrayFloatType | None = None

--- a/src/nav/nav_orchestrator/orchestrator.py
+++ b/src/nav/nav_orchestrator/orchestrator.py
@@ -40,8 +40,7 @@ from nav.nav_orchestrator.image_classifier_result import (
 )
 from nav.nav_orchestrator.image_derivatives import (
     ImageDerivativesConfig,
-    build_image_edge_dt,
-    compute_image_gradient_vu,
+    compute_all_image_derivatives,
 )
 from nav.nav_orchestrator.nav_context import NavContext
 from nav.nav_orchestrator.nav_result import NavResult
@@ -357,14 +356,14 @@ class NavOrchestrator(NavBase):
             if classifier_result.noise_sigma > 0.0
             else estimate_image_noise_sigma(image, sensor_mask)
         )
-        gradient_ext, edge_dt_ext = build_image_edge_dt(
+        # Single-pass derivative computation: one gaussian + sobel pair
+        # produces gradient magnitude, edge DT, and the signed gradient
+        # vector image together rather than doing the heavy smoothing
+        # twice for separate calls.
+        gradient_ext, edge_dt_ext, gradient_vu_ext = compute_all_image_derivatives(
             image,
             noise_sigma,
             config=self._image_derivatives_config,
-        )
-        gradient_vu_ext = compute_image_gradient_vu(
-            image,
-            sigma_px=self._image_derivatives_config.image_gradient_sigma_px,
         )
         context = NavContext(
             obs=obs,

--- a/src/nav/nav_orchestrator/orchestrator.py
+++ b/src/nav/nav_orchestrator/orchestrator.py
@@ -18,7 +18,6 @@ models or techniques run for debugging (``only_models='body:MIMAS'``,
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -39,6 +38,11 @@ from nav.nav_orchestrator.image_classifier_result import (
     ImageClass,
     NavImageClassifierResult,
 )
+from nav.nav_orchestrator.image_derivatives import (
+    ImageDerivativesConfig,
+    build_image_edge_dt,
+    compute_image_gradient_vu,
+)
 from nav.nav_orchestrator.nav_context import NavContext
 from nav.nav_orchestrator.nav_result import NavResult
 from nav.nav_orchestrator.provenance import Provenance
@@ -51,8 +55,6 @@ from nav.support.status_reason import NavStatusReason
 
 if TYPE_CHECKING:  # pragma: no cover - typing-only import
     from nav.obs import ObsSnapshotInst
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     'NavOrchestrator',
@@ -132,6 +134,7 @@ class NavOrchestrator(NavBase):
         only_techniques: str | list[str] = '*',
         ensemble_config: EnsembleConfig | None = None,
         image_quality_thresholds: ImageQualityThresholds | None = None,
+        image_derivatives_config: ImageDerivativesConfig | None = None,
         rms_nav_version: str = '0.0.0',
     ) -> None:
         super().__init__(config=config)
@@ -143,6 +146,7 @@ class NavOrchestrator(NavBase):
         self._image_classifier = NavImageClassifier(
             thresholds=image_quality_thresholds or ImageQualityThresholds()
         )
+        self._image_derivatives_config = image_derivatives_config or ImageDerivativesConfig()
         self._gate = FeatureReliabilityGate()
         self._rms_nav_version = rms_nav_version
 
@@ -353,6 +357,15 @@ class NavOrchestrator(NavBase):
             if classifier_result.noise_sigma > 0.0
             else estimate_image_noise_sigma(image, sensor_mask)
         )
+        gradient_ext, edge_dt_ext = build_image_edge_dt(
+            image,
+            noise_sigma,
+            config=self._image_derivatives_config,
+        )
+        gradient_vu_ext = compute_image_gradient_vu(
+            image,
+            sigma_px=self._image_derivatives_config.image_gradient_sigma_px,
+        )
         context = NavContext(
             obs=obs,
             image_ext=image,
@@ -362,6 +375,9 @@ class NavOrchestrator(NavBase):
             cosmic_ray_mask_ext=cr_mask,
             image_classifier=classifier_result,
             provenance=provenance,
+            image_gradient_ext=gradient_ext,
+            image_gradient_vu_ext=gradient_vu_ext,
+            image_edge_dt_ext=edge_dt_ext,
         )
         return context, classifier_result
 

--- a/src/nav/nav_technique/__init__.py
+++ b/src/nav/nav_technique/__init__.py
@@ -19,8 +19,6 @@ Modules:
         / ``ConfidenceTerm`` dataclasses.
 """
 
-import logging
-
 from nav.nav_technique.confidence import (
     ConfidenceSpec,
     ConfidenceTerm,
@@ -31,7 +29,6 @@ from nav.nav_technique.diagnostics import (
     BodyDiscDiagnostics,
     BodyLimbDiagnostics,
     BodyTerminatorDiagnostics,
-    CartographicDiagnostics,
     NavTechniqueDiagnostics,
     RingAnnulusDiagnostics,
     RingEdgeDiagnostics,
@@ -41,17 +38,19 @@ from nav.nav_technique.diagnostics import (
 )
 from nav.nav_technique.feasibility import NavFeasibilityReport
 from nav.nav_technique.nav_technique import NavTechnique, filter_technique_names
+from nav.nav_technique.nav_technique_body_limb import BodyLimbNav
+from nav.nav_technique.nav_technique_body_terminator import BodyTerminatorNav
 from nav.nav_technique.nav_technique_manual import NavTechniqueManual
+from nav.nav_technique.nav_technique_ring_edge import RingEdgeNav
 from nav.nav_technique.technique_result import NavTechniqueResult
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     'BodyBlobDiagnostics',
     'BodyDiscDiagnostics',
     'BodyLimbDiagnostics',
+    'BodyLimbNav',
     'BodyTerminatorDiagnostics',
-    'CartographicDiagnostics',
+    'BodyTerminatorNav',
     'ConfidenceSpec',
     'ConfidenceTerm',
     'NavFeasibilityReport',
@@ -61,6 +60,7 @@ __all__ = [
     'NavTechniqueResult',
     'RingAnnulusDiagnostics',
     'RingEdgeDiagnostics',
+    'RingEdgeNav',
     'StarFieldDiagnostics',
     'StarRefineDiagnostics',
     'StarUniqueMatchDiagnostics',

--- a/src/nav/nav_technique/confidence.py
+++ b/src/nav/nav_technique/confidence.py
@@ -14,7 +14,6 @@ uniformly and a config-load validation pass can verify every spec at
 startup.
 """
 
-import logging
 import math
 from dataclasses import dataclass, field
 from typing import Any
@@ -24,9 +23,6 @@ __all__ = [
     'ConfidenceTerm',
     'evaluate_sigmoid_combination',
 ]
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
-
 
 _NumberType = (int, float)
 

--- a/src/nav/nav_technique/diagnostics.py
+++ b/src/nav/nav_technique/diagnostics.py
@@ -257,8 +257,7 @@ NavTechniqueDiagnostics = (
 )
 """Sum type spanning every per-technique diagnostics dataclass.
 
-A ``CartographicDiagnostics`` variant returns alongside ``CartographicNav``
-when the technique itself lands; the diagnostics class lives in git history
-(see the cutover commits) until then so production code does not carry a
-dataclass that no technique populates.
+The orchestrator's curator and the technique-result type both consume
+this union; adding a new technique means adding both its diagnostics
+dataclass above and a new entry into this union.
 """

--- a/src/nav/nav_technique/diagnostics.py
+++ b/src/nav/nav_technique/diagnostics.py
@@ -14,7 +14,6 @@ __all__ = [
     'BodyDiscDiagnostics',
     'BodyLimbDiagnostics',
     'BodyTerminatorDiagnostics',
-    'CartographicDiagnostics',
     'NavTechniqueDiagnostics',
     'RingAnnulusDiagnostics',
     'RingEdgeDiagnostics',
@@ -245,27 +244,6 @@ class StarRefineDiagnostics:
     }
 
 
-@dataclass(frozen=True)
-class CartographicDiagnostics:
-    """Diagnostics emitted by ``CartographicNav``.
-
-    Parameters:
-        ncc_peak: Peak NCC value.
-        visible_body_area_px: Cartographic-model area in pixels that
-            overlapped the predicted body silhouette.
-        used_gradient: True if gradient mode was selected.
-    """
-
-    ncc_peak: float = 0.0
-    visible_body_area_px: float = 0.0
-    used_gradient: bool = False
-    CURATOR_FIELDS: ClassVar[dict[str, str | None]] = {
-        'ncc_peak': 'ncc_peak',
-        'visible_body_area_px': 'visible_body_area_px',
-        'used_gradient': 'used_gradient',
-    }
-
-
 NavTechniqueDiagnostics = (
     BodyDiscDiagnostics
     | BodyLimbDiagnostics
@@ -276,6 +254,11 @@ NavTechniqueDiagnostics = (
     | StarFieldDiagnostics
     | StarUniqueMatchDiagnostics
     | StarRefineDiagnostics
-    | CartographicDiagnostics
 )
-"""Sum type spanning every per-technique diagnostics dataclass."""
+"""Sum type spanning every per-technique diagnostics dataclass.
+
+A ``CartographicDiagnostics`` variant returns alongside ``CartographicNav``
+when the technique itself lands; the diagnostics class lives in git history
+(see the cutover commits) until then so production code does not carry a
+dataclass that no technique populates.
+"""

--- a/src/nav/nav_technique/dt_fitting.py
+++ b/src/nav/nav_technique/dt_fitting.py
@@ -151,7 +151,6 @@ def coarse_ncc_search(
         raise ValueError(f'search_window_vu must be non-negative; got {search_window_vu!r}')
     height, width = edge_mask.shape
     edge_f = edge_mask.astype(np.float64, copy=False)
-    poly_f = polyline_mask.astype(np.float64, copy=False)
     # Scan the bounded window directly: brute-force over O(margin_v * margin_u)
     # offsets is faster than FFT for the typical (50, 50) margins on a
     # 1024 x 1024 image because the cross-correlation involves only the
@@ -176,10 +175,11 @@ def coarse_ncc_search(
                 continue
             sv = shifted_v[valid]
             su = shifted_u[valid]
-            score = float(edge_f[sv, su].sum() * poly_f[poly_vs[valid], poly_us[valid]].sum())
-            # Use the squared score to keep computation in non-negative
-            # ints; ``poly_f[...]`` is constant 1 along ``valid``, so
-            # ``score`` reduces to the overlap count of edge pixels.
+            # Score is the count of polyline points (after shift) that fall
+            # on edge pixels.  ``edge_mask`` is binary, so summing the
+            # binary slice over the in-bounds polyline indices gives the
+            # number of overlapping pixels directly.
+            score = float(edge_f[sv, su].sum())
             key = (abs(dv) + abs(du), abs(dv), dv, du)
             if score > best_score or (score == best_score and key < best_key):
                 best_score = score
@@ -598,8 +598,8 @@ def lm_subpixel_refine(
     verts = np.asarray(vertices_vu, np.float64)
     norms = np.asarray(normals_vu, np.float64)
     sigmas = np.asarray(sigma_normal_per_vertex_px, np.float64)
-    if verts.ndim != 2 or verts.shape[1] != 2:
-        raise ValueError(f'vertices_vu must have shape (N, 2); got {verts.shape}')
+    if verts.ndim != 2 or verts.shape[1] != 2 or verts.shape[0] == 0:
+        raise ValueError(f'vertices_vu must have shape (N, 2) with N > 0; got {verts.shape}')
     if norms.shape != verts.shape:
         raise ValueError(f'normals_vu must match vertices_vu shape; got {norms.shape}')
     if sigmas.ndim != 1 or sigmas.shape[0] != verts.shape[0]:

--- a/src/nav/nav_technique/dt_fitting.py
+++ b/src/nav/nav_technique/dt_fitting.py
@@ -702,27 +702,31 @@ def lm_subpixel_refine(
                 pivot_distance_px=pivot_distance_px,
             )
             state.iteration += 1
+            # Recompute residuals / weights / Jacobian at the accepted pose
+            # immediately so diagnostics (rms_px, inlier_count, covariance)
+            # reflect the committed parameters even if the loop exits via
+            # max_iterations on the next check.  Without this, an accepted
+            # step in the final iteration would leave state.raw_residuals /
+            # state.weights / state.jacobian reflecting the pre-step pose.
+            residuals_final, jacobian_final = _compute_residuals_and_jacobian(
+                vertices_vu=verts,
+                pivot_vu=pivot,
+                image_dt=image_edge_dt,
+                dv=state.dv,
+                du=state.du,
+                dtheta=state.dtheta,
+                fit_rotation=fit_rotation,
+            )
+            residuals_final = np.where(
+                state.polarity_mask, residuals_final, _INFINITY_DT_PENALTY_PX
+            )
+            final_scaled = residuals_final / sigmas
+            final_tukey = tukey_biweight_weights(final_scaled, c=tukey_c)
+            state.raw_residuals = residuals_final
+            state.weights = inv_sigma_sq * final_tukey
+            state.jacobian = jacobian_final
             if step_norm < step_tolerance_px:
                 state.converged = True
-                # Recompute residuals / weights at the accepted point so
-                # the returned diagnostics are consistent.
-                residuals_final, jacobian_final = _compute_residuals_and_jacobian(
-                    vertices_vu=verts,
-                    pivot_vu=pivot,
-                    image_dt=image_edge_dt,
-                    dv=state.dv,
-                    du=state.du,
-                    dtheta=state.dtheta,
-                    fit_rotation=fit_rotation,
-                )
-                residuals_final = np.where(
-                    state.polarity_mask, residuals_final, _INFINITY_DT_PENALTY_PX
-                )
-                final_scaled = residuals_final / sigmas
-                final_tukey = tukey_biweight_weights(final_scaled, c=tukey_c)
-                state.raw_residuals = residuals_final
-                state.weights = inv_sigma_sq * final_tukey
-                state.jacobian = jacobian_final
                 break
         else:
             lambda_ = min(lambda_ * 2.0, 1.0e6)
@@ -762,7 +766,18 @@ def lm_subpixel_refine(
     else:
         rms_px = 0.0
     covariance: NDArrayFloatType
-    if state.jacobian.size == 0 or state.jacobian.shape[1] != n_params:
+    # Guard against three "no information" cases that would otherwise let
+    # information_matrix_to_covariance produce a misleading zero-covariance
+    # answer (pinvh of the zero information matrix is zero — which would
+    # falsely advertise perfect certainty about the fit).  All three
+    # conditions mean there is no inlier evidence to constrain the
+    # parameters; the inf sentinel correctly signals "fully unconstrained".
+    if (
+        state.jacobian.size == 0
+        or state.jacobian.shape[1] != n_params
+        or inlier_count == 0
+        or final_weights.sum() == 0.0
+    ):
         covariance = cast(NDArrayFloatType, np.full((n_params, n_params), np.inf, dtype=np.float64))
     else:
         covariance = information_matrix_to_covariance(

--- a/src/nav/nav_technique/dt_fitting.py
+++ b/src/nav/nav_technique/dt_fitting.py
@@ -1,0 +1,781 @@
+"""Shared distance-transform fitting machinery for polyline-based techniques.
+
+The body-limb, body-terminator, and ring-edge techniques all follow the
+same algorithm: render the model polyline as a binary mask, take a coarse
+2-D NCC against the image edge mask to get an integer offset, then refine
+to sub-pixel precision by Levenberg-Marquardt minimisation against the
+image distance transform with Tukey-biweight outlier rejection.  After
+convergence the M-estimator information matrix is inverted to produce a
+covariance estimate.
+
+Each helper here is a pure function over numpy arrays; the per-technique
+classes simply assemble vertices / normals / weights and call into them.
+The interface is:
+
+* :func:`coarse_ncc_search` — integer-pixel offset from binary masks.
+* :func:`polarity_filter` — per-vertex acceptance from gradient direction.
+* :func:`tukey_biweight_weights` — Holland-Welsch redescender weights.
+* :func:`lm_subpixel_refine` — translation (or translation + rotation) LM
+  refinement with Tukey reweighting against a precomputed DT.
+* :func:`information_matrix_to_covariance` — Hessian → covariance via
+  ``pinvh`` so rank-deficient inputs are handled.
+"""
+
+import math
+from dataclasses import dataclass, field
+from typing import cast
+
+import numpy as np
+from scipy.linalg import pinvh
+
+from nav.support.distance_transform import sample_dt_bilinear
+from nav.support.types import NDArrayBoolType, NDArrayFloatType
+
+__all__ = [
+    'DEFAULT_LM_DAMPING',
+    'DEFAULT_LM_MAX_ITERATIONS',
+    'DEFAULT_LM_STEP_TOLERANCE',
+    'DEFAULT_PINVH_RCOND',
+    'DEFAULT_TUKEY_C',
+    'LMRefineResult',
+    'coarse_ncc_search',
+    'information_matrix_to_covariance',
+    'lm_subpixel_refine',
+    'polarity_filter',
+    'tukey_biweight_weights',
+]
+
+
+DEFAULT_TUKEY_C: float = 4.685
+"""Holland-Welsch redescender constant.
+
+The 4.685 value gives 95 % asymptotic efficiency on Gaussian residuals
+when the residuals are pre-scaled by an estimate of the residual scale.
+The biweight has zero weight outside ``[-c, c]`` so vertices whose
+scaled residuals exceed the constant are rejected entirely.
+"""
+
+
+DEFAULT_LM_DAMPING: float = 1.0e-3
+"""Default Levenberg-Marquardt damping ``lambda``.
+
+Mixes Gauss-Newton and gradient-descent: small values trust the
+quadratic model, large values fall back on gradient descent.  The
+``1e-3`` start value matches the design's prescription and is updated
+multiplicatively after each accepted / rejected step.
+"""
+
+
+DEFAULT_LM_MAX_ITERATIONS: int = 30
+"""Maximum number of LM iterations before bailing out.
+
+The convergence criterion (combined step norm below
+:data:`DEFAULT_LM_STEP_TOLERANCE`) almost always fires within a dozen
+iterations; the cap is a safety net for pathological inputs.
+"""
+
+
+DEFAULT_LM_STEP_TOLERANCE: float = 1.0e-3
+"""Termination threshold on the combined step norm (pixels).
+
+The combined step norm is ``sqrt(d_dv**2 + d_du**2 + (d_theta * pivot_dist)**2)``;
+when rotation is disabled the rotation term is zero.  Once the norm drops
+below this threshold the LM iteration stops.
+"""
+
+
+DEFAULT_PINVH_RCOND: float = 1.0e-9
+"""Default cutoff for the Hermitian pseudoinverse used in covariance.
+
+Matches the same value the orchestrator's ensemble combine uses; a
+single project-wide cutoff keeps rank-deficiency handling consistent.
+"""
+
+
+_INFINITY_DT_PENALTY_PX: float = 1.0e6
+"""Effective ``+inf`` penalty assigned to polarity-rejected vertices.
+
+The polarity filter forces a vertex to contribute an unbounded cost; we
+encode ``+inf`` as a very large finite number so the LM linear system
+remains numerically well-defined.  Such a vertex's residual is so large
+the Tukey biweight zeroes its weight on the first reweighting step, so
+the value's exact magnitude does not influence the converged estimate.
+"""
+
+
+def coarse_ncc_search(
+    edge_mask: NDArrayBoolType,
+    polyline_mask: NDArrayBoolType,
+    search_window_vu: tuple[int, int],
+) -> tuple[int, int]:
+    """Return the integer offset that maximises overlap of two binary masks.
+
+    The cost function is the cross-correlation
+    ``f(dv, du) = sum_{v, u} polyline_mask[v, u] * edge_mask[v + dv, u + du]``,
+    evaluated for every integer ``(dv, du)`` in
+    ``[-margin_v, +margin_v] x [-margin_u, +margin_u]``.  Because both
+    inputs are binary, the cross-correlation peak coincides with the
+    NCC peak — the per-shift normaliser ``sqrt(|polyline_mask| * |edge_mask|)``
+    is constant in ``polyline_mask`` and varies only mildly with
+    ``edge_mask`` over the small search window, so the argmax is unchanged.
+
+    Ties are broken by the smaller ``(|dv| + |du|, |dv|, dv, du)`` tuple,
+    so the nearest-to-origin shift (by Manhattan distance) wins on
+    perfectly flat inputs.
+
+    Parameters:
+        edge_mask: ``(H, W)`` boolean image edge map.
+        polyline_mask: ``(H, W)`` boolean model polyline mask aligned to
+            ``edge_mask``.  Must have the same shape as ``edge_mask``.
+        search_window_vu: ``(margin_v, margin_u)`` non-negative integers
+            bounding the search range in v and u.
+
+    Returns:
+        ``(dv, du)`` integer offset pair at the peak.
+
+    Raises:
+        ValueError: if shapes disagree, masks are not 2-D, or
+            ``search_window_vu`` contains a negative entry.
+    """
+    if edge_mask.ndim != 2 or polyline_mask.ndim != 2:
+        raise ValueError(
+            'edge_mask and polyline_mask must be 2-D; got '
+            f'ndims {edge_mask.ndim}, {polyline_mask.ndim}'
+        )
+    if edge_mask.shape != polyline_mask.shape:
+        raise ValueError(
+            f'shape mismatch: edge_mask {edge_mask.shape} vs polyline_mask {polyline_mask.shape}'
+        )
+    margin_v, margin_u = int(search_window_vu[0]), int(search_window_vu[1])
+    if margin_v < 0 or margin_u < 0:
+        raise ValueError(f'search_window_vu must be non-negative; got {search_window_vu!r}')
+    height, width = edge_mask.shape
+    edge_f = edge_mask.astype(np.float64, copy=False)
+    poly_f = polyline_mask.astype(np.float64, copy=False)
+    # Scan the bounded window directly: brute-force over O(margin_v * margin_u)
+    # offsets is faster than FFT for the typical (50, 50) margins on a
+    # 1024 x 1024 image because the cross-correlation involves only the
+    # sparse polyline support.  Pre-fetching the polyline indices avoids
+    # repeat numpy re-broadcasts.
+    poly_vs, poly_us = np.where(polyline_mask)
+    if poly_vs.size == 0:
+        return (0, 0)
+    best_dv = 0
+    best_du = 0
+    best_score = -1.0
+    best_key = (math.inf, math.inf, math.inf, math.inf)
+    for dv in range(-margin_v, margin_v + 1):
+        shifted_v = poly_vs + dv
+        valid_v = (shifted_v >= 0) & (shifted_v < height)
+        if not valid_v.any():
+            continue
+        for du in range(-margin_u, margin_u + 1):
+            shifted_u = poly_us + du
+            valid = valid_v & (shifted_u >= 0) & (shifted_u < width)
+            if not valid.any():
+                continue
+            sv = shifted_v[valid]
+            su = shifted_u[valid]
+            score = float(edge_f[sv, su].sum() * poly_f[poly_vs[valid], poly_us[valid]].sum())
+            # Use the squared score to keep computation in non-negative
+            # ints; ``poly_f[...]`` is constant 1 along ``valid``, so
+            # ``score`` reduces to the overlap count of edge pixels.
+            key = (abs(dv) + abs(du), abs(dv), dv, du)
+            if score > best_score or (score == best_score and key < best_key):
+                best_score = score
+                best_key = key
+                best_dv = dv
+                best_du = du
+    return best_dv, best_du
+
+
+def polarity_filter(
+    vertices_vu: NDArrayFloatType,
+    normals_vu: NDArrayFloatType,
+    image_gradient_vu: NDArrayFloatType,
+    *,
+    offset_vu: tuple[float, float] = (0.0, 0.0),
+) -> NDArrayBoolType:
+    """Return per-vertex polarity acceptance against an image gradient.
+
+    For each vertex the helper samples the image gradient vector at the
+    vertex's current shifted position and compares the gradient to the
+    model's outward normal.  The polarity test is *strictly* greater than
+    zero: orthogonal hits (dot product exactly zero, vanishingly rare in
+    floating-point arithmetic) are rejected, never silently kept.
+
+    Out-of-bounds vertices have their gradient sampled at the nearest
+    in-bounds pixel via clamping; that pixel's gradient is rarely a real
+    edge, so the dot product is dominated by background noise and the
+    vertex is rejected on its own merits.
+
+    Parameters:
+        vertices_vu: ``(N, 2)`` model vertex positions.
+        normals_vu: ``(N, 2)`` model outward normal at each vertex.
+        image_gradient_vu: ``(H, W, 2)`` per-pixel gradient image as
+            produced by
+            :func:`nav.nav_orchestrator.image_derivatives.compute_image_gradient_vu`.
+        offset_vu: ``(dv, du)`` shift applied to each vertex before
+            sampling.  Defaults to no shift.
+
+    Returns:
+        ``(N,)`` boolean mask True where the vertex's polarity agrees
+        with the image's local edge direction.
+
+    Raises:
+        ValueError: if shape requirements are violated.
+    """
+    verts = np.asarray(vertices_vu, np.float64)
+    norms = np.asarray(normals_vu, np.float64)
+    if verts.ndim != 2 or verts.shape[1] != 2:
+        raise ValueError(f'vertices_vu must have shape (N, 2); got {verts.shape}')
+    if norms.shape != verts.shape:
+        raise ValueError(f'normals_vu must match vertices_vu shape; got {norms.shape}')
+    if image_gradient_vu.ndim != 3 or image_gradient_vu.shape[2] != 2:
+        raise ValueError(
+            f'image_gradient_vu must have shape (H, W, 2); got {image_gradient_vu.shape}'
+        )
+    height, width, _ = image_gradient_vu.shape
+    dv, du = float(offset_vu[0]), float(offset_vu[1])
+    sample_v = np.clip(np.rint(verts[:, 0] + dv).astype(np.int64), 0, height - 1)
+    sample_u = np.clip(np.rint(verts[:, 1] + du).astype(np.int64), 0, width - 1)
+    gv = image_gradient_vu[sample_v, sample_u, 0]
+    gu = image_gradient_vu[sample_v, sample_u, 1]
+    dot = norms[:, 0] * gv + norms[:, 1] * gu
+    return cast(NDArrayBoolType, dot > 0.0)
+
+
+def tukey_biweight_weights(
+    residuals: NDArrayFloatType,
+    *,
+    c: float = DEFAULT_TUKEY_C,
+) -> NDArrayFloatType:
+    """Return Tukey biweight weights for a vector of residuals.
+
+    The Holland-Welsch biweight is
+
+    .. math::
+        w_i = \\begin{cases}
+            \\bigl(1 - (r_i / c)^2\\bigr)^2 & |r_i| \\le c \\\\
+            0 & \\text{otherwise}
+        \\end{cases}
+
+    so residuals beyond ``c`` are dropped completely.  Callers are
+    responsible for scaling residuals to the desired robust scale before
+    invoking — typically dividing by an estimate of the residual standard
+    deviation so that ``c = 4.685`` corresponds to the conventional 95 %
+    asymptotic efficiency under Gaussian errors.
+
+    Parameters:
+        residuals: ``(N,)`` array of (already-scaled) residuals.  May
+            contain negative entries; only the magnitude is consulted.
+        c: Strictly positive cutoff in residual units.  Must be finite.
+
+    Returns:
+        ``(N,)`` float64 array of weights in ``[0, 1]``.
+
+    Raises:
+        ValueError: if ``c`` is not strictly positive or
+            ``residuals`` is not 1-D.
+    """
+    if not (c > 0.0) or not math.isfinite(c):
+        raise ValueError(f'c must be a positive finite number; got {c!r}')
+    arr = np.asarray(residuals, np.float64)
+    if arr.ndim != 1:
+        raise ValueError(f'residuals must be 1-D; got ndim={arr.ndim}')
+    scaled = arr / c
+    inside = np.abs(scaled) <= 1.0
+    weights = np.zeros_like(arr)
+    inside_vals = scaled[inside]
+    weights[inside] = (1.0 - inside_vals * inside_vals) ** 2
+    return cast(NDArrayFloatType, weights)
+
+
+def information_matrix_to_covariance(
+    jacobian: NDArrayFloatType,
+    weights: NDArrayFloatType,
+    *,
+    rcond: float = DEFAULT_PINVH_RCOND,
+) -> NDArrayFloatType:
+    """Return the parameter covariance from a weighted Jacobian.
+
+    The M-estimator information matrix is ``J^T diag(w) J``; the
+    parameter covariance is its Moore-Penrose pseudoinverse via
+    :func:`scipy.linalg.pinvh`, which gracefully handles rank-deficient
+    inputs (a flat polyline produces a rank-1 information matrix; the
+    returned covariance has unbounded variance along the unobservable
+    null direction).
+
+    The ``weights`` argument is the per-residual weight (Tukey biweight
+    times any prior precision) and is multiplied into ``J`` before the
+    matrix product, which both incorporates the IRLS reweighting and
+    keeps the result symmetric within numerical tolerance.
+
+    Parameters:
+        jacobian: ``(N, P)`` Jacobian of the residual vector with respect
+            to the parameter vector.
+        weights: ``(N,)`` non-negative residual weights.
+        rcond: Pseudoinverse cutoff; eigenvalues smaller than this
+            relative to the largest are treated as null.
+
+    Returns:
+        ``(P, P)`` covariance matrix.  Symmetric; positive semidefinite
+        within ``rcond``.
+
+    Raises:
+        ValueError: if shapes disagree, ``weights`` contains negative
+            entries, or ``jacobian`` is not 2-D.
+    """
+    if jacobian.ndim != 2:
+        raise ValueError(f'jacobian must be 2-D; got ndim={jacobian.ndim}')
+    if weights.ndim != 1 or weights.shape[0] != jacobian.shape[0]:
+        raise ValueError(
+            'weights must be a 1-D vector matching the Jacobian rows; '
+            f'got weights {weights.shape}, jacobian {jacobian.shape}'
+        )
+    if (weights < 0).any():
+        raise ValueError('weights must be non-negative')
+    sqrt_w = np.sqrt(weights)
+    weighted_j = sqrt_w[:, None] * jacobian
+    info = weighted_j.T @ weighted_j
+    cov = pinvh(info, rtol=rcond)
+    cov = 0.5 * (cov + cov.T)
+    return cast(NDArrayFloatType, cov)
+
+
+@dataclass(frozen=True)
+class LMRefineResult:
+    """Structured output of :func:`lm_subpixel_refine`.
+
+    Parameters:
+        offset_vu: ``(dv, du)`` converged translation in pixels.
+        rotation_rad: Converged rotation in radians; ``0.0`` when
+            ``fit_rotation`` was False.
+        covariance: ``(2, 2)`` or ``(3, 3)`` parameter covariance derived
+            from the M-estimator information matrix at the converged
+            point.
+        residuals_px: ``(N,)`` per-vertex DT residuals at the final
+            estimate (raw, unweighted).
+        weights: ``(N,)`` per-vertex weights at the final estimate
+            (prior precision times Tukey biweight).
+        rms_px: Weighted root-mean-square of the residuals, computed as
+            ``sqrt(sum(w * r**2) / sum(w))`` over surviving vertices;
+            ``0.0`` when every vertex was rejected.
+        iterations: Number of LM iterations actually performed.
+        converged: True if the step-norm tolerance was met before the
+            iteration cap.
+        inlier_count: Number of vertices that retained a strictly
+            positive Tukey weight at the final estimate.
+    """
+
+    offset_vu: tuple[float, float]
+    rotation_rad: float
+    covariance: NDArrayFloatType
+    residuals_px: NDArrayFloatType
+    weights: NDArrayFloatType
+    rms_px: float
+    iterations: int
+    converged: bool
+    inlier_count: int
+
+    def __post_init__(self) -> None:
+        """Freeze the numpy arrays and validate shapes."""
+        for name in ('covariance', 'residuals_px', 'weights'):
+            arr = getattr(self, name)
+            if not isinstance(arr, np.ndarray):
+                raise TypeError(f'LMRefineResult.{name} must be an ndarray')
+            arr.setflags(write=False)
+
+
+@dataclass
+class _LMState:
+    """Mutable LM iteration state.  Internal to :func:`lm_subpixel_refine`."""
+
+    dv: float
+    du: float
+    dtheta: float
+    polarity_mask: NDArrayBoolType
+    iteration: int = 0
+    converged: bool = False
+    raw_residuals: NDArrayFloatType = field(default_factory=lambda: np.zeros(0, np.float64))
+    weights: NDArrayFloatType = field(default_factory=lambda: np.zeros(0, np.float64))
+    jacobian: NDArrayFloatType = field(default_factory=lambda: np.zeros((0, 2), np.float64))
+
+
+def _rotate_vertices(
+    vertices_vu: NDArrayFloatType,
+    pivot_vu: tuple[float, float],
+    theta: float,
+) -> NDArrayFloatType:
+    """Rotate ``vertices_vu`` about ``pivot_vu`` by ``theta`` radians."""
+    if theta == 0.0:
+        return vertices_vu
+    pv, pu = pivot_vu
+    cos_t = math.cos(theta)
+    sin_t = math.sin(theta)
+    centred_v = vertices_vu[:, 0] - pv
+    centred_u = vertices_vu[:, 1] - pu
+    new_v = pv + cos_t * centred_v - sin_t * centred_u
+    new_u = pu + sin_t * centred_v + cos_t * centred_u
+    return cast(NDArrayFloatType, np.stack([new_v, new_u], axis=-1))
+
+
+def _shift_vertices(
+    vertices_vu: NDArrayFloatType,
+    dv: float,
+    du: float,
+) -> NDArrayFloatType:
+    """Return a copy of ``vertices_vu`` shifted by ``(dv, du)``."""
+    out = vertices_vu.copy()
+    out[:, 0] += dv
+    out[:, 1] += du
+    return out
+
+
+def _compute_residuals_and_jacobian(
+    *,
+    vertices_vu: NDArrayFloatType,
+    pivot_vu: tuple[float, float],
+    image_dt: NDArrayFloatType,
+    dv: float,
+    du: float,
+    dtheta: float,
+    fit_rotation: bool,
+) -> tuple[NDArrayFloatType, NDArrayFloatType]:
+    """Sample the DT and finite-difference its parameter Jacobian.
+
+    Bilinear DT samples are differentiable almost everywhere, so a
+    central-difference Jacobian with a small step gives a good local
+    linearisation.  The step is fixed at 0.5 pixels — large enough to
+    cross many DT cells, small enough to remain within the bilinear
+    interpolant's local quadratic regime.
+    """
+    base_pos = _shift_vertices(_rotate_vertices(vertices_vu, pivot_vu, dtheta), dv, du)
+    residuals = sample_dt_bilinear(image_dt, base_pos)
+    # Central differences with a sub-pixel step.  A 0.25 px step is large
+    # enough to cross several DT bilinear cells (the DT grows by 1 every
+    # full pixel) but small enough that the linearisation stays inside
+    # the local quadratic regime around the converged offset.
+    eps = 0.25
+    pdv = sample_dt_bilinear(image_dt, _shift_vertices(base_pos, eps, 0.0))
+    mdv = sample_dt_bilinear(image_dt, _shift_vertices(base_pos, -eps, 0.0))
+    pdu = sample_dt_bilinear(image_dt, _shift_vertices(base_pos, 0.0, eps))
+    mdu = sample_dt_bilinear(image_dt, _shift_vertices(base_pos, 0.0, -eps))
+    drdv = (pdv - mdv) / (2.0 * eps)
+    drdu = (pdu - mdu) / (2.0 * eps)
+    if not fit_rotation:
+        jacobian = np.stack([drdv, drdu], axis=-1)
+        return residuals, cast(NDArrayFloatType, jacobian)
+    # Numerical derivative w.r.t. dtheta
+    eps_t = 1.0e-3
+    plus = sample_dt_bilinear(
+        image_dt,
+        _shift_vertices(_rotate_vertices(vertices_vu, pivot_vu, dtheta + eps_t), dv, du),
+    )
+    minus = sample_dt_bilinear(
+        image_dt,
+        _shift_vertices(_rotate_vertices(vertices_vu, pivot_vu, dtheta - eps_t), dv, du),
+    )
+    drdth = (plus - minus) / (2.0 * eps_t)
+    jacobian = np.stack([drdv, drdu, drdth], axis=-1)
+    return residuals, cast(NDArrayFloatType, jacobian)
+
+
+def _weighted_normal_equations(
+    jacobian: NDArrayFloatType,
+    residuals: NDArrayFloatType,
+    weights: NDArrayFloatType,
+) -> tuple[NDArrayFloatType, NDArrayFloatType]:
+    """Return ``(J^T W J, J^T W r)`` weighted by ``weights``."""
+    sqrt_w = np.sqrt(weights)
+    weighted_j = sqrt_w[:, None] * jacobian
+    weighted_r = sqrt_w * residuals
+    hessian = weighted_j.T @ weighted_j
+    rhs = weighted_j.T @ weighted_r
+    return cast(NDArrayFloatType, hessian), cast(NDArrayFloatType, rhs)
+
+
+def _weighted_cost(weights: NDArrayFloatType, residuals: NDArrayFloatType) -> float:
+    """Sum of ``w_i * r_i**2`` (the quantity LM minimises)."""
+    return float(np.sum(weights * residuals * residuals))
+
+
+def _step_norm_px(
+    step: NDArrayFloatType,
+    *,
+    fit_rotation: bool,
+    pivot_distance_px: float,
+) -> float:
+    """Return the LM convergence step norm in pixel-equivalent units.
+
+    Translation steps contribute their Euclidean magnitude directly; the
+    rotation step (when present) is multiplied by ``pivot_distance_px``
+    to convert radians into a pixel displacement at the pivot's typical
+    distance.  Combined as a Euclidean norm so the same tolerance
+    threshold applies to translation-only and translation-plus-rotation
+    fits.
+    """
+    if not fit_rotation:
+        return float(math.hypot(step[0], step[1]))
+    rotation_step_px = float(step[2]) * pivot_distance_px
+    return float(math.sqrt(step[0] ** 2 + step[1] ** 2 + rotation_step_px**2))
+
+
+def lm_subpixel_refine(
+    *,
+    vertices_vu: NDArrayFloatType,
+    normals_vu: NDArrayFloatType,
+    sigma_normal_per_vertex_px: NDArrayFloatType,
+    image_edge_dt: NDArrayFloatType,
+    image_gradient_vu: NDArrayFloatType | None = None,
+    initial_offset_vu: tuple[float, float] = (0.0, 0.0),
+    initial_rotation_rad: float = 0.0,
+    fit_rotation: bool = False,
+    pivot_vu: tuple[float, float] | None = None,
+    pivot_distance_px: float = 0.0,
+    use_polarity: bool = True,
+    max_iterations: int = DEFAULT_LM_MAX_ITERATIONS,
+    damping: float = DEFAULT_LM_DAMPING,
+    step_tolerance_px: float = DEFAULT_LM_STEP_TOLERANCE,
+    tukey_c: float = DEFAULT_TUKEY_C,
+    pinvh_rcond: float = DEFAULT_PINVH_RCOND,
+) -> LMRefineResult:
+    """Refine a polyline-vs-image alignment by Levenberg-Marquardt.
+
+    The cost function is
+
+    .. math::
+        C(p) = \\sum_i w_i \\, \\bigl[\\mathrm{DT}\\bigl(R(\\theta)\\,(x_i - x_p)
+                                              + x_p + (\\Delta v, \\Delta u)\\bigr)\\bigr]^2
+
+    where :math:`x_i` are the input vertices, :math:`x_p` is the rotation
+    pivot, :math:`R(\\theta)` is the in-plane rotation, ``DT`` is the
+    bilinearly-sampled image distance transform, and the per-vertex
+    weight :math:`w_i` is the product of the prior precision
+    :math:`1 / \\sigma_i^2` and the Tukey biweight evaluated at the
+    scaled residual :math:`r_i / \\sigma_i`.  The Tukey weights are
+    recomputed after each accepted LM step (iteratively-reweighted
+    least squares).
+
+    Parameters:
+        vertices_vu: ``(N, 2)`` model vertex positions.
+        normals_vu: ``(N, 2)`` model outward normals (only used if
+            ``use_polarity`` is True).
+        sigma_normal_per_vertex_px: ``(N,)`` strictly-positive prior
+            sigma in pixels.  ``1 / sigma**2`` is the prior precision
+            weight.
+        image_edge_dt: ``(H, W)`` precomputed image distance transform.
+        image_gradient_vu: ``(H, W, 2)`` gradient vector image; required
+            when ``use_polarity`` is True, ignored otherwise.
+        initial_offset_vu: ``(dv0, du0)`` starting translation.
+        initial_rotation_rad: Starting rotation in radians.
+        fit_rotation: When True the parameter vector is
+            ``(dv, du, dtheta)``; otherwise ``(dv, du)``.
+        pivot_vu: ``(v_p, u_p)`` rotation pivot.  Defaults to the
+            centroid of ``vertices_vu``.
+        pivot_distance_px: Approximate pivot-to-image-centre distance in
+            pixels; used to convert rotation steps into pixel-equivalent
+            increments for the convergence test.  Required when
+            ``fit_rotation`` is True; ignored otherwise.
+        use_polarity: When True, polarity-rejected vertices are assigned
+            an effectively-infinite residual so the Tukey biweight zeroes
+            their contribution.
+        max_iterations: Iteration cap.
+        damping: Initial Levenberg-Marquardt damping ``lambda``.
+        step_tolerance_px: Step-norm threshold below which the iteration
+            terminates with ``converged=True``.
+        tukey_c: Holland-Welsch Tukey biweight constant.
+        pinvh_rcond: Pseudoinverse cutoff for the final covariance.
+
+    Returns:
+        :class:`LMRefineResult`.
+
+    Raises:
+        ValueError: if any shape requirement is violated, the prior
+            sigmas are not strictly positive, or ``fit_rotation`` is
+            True without a positive ``pivot_distance_px``.
+    """
+    verts = np.asarray(vertices_vu, np.float64)
+    norms = np.asarray(normals_vu, np.float64)
+    sigmas = np.asarray(sigma_normal_per_vertex_px, np.float64)
+    if verts.ndim != 2 or verts.shape[1] != 2:
+        raise ValueError(f'vertices_vu must have shape (N, 2); got {verts.shape}')
+    if norms.shape != verts.shape:
+        raise ValueError(f'normals_vu must match vertices_vu shape; got {norms.shape}')
+    if sigmas.ndim != 1 or sigmas.shape[0] != verts.shape[0]:
+        raise ValueError(
+            'sigma_normal_per_vertex_px must be a 1-D vector matching '
+            f'vertices_vu; got {sigmas.shape}'
+        )
+    if (sigmas <= 0.0).any() or not np.isfinite(sigmas).all():
+        raise ValueError('sigma_normal_per_vertex_px entries must be finite and > 0')
+    if image_edge_dt.ndim != 2:
+        raise ValueError(f'image_edge_dt must be 2-D; got ndim={image_edge_dt.ndim}')
+    if fit_rotation and not (pivot_distance_px > 0.0):
+        raise ValueError(
+            'fit_rotation=True requires pivot_distance_px > 0 for the convergence test'
+        )
+    if use_polarity:
+        if image_gradient_vu is None:
+            raise ValueError('use_polarity=True requires image_gradient_vu')
+        polarity_mask = polarity_filter(
+            verts,
+            norms,
+            image_gradient_vu,
+            offset_vu=initial_offset_vu,
+        )
+    else:
+        polarity_mask = np.ones(verts.shape[0], dtype=bool)
+    pivot = (
+        (float(verts[:, 0].mean()), float(verts[:, 1].mean()))
+        if pivot_vu is None
+        else (float(pivot_vu[0]), float(pivot_vu[1]))
+    )
+    inv_sigma_sq = 1.0 / (sigmas * sigmas)
+    state = _LMState(
+        dv=float(initial_offset_vu[0]),
+        du=float(initial_offset_vu[1]),
+        dtheta=float(initial_rotation_rad),
+        polarity_mask=polarity_mask,
+    )
+    lambda_ = float(damping)
+    best_cost = math.inf
+    n_params = 3 if fit_rotation else 2
+    while state.iteration < max_iterations:
+        residuals, jacobian = _compute_residuals_and_jacobian(
+            vertices_vu=verts,
+            pivot_vu=pivot,
+            image_dt=image_edge_dt,
+            dv=state.dv,
+            du=state.du,
+            dtheta=state.dtheta,
+            fit_rotation=fit_rotation,
+        )
+        # Polarity-reject vertices contribute the constant penalty that
+        # the Tukey biweight will zero on the next reweighting step.
+        residuals = np.where(state.polarity_mask, residuals, _INFINITY_DT_PENALTY_PX)
+        # Compute Tukey biweight weights from the (sigma-scaled) residuals.
+        scaled = residuals / sigmas
+        tukey_w = tukey_biweight_weights(scaled, c=tukey_c)
+        weights = inv_sigma_sq * tukey_w
+        cost_before = _weighted_cost(weights, residuals)
+        state.raw_residuals = residuals
+        state.weights = weights
+        state.jacobian = jacobian
+        if not np.any(weights > 0):
+            break
+        hessian, rhs = _weighted_normal_equations(jacobian, residuals, weights)
+        # LM dampening: H_lm = H + lambda * diag(H).
+        diag = np.diag(np.diag(hessian))
+        hessian_lm = hessian + lambda_ * diag
+        try:
+            step = -np.linalg.solve(hessian_lm, rhs)
+        except np.linalg.LinAlgError:
+            step = -pinvh(hessian_lm, rtol=pinvh_rcond) @ rhs
+        trial_dv = state.dv + float(step[0])
+        trial_du = state.du + float(step[1])
+        trial_dtheta = state.dtheta + float(step[2]) if fit_rotation else state.dtheta
+        # Evaluate cost at the trial point.
+        trial_residuals, _ = _compute_residuals_and_jacobian(
+            vertices_vu=verts,
+            pivot_vu=pivot,
+            image_dt=image_edge_dt,
+            dv=trial_dv,
+            du=trial_du,
+            dtheta=trial_dtheta,
+            fit_rotation=fit_rotation,
+        )
+        trial_residuals = np.where(state.polarity_mask, trial_residuals, _INFINITY_DT_PENALTY_PX)
+        trial_scaled = trial_residuals / sigmas
+        trial_tukey = tukey_biweight_weights(trial_scaled, c=tukey_c)
+        trial_weights = inv_sigma_sq * trial_tukey
+        trial_cost = _weighted_cost(trial_weights, trial_residuals)
+        if trial_cost < cost_before:
+            state.dv = trial_dv
+            state.du = trial_du
+            state.dtheta = trial_dtheta
+            lambda_ = max(lambda_ * 0.5, 1.0e-12)
+            best_cost = trial_cost
+            step_norm = _step_norm_px(
+                step,
+                fit_rotation=fit_rotation,
+                pivot_distance_px=pivot_distance_px,
+            )
+            state.iteration += 1
+            if step_norm < step_tolerance_px:
+                state.converged = True
+                # Recompute residuals / weights at the accepted point so
+                # the returned diagnostics are consistent.
+                residuals_final, jacobian_final = _compute_residuals_and_jacobian(
+                    vertices_vu=verts,
+                    pivot_vu=pivot,
+                    image_dt=image_edge_dt,
+                    dv=state.dv,
+                    du=state.du,
+                    dtheta=state.dtheta,
+                    fit_rotation=fit_rotation,
+                )
+                residuals_final = np.where(
+                    state.polarity_mask, residuals_final, _INFINITY_DT_PENALTY_PX
+                )
+                final_scaled = residuals_final / sigmas
+                final_tukey = tukey_biweight_weights(final_scaled, c=tukey_c)
+                state.raw_residuals = residuals_final
+                state.weights = inv_sigma_sq * final_tukey
+                state.jacobian = jacobian_final
+                break
+        else:
+            lambda_ = min(lambda_ * 2.0, 1.0e6)
+            state.iteration += 1
+            if lambda_ >= 1.0e6:
+                break
+    if best_cost == math.inf:
+        # Iteration exited without finding any improvement: fall back to
+        # the latest residual / weight set already cached on ``state``.
+        residuals_final = state.raw_residuals
+        if residuals_final.size == 0:
+            residuals_final = sample_dt_bilinear(
+                image_edge_dt,
+                _shift_vertices(_rotate_vertices(verts, pivot, state.dtheta), state.dv, state.du),
+            )
+            residuals_final = np.where(
+                state.polarity_mask, residuals_final, _INFINITY_DT_PENALTY_PX
+            )
+            final_scaled = residuals_final / sigmas
+            final_tukey = tukey_biweight_weights(final_scaled, c=tukey_c)
+            state.raw_residuals = residuals_final
+            state.weights = inv_sigma_sq * final_tukey
+            _, state.jacobian = _compute_residuals_and_jacobian(
+                vertices_vu=verts,
+                pivot_vu=pivot,
+                image_dt=image_edge_dt,
+                dv=state.dv,
+                du=state.du,
+                dtheta=state.dtheta,
+                fit_rotation=fit_rotation,
+            )
+    final_weights = state.weights
+    final_residuals = state.raw_residuals
+    inlier_count = int(np.sum(final_weights > 0))
+    if inlier_count > 0 and final_weights.sum() > 0.0:
+        rms_px = float(math.sqrt(np.sum(final_weights * final_residuals**2) / final_weights.sum()))
+    else:
+        rms_px = 0.0
+    covariance: NDArrayFloatType
+    if state.jacobian.size == 0 or state.jacobian.shape[1] != n_params:
+        covariance = cast(NDArrayFloatType, np.full((n_params, n_params), np.inf, dtype=np.float64))
+    else:
+        covariance = information_matrix_to_covariance(
+            state.jacobian, final_weights, rcond=pinvh_rcond
+        )
+    return LMRefineResult(
+        offset_vu=(state.dv, state.du),
+        rotation_rad=state.dtheta,
+        covariance=covariance,
+        residuals_px=final_residuals,
+        weights=final_weights,
+        rms_px=rms_px,
+        iterations=state.iteration,
+        converged=state.converged,
+        inlier_count=inlier_count,
+    )

--- a/src/nav/nav_technique/dt_fitting.py
+++ b/src/nav/nav_technique/dt_fitting.py
@@ -134,8 +134,10 @@ def coarse_ncc_search(
         ``(dv, du)`` integer offset pair at the peak.
 
     Raises:
+        TypeError: if either entry of ``search_window_vu`` is not an int.
         ValueError: if shapes disagree, masks are not 2-D, or
-            ``search_window_vu`` contains a negative entry.
+            ``search_window_vu`` is not a length-2 sequence of
+            non-negative ints.
     """
     if edge_mask.ndim != 2 or polyline_mask.ndim != 2:
         raise ValueError(
@@ -146,9 +148,21 @@ def coarse_ncc_search(
         raise ValueError(
             f'shape mismatch: edge_mask {edge_mask.shape} vs polyline_mask {polyline_mask.shape}'
         )
-    margin_v, margin_u = int(search_window_vu[0]), int(search_window_vu[1])
-    if margin_v < 0 or margin_u < 0:
+    # Validate explicitly rather than relying on int() coercion, which would
+    # silently truncate floats and raise an unhelpful IndexError on
+    # wrong-length sequences.
+    if not isinstance(search_window_vu, tuple | list) or len(search_window_vu) != 2:
+        raise ValueError(
+            f'search_window_vu must be a length-2 sequence of ints; got {search_window_vu!r}'
+        )
+    margin_v_raw, margin_u_raw = search_window_vu[0], search_window_vu[1]
+    if not isinstance(margin_v_raw, int) or isinstance(margin_v_raw, bool):
+        raise TypeError(f'search_window_vu[0] must be int; got {type(margin_v_raw).__name__}')
+    if not isinstance(margin_u_raw, int) or isinstance(margin_u_raw, bool):
+        raise TypeError(f'search_window_vu[1] must be int; got {type(margin_u_raw).__name__}')
+    if margin_v_raw < 0 or margin_u_raw < 0:
         raise ValueError(f'search_window_vu must be non-negative; got {search_window_vu!r}')
+    margin_v, margin_u = margin_v_raw, margin_u_raw
     height, width = edge_mask.shape
     edge_f = edge_mask.astype(np.float64, copy=False)
     # Scan the bounded window directly: brute-force over O(margin_v * margin_u)
@@ -446,9 +460,10 @@ def _compute_residuals_and_jacobian(
 
     Bilinear DT samples are differentiable almost everywhere, so a
     central-difference Jacobian with a small step gives a good local
-    linearisation.  The step is fixed at 0.5 pixels — large enough to
-    cross many DT cells, small enough to remain within the bilinear
-    interpolant's local quadratic regime.
+    linearisation.  The step is fixed at 0.25 pixels — large enough to
+    cross several DT bilinear cells (the DT grows by 1 every full
+    pixel), small enough to remain within the bilinear interpolant's
+    local quadratic regime.
     """
     base_pos = _shift_vertices(_rotate_vertices(vertices_vu, pivot_vu, dtheta), dv, du)
     residuals = sample_dt_bilinear(image_dt, base_pos)

--- a/src/nav/nav_technique/nav_technique.py
+++ b/src/nav/nav_technique/nav_technique.py
@@ -10,7 +10,6 @@ constructed at import time.
 from __future__ import annotations
 
 import fnmatch
-import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -22,8 +21,6 @@ from nav.support.nav_base import NavBase
 
 if TYPE_CHECKING:  # pragma: no cover - typing-only import
     from nav.nav_orchestrator.nav_context import NavContext
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     'NavTechnique',

--- a/src/nav/nav_technique/nav_technique_body_limb.py
+++ b/src/nav/nav_technique/nav_technique_body_limb.py
@@ -1,0 +1,371 @@
+"""``BodyLimbNav`` — translation fit from body limb polylines.
+
+Consumes every ``LIMB_ARC`` feature in the input set, concatenates their
+per-vertex positions, weights them by ``1 / sigma_normal_per_vertex_px**2``,
+and runs the shared distance-transform fitter to recover a single
+translation that minimises the joint cost across all bodies.  Multi-body
+inputs improve the fit by ``sqrt(N_bodies)`` when SPICE relative geometry
+is correct; the joint-translation parameterisation cannot represent
+"swap two moons" mistakes by construction.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from nav.config import Config
+from nav.feature.feature import NavFeature
+from nav.feature.feature_type import NavFeatureType
+from nav.feature.geometry import LimbPolyline
+from nav.nav_technique.confidence import (
+    ConfidenceSpec,
+    ConfidenceTerm,
+    evaluate_sigmoid_combination,
+)
+from nav.nav_technique.diagnostics import BodyLimbDiagnostics
+from nav.nav_technique.dt_fitting import (
+    coarse_ncc_search,
+    lm_subpixel_refine,
+)
+from nav.nav_technique.feasibility import NavFeasibilityReport
+from nav.nav_technique.nav_technique import NavTechnique
+from nav.nav_technique.technique_result import NavTechniqueResult
+from nav.support.types import NDArrayBoolType, NDArrayFloatType
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from nav.nav_orchestrator.nav_context import NavContext
+
+__all__ = ['BodyLimbNav']
+
+
+LIMB_MIN_ARC_PX: float = 30.0
+"""Minimum surviving polyline length per LIMB_ARC feature for feasibility.
+
+Shorter limbs do not constrain a 2-D translation enough to be worth
+running the LM iteration for; the technique reports infeasibility.
+"""
+
+
+SPURIOUS_DT_RMS_FACTOR: float = 5.0
+"""Final DT residual exceeding this many limb-sigmas marks the result spurious."""
+
+
+SPURIOUS_DT_FLOOR_PX: float = 3.0
+"""Minimum surviving DT residual below which spurious detection is skipped."""
+
+
+SPURIOUS_MIN_INLIERS: int = 6
+"""Below this Tukey-inlier count the final fit is flagged spurious.
+
+Six surviving vertices is the smallest count at which the M-estimator
+covariance is meaningfully informative for a 2-D translation.
+"""
+
+
+_AT_EDGE_TOLERANCE_PX: float = 1.0
+"""Pixels of slack around the search-window axis bounds for at-edge detection.
+
+A converged offset whose absolute distance from any axis bound (``+/-margin_v``,
+``+/-margin_u``) falls within this tolerance is flagged ``at_edge=True`` and
+forced to zero confidence by the technique's ``hard_zero_if`` gate.  One pixel
+matches the bilinear DT half-cell width: any closer to the boundary and the
+LM gradient information is unreliable.
+"""
+
+
+_BODY_LIMB_CONFIDENCE_SPEC = ConfidenceSpec(
+    alpha0=-1.0,
+    terms=(
+        ConfidenceTerm(feature='visible_limb_arc_fraction', alpha=3.0),
+        ConfidenceTerm(feature='dt_fit_rms_px', alpha=-1.5),
+        ConfidenceTerm(
+            feature='visible_arc_px',
+            alpha=0.4,
+            divisor=100.0,
+            cap_at=1.0,
+        ),
+    ),
+    hard_zero_if={'at_edge': True},
+)
+"""Default confidence spec for the body-limb technique.
+
+The placeholder coefficients match the design's calibration target:
+half-visible 30-vertex limbs converge to "medium" and full-visible
+60+-vertex limbs converge to "high" once the planted-offset library is
+used to retune the alphas.
+"""
+
+
+def _build_polyline_mask(
+    vertices_vu: NDArrayFloatType, shape_vu: tuple[int, int]
+) -> NDArrayBoolType:
+    """Render polyline vertices into a boolean image mask aligned to shape_vu."""
+    vs = np.rint(vertices_vu[:, 0]).astype(np.int64)
+    us = np.rint(vertices_vu[:, 1]).astype(np.int64)
+    valid = (vs >= 0) & (vs < shape_vu[0]) & (us >= 0) & (us < shape_vu[1])
+    mask = np.zeros(shape_vu, dtype=bool)
+    if valid.any():
+        mask[vs[valid], us[valid]] = True
+    return mask
+
+
+def _aggregate_limb_features(
+    features: list[NavFeature],
+) -> tuple[
+    NDArrayFloatType,
+    NDArrayFloatType,
+    NDArrayFloatType,
+    list[str],
+]:
+    """Concatenate vertices, normals, and per-vertex sigmas from LIMB_ARC features.
+
+    The model normals are negated relative to the geometric outward normal
+    so that the ``polarity_filter`` ``dot > 0`` rule corresponds to "image
+    gradient points into the body silhouette" — which is the typical
+    bright-body convention used by the body NavModel.
+
+    Returns:
+        ``(vertices, polarity_normals, sigmas, feature_ids)``.
+    """
+    vert_chunks: list[NDArrayFloatType] = []
+    normal_chunks: list[NDArrayFloatType] = []
+    sigma_chunks: list[NDArrayFloatType] = []
+    ids: list[str] = []
+    for feat in features:
+        if not isinstance(feat.geometry, LimbPolyline):
+            continue
+        if feat.geometry.vertices_vu.shape[0] == 0:
+            continue
+        vert_chunks.append(feat.geometry.vertices_vu.astype(np.float64))
+        # Negate to obtain "polarity normals": the direction the image
+        # gradient is expected to point at a bright-body limb.
+        normal_chunks.append(-feat.geometry.normals_vu.astype(np.float64))
+        sigma_chunks.append(feat.geometry.sigma_normal_per_vertex_px.astype(np.float64))
+        ids.append(feat.feature_id)
+    empty_2 = np.empty((0, 2), np.float64)
+    empty_1 = np.empty(0, np.float64)
+    vertices = np.concatenate(vert_chunks, axis=0) if vert_chunks else empty_2
+    normals = np.concatenate(normal_chunks, axis=0) if normal_chunks else empty_2
+    sigmas = np.concatenate(sigma_chunks, axis=0) if sigma_chunks else empty_1
+    return vertices, normals, sigmas, ids
+
+
+class BodyLimbNav(NavTechnique):
+    """Body-limb DT-based translation fit.
+
+    Consumes every ``LIMB_ARC`` feature whose visible arc length meets the
+    feasibility threshold and produces one combined translation offset by
+    minimising the summed weighted squared distance from the model
+    polylines to the image edge distance transform.  Per-vertex weights
+    follow the prior precision ``1 / sigma_normal_per_vertex_px**2``;
+    Tukey biweight reweighting handles the per-image outliers.
+
+    Class attributes:
+        accepts_feature_types: ``frozenset({LIMB_ARC})``.
+        requires_prior: ``False`` — the technique runs in pass 1.
+    """
+
+    name = 'BodyLimbNav'
+    accepts_feature_types = frozenset({NavFeatureType.LIMB_ARC})
+    requires_prior = False
+
+    def __init__(self, *, config: Config | None = None) -> None:
+        super().__init__(config=config)
+
+    def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
+        """Return whether the input set carries any usable limb arc.
+
+        Reads only the polyline vertex count per feature — never any
+        pixels — so the report is cheap to obtain even on large feature
+        sets.
+
+        Parameters:
+            features: Feature list filtered to this technique's accepted
+                types.
+
+        Returns:
+            ``NavFeasibilityReport`` with ``feasible=True`` iff at least
+            one LIMB_ARC has at least :data:`LIMB_MIN_ARC_PX` surviving
+            vertices.
+        """
+        eligible = [
+            f
+            for f in features
+            if isinstance(f.geometry, LimbPolyline)
+            and f.geometry.vertices_vu.shape[0] >= LIMB_MIN_ARC_PX
+        ]
+        if not eligible:
+            return NavFeasibilityReport(
+                feasible=False,
+                reason='no_limb_arc_features_with_sufficient_visible_arc',
+            )
+        return NavFeasibilityReport(
+            feasible=True,
+            reason='ok',
+            consumed_feature_count=len(eligible),
+        )
+
+    def navigate(self, features: list[NavFeature], context: NavContext) -> NavTechniqueResult:
+        """Compute the joint-translation offset from the input limb polylines.
+
+        Parameters:
+            features: Feature list filtered to the technique's accepted
+                types.  Polylines with fewer than :data:`LIMB_MIN_ARC_PX`
+                vertices are dropped before fitting.
+            context: Per-image NavContext.  Must carry
+                ``image_edge_dt_ext`` and ``image_gradient_vu_ext`` —
+                both populated by the orchestrator's ``_make_context``.
+
+        Returns:
+            A ``NavTechniqueResult`` with the recovered offset, 2x2
+            covariance, calibrated confidence, and a populated
+            :class:`BodyLimbDiagnostics`.
+        """
+        with self.logger.open(f'TECHNIQUE: {self.name}'):
+            if context.image_edge_dt_ext is None or context.image_gradient_vu_ext is None:
+                raise RuntimeError(
+                    'BodyLimbNav requires NavContext.image_edge_dt_ext and '
+                    'NavContext.image_gradient_vu_ext to be populated by the orchestrator'
+                )
+            eligible_features = [
+                f
+                for f in features
+                if isinstance(f.geometry, LimbPolyline)
+                and f.geometry.vertices_vu.shape[0] >= LIMB_MIN_ARC_PX
+            ]
+            self.logger.info(
+                'Consuming %d LIMB_ARC features (out of %d offered)',
+                len(eligible_features),
+                len(features),
+            )
+            vertices, polarity_normals, sigmas, feature_ids = _aggregate_limb_features(
+                eligible_features
+            )
+            edge_dt = context.image_edge_dt_ext
+            gradient_vu = context.image_gradient_vu_ext
+            edge_mask = edge_dt <= 0.5
+            polyline_mask = _build_polyline_mask(vertices, edge_dt.shape[:2])
+            margin_v, margin_u = _search_window_for_obs(context)
+            coarse_dv, coarse_du = coarse_ncc_search(
+                edge_mask,
+                polyline_mask,
+                (margin_v, margin_u),
+            )
+            self.logger.debug('Coarse NCC offset: (%d, %d)', coarse_dv, coarse_du)
+            result = lm_subpixel_refine(
+                vertices_vu=vertices,
+                normals_vu=polarity_normals,
+                sigma_normal_per_vertex_px=sigmas,
+                image_edge_dt=edge_dt,
+                image_gradient_vu=gradient_vu,
+                initial_offset_vu=(float(coarse_dv), float(coarse_du)),
+                use_polarity=True,
+            )
+            dv_final, du_final = result.offset_vu
+            at_edge = (
+                abs(dv_final - margin_v) <= _AT_EDGE_TOLERANCE_PX
+                or abs(dv_final + margin_v) <= _AT_EDGE_TOLERANCE_PX
+                or abs(du_final - margin_u) <= _AT_EDGE_TOLERANCE_PX
+                or abs(du_final + margin_u) <= _AT_EDGE_TOLERANCE_PX
+            )
+            sigma_min_px = float(sigmas.min()) if sigmas.size else 1.0
+            spurious = (
+                result.rms_px > max(SPURIOUS_DT_FLOOR_PX, SPURIOUS_DT_RMS_FACTOR * sigma_min_px)
+                or result.inlier_count < SPURIOUS_MIN_INLIERS
+            )
+            visible_limb_arc_fraction = _aggregate_visible_arc_fraction(eligible_features)
+            diagnostics = BodyLimbDiagnostics(
+                visible_limb_arc_fraction=visible_limb_arc_fraction,
+                visible_arc_px=float(vertices.shape[0]),
+                dt_fit_rms_px=float(result.rms_px),
+                lm_iterations=int(result.iterations),
+                tukey_inlier_count=int(result.inlier_count),
+            )
+            confidence = evaluate_sigmoid_combination(
+                _BODY_LIMB_CONFIDENCE_SPEC,
+                _LimbConfidenceContext(at_edge=at_edge, diagnostics=diagnostics),
+                technique_name=self.name,
+            )
+            self.logger.info(
+                'Converged at offset (%.4f, %.4f) px, RMS %.4f px, inliers %d / %d, '
+                'confidence %.4f',
+                dv_final,
+                du_final,
+                result.rms_px,
+                result.inlier_count,
+                int(vertices.shape[0]),
+                float(confidence),
+            )
+            covariance = result.covariance
+            if covariance.shape != (2, 2):
+                covariance = covariance[:2, :2]
+            return NavTechniqueResult(
+                technique_name=self.name,
+                feature_ids=tuple(feature_ids),
+                offset_px=(float(dv_final), float(du_final)),
+                covariance_px2=covariance,
+                confidence=float(confidence),
+                spurious=bool(spurious),
+                at_edge=bool(at_edge),
+                diagnostics=diagnostics,
+            )
+
+
+class _LimbConfidenceContext:
+    """Adapter binding ``BodyLimbDiagnostics`` plus ``at_edge`` for confidence eval.
+
+    The shared :func:`evaluate_sigmoid_combination` helper accepts any
+    object whose attributes match the spec's term names.  ``at_edge`` is
+    not part of ``BodyLimbDiagnostics`` (it lives on
+    ``NavTechniqueResult``) so this small adapter exposes both as
+    attributes of one object the spec can dot into.
+    """
+
+    def __init__(self, *, at_edge: bool, diagnostics: BodyLimbDiagnostics) -> None:
+        self.at_edge = at_edge
+        self.visible_limb_arc_fraction = diagnostics.visible_limb_arc_fraction
+        self.visible_arc_px = diagnostics.visible_arc_px
+        self.dt_fit_rms_px = diagnostics.dt_fit_rms_px
+        self.lm_iterations = diagnostics.lm_iterations
+        self.tukey_inlier_count = diagnostics.tukey_inlier_count
+
+
+def _aggregate_visible_arc_fraction(features: list[NavFeature]) -> float:
+    """Return the per-feature ``visible_arc_fraction`` weighted by vertex count.
+
+    The reliability breakdown carries each feature's visible-arc fraction
+    on the predicted polyline; the diagnostic on the navigation result
+    summarises across all consumed features by weighting each fraction by
+    the count of surviving vertices.  The result is in ``[0, 1]``.
+    """
+    total_weighted = 0.0
+    total_count = 0.0
+    for feat in features:
+        fraction = feat.reliability_reasons.visible_arc_fraction
+        if fraction is None:
+            continue
+        if not isinstance(feat.geometry, LimbPolyline):
+            continue
+        n = float(feat.geometry.vertices_vu.shape[0])
+        total_weighted += float(fraction) * n
+        total_count += n
+    if total_count == 0.0:
+        return 0.0
+    return total_weighted / total_count
+
+
+def _search_window_for_obs(context: NavContext) -> tuple[int, int]:
+    """Return the ``(margin_v, margin_u)`` search window for the coarse NCC.
+
+    The technique respects the per-instrument extfov margin attached to
+    the observation; if the obs does not expose that attribute (e.g.,
+    test fixtures), a 32 x 32 fallback is used so the technique still
+    runs end-to-end for unit-test scenes.
+    """
+    obs = context.obs
+    margin = getattr(obs, 'extfov_margin_vu', None)
+    if margin is None:
+        return (32, 32)
+    return (int(margin[0]), int(margin[1]))

--- a/src/nav/nav_technique/nav_technique_body_terminator.py
+++ b/src/nav/nav_technique/nav_technique_body_terminator.py
@@ -1,0 +1,383 @@
+"""``BodyTerminatorNav`` — translation fit from body terminator polylines.
+
+Mirrors :class:`BodyLimbNav` with three terminator-specific differences:
+
+1. The accepted feature type is ``TERMINATOR_ARC`` instead of ``LIMB_ARC``.
+2. Per-body uniform weighting: every vertex of a given body shares one
+   inverse-variance weight derived from the body's mean
+   ``sigma_normal_per_vertex_px``.  Cross-body weighting reflects albedo
+   variation (low-albedo bodies provide tighter terminators than
+   high-albedo ones).
+3. The confidence spec includes additional terms for the per-body
+   visible-terminator-arc fraction and the phase-angle factor flag,
+   capturing the design's albedo / phase-geometry sensitivity.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from nav.config import Config
+from nav.feature.feature import NavFeature
+from nav.feature.feature_type import NavFeatureType
+from nav.feature.flags import TerminatorArcFlags
+from nav.feature.geometry import TerminatorPolyline
+from nav.nav_technique.confidence import (
+    ConfidenceSpec,
+    ConfidenceTerm,
+    evaluate_sigmoid_combination,
+)
+from nav.nav_technique.diagnostics import BodyTerminatorDiagnostics
+from nav.nav_technique.dt_fitting import (
+    coarse_ncc_search,
+    lm_subpixel_refine,
+)
+from nav.nav_technique.feasibility import NavFeasibilityReport
+from nav.nav_technique.nav_technique import NavTechnique
+from nav.nav_technique.technique_result import NavTechniqueResult
+from nav.support.types import NDArrayBoolType, NDArrayFloatType
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from nav.nav_orchestrator.nav_context import NavContext
+
+__all__ = ['BodyTerminatorNav']
+
+
+TERMINATOR_MIN_ARC_PX: float = 30.0
+"""Minimum surviving polyline length per TERMINATOR_ARC feature for feasibility."""
+
+
+SPURIOUS_DT_RMS_FACTOR: float = 5.0
+"""Final DT residual exceeding this many limb-sigmas marks the result spurious."""
+
+
+SPURIOUS_DT_FLOOR_PX: float = 4.0
+"""Floor for the spurious-detection threshold (terminators are softer than limbs)."""
+
+
+SPURIOUS_MIN_INLIERS: int = 6
+"""Below this Tukey-inlier count the final fit is flagged spurious."""
+
+
+_AT_EDGE_TOLERANCE_PX: float = 1.0
+"""Pixels of slack around the search-window axis bounds for at-edge detection.
+
+A converged offset whose absolute distance from any axis bound (``+/-margin_v``,
+``+/-margin_u``) falls within this tolerance is flagged ``at_edge=True`` and
+forced to zero confidence by the technique's ``hard_zero_if`` gate.  One pixel
+matches the bilinear DT half-cell width: any closer to the boundary and the
+LM gradient information is unreliable.
+"""
+
+
+_BODY_TERMINATOR_CONFIDENCE_SPEC = ConfidenceSpec(
+    alpha0=-1.0,
+    terms=(
+        ConfidenceTerm(feature='visible_terminator_arc_fraction', alpha=2.0),
+        ConfidenceTerm(feature='dt_fit_rms_px', alpha=-1.0),
+        ConfidenceTerm(
+            feature='visible_arc_px',
+            alpha=0.4,
+            divisor=100.0,
+            cap_at=1.0,
+        ),
+        ConfidenceTerm(feature='mean_phase_angle_factor', alpha=1.0),
+        ConfidenceTerm(feature='mean_albedo_penalty', alpha=-1.5),
+    ),
+    hard_zero_if={'at_edge': True},
+)
+"""Default confidence spec for the body-terminator technique.
+
+Terminator ceiling sits below the limb's ceiling because albedo variation
+softens the photometric edge; the phase-angle-factor term boosts
+crescent-illumination geometries (where the terminator is geometrically
+sharp) and the albedo-penalty term suppresses scenes where surface
+mottling would otherwise dominate.
+"""
+
+
+def _build_polyline_mask(
+    vertices_vu: NDArrayFloatType, shape_vu: tuple[int, int]
+) -> NDArrayBoolType:
+    """Render polyline vertices into a boolean image mask aligned to shape_vu."""
+    vs = np.rint(vertices_vu[:, 0]).astype(np.int64)
+    us = np.rint(vertices_vu[:, 1]).astype(np.int64)
+    valid = (vs >= 0) & (vs < shape_vu[0]) & (us >= 0) & (us < shape_vu[1])
+    mask = np.zeros(shape_vu, dtype=bool)
+    if valid.any():
+        mask[vs[valid], us[valid]] = True
+    return mask
+
+
+def _aggregate_terminator_features(
+    features: list[NavFeature],
+) -> tuple[
+    NDArrayFloatType,
+    NDArrayFloatType,
+    NDArrayFloatType,
+    list[str],
+    list[float],
+    list[float],
+]:
+    """Concatenate per-body vertices and uniform-per-body sigmas.
+
+    The design dictates that every vertex of a given body shares
+    ``1 / sigma_normal_per_vertex_px**2`` derived from the body's mean
+    sigma — that captures cross-body albedo variation while smoothing
+    out per-vertex sigma noise.  The ``polarity_normals`` are the
+    geometric outward normal negated, identical to the limb pipeline,
+    because the terminator's image gradient also points from the dark
+    side toward the lit side.
+
+    Returns:
+        ``(vertices, polarity_normals, sigmas_uniform_per_body,
+        feature_ids, phase_angle_factors, albedo_penalties)``.
+    """
+    vert_chunks: list[NDArrayFloatType] = []
+    normal_chunks: list[NDArrayFloatType] = []
+    sigma_chunks: list[NDArrayFloatType] = []
+    ids: list[str] = []
+    phase_factors: list[float] = []
+    albedo_penalties: list[float] = []
+    for feat in features:
+        if not isinstance(feat.geometry, TerminatorPolyline):
+            continue
+        if feat.geometry.vertices_vu.shape[0] == 0:
+            continue
+        vertices = feat.geometry.vertices_vu.astype(np.float64)
+        outward = feat.geometry.normals_vu.astype(np.float64)
+        per_body_sigma = float(feat.geometry.sigma_normal_per_vertex_px.astype(np.float64).mean())
+        per_body_sigma_arr = np.full(vertices.shape[0], per_body_sigma, dtype=np.float64)
+        vert_chunks.append(vertices)
+        normal_chunks.append(-outward)
+        sigma_chunks.append(per_body_sigma_arr)
+        ids.append(feat.feature_id)
+        flags = feat.flags
+        if isinstance(flags, TerminatorArcFlags):
+            phase_factors.append(float(flags.phase_angle_factor))
+        else:
+            phase_factors.append(1.0)
+        albedo_penalty = feat.reliability_reasons.albedo_penalty
+        albedo_penalties.append(float(albedo_penalty) if albedo_penalty is not None else 0.0)
+    empty_2 = np.empty((0, 2), np.float64)
+    empty_1 = np.empty(0, np.float64)
+    vertices_out = np.concatenate(vert_chunks, axis=0) if vert_chunks else empty_2
+    normals_out = np.concatenate(normal_chunks, axis=0) if normal_chunks else empty_2
+    sigmas_out = np.concatenate(sigma_chunks, axis=0) if sigma_chunks else empty_1
+    return vertices_out, normals_out, sigmas_out, ids, phase_factors, albedo_penalties
+
+
+class BodyTerminatorNav(NavTechnique):
+    """Body-terminator DT-based translation fit.
+
+    Class attributes:
+        accepts_feature_types: ``frozenset({TERMINATOR_ARC})``.
+        requires_prior: ``False`` — the technique runs in pass 1.
+    """
+
+    name = 'BodyTerminatorNav'
+    accepts_feature_types = frozenset({NavFeatureType.TERMINATOR_ARC})
+    requires_prior = False
+
+    def __init__(self, *, config: Config | None = None) -> None:
+        super().__init__(config=config)
+
+    def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
+        """Return whether the input set carries a usable terminator arc.
+
+        Reads only the polyline vertex count per feature.
+
+        Parameters:
+            features: Feature list filtered to this technique's accepted
+                types.
+
+        Returns:
+            ``NavFeasibilityReport`` with ``feasible=True`` iff at least
+            one TERMINATOR_ARC has at least :data:`TERMINATOR_MIN_ARC_PX`
+            surviving vertices.
+        """
+        eligible = [
+            f
+            for f in features
+            if isinstance(f.geometry, TerminatorPolyline)
+            and f.geometry.vertices_vu.shape[0] >= TERMINATOR_MIN_ARC_PX
+        ]
+        if not eligible:
+            return NavFeasibilityReport(
+                feasible=False,
+                reason='no_terminator_arc_features_with_sufficient_visible_arc',
+            )
+        return NavFeasibilityReport(
+            feasible=True,
+            reason='ok',
+            consumed_feature_count=len(eligible),
+        )
+
+    def navigate(self, features: list[NavFeature], context: NavContext) -> NavTechniqueResult:
+        """Compute the joint-translation offset from the input terminator polylines.
+
+        Parameters:
+            features: Feature list filtered to the technique's accepted
+                types.  Polylines with fewer than
+                :data:`TERMINATOR_MIN_ARC_PX` vertices are dropped before
+                fitting.
+            context: Per-image NavContext.  Must carry
+                ``image_edge_dt_ext`` and ``image_gradient_vu_ext`` —
+                both populated by the orchestrator's ``_make_context``.
+
+        Returns:
+            A ``NavTechniqueResult`` with the recovered offset, 2x2
+            covariance, calibrated confidence, and a populated
+            :class:`BodyTerminatorDiagnostics`.
+        """
+        with self.logger.open(f'TECHNIQUE: {self.name}'):
+            if context.image_edge_dt_ext is None or context.image_gradient_vu_ext is None:
+                raise RuntimeError(
+                    'BodyTerminatorNav requires NavContext.image_edge_dt_ext and '
+                    'NavContext.image_gradient_vu_ext to be populated by the orchestrator'
+                )
+            eligible_features = [
+                f
+                for f in features
+                if isinstance(f.geometry, TerminatorPolyline)
+                and f.geometry.vertices_vu.shape[0] >= TERMINATOR_MIN_ARC_PX
+            ]
+            self.logger.info(
+                'Consuming %d TERMINATOR_ARC features (out of %d offered)',
+                len(eligible_features),
+                len(features),
+            )
+            (
+                vertices,
+                polarity_normals,
+                sigmas,
+                feature_ids,
+                phase_factors,
+                albedo_penalties,
+            ) = _aggregate_terminator_features(eligible_features)
+            edge_dt = context.image_edge_dt_ext
+            gradient_vu = context.image_gradient_vu_ext
+            edge_mask = edge_dt <= 0.5
+            polyline_mask = _build_polyline_mask(vertices, edge_dt.shape[:2])
+            margin_v, margin_u = _search_window_for_obs(context)
+            coarse_dv, coarse_du = coarse_ncc_search(
+                edge_mask,
+                polyline_mask,
+                (margin_v, margin_u),
+            )
+            self.logger.debug('Coarse NCC offset: (%d, %d)', coarse_dv, coarse_du)
+            result = lm_subpixel_refine(
+                vertices_vu=vertices,
+                normals_vu=polarity_normals,
+                sigma_normal_per_vertex_px=sigmas,
+                image_edge_dt=edge_dt,
+                image_gradient_vu=gradient_vu,
+                initial_offset_vu=(float(coarse_dv), float(coarse_du)),
+                use_polarity=True,
+            )
+            dv_final, du_final = result.offset_vu
+            at_edge = (
+                abs(dv_final - margin_v) <= _AT_EDGE_TOLERANCE_PX
+                or abs(dv_final + margin_v) <= _AT_EDGE_TOLERANCE_PX
+                or abs(du_final - margin_u) <= _AT_EDGE_TOLERANCE_PX
+                or abs(du_final + margin_u) <= _AT_EDGE_TOLERANCE_PX
+            )
+            sigma_min_px = float(sigmas.min()) if sigmas.size else 1.0
+            spurious = (
+                result.rms_px > max(SPURIOUS_DT_FLOOR_PX, SPURIOUS_DT_RMS_FACTOR * sigma_min_px)
+                or result.inlier_count < SPURIOUS_MIN_INLIERS
+            )
+            visible_terminator_arc_fraction = _aggregate_visible_arc_fraction(eligible_features)
+            mean_phase = float(np.mean(phase_factors)) if phase_factors else 0.0
+            mean_albedo = float(np.mean(albedo_penalties)) if albedo_penalties else 0.0
+            diagnostics = BodyTerminatorDiagnostics(
+                visible_terminator_arc_fraction=visible_terminator_arc_fraction,
+                visible_arc_px=float(vertices.shape[0]),
+                dt_fit_rms_px=float(result.rms_px),
+                lm_iterations=int(result.iterations),
+                tukey_inlier_count=int(result.inlier_count),
+            )
+            confidence_context = _TerminatorConfidenceContext(
+                at_edge=at_edge,
+                diagnostics=diagnostics,
+                mean_phase_angle_factor=mean_phase,
+                mean_albedo_penalty=mean_albedo,
+            )
+            confidence = evaluate_sigmoid_combination(
+                _BODY_TERMINATOR_CONFIDENCE_SPEC,
+                confidence_context,
+                technique_name=self.name,
+            )
+            self.logger.info(
+                'Converged at offset (%.4f, %.4f) px, RMS %.4f px, inliers %d / %d, '
+                'confidence %.4f',
+                dv_final,
+                du_final,
+                result.rms_px,
+                result.inlier_count,
+                int(vertices.shape[0]),
+                float(confidence),
+            )
+            covariance = result.covariance
+            if covariance.shape != (2, 2):
+                covariance = covariance[:2, :2]
+            return NavTechniqueResult(
+                technique_name=self.name,
+                feature_ids=tuple(feature_ids),
+                offset_px=(float(dv_final), float(du_final)),
+                covariance_px2=covariance,
+                confidence=float(confidence),
+                spurious=bool(spurious),
+                at_edge=bool(at_edge),
+                diagnostics=diagnostics,
+            )
+
+
+class _TerminatorConfidenceContext:
+    """Adapter exposing terminator confidence terms in a single attribute set."""
+
+    def __init__(
+        self,
+        *,
+        at_edge: bool,
+        diagnostics: BodyTerminatorDiagnostics,
+        mean_phase_angle_factor: float,
+        mean_albedo_penalty: float,
+    ) -> None:
+        self.at_edge = at_edge
+        self.visible_terminator_arc_fraction = diagnostics.visible_terminator_arc_fraction
+        self.visible_arc_px = diagnostics.visible_arc_px
+        self.dt_fit_rms_px = diagnostics.dt_fit_rms_px
+        self.lm_iterations = diagnostics.lm_iterations
+        self.tukey_inlier_count = diagnostics.tukey_inlier_count
+        self.mean_phase_angle_factor = mean_phase_angle_factor
+        self.mean_albedo_penalty = mean_albedo_penalty
+
+
+def _aggregate_visible_arc_fraction(features: list[NavFeature]) -> float:
+    """Return the per-feature ``visible_arc_fraction`` weighted by vertex count."""
+    total_weighted = 0.0
+    total_count = 0.0
+    for feat in features:
+        fraction = feat.reliability_reasons.visible_arc_fraction
+        if fraction is None:
+            continue
+        if not isinstance(feat.geometry, TerminatorPolyline):
+            continue
+        n = float(feat.geometry.vertices_vu.shape[0])
+        total_weighted += float(fraction) * n
+        total_count += n
+    if total_count == 0.0:
+        return 0.0
+    return total_weighted / total_count
+
+
+def _search_window_for_obs(context: NavContext) -> tuple[int, int]:
+    """Return ``(margin_v, margin_u)`` for the coarse search."""
+    obs = context.obs
+    margin = getattr(obs, 'extfov_margin_vu', None)
+    if margin is None:
+        return (32, 32)
+    return (int(margin[0]), int(margin[1]))

--- a/src/nav/nav_technique/nav_technique_ring_edge.py
+++ b/src/nav/nav_technique/nav_technique_ring_edge.py
@@ -1,0 +1,369 @@
+"""``RingEdgeNav`` — translation fit from ring-edge polylines.
+
+Consumes every ``RING_EDGE`` feature in the input set and produces a
+single combined translation by minimising the joint distance-transform
+cost.  When every input ring edge is flagged ``is_straight_line`` the
+combined Jacobian is rank-deficient — all parallel ring edges share a
+single ring-plane normal, so the along-edge axis is unobservable.  The
+returned covariance is honestly rank-1 in that case; the ensemble
+combine fuses it with any orthogonal-axis result (a star, body limb,
+body blob) before declaring a final answer.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from nav.config import Config
+from nav.feature.feature import NavFeature
+from nav.feature.feature_type import NavFeatureType
+from nav.feature.geometry import RingEdgePolyline
+from nav.nav_technique.confidence import (
+    ConfidenceSpec,
+    ConfidenceTerm,
+    evaluate_sigmoid_combination,
+)
+from nav.nav_technique.diagnostics import RingEdgeDiagnostics
+from nav.nav_technique.dt_fitting import (
+    coarse_ncc_search,
+    lm_subpixel_refine,
+)
+from nav.nav_technique.feasibility import NavFeasibilityReport
+from nav.nav_technique.nav_technique import NavTechnique
+from nav.nav_technique.technique_result import NavTechniqueResult
+from nav.support.types import NDArrayBoolType, NDArrayFloatType
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from nav.nav_orchestrator.nav_context import NavContext
+
+__all__ = ['RingEdgeNav']
+
+
+_AT_EDGE_TOLERANCE_PX: float = 1.0
+"""Pixels of slack around the search-window axis bounds for at-edge detection.
+
+A converged offset whose absolute distance from any axis bound (``+/-margin_v``,
+``+/-margin_u``) falls within this tolerance is flagged ``at_edge=True`` and
+forced to zero confidence by the technique's ``hard_zero_if`` gate.  One pixel
+matches the bilinear DT half-cell width: any closer to the boundary and the
+LM gradient information is unreliable.
+"""
+
+
+SPURIOUS_DT_RMS_FACTOR: float = 5.0
+"""Final DT residual exceeding this many radial-sigmas marks the result spurious."""
+
+
+SPURIOUS_DT_FLOOR_PX: float = 3.0
+"""Floor for the spurious-detection threshold."""
+
+
+SPURIOUS_MIN_INLIERS: int = 6
+"""Below this Tukey-inlier count the final fit is flagged spurious."""
+
+
+_RANK1_NULL_RELATIVE_THRESHOLD: float = 1.0e-8
+"""Eigenvalue ratio below which a 2x2 covariance is treated as rank-1.
+
+Matches the ensemble's scale-independent rank-deficiency test so the
+two paths agree on whether a result is rank-deficient.
+"""
+
+
+_RING_EDGE_CONFIDENCE_SPEC = ConfidenceSpec(
+    alpha0=-1.0,
+    terms=(
+        ConfidenceTerm(
+            feature='total_edge_length_px',
+            alpha=1.0,
+            divisor=200.0,
+            cap_at=1.0,
+        ),
+        ConfidenceTerm(feature='per_edge_dt_rms_summed', alpha=-2.0),
+    ),
+    hard_zero_if={'at_edge': True},
+)
+"""Default confidence spec for the ring-edge technique.
+
+Long, low-residual fits get high confidence; very short or noisy fits
+collapse below the 0.2 floor.  When the result is rank-1 (every input
+edge is a straight line), the ensemble multiplies the unobservable axis
+by 0.0, so the per-axis confidence is meaningful even at full numeric
+value.
+"""
+
+
+def _build_polyline_mask(
+    vertices_vu: NDArrayFloatType, shape_vu: tuple[int, int]
+) -> NDArrayBoolType:
+    """Render polyline vertices into a boolean image mask aligned to shape_vu."""
+    vs = np.rint(vertices_vu[:, 0]).astype(np.int64)
+    us = np.rint(vertices_vu[:, 1]).astype(np.int64)
+    valid = (vs >= 0) & (vs < shape_vu[0]) & (us >= 0) & (us < shape_vu[1])
+    mask = np.zeros(shape_vu, dtype=bool)
+    if valid.any():
+        mask[vs[valid], us[valid]] = True
+    return mask
+
+
+def _aggregate_ring_edges(
+    features: list[NavFeature],
+) -> tuple[
+    NDArrayFloatType,
+    NDArrayFloatType,
+    NDArrayFloatType,
+    list[str],
+    bool,
+]:
+    """Concatenate vertices, polarity normals, and per-vertex sigmas for ring edges.
+
+    Returns:
+        ``(vertices, polarity_normals, sigmas, feature_ids,
+        every_edge_is_straight)``.  ``every_edge_is_straight`` is True
+        when every input edge has ``is_straight_line=True``; the
+        technique uses it to drive the rank-1 covariance path.
+    """
+    vert_chunks: list[NDArrayFloatType] = []
+    normal_chunks: list[NDArrayFloatType] = []
+    sigma_chunks: list[NDArrayFloatType] = []
+    ids: list[str] = []
+    every_straight = True
+    seen_any = False
+    for feat in features:
+        if not isinstance(feat.geometry, RingEdgePolyline):
+            continue
+        if feat.geometry.vertices_vu.shape[0] == 0:
+            continue
+        seen_any = True
+        if not feat.geometry.is_straight_line:
+            every_straight = False
+        vert_chunks.append(feat.geometry.vertices_vu.astype(np.float64))
+        # Negate the radial outward normal so the polarity check
+        # (``dot(model, image_gradient) > 0``) accepts edges whose image
+        # gradient points across the edge in the same sense as the
+        # negated normal.
+        normal_chunks.append(-feat.geometry.normals_vu.astype(np.float64))
+        sigma_chunks.append(feat.geometry.sigma_radial_per_vertex_px.astype(np.float64))
+        ids.append(feat.feature_id)
+    empty_2 = np.empty((0, 2), np.float64)
+    empty_1 = np.empty(0, np.float64)
+    vertices = np.concatenate(vert_chunks, axis=0) if vert_chunks else empty_2
+    normals = np.concatenate(normal_chunks, axis=0) if normal_chunks else empty_2
+    sigmas = np.concatenate(sigma_chunks, axis=0) if sigma_chunks else empty_1
+    return vertices, normals, sigmas, ids, (every_straight if seen_any else False)
+
+
+class RingEdgeNav(NavTechnique):
+    """Ring-edge DT-based translation fit.
+
+    Class attributes:
+        accepts_feature_types: ``frozenset({RING_EDGE})``.
+        requires_prior: ``False`` — the technique runs in pass 1.
+    """
+
+    name = 'RingEdgeNav'
+    accepts_feature_types = frozenset({NavFeatureType.RING_EDGE})
+    requires_prior = False
+
+    def __init__(self, *, config: Config | None = None) -> None:
+        super().__init__(config=config)
+
+    def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
+        """Return whether the input set carries any usable ring edge.
+
+        Reads only the polyline vertex count per feature.  A single
+        non-empty ring-edge polyline is sufficient: even an all-flat
+        scene produces a useful rank-1 constraint that the ensemble
+        will fuse with another feature.
+
+        Parameters:
+            features: Feature list filtered to this technique's accepted
+                types.
+
+        Returns:
+            ``NavFeasibilityReport`` with ``feasible=True`` iff at least
+            one RING_EDGE has a non-empty polyline.
+        """
+        eligible = [
+            f
+            for f in features
+            if isinstance(f.geometry, RingEdgePolyline) and f.geometry.vertices_vu.shape[0] > 0
+        ]
+        if not eligible:
+            return NavFeasibilityReport(
+                feasible=False,
+                reason='no_ring_edge_features',
+            )
+        return NavFeasibilityReport(
+            feasible=True,
+            reason='ok',
+            consumed_feature_count=len(eligible),
+        )
+
+    def navigate(self, features: list[NavFeature], context: NavContext) -> NavTechniqueResult:
+        """Compute the joint-translation offset from ring-edge polylines.
+
+        Parameters:
+            features: Feature list filtered to the technique's accepted
+                types.
+            context: Per-image NavContext.  Must carry
+                ``image_edge_dt_ext`` and ``image_gradient_vu_ext`` —
+                both populated by the orchestrator's ``_make_context``.
+
+        Returns:
+            A ``NavTechniqueResult`` with the recovered offset, 2x2
+            covariance (rank-1 when every input edge is straight),
+            calibrated confidence, and a populated
+            :class:`RingEdgeDiagnostics`.
+        """
+        with self.logger.open(f'TECHNIQUE: {self.name}'):
+            if context.image_edge_dt_ext is None or context.image_gradient_vu_ext is None:
+                raise RuntimeError(
+                    'RingEdgeNav requires NavContext.image_edge_dt_ext and '
+                    'NavContext.image_gradient_vu_ext to be populated by the orchestrator'
+                )
+            (
+                vertices,
+                polarity_normals,
+                sigmas,
+                feature_ids,
+                every_straight,
+            ) = _aggregate_ring_edges(features)
+            self.logger.info(
+                'Consuming %d RING_EDGE features (out of %d offered); every_straight=%s',
+                len(feature_ids),
+                len(features),
+                every_straight,
+            )
+            edge_dt = context.image_edge_dt_ext
+            gradient_vu = context.image_gradient_vu_ext
+            edge_mask = edge_dt <= 0.5
+            polyline_mask = _build_polyline_mask(vertices, edge_dt.shape[:2])
+            margin_v, margin_u = _search_window_for_obs(context)
+            coarse_dv, coarse_du = coarse_ncc_search(
+                edge_mask,
+                polyline_mask,
+                (margin_v, margin_u),
+            )
+            self.logger.debug('Coarse NCC offset: (%d, %d)', coarse_dv, coarse_du)
+            # Ring-edge polarity prediction depends on lighting / gap-vs-ringlet
+            # context the catalog does not encode today; skip polarity until
+            # the polarity-predictable flag is wired (deferred work).
+            result = lm_subpixel_refine(
+                vertices_vu=vertices,
+                normals_vu=polarity_normals,
+                sigma_normal_per_vertex_px=sigmas,
+                image_edge_dt=edge_dt,
+                image_gradient_vu=gradient_vu,
+                initial_offset_vu=(float(coarse_dv), float(coarse_du)),
+                use_polarity=False,
+            )
+            dv_final, du_final = result.offset_vu
+            at_edge = (
+                abs(dv_final - margin_v) <= _AT_EDGE_TOLERANCE_PX
+                or abs(dv_final + margin_v) <= _AT_EDGE_TOLERANCE_PX
+                or abs(du_final - margin_u) <= _AT_EDGE_TOLERANCE_PX
+                or abs(du_final + margin_u) <= _AT_EDGE_TOLERANCE_PX
+            )
+            sigma_min_px = float(sigmas.min()) if sigmas.size else 1.0
+            spurious = (
+                result.rms_px > max(SPURIOUS_DT_FLOOR_PX, SPURIOUS_DT_RMS_FACTOR * sigma_min_px)
+                or result.inlier_count < SPURIOUS_MIN_INLIERS
+            )
+            covariance = result.covariance
+            if covariance.shape != (2, 2):
+                covariance = covariance[:2, :2]
+            covariance = np.asarray(covariance, np.float64)
+            is_rank_1 = _is_rank_1(covariance) or every_straight
+            total_edge_length_px = float(vertices.shape[0])
+            per_edge_rms_summed = _per_edge_rms_summed(features, result.residuals_px)
+            diagnostics = RingEdgeDiagnostics(
+                total_edge_length_px=total_edge_length_px,
+                per_edge_dt_rms_summed=per_edge_rms_summed,
+                edge_count=len(feature_ids),
+                is_rank_1=bool(is_rank_1),
+            )
+            confidence = evaluate_sigmoid_combination(
+                _RING_EDGE_CONFIDENCE_SPEC,
+                _RingEdgeConfidenceContext(at_edge=at_edge, diagnostics=diagnostics),
+                technique_name=self.name,
+            )
+            self.logger.info(
+                'Converged at offset (%.4f, %.4f) px, RMS %.4f px, inliers %d / %d, '
+                'rank_1=%s, confidence %.4f',
+                dv_final,
+                du_final,
+                result.rms_px,
+                result.inlier_count,
+                int(vertices.shape[0]),
+                is_rank_1,
+                float(confidence),
+            )
+            return NavTechniqueResult(
+                technique_name=self.name,
+                feature_ids=tuple(feature_ids),
+                offset_px=(float(dv_final), float(du_final)),
+                covariance_px2=covariance,
+                confidence=float(confidence),
+                spurious=bool(spurious),
+                at_edge=bool(at_edge),
+                diagnostics=diagnostics,
+            )
+
+
+def _is_rank_1(covariance: NDArrayFloatType) -> bool:
+    """Return True when the 2x2 covariance is rank-deficient.
+
+    Uses the same scale-independent test as the ensemble combine: the
+    ratio of the smallest absolute eigenvalue to the largest must fall
+    below :data:`_RANK1_NULL_RELATIVE_THRESHOLD`.
+    """
+    if covariance.shape != (2, 2):
+        return False
+    eigvals = np.linalg.eigvalsh(covariance)
+    largest = float(np.abs(eigvals).max())
+    smallest = float(np.abs(eigvals).min())
+    if largest == 0.0:
+        return True
+    return smallest / largest < _RANK1_NULL_RELATIVE_THRESHOLD
+
+
+def _per_edge_rms_summed(features: list[NavFeature], residuals: NDArrayFloatType) -> float:
+    """Sum the per-edge weighted RMS DT residual across all consumed edges."""
+    total = 0.0
+    cursor = 0
+    for feat in features:
+        if not isinstance(feat.geometry, RingEdgePolyline):
+            continue
+        n = feat.geometry.vertices_vu.shape[0]
+        if n == 0:
+            continue
+        slice_residuals = residuals[cursor : cursor + n]
+        cursor += n
+        if slice_residuals.size == 0:
+            continue
+        rms = float(np.sqrt(np.mean(slice_residuals * slice_residuals)))
+        total += rms
+    return total
+
+
+class _RingEdgeConfidenceContext:
+    """Adapter exposing ring-edge confidence terms in a single attribute set."""
+
+    def __init__(self, *, at_edge: bool, diagnostics: RingEdgeDiagnostics) -> None:
+        self.at_edge = at_edge
+        self.total_edge_length_px = diagnostics.total_edge_length_px
+        self.per_edge_dt_rms_summed = diagnostics.per_edge_dt_rms_summed
+        self.edge_count = diagnostics.edge_count
+        self.is_rank_1 = diagnostics.is_rank_1
+
+
+def _search_window_for_obs(context: NavContext) -> tuple[int, int]:
+    """Return ``(margin_v, margin_u)`` for the coarse search."""
+    obs = context.obs
+    margin = getattr(obs, 'extfov_margin_vu', None)
+    if margin is None:
+        return (32, 32)
+    return (int(margin[0]), int(margin[1]))

--- a/src/nav/support/distance_transform.py
+++ b/src/nav/support/distance_transform.py
@@ -11,14 +11,11 @@ sub-pixel precision; the orchestrator's ``NavContext`` carries the per-image
 DT array so callers reach in once and the gradient is shared.
 """
 
-import logging
 from typing import cast
 
 import numpy as np
 
 from nav.support.types import NDArrayFloatType
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     'apply_translation',

--- a/src/nav/support/filters.py
+++ b/src/nav/support/filters.py
@@ -19,7 +19,6 @@ Thread safety: all functions in this module are pure / stateless; safe for
 concurrent use on independent inputs.
 """
 
-import logging
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import cast
@@ -34,8 +33,6 @@ from scipy.ndimage import (
 )
 
 from nav.support.types import NDArrayFloatType
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     'NavFilterKind',

--- a/src/nav/support/image_quality.py
+++ b/src/nav/support/image_quality.py
@@ -13,14 +13,10 @@ operations are global by design — no helper here crops to a predicted
 position.
 """
 
-import logging
-
 import numpy as np
 from scipy.ndimage import median_filter
 
 from nav.support.types import NDArrayBoolType, NDArrayFloatType
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     'cosmic_ray_mask',

--- a/src/nav/support/noise_estimate.py
+++ b/src/nav/support/noise_estimate.py
@@ -10,14 +10,10 @@ lives in the image, and is therefore not biased by a wrong SPICE pointing
 prediction.
 """
 
-import logging
-
 import numpy as np
 
 from nav.support.misc import mad_std
 from nav.support.types import NDArrayBoolType, NDArrayFloatType
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     'estimate_image_noise_sigma',

--- a/src/nav/support/status_reason.py
+++ b/src/nav/support/status_reason.py
@@ -12,10 +12,7 @@ outside the orchestrator (image-quality classifier, kernel-loading shim,
 dataset enumeration).
 """
 
-import logging
 from enum import StrEnum
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = ['NavStatusReason']
 

--- a/src/nav/ui/manual_nav_dialog.py
+++ b/src/nav/ui/manual_nav_dialog.py
@@ -372,8 +372,9 @@ class ManualNavDialog(QDialog):
         model = np.asarray(self._model_img_ext, dtype=np.float64)
         mask = np.asarray(self._model_mask_ext, dtype=bool)
         # Use the bi-directional (data-mask aware) NCC so the surface the user
-        # sees -- and the peak the Auto button finds -- matches what the
-        # correlate_all pipeline produces; without data_mask the zero-padded
+        # sees -- and the peak the Auto button finds -- matches the
+        # composite-template stream this dialog consumes from
+        # ``compose_template_features``; without data_mask the zero-padded
         # extfov margin biases the peak toward |dV| = extfov_margin_v.
         data_mask = self._obs.extfov_data_sensor_mask()
         self._corr_surface, _ = masked_ncc(image, model, mask, data_mask=data_mask)
@@ -792,9 +793,10 @@ class ManualNavDialog(QDialog):
         dlg.exec()
 
     def _on_auto(self) -> None:
-        # Call the same KPeaks correlation used by correlate_all, including
-        # the bi-directional data_mask so that a body model extending into
-        # the extfov zero-padded margin does not bias the peak toward
+        # Auto-pick: run the same KPeaks pyramid NCC against the composite
+        # template the dialog assembled via ``compose_template_features``.
+        # The bi-directional ``data_mask`` keeps a body model that extends
+        # into the extfov zero-padded margin from biasing the peak toward
         # |dV| = extfov_margin_v.
         up_factor = (
             getattr(self._config.offset, 'correlation_fft_upsample_factor', 128)

--- a/tests/nav/nav_orchestrator/test_image_derivatives.py
+++ b/tests/nav/nav_orchestrator/test_image_derivatives.py
@@ -1,0 +1,215 @@
+"""Unit tests for ``nav.nav_orchestrator.image_derivatives``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from nav.nav_orchestrator.image_derivatives import (
+    DEFAULT_DT_HALF_WIDTH_PX,
+    DEFAULT_EDGE_THRESHOLD_K_SIGMA,
+    DEFAULT_IMAGE_GRADIENT_SIGMA_PX,
+    ImageDerivativesConfig,
+    build_image_edge_dt,
+    compute_image_gradient_vu,
+)
+
+
+def _step_image(shape: tuple[int, int], step_v: int) -> np.ndarray:
+    """Return an image with a single horizontal bright bar centred on ``step_v``.
+
+    The bar is 8 pixels tall so the borders of the image stay in the same
+    background as their interior neighbours, suppressing the
+    sobel-with-constant-padding boundary artefact that would otherwise
+    dominate the gradient image on a small test fixture.
+    """
+    img = np.zeros(shape, dtype=np.float64)
+    img[step_v - 4 : step_v + 4, :] = 100.0
+    return img
+
+
+def test_image_derivatives_config_defaults_match_design() -> None:
+    cfg = ImageDerivativesConfig()
+    assert cfg.image_gradient_sigma_px == DEFAULT_IMAGE_GRADIENT_SIGMA_PX
+    assert cfg.edge_threshold_k_sigma == DEFAULT_EDGE_THRESHOLD_K_SIGMA
+    assert cfg.dt_half_width_px == DEFAULT_DT_HALF_WIDTH_PX
+
+
+def test_image_derivatives_config_rejects_zero_sigma() -> None:
+    with pytest.raises(ValueError, match='image_gradient_sigma_px'):
+        ImageDerivativesConfig(image_gradient_sigma_px=0.0)
+
+
+def test_image_derivatives_config_rejects_zero_threshold() -> None:
+    with pytest.raises(ValueError, match='edge_threshold_k_sigma'):
+        ImageDerivativesConfig(edge_threshold_k_sigma=0.0)
+
+
+def test_image_derivatives_config_rejects_zero_half_width() -> None:
+    with pytest.raises(ValueError, match='dt_half_width_px'):
+        ImageDerivativesConfig(dt_half_width_px=-1.0)
+
+
+def test_build_image_edge_dt_peak_aligns_with_step_edge() -> None:
+    # A horizontal bar centred on row 16 has its leading edge near row 12
+    # and trailing edge near row 19; the gradient row-sum peaks at one of
+    # those rows after Gaussian smoothing.
+    shape = (40, 40)
+    img = _step_image(shape, step_v=16)
+    gradient, edge_dt = build_image_edge_dt(img, image_noise_sigma=1.0)
+    assert gradient.shape == shape
+    assert edge_dt.shape == shape
+    peak_row = int(np.argmax(gradient.sum(axis=1)))
+    leading_edge = 12
+    trailing_edge = 19
+    assert min(abs(peak_row - leading_edge), abs(peak_row - trailing_edge)) <= 1
+
+
+def test_build_image_edge_dt_zeros_edge_dt_on_thresholded_pixels() -> None:
+    img = _step_image((40, 40), step_v=16)
+    _, edge_dt = build_image_edge_dt(img, image_noise_sigma=1.0)
+    # Pixels along the leading edge (row 12) get DT = 0 exactly --
+    # ``distance_transform_edt`` returns integer-zero on edge pixels of a
+    # binary mask, so the assertion can be exact rather than approximate.
+    assert float(edge_dt[12, 20]) == 0.0
+    # A pixel far from any edge has positive DT.
+    assert float(edge_dt[0, 0]) > 0.0
+
+
+def test_build_image_edge_dt_falls_back_when_no_pixel_exceeds_threshold() -> None:
+    img = np.full((16, 16), 1.0, dtype=np.float64)
+    cfg = ImageDerivativesConfig(
+        edge_threshold_k_sigma=1000.0,
+        dt_half_width_px=5.0,
+    )
+    gradient, edge_dt = build_image_edge_dt(img, image_noise_sigma=10.0, config=cfg)
+    # No edge pixels survive the very high threshold; DT saturates at the
+    # half width even though the gradient itself has small boundary
+    # artefacts from the constant-padded Sobel.
+    threshold = cfg.edge_threshold_k_sigma * 10.0
+    assert (gradient <= threshold).all()
+    assert np.allclose(edge_dt, cfg.dt_half_width_px, atol=1e-12)
+
+
+def test_build_image_edge_dt_threshold_sweep_matches_expected_count() -> None:
+    img = _step_image((40, 40), step_v=16)
+    # Decreasing the k_sigma factor lets more pixels pass the threshold;
+    # binarized edge counts must be monotonically non-decreasing.
+    counts: list[int] = []
+    for k in (8.0, 4.0, 2.0):
+        cfg = ImageDerivativesConfig(edge_threshold_k_sigma=k)
+        gradient, _ = build_image_edge_dt(img, image_noise_sigma=1.0, config=cfg)
+        threshold = k * 1.0
+        edge_count = int((gradient > threshold).sum())
+        counts.append(edge_count)
+    assert counts[0] <= counts[1] <= counts[2]
+
+
+def test_build_image_edge_dt_rejects_non_2d_input() -> None:
+    with pytest.raises(TypeError, match='image_ext must be 2-D'):
+        build_image_edge_dt(np.zeros((4, 4, 4)), image_noise_sigma=1.0)
+
+
+def test_build_image_edge_dt_rejects_negative_noise_sigma() -> None:
+    with pytest.raises(ValueError, match='image_noise_sigma'):
+        build_image_edge_dt(np.zeros((4, 4)), image_noise_sigma=-1.0)
+
+
+def test_build_image_edge_dt_rejects_nan_noise_sigma() -> None:
+    with pytest.raises(ValueError, match='image_noise_sigma'):
+        build_image_edge_dt(np.zeros((4, 4)), image_noise_sigma=float('nan'))
+
+
+def test_compute_image_gradient_vu_horizontal_step_points_along_v() -> None:
+    shape = (40, 40)
+    img = _step_image(shape, step_v=16)
+    grad = compute_image_gradient_vu(img, sigma_px=1.0)
+    assert grad.shape == (40, 40, 2)
+    # The leading edge of the bar (image rises from 0 to 100 with
+    # increasing row index) sits near row 12: g_v is strictly positive
+    # there because Sobel returns a positive derivative when image values
+    # increase with row.
+    assert float(grad[12, 20, 0]) > 0.0
+    # The orthogonal u-axis gradient is essentially zero on a horizontal
+    # bar.
+    assert abs(float(grad[12, 20, 1])) < 1.0
+
+
+def test_compute_image_gradient_vu_vertical_step_points_along_u() -> None:
+    img = np.zeros((32, 32), dtype=np.float64)
+    img[:, 16:] = 100.0
+    grad = compute_image_gradient_vu(img, sigma_px=1.0)
+    assert float(grad[16, 16, 1]) > 0.0
+    assert abs(float(grad[16, 16, 0])) < 1.0
+
+
+def test_compute_image_gradient_vu_rejects_non_2d_input() -> None:
+    with pytest.raises(TypeError, match='image_ext must be 2-D'):
+        compute_image_gradient_vu(np.zeros((4, 4, 2)))
+
+
+def test_compute_image_gradient_vu_rejects_zero_sigma() -> None:
+    with pytest.raises(ValueError, match='sigma_px must be > 0'):
+        compute_image_gradient_vu(np.zeros((4, 4)), sigma_px=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Boundary tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_image_edge_dt_handles_minimal_4x4_image() -> None:
+    """Smallest meaningful image: 4x4 still produces correctly-shaped outputs.
+
+    The Gaussian smooth, Sobel, NMS, and DT pipeline must all tolerate
+    a 4x4 input without raising or producing degenerate-shape arrays.
+    Sobel-with-constant-padding boundary artefacts may produce a few
+    edge pixels at the corners; what we verify is that the pipeline
+    completes and returns 2-D float64 arrays of the right shape with
+    finite values throughout.
+    """
+    img = np.full((4, 4), 5.0, dtype=np.float64)
+    cfg = ImageDerivativesConfig(dt_half_width_px=3.0)
+    gradient, edge_dt = build_image_edge_dt(img, image_noise_sigma=1.0, config=cfg)
+    assert gradient.shape == (4, 4)
+    assert edge_dt.shape == (4, 4)
+    assert np.isfinite(gradient).all()
+    assert np.isfinite(edge_dt).all()
+    # DT entries are bounded by the configured half-width.
+    assert float(edge_dt.max()) <= cfg.dt_half_width_px
+
+
+def test_compute_image_gradient_vu_handles_minimal_4x4_image() -> None:
+    """Gradient-vector helper produces a (4, 4, 2) output on a 4x4 input."""
+    img = np.full((4, 4), 5.0, dtype=np.float64)
+    grad = compute_image_gradient_vu(img, sigma_px=1.0)
+    assert grad.shape == (4, 4, 2)
+
+
+def test_build_image_edge_dt_threshold_boundary_exact() -> None:
+    """A pixel whose gradient magnitude equals the threshold is excluded.
+
+    The implementation uses a strict ``gradient > threshold`` comparison
+    inside ``_directional_nms``; this test plants a gradient profile
+    chosen so that exactly one pixel sits at the threshold value and
+    verifies it is *not* kept in the edge mask.  The next-larger value
+    is kept, confirming the "at boundary -> excluded" half-open
+    convention.
+    """
+    img = _step_image((40, 40), step_v=16)
+    # Probe a noise sigma that makes the gradient peak exactly on the
+    # k_sigma boundary.  Compute the actual peak first to derive the
+    # noise sigma that makes it fall right at the threshold.
+    cfg = ImageDerivativesConfig(edge_threshold_k_sigma=4.0)
+    gradient_only, _ = build_image_edge_dt(img, image_noise_sigma=1.0e-6, config=cfg)
+    peak = float(gradient_only.max())
+    # Set noise sigma so threshold == peak exactly: peak == 4 * sigma.
+    boundary_sigma = peak / cfg.edge_threshold_k_sigma
+    _, edge_dt_boundary = build_image_edge_dt(img, image_noise_sigma=boundary_sigma, config=cfg)
+    # No pixel exceeds the threshold (strict ``>`` rejects the equality
+    # case), so the DT saturates everywhere at the half-width.
+    assert np.allclose(edge_dt_boundary, cfg.dt_half_width_px)
+    # A noise sigma fractionally below the boundary lets the peak
+    # through and produces at least one zero-DT pixel.
+    _, edge_dt_below = build_image_edge_dt(img, image_noise_sigma=boundary_sigma * 0.99, config=cfg)
+    assert float(edge_dt_below.min()) == 0.0

--- a/tests/nav/nav_orchestrator/test_image_derivatives.py
+++ b/tests/nav/nav_orchestrator/test_image_derivatives.py
@@ -11,6 +11,7 @@ from nav.nav_orchestrator.image_derivatives import (
     DEFAULT_IMAGE_GRADIENT_SIGMA_PX,
     ImageDerivativesConfig,
     build_image_edge_dt,
+    compute_all_image_derivatives,
     compute_image_gradient_vu,
 )
 
@@ -49,9 +50,9 @@ def test_image_derivatives_config_rejects_zero_threshold() -> None:
 
 
 def test_image_derivatives_config_rejects_zero_half_width() -> None:
-    """A non-positive ``dt_half_width_px`` is rejected with a named field message."""
+    """A zero ``dt_half_width_px`` is rejected with a named field message."""
     with pytest.raises(ValueError, match='dt_half_width_px'):
-        ImageDerivativesConfig(dt_half_width_px=-1.0)
+        ImageDerivativesConfig(dt_half_width_px=0.0)
 
 
 def test_build_image_edge_dt_peak_aligns_with_step_edge() -> None:
@@ -247,3 +248,63 @@ def test_build_image_edge_dt_threshold_boundary_exact() -> None:
     # through and produces at least one zero-DT pixel.
     _, edge_dt_below = build_image_edge_dt(img, image_noise_sigma=boundary_sigma * 0.99, config=cfg)
     assert float(edge_dt_below.min()) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Combined entry point — orchestrator-friendly single-pass derivative bundle
+# ---------------------------------------------------------------------------
+
+
+def test_compute_all_image_derivatives_matches_separate_calls() -> None:
+    """Combined entry point produces the same arrays as the two split calls.
+
+    The orchestrator switched from calling ``build_image_edge_dt`` and
+    ``compute_image_gradient_vu`` separately to using the combined entry
+    point.  Both paths must return byte-identical results because they
+    share the same underlying gaussian + sobel pipeline.
+    """
+    shape = (40, 40)
+    img = _step_image(shape, step_v=16)
+    cfg = ImageDerivativesConfig()
+    gradient_split, edge_dt_split = build_image_edge_dt(img, image_noise_sigma=1.0, config=cfg)
+    gradient_vu_split = compute_image_gradient_vu(img, sigma_px=cfg.image_gradient_sigma_px)
+    gradient_combo, edge_dt_combo, gradient_vu_combo = compute_all_image_derivatives(
+        img, image_noise_sigma=1.0, config=cfg
+    )
+    np.testing.assert_array_equal(gradient_combo, gradient_split)
+    np.testing.assert_array_equal(edge_dt_combo, edge_dt_split)
+    np.testing.assert_array_equal(gradient_vu_combo, gradient_vu_split)
+
+
+def test_compute_all_image_derivatives_rejects_non_2d_input() -> None:
+    """A non-2-D ``image_ext`` is rejected with a TypeError naming the field."""
+    with pytest.raises(TypeError, match='image_ext must be 2-D'):
+        compute_all_image_derivatives(np.zeros((4, 4, 4)), image_noise_sigma=1.0)
+
+
+def test_compute_all_image_derivatives_rejects_nan_image() -> None:
+    """A non-finite ``image_ext`` is rejected before any heavy work runs."""
+    img = np.zeros((8, 8), dtype=np.float64)
+    img[3, 3] = np.nan
+    with pytest.raises(ValueError, match='image_ext must contain only finite values'):
+        compute_all_image_derivatives(img, image_noise_sigma=1.0)
+
+
+def test_compute_all_image_derivatives_rejects_negative_noise_sigma() -> None:
+    """A negative ``image_noise_sigma`` is rejected with a named field message."""
+    with pytest.raises(ValueError, match='image_noise_sigma'):
+        compute_all_image_derivatives(np.zeros((4, 4)), image_noise_sigma=-1.0)
+
+
+def test_compute_all_image_derivatives_uses_default_config_when_none() -> None:
+    """``config=None`` resolves to the documented defaults."""
+    img = _step_image((40, 40), step_v=16)
+    gradient_default, edge_dt_default, gradient_vu_default = compute_all_image_derivatives(
+        img, image_noise_sigma=1.0
+    )
+    gradient_explicit, edge_dt_explicit, gradient_vu_explicit = compute_all_image_derivatives(
+        img, image_noise_sigma=1.0, config=ImageDerivativesConfig()
+    )
+    np.testing.assert_array_equal(gradient_default, gradient_explicit)
+    np.testing.assert_array_equal(edge_dt_default, edge_dt_explicit)
+    np.testing.assert_array_equal(gradient_vu_default, gradient_vu_explicit)

--- a/tests/nav/nav_orchestrator/test_image_derivatives.py
+++ b/tests/nav/nav_orchestrator/test_image_derivatives.py
@@ -149,8 +149,23 @@ def test_compute_image_gradient_vu_rejects_non_2d_input() -> None:
 
 
 def test_compute_image_gradient_vu_rejects_zero_sigma() -> None:
-    with pytest.raises(ValueError, match='sigma_px must be > 0'):
+    with pytest.raises(ValueError, match='sigma_px must be a finite positive number'):
         compute_image_gradient_vu(np.zeros((4, 4)), sigma_px=0.0)
+
+
+def test_compute_image_gradient_vu_rejects_inf_sigma() -> None:
+    with pytest.raises(ValueError, match='sigma_px must be a finite positive number'):
+        compute_image_gradient_vu(np.zeros((4, 4)), sigma_px=float('inf'))
+
+
+def test_build_image_edge_dt_rejects_inf_noise_sigma() -> None:
+    with pytest.raises(ValueError, match='image_noise_sigma must be finite'):
+        build_image_edge_dt(np.zeros((4, 4)), image_noise_sigma=float('inf'))
+
+
+def test_image_derivatives_config_rejects_inf_sigma() -> None:
+    with pytest.raises(ValueError, match='image_gradient_sigma_px'):
+        ImageDerivativesConfig(image_gradient_sigma_px=float('inf'))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/nav/nav_orchestrator/test_image_derivatives.py
+++ b/tests/nav/nav_orchestrator/test_image_derivatives.py
@@ -29,6 +29,7 @@ def _step_image(shape: tuple[int, int], step_v: int) -> np.ndarray:
 
 
 def test_image_derivatives_config_defaults_match_design() -> None:
+    """Default ``ImageDerivativesConfig`` carries the documented constants."""
     cfg = ImageDerivativesConfig()
     assert cfg.image_gradient_sigma_px == DEFAULT_IMAGE_GRADIENT_SIGMA_PX
     assert cfg.edge_threshold_k_sigma == DEFAULT_EDGE_THRESHOLD_K_SIGMA
@@ -36,21 +37,25 @@ def test_image_derivatives_config_defaults_match_design() -> None:
 
 
 def test_image_derivatives_config_rejects_zero_sigma() -> None:
+    """A zero ``image_gradient_sigma_px`` is rejected with a named field message."""
     with pytest.raises(ValueError, match='image_gradient_sigma_px'):
         ImageDerivativesConfig(image_gradient_sigma_px=0.0)
 
 
 def test_image_derivatives_config_rejects_zero_threshold() -> None:
+    """A zero ``edge_threshold_k_sigma`` is rejected with a named field message."""
     with pytest.raises(ValueError, match='edge_threshold_k_sigma'):
         ImageDerivativesConfig(edge_threshold_k_sigma=0.0)
 
 
 def test_image_derivatives_config_rejects_zero_half_width() -> None:
+    """A non-positive ``dt_half_width_px`` is rejected with a named field message."""
     with pytest.raises(ValueError, match='dt_half_width_px'):
         ImageDerivativesConfig(dt_half_width_px=-1.0)
 
 
 def test_build_image_edge_dt_peak_aligns_with_step_edge() -> None:
+    """Gradient peak row matches the leading or trailing edge of a planted bar."""
     # A horizontal bar centred on row 16 has its leading edge near row 12
     # and trailing edge near row 19; the gradient row-sum peaks at one of
     # those rows after Gaussian smoothing.
@@ -66,6 +71,7 @@ def test_build_image_edge_dt_peak_aligns_with_step_edge() -> None:
 
 
 def test_build_image_edge_dt_zeros_edge_dt_on_thresholded_pixels() -> None:
+    """Distance transform is exactly zero on retained edge pixels and positive elsewhere."""
     img = _step_image((40, 40), step_v=16)
     _, edge_dt = build_image_edge_dt(img, image_noise_sigma=1.0)
     # Pixels along the leading edge (row 12) get DT = 0 exactly --
@@ -77,6 +83,7 @@ def test_build_image_edge_dt_zeros_edge_dt_on_thresholded_pixels() -> None:
 
 
 def test_build_image_edge_dt_falls_back_when_no_pixel_exceeds_threshold() -> None:
+    """Empty edge mask saturates the DT at the configured half-width everywhere."""
     img = np.full((16, 16), 1.0, dtype=np.float64)
     cfg = ImageDerivativesConfig(
         edge_threshold_k_sigma=1000.0,
@@ -92,6 +99,7 @@ def test_build_image_edge_dt_falls_back_when_no_pixel_exceeds_threshold() -> Non
 
 
 def test_build_image_edge_dt_threshold_sweep_matches_expected_count() -> None:
+    """Edge-pixel count is monotonically non-decreasing as the k-sigma threshold drops."""
     img = _step_image((40, 40), step_v=16)
     # Decreasing the k_sigma factor lets more pixels pass the threshold;
     # binarized edge counts must be monotonically non-decreasing.
@@ -102,25 +110,30 @@ def test_build_image_edge_dt_threshold_sweep_matches_expected_count() -> None:
         threshold = k * 1.0
         edge_count = int((gradient > threshold).sum())
         counts.append(edge_count)
-    assert counts[0] <= counts[1] <= counts[2]
+    assert counts[0] <= counts[1]
+    assert counts[1] <= counts[2]
 
 
 def test_build_image_edge_dt_rejects_non_2d_input() -> None:
+    """A non-2-D ``image_ext`` is rejected with a TypeError naming the field."""
     with pytest.raises(TypeError, match='image_ext must be 2-D'):
         build_image_edge_dt(np.zeros((4, 4, 4)), image_noise_sigma=1.0)
 
 
 def test_build_image_edge_dt_rejects_negative_noise_sigma() -> None:
+    """A negative ``image_noise_sigma`` is rejected with a named field message."""
     with pytest.raises(ValueError, match='image_noise_sigma'):
         build_image_edge_dt(np.zeros((4, 4)), image_noise_sigma=-1.0)
 
 
 def test_build_image_edge_dt_rejects_nan_noise_sigma() -> None:
+    """A NaN ``image_noise_sigma`` is rejected with a named field message."""
     with pytest.raises(ValueError, match='image_noise_sigma'):
         build_image_edge_dt(np.zeros((4, 4)), image_noise_sigma=float('nan'))
 
 
 def test_compute_image_gradient_vu_horizontal_step_points_along_v() -> None:
+    """Horizontal step edge produces a positive ``g_v`` and near-zero ``g_u``."""
     shape = (40, 40)
     img = _step_image(shape, step_v=16)
     grad = compute_image_gradient_vu(img, sigma_px=1.0)
@@ -136,6 +149,7 @@ def test_compute_image_gradient_vu_horizontal_step_points_along_v() -> None:
 
 
 def test_compute_image_gradient_vu_vertical_step_points_along_u() -> None:
+    """Vertical step edge produces a positive ``g_u`` and near-zero ``g_v``."""
     img = np.zeros((32, 32), dtype=np.float64)
     img[:, 16:] = 100.0
     grad = compute_image_gradient_vu(img, sigma_px=1.0)
@@ -144,26 +158,31 @@ def test_compute_image_gradient_vu_vertical_step_points_along_u() -> None:
 
 
 def test_compute_image_gradient_vu_rejects_non_2d_input() -> None:
+    """A non-2-D ``image_ext`` is rejected with a TypeError naming the field."""
     with pytest.raises(TypeError, match='image_ext must be 2-D'):
         compute_image_gradient_vu(np.zeros((4, 4, 2)))
 
 
 def test_compute_image_gradient_vu_rejects_zero_sigma() -> None:
+    """A zero ``sigma_px`` is rejected with a finite-positive-number message."""
     with pytest.raises(ValueError, match='sigma_px must be a finite positive number'):
         compute_image_gradient_vu(np.zeros((4, 4)), sigma_px=0.0)
 
 
 def test_compute_image_gradient_vu_rejects_inf_sigma() -> None:
+    """An infinite ``sigma_px`` is rejected with a finite-positive-number message."""
     with pytest.raises(ValueError, match='sigma_px must be a finite positive number'):
         compute_image_gradient_vu(np.zeros((4, 4)), sigma_px=float('inf'))
 
 
 def test_build_image_edge_dt_rejects_inf_noise_sigma() -> None:
+    """An infinite ``image_noise_sigma`` is rejected with a finite-required message."""
     with pytest.raises(ValueError, match='image_noise_sigma must be finite'):
         build_image_edge_dt(np.zeros((4, 4)), image_noise_sigma=float('inf'))
 
 
 def test_image_derivatives_config_rejects_inf_sigma() -> None:
+    """An infinite ``image_gradient_sigma_px`` is rejected with a named field message."""
     with pytest.raises(ValueError, match='image_gradient_sigma_px'):
         ImageDerivativesConfig(image_gradient_sigma_px=float('inf'))
 

--- a/tests/nav/nav_technique/conftest.py
+++ b/tests/nav/nav_technique/conftest.py
@@ -1,0 +1,405 @@
+"""Shared fixtures and helpers for ``nav.nav_technique`` test files.
+
+Each technique end-to-end test needs the same scaffolding: a fake observation
+(``FakeObs``), a synthetic image, a populated ``NavContext``, and per-feature
+polyline / feature factories.  Centralising these here removes the per-file
+duplication and makes the technique tests focus on their assertions instead of
+their setup.
+
+Fixtures are exposed as **factory fixtures** — each yields a small builder
+function, so each test calls the builder with its own per-test parameters.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+
+from nav.feature.feature import NavFeature, NavReliabilityBreakdown
+from nav.feature.feature_type import NavFeatureType
+from nav.feature.flags import LimbArcFlags, RingEdgeFlags, TerminatorArcFlags
+from nav.feature.geometry import LimbPolyline, RingEdgePolyline, TerminatorPolyline
+from nav.nav_orchestrator.image_classifier_result import NavImageClassifierResult
+from nav.nav_orchestrator.image_derivatives import (
+    DEFAULT_IMAGE_GRADIENT_SIGMA_PX,
+    build_image_edge_dt,
+    compute_image_gradient_vu,
+)
+from nav.nav_orchestrator.nav_context import NavContext
+from nav.nav_orchestrator.provenance import Provenance
+from nav.support.filters import NavFilterKind, NavFilterSpec
+
+# Public type aliases for the factory fixtures defined below.  Test
+# functions annotate their fixture arguments using these so the test
+# tree stays mypy-strict-clean.
+
+DiscImageFactory = Callable[[tuple[int, int], tuple[float, float], float], np.ndarray]
+"""Signature of the ``disc_image`` factory fixture."""
+
+HorizontalStepImageFactory = Callable[[tuple[int, int], float], np.ndarray]
+"""Signature of the ``horizontal_step_image`` factory fixture."""
+
+CirclePolylineFactory = Callable[[tuple[float, float], float, int], tuple[np.ndarray, np.ndarray]]
+"""Signature of the ``circle_polyline`` factory fixture."""
+
+ArcPolylineFactory = Callable[
+    [tuple[float, float], float, int, float, float], tuple[np.ndarray, np.ndarray]
+]
+"""Signature of the ``arc_polyline`` factory fixture."""
+
+FlatPolylineFactory = Callable[[float, float, float, int], tuple[np.ndarray, np.ndarray]]
+"""Signature of the ``flat_polyline`` factory fixture."""
+
+NavContextFactory = Callable[..., NavContext]
+"""Signature of the ``make_nav_context`` factory fixture (kwargs-flexible)."""
+
+NavFeatureFactory = Callable[..., NavFeature]
+"""Signature of the ``make_*_feature`` factory fixtures (kwargs-flexible)."""
+
+
+class FakeObs:
+    """Minimal observation stand-in matching the obs.* attribute access used by
+    the DT techniques.
+
+    The technique implementations only read ``obs.extfov_margin_vu`` (via the
+    private ``_search_window_for_obs`` helper); the rest of the obs surface is
+    irrelevant once a fully-populated ``NavContext`` is supplied directly.
+
+    Parameters:
+        extfov_margin_vu: ``(margin_v, margin_u)`` extfov margin tuple
+            returned to callers; defaults to ``(32, 32)``.
+    """
+
+    def __init__(self, extfov_margin_vu: tuple[int, int] = (32, 32)) -> None:
+        self.extfov_margin_vu = extfov_margin_vu
+
+
+# ---------------------------------------------------------------------------
+# Image factories
+# ---------------------------------------------------------------------------
+
+
+def _render_disc_image(
+    shape: tuple[int, int], center_vu: tuple[float, float], radius: float
+) -> np.ndarray:
+    """Anti-aliased bright disc on a dark background.
+
+    A 1-pixel-wide brightness ramp at ``radius`` puts the gradient peak at
+    exactly the geometric edge so the DT-based fitter can converge below
+    0.05 px on noise-free fixtures without integer-grid bias.
+    """
+    vs, us = np.meshgrid(np.arange(shape[0]), np.arange(shape[1]), indexing='ij')
+    rr = np.hypot(vs - center_vu[0], us - center_vu[1])
+    inside = rr <= radius - 0.5
+    outside = rr >= radius + 0.5
+    ramp = np.clip(radius + 0.5 - rr, 0.0, 1.0)
+    image = np.where(inside, 100.0, np.where(outside, 0.0, 100.0 * ramp))
+    return image.astype(np.float64)
+
+
+def _render_horizontal_step_image(shape: tuple[int, int], step_v: float) -> np.ndarray:
+    """Vertical step: bright above row ``step_v``, dark below.
+
+    The Sobel-of-Gaussian gradient peaks one pixel wide at ``step_v``, giving
+    the LM a clean single minimum to converge to.
+    """
+    vs, _ = np.meshgrid(np.arange(shape[0]), np.arange(shape[1]), indexing='ij')
+    image = np.where(vs <= step_v, 100.0, 0.0)
+    return image.astype(np.float64)
+
+
+@pytest.fixture
+def disc_image() -> DiscImageFactory:
+    """Factory fixture producing anti-aliased bright-disc images."""
+    return _render_disc_image
+
+
+@pytest.fixture
+def horizontal_step_image() -> HorizontalStepImageFactory:
+    """Factory fixture producing horizontal-step images for flat-edge tests."""
+    return _render_horizontal_step_image
+
+
+# ---------------------------------------------------------------------------
+# Polyline factories
+# ---------------------------------------------------------------------------
+
+
+def _circle_polyline(
+    center_vu: tuple[float, float], radius: float, n_vertices: int
+) -> tuple[np.ndarray, np.ndarray]:
+    """Full closed circle: ``(N, 2)`` vertices and ``(N, 2)`` outward normals."""
+    angles = np.linspace(0.0, 2.0 * np.pi, n_vertices, endpoint=False)
+    vs = center_vu[0] + radius * np.sin(angles)
+    us = center_vu[1] + radius * np.cos(angles)
+    nv = np.sin(angles)
+    nu = np.cos(angles)
+    return (
+        np.stack([vs, us], axis=-1).astype(np.float64),
+        np.stack([nv, nu], axis=-1).astype(np.float64),
+    )
+
+
+def _arc_polyline(
+    center_vu: tuple[float, float],
+    radius: float,
+    n_vertices: int,
+    angle_start: float,
+    angle_end: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Partial arc between ``angle_start`` and ``angle_end`` radians.
+
+    Useful for half-visible limbs (``[-pi/2, pi/2]``) or terminator arcs on a
+    crescent geometry.
+    """
+    angles = np.linspace(angle_start, angle_end, n_vertices)
+    vs = center_vu[0] + radius * np.sin(angles)
+    us = center_vu[1] + radius * np.cos(angles)
+    nv = np.sin(angles)
+    nu = np.cos(angles)
+    return (
+        np.stack([vs, us], axis=-1).astype(np.float64),
+        np.stack([nv, nu], axis=-1).astype(np.float64),
+    )
+
+
+def _flat_polyline(
+    v_value: float, u_start: float, u_end: float, n_vertices: int
+) -> tuple[np.ndarray, np.ndarray]:
+    """Horizontal polyline at row ``v_value`` plus outward radial normal ``+v``."""
+    us = np.linspace(u_start, u_end, n_vertices)
+    vs = np.full_like(us, v_value)
+    nv = np.ones_like(us)
+    nu = np.zeros_like(us)
+    return (
+        np.stack([vs, us], axis=-1).astype(np.float64),
+        np.stack([nv, nu], axis=-1).astype(np.float64),
+    )
+
+
+@pytest.fixture
+def circle_polyline() -> CirclePolylineFactory:
+    """Factory fixture producing full-circle polylines."""
+    return _circle_polyline
+
+
+@pytest.fixture
+def arc_polyline() -> ArcPolylineFactory:
+    """Factory fixture producing partial-arc polylines."""
+    return _arc_polyline
+
+
+@pytest.fixture
+def flat_polyline() -> FlatPolylineFactory:
+    """Factory fixture producing horizontal flat-edge polylines."""
+    return _flat_polyline
+
+
+# ---------------------------------------------------------------------------
+# NavContext factory
+# ---------------------------------------------------------------------------
+
+
+def _make_nav_context(
+    image: np.ndarray,
+    *,
+    extfov_margin_vu: tuple[int, int] = (32, 32),
+    technique_names: tuple[str, ...] = (),
+) -> NavContext:
+    """Build a fully-populated ``NavContext`` from ``image``.
+
+    All masks are trivially populated (full-sensor, no saturation, no cosmic
+    rays); the image classifier reports a clean image; provenance is filled
+    with deterministic values.  Image gradient / DT derivatives are computed
+    via :func:`build_image_edge_dt` + :func:`compute_image_gradient_vu` so
+    the techniques' ``image_edge_dt_ext`` / ``image_gradient_vu_ext`` reads
+    behave exactly as they would under the orchestrator.
+    """
+    sensor_mask = np.ones(image.shape, dtype=bool)
+    saturation_mask = np.zeros(image.shape, dtype=bool)
+    cosmic_ray_mask = np.zeros(image.shape, dtype=bool)
+    classifier_result = NavImageClassifierResult(
+        image_class='clean',
+        saturation_frac=0.0,
+        missing_frac=0.0,
+        noise_sigma=1.0,
+        max_dn=float(image.max()),
+        flags=[],
+    )
+    provenance = Provenance(
+        rms_nav_version='0.0.0',
+        image_et=0.0,
+        pipeline_run_iso8601='2026-04-27T00:00:00Z',
+        technique_names=technique_names,
+        extractor_names=(),
+    )
+    gradient, edge_dt = build_image_edge_dt(image, image_noise_sigma=1.0)
+    gradient_vu = compute_image_gradient_vu(image, sigma_px=DEFAULT_IMAGE_GRADIENT_SIGMA_PX)
+    return NavContext(
+        obs=FakeObs(extfov_margin_vu=extfov_margin_vu),
+        image_ext=image,
+        sensor_mask_ext=sensor_mask,
+        image_noise_sigma=1.0,
+        saturation_mask_ext=saturation_mask,
+        cosmic_ray_mask_ext=cosmic_ray_mask,
+        image_classifier=classifier_result,
+        provenance=provenance,
+        image_gradient_ext=gradient,
+        image_gradient_vu_ext=gradient_vu,
+        image_edge_dt_ext=edge_dt,
+    )
+
+
+@pytest.fixture
+def make_nav_context() -> NavContextFactory:
+    """Factory fixture returning fully-populated ``NavContext`` objects."""
+    return _make_nav_context
+
+
+# ---------------------------------------------------------------------------
+# Feature factories (per-feature-type)
+# ---------------------------------------------------------------------------
+
+
+def _bbox_for_vertices(vertices: np.ndarray) -> tuple[int, int, int, int]:
+    """Return a ``(v_min, u_min, v_max, u_max)`` bounding box for a polyline."""
+    n = vertices.shape[0]
+    if n == 0:
+        return (0, 0, 0, 0)
+    vmin = int(vertices[:, 0].min())
+    vmax = int(vertices[:, 0].max()) + 1
+    umin = int(vertices[:, 1].min())
+    umax = int(vertices[:, 1].max()) + 1
+    return (vmin, umin, vmax, umax)
+
+
+def _make_limb_feature(
+    body_name: str,
+    *,
+    vertices: np.ndarray,
+    outward_normals: np.ndarray,
+    sigma_normal_px: float = 0.5,
+    visible_arc_fraction: float = 1.0,
+) -> NavFeature:
+    """Build a ``LIMB_ARC`` ``NavFeature`` from a vertex / outward-normal pair."""
+    n = vertices.shape[0]
+    return NavFeature(
+        feature_id=f'limb_arc:{body_name}',
+        feature_type=NavFeatureType.LIMB_ARC,
+        source_model='body',
+        geometry=LimbPolyline(
+            vertices_vu=vertices,
+            normals_vu=outward_normals,
+            sigma_normal_per_vertex_px=np.full(n, sigma_normal_px, dtype=np.float64),
+            sigma_tangent_per_vertex_px=np.full(n, 0.5, dtype=np.float64),
+            bbox_extfov_vu=_bbox_for_vertices(vertices),
+        ),
+        subject_range_km=1.0e6,
+        position_cov_px=None,
+        intensity_sigma_rel=0.0,
+        preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
+        reliability=0.9,
+        reliability_reasons=NavReliabilityBreakdown(visible_arc_fraction=visible_arc_fraction),
+        usable_types=frozenset({NavFeatureType.LIMB_ARC}),
+        flags=LimbArcFlags(body_name=body_name, visible_arc_fraction=visible_arc_fraction),
+    )
+
+
+def _make_terminator_feature(
+    body_name: str,
+    *,
+    vertices: np.ndarray,
+    outward_normals: np.ndarray,
+    sigma_normal_px: float = 1.0,
+    visible_arc_fraction: float = 1.0,
+    phase_angle_factor: float = 0.7,
+    albedo_penalty: float = 0.1,
+) -> NavFeature:
+    """Build a ``TERMINATOR_ARC`` ``NavFeature``."""
+    n = vertices.shape[0]
+    return NavFeature(
+        feature_id=f'terminator_arc:{body_name}',
+        feature_type=NavFeatureType.TERMINATOR_ARC,
+        source_model='body',
+        geometry=TerminatorPolyline(
+            vertices_vu=vertices,
+            normals_vu=outward_normals,
+            sigma_normal_per_vertex_px=np.full(n, sigma_normal_px, dtype=np.float64),
+            sigma_tangent_per_vertex_px=np.full(n, 0.5, dtype=np.float64),
+            bbox_extfov_vu=_bbox_for_vertices(vertices),
+        ),
+        subject_range_km=1.0e6,
+        position_cov_px=None,
+        intensity_sigma_rel=0.0,
+        preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
+        reliability=0.7,
+        reliability_reasons=NavReliabilityBreakdown(
+            visible_arc_fraction=visible_arc_fraction,
+            albedo_penalty=albedo_penalty,
+        ),
+        usable_types=frozenset({NavFeatureType.TERMINATOR_ARC}),
+        flags=TerminatorArcFlags(
+            body_name=body_name,
+            visible_arc_fraction=visible_arc_fraction,
+            phase_angle_factor=phase_angle_factor,
+        ),
+    )
+
+
+def _make_ring_feature(
+    name: str,
+    *,
+    vertices: np.ndarray,
+    outward_normals: np.ndarray,
+    is_straight_line: bool,
+    sigma_radial_px: float = 0.5,
+    planet_name: str = 'SATURN',
+) -> NavFeature:
+    """Build a ``RING_EDGE`` ``NavFeature``."""
+    n = vertices.shape[0]
+    return NavFeature(
+        feature_id=f'ring_edge:{name}',
+        feature_type=NavFeatureType.RING_EDGE,
+        source_model='rings',
+        geometry=RingEdgePolyline(
+            vertices_vu=vertices,
+            normals_vu=outward_normals,
+            sigma_radial_per_vertex_px=np.full(n, sigma_radial_px, dtype=np.float64),
+            sigma_along_edge_per_vertex_px=np.full(n, 0.5, dtype=np.float64),
+            is_straight_line=is_straight_line,
+            bbox_extfov_vu=_bbox_for_vertices(vertices),
+        ),
+        subject_range_km=1.0e6,
+        position_cov_px=None,
+        intensity_sigma_rel=0.0,
+        preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
+        reliability=0.8,
+        reliability_reasons=NavReliabilityBreakdown(visible_arc_fraction=1.0),
+        usable_types=frozenset({NavFeatureType.RING_EDGE}),
+        flags=RingEdgeFlags(
+            is_straight_line=is_straight_line,
+            polarity_predictable=False,
+            edge_name=name,
+            planet_name=planet_name,
+        ),
+    )
+
+
+@pytest.fixture
+def make_limb_feature() -> NavFeatureFactory:
+    """Factory fixture producing ``LIMB_ARC`` ``NavFeature`` instances."""
+    return _make_limb_feature
+
+
+@pytest.fixture
+def make_terminator_feature() -> NavFeatureFactory:
+    """Factory fixture producing ``TERMINATOR_ARC`` ``NavFeature`` instances."""
+    return _make_terminator_feature
+
+
+@pytest.fixture
+def make_ring_feature() -> NavFeatureFactory:
+    """Factory fixture producing ``RING_EDGE`` ``NavFeature`` instances."""
+    return _make_ring_feature

--- a/tests/nav/nav_technique/test_diagnostics.py
+++ b/tests/nav/nav_technique/test_diagnostics.py
@@ -9,7 +9,6 @@ from nav.nav_technique.diagnostics import (
     BodyDiscDiagnostics,
     BodyLimbDiagnostics,
     BodyTerminatorDiagnostics,
-    CartographicDiagnostics,
     RingAnnulusDiagnostics,
     RingEdgeDiagnostics,
     StarFieldDiagnostics,
@@ -30,7 +29,6 @@ from nav.nav_technique.diagnostics import (
         StarFieldDiagnostics,
         StarUniqueMatchDiagnostics,
         StarRefineDiagnostics,
-        CartographicDiagnostics,
     ],
 )
 def test_diagnostic_dataclasses_construct_with_defaults(cls: type) -> None:
@@ -51,7 +49,6 @@ def test_diagnostic_dataclasses_construct_with_defaults(cls: type) -> None:
         StarFieldDiagnostics,
         StarUniqueMatchDiagnostics,
         StarRefineDiagnostics,
-        CartographicDiagnostics,
     ],
 )
 def test_curator_fields_lists_every_attribute(cls: type) -> None:

--- a/tests/nav/nav_technique/test_dt_fitting.py
+++ b/tests/nav/nav_technique/test_dt_fitting.py
@@ -1,0 +1,565 @@
+"""Unit tests for the shared distance-transform fitting helpers."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from scipy.ndimage import distance_transform_edt
+
+from nav.nav_orchestrator.image_derivatives import (
+    DEFAULT_IMAGE_GRADIENT_SIGMA_PX,
+    compute_image_gradient_vu,
+)
+from nav.nav_technique.dt_fitting import (
+    DEFAULT_TUKEY_C,
+    LMRefineResult,
+    coarse_ncc_search,
+    information_matrix_to_covariance,
+    lm_subpixel_refine,
+    polarity_filter,
+    tukey_biweight_weights,
+)
+
+
+def _build_circle_polyline(
+    center_vu: tuple[float, float], radius_px: float, n_vertices: int
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return ``(N, 2)`` vertices and ``(N, 2)`` outward normals on a circle."""
+    angles = np.linspace(0.0, 2.0 * np.pi, n_vertices, endpoint=False)
+    cv, cu = center_vu
+    vs = cv + radius_px * np.sin(angles)
+    us = cu + radius_px * np.cos(angles)
+    nv = np.sin(angles)
+    nu = np.cos(angles)
+    vertices = np.stack([vs, us], axis=-1).astype(np.float64)
+    normals = np.stack([nv, nu], axis=-1).astype(np.float64)
+    return vertices, normals
+
+
+def _render_circle_mask(
+    shape_vu: tuple[int, int],
+    center_vu: tuple[float, float],
+    radius_px: float,
+    thickness_px: float = 1.0,
+) -> np.ndarray:
+    """Return a boolean mask of an annulus around the given circle."""
+    vs, us = np.meshgrid(
+        np.arange(shape_vu[0]),
+        np.arange(shape_vu[1]),
+        indexing='ij',
+    )
+    cv, cu = center_vu
+    rr = np.hypot(vs - cv, us - cu)
+    out: np.ndarray = np.abs(rr - radius_px) <= thickness_px
+    return out
+
+
+def _render_image_with_circle(
+    shape_vu: tuple[int, int],
+    center_vu: tuple[float, float],
+    radius_px: float,
+    *,
+    inside_dn: float = 100.0,
+    outside_dn: float = 0.0,
+) -> np.ndarray:
+    """Return a step-edge disc image (inside_dn inside, outside_dn outside)."""
+    vs, us = np.meshgrid(
+        np.arange(shape_vu[0]),
+        np.arange(shape_vu[1]),
+        indexing='ij',
+    )
+    cv, cu = center_vu
+    rr = np.hypot(vs - cv, us - cu)
+    image = np.where(rr <= radius_px, inside_dn, outside_dn)
+    return image.astype(np.float64)
+
+
+# ---------------------------------------------------------------------------
+# tukey_biweight_weights
+# ---------------------------------------------------------------------------
+
+
+def test_tukey_biweight_weights_returns_one_at_zero_residual() -> None:
+    weights = tukey_biweight_weights(np.array([0.0, 0.0, 0.0]))
+    assert np.allclose(weights, [1.0, 1.0, 1.0])
+
+
+def test_tukey_biweight_weights_is_zero_outside_cutoff() -> None:
+    c = DEFAULT_TUKEY_C
+    weights = tukey_biweight_weights(np.array([c + 0.01, -c - 0.5, 100.0]))
+    assert np.array_equal(weights, [0.0, 0.0, 0.0])
+
+
+def test_tukey_biweight_weights_matches_holland_welsch_at_half_cutoff() -> None:
+    c = DEFAULT_TUKEY_C
+    r = c / 2.0
+    weights = tukey_biweight_weights(np.array([r]))
+    expected = (1.0 - 0.25) ** 2
+    assert weights[0] == pytest.approx(expected, rel=1e-12)
+
+
+@pytest.mark.parametrize(
+    ('invalid_c', 'message'),
+    [
+        (-1.0, 'c must be a positive finite'),
+        (0.0, 'c must be a positive finite'),
+        (float('inf'), 'c must be a positive finite'),
+        (float('nan'), 'c must be a positive finite'),
+    ],
+)
+def test_tukey_biweight_weights_rejects_invalid_c(invalid_c: float, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        tukey_biweight_weights(np.array([1.0]), c=invalid_c)
+
+
+@pytest.mark.parametrize('shape', [(2, 2), (3, 3, 3), (1, 4)])
+def test_tukey_biweight_weights_rejects_non_1d_input(shape: tuple[int, ...]) -> None:
+    with pytest.raises(ValueError, match='residuals must be 1-D'):
+        tukey_biweight_weights(np.zeros(shape))
+
+
+# ---------------------------------------------------------------------------
+# information_matrix_to_covariance
+# ---------------------------------------------------------------------------
+
+
+def test_information_matrix_to_covariance_recovers_identity() -> None:
+    jacobian = np.eye(2, dtype=np.float64)
+    weights = np.array([1.0, 1.0])
+    cov = information_matrix_to_covariance(jacobian, weights)
+    assert np.allclose(cov, np.eye(2), atol=1e-12)
+
+
+def test_information_matrix_to_covariance_handles_rank_one_input() -> None:
+    # All Jacobian rows along axis 0: only "v" axis is observable.
+    jacobian = np.zeros((10, 2), dtype=np.float64)
+    jacobian[:, 0] = 1.0
+    weights = np.ones(10)
+    cov = information_matrix_to_covariance(jacobian, weights)
+    eigvals = np.linalg.eigvalsh(cov)
+    null_eigval = float(eigvals.min())
+    observed_eigval = float(eigvals.max())
+    assert abs(null_eigval) < 1.0e-12
+    assert observed_eigval == pytest.approx(0.1, rel=1e-9)
+
+
+@pytest.mark.parametrize(
+    ('jacobian', 'weights', 'message'),
+    [
+        # Negative weight: rejected by the non-negativity guard.
+        (np.eye(2), np.array([1.0, -0.5]), 'weights must be non-negative'),
+        # Wrong-rank weight vector: caught by the 1-D shape guard.
+        (np.eye(3), np.ones(2), 'must be a 1-D vector'),
+        # 1-D Jacobian: caught by the 2-D shape guard.
+        (np.zeros(3), np.ones(3), 'jacobian must be 2-D'),
+    ],
+)
+def test_information_matrix_to_covariance_rejects_invalid_inputs(
+    jacobian: np.ndarray, weights: np.ndarray, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        information_matrix_to_covariance(jacobian, weights)
+
+
+# ---------------------------------------------------------------------------
+# coarse_ncc_search
+# ---------------------------------------------------------------------------
+
+
+def test_coarse_ncc_search_recovers_planted_integer_offset() -> None:
+    shape = (64, 64)
+    polyline_mask = _render_circle_mask(shape, (32.0, 32.0), 12.0)
+    edge_mask = np.roll(polyline_mask, shift=(3, -2), axis=(0, 1))
+    dv, du = coarse_ncc_search(edge_mask, polyline_mask, (10, 10))
+    assert (dv, du) == (3, -2)
+
+
+def test_coarse_ncc_search_returns_zero_for_aligned_inputs() -> None:
+    shape = (32, 32)
+    polyline_mask = _render_circle_mask(shape, (16.0, 16.0), 8.0)
+    dv, du = coarse_ncc_search(polyline_mask, polyline_mask, (4, 4))
+    assert (dv, du) == (0, 0)
+
+
+def test_coarse_ncc_search_returns_zero_with_empty_polyline() -> None:
+    edge_mask = np.zeros((16, 16), dtype=bool)
+    edge_mask[8, 8] = True
+    polyline_mask = np.zeros_like(edge_mask)
+    dv, du = coarse_ncc_search(edge_mask, polyline_mask, (3, 3))
+    assert (dv, du) == (0, 0)
+
+
+@pytest.mark.parametrize(
+    ('edge_mask', 'polyline_mask', 'window', 'message'),
+    [
+        # Shape mismatch between the two masks.
+        (
+            np.zeros((4, 4), bool),
+            np.zeros((5, 5), bool),
+            (1, 1),
+            'shape mismatch',
+        ),
+        # 1-D edge mask: caught by the 2-D shape guard.
+        (np.zeros(4, bool), np.zeros((4, 4), bool), (1, 1), 'must be 2-D'),
+        # Negative window margin: caught by the non-negative guard.
+        (
+            np.zeros((4, 4), bool),
+            np.zeros((4, 4), bool),
+            (-1, 1),
+            'must be non-negative',
+        ),
+        (
+            np.zeros((4, 4), bool),
+            np.zeros((4, 4), bool),
+            (1, -1),
+            'must be non-negative',
+        ),
+    ],
+)
+def test_coarse_ncc_search_rejects_invalid_inputs(
+    edge_mask: np.ndarray,
+    polyline_mask: np.ndarray,
+    window: tuple[int, int],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        coarse_ncc_search(edge_mask, polyline_mask, window)
+
+
+# ---------------------------------------------------------------------------
+# polarity_filter
+# ---------------------------------------------------------------------------
+
+
+def test_polarity_filter_accepts_normals_aligned_with_image_gradient() -> None:
+    shape = (32, 32)
+    image = _render_image_with_circle(shape, (16.0, 16.0), 8.0)
+    grad = compute_image_gradient_vu(image, sigma_px=DEFAULT_IMAGE_GRADIENT_SIGMA_PX)
+    vertices, outward_normals = _build_circle_polyline((16.0, 16.0), 8.0, 16)
+    # Bright-disc on dark sky: the image gradient at the limb points INTO the
+    # body (low DN to high DN).  ``polarity_filter`` tests strict
+    # ``model_dir . image_gradient > 0``, so the model must supply the inward
+    # direction (the negation of the geometric outward normal) to be accepted.
+    inward_normals = -outward_normals
+    keep = polarity_filter(vertices, inward_normals, grad)
+    assert keep.sum() == 16
+
+
+def test_polarity_filter_rejects_normals_opposing_image_gradient() -> None:
+    shape = (32, 32)
+    image = _render_image_with_circle(shape, (16.0, 16.0), 8.0)
+    grad = compute_image_gradient_vu(image, sigma_px=DEFAULT_IMAGE_GRADIENT_SIGMA_PX)
+    vertices, outward_normals = _build_circle_polyline((16.0, 16.0), 8.0, 16)
+    keep = polarity_filter(vertices, outward_normals, grad)
+    assert keep.sum() == 0
+
+
+def test_polarity_filter_per_vertex_decision() -> None:
+    shape = (32, 32)
+    image = _render_image_with_circle(shape, (16.0, 16.0), 8.0)
+    grad = compute_image_gradient_vu(image, sigma_px=DEFAULT_IMAGE_GRADIENT_SIGMA_PX)
+    vertices, outward_normals = _build_circle_polyline((16.0, 16.0), 8.0, 16)
+    inward_normals = -outward_normals
+    # Half the vertices kept aligned (inward), half flipped to outward.
+    mixed_normals = inward_normals.copy()
+    mixed_normals[::2] = outward_normals[::2]
+    keep = polarity_filter(vertices, mixed_normals, grad)
+    assert keep.sum() == 8
+
+
+def test_polarity_filter_rejects_misshaped_inputs() -> None:
+    grad = np.zeros((4, 4, 2))
+    with pytest.raises(ValueError, match='vertices_vu must have shape'):
+        polarity_filter(np.zeros(2), np.zeros(2), grad)
+
+
+def test_polarity_filter_rejects_2d_gradient() -> None:
+    with pytest.raises(ValueError, match='image_gradient_vu must have shape'):
+        polarity_filter(np.zeros((1, 2)), np.zeros((1, 2)), np.zeros((4, 4)))
+
+
+# ---------------------------------------------------------------------------
+# lm_subpixel_refine — translation-only
+# ---------------------------------------------------------------------------
+
+
+def _build_dt_for_circle(shape: tuple[int, int], radius: float) -> np.ndarray:
+    cv = shape[0] / 2.0
+    cu = shape[1] / 2.0
+    edge_mask = _render_circle_mask(shape, (cv, cu), radius, thickness_px=0.5)
+    raw = distance_transform_edt(~edge_mask)
+    dt: np.ndarray = np.asarray(raw, dtype=np.float64)
+    return dt
+
+
+def test_lm_subpixel_refine_recovers_subpixel_translation() -> None:
+    shape = (96, 96)
+    radius = 18.0
+    dt = _build_dt_for_circle(shape, radius)
+    cv = shape[0] / 2.0 + 1.5
+    cu = shape[1] / 2.0 + 2.5
+    vertices, outward_normals = _build_circle_polyline((cv, cu), radius, 64)
+    inward_normals = -outward_normals
+    sigmas = np.full(vertices.shape[0], 0.5, dtype=np.float64)
+    image = _render_image_with_circle(shape, (shape[0] / 2.0, shape[1] / 2.0), radius)
+    grad = compute_image_gradient_vu(image, sigma_px=DEFAULT_IMAGE_GRADIENT_SIGMA_PX)
+    result = lm_subpixel_refine(
+        vertices_vu=vertices,
+        normals_vu=inward_normals,
+        sigma_normal_per_vertex_px=sigmas,
+        image_edge_dt=dt,
+        image_gradient_vu=grad,
+        initial_offset_vu=(-1.0, -2.0),
+        use_polarity=True,
+    )
+    assert result.offset_vu[0] == pytest.approx(-1.5, abs=0.05)
+    assert result.offset_vu[1] == pytest.approx(-2.5, abs=0.05)
+    assert result.iterations >= 1
+    assert result.inlier_count == 64
+
+
+def test_lm_subpixel_refine_rejects_outliers_via_tukey() -> None:
+    shape = (96, 96)
+    radius = 18.0
+    dt = _build_dt_for_circle(shape, radius)
+    cv = shape[0] / 2.0
+    cu = shape[1] / 2.0
+    vertices, normals = _build_circle_polyline((cv, cu), radius, 100)
+    # Move 10 % of the vertices far away from the actual circle: they should
+    # be Tukey-rejected so the recovered offset is dominated by the inliers.
+    bad = np.arange(0, 100, 10)
+    vertices[bad, 0] += 30.0
+    sigmas = np.full(vertices.shape[0], 0.5, dtype=np.float64)
+    image = _render_image_with_circle(shape, (cv, cu), radius)
+    grad = compute_image_gradient_vu(image, sigma_px=DEFAULT_IMAGE_GRADIENT_SIGMA_PX)
+    result = lm_subpixel_refine(
+        vertices_vu=vertices,
+        normals_vu=normals,
+        sigma_normal_per_vertex_px=sigmas,
+        image_edge_dt=dt,
+        image_gradient_vu=grad,
+        initial_offset_vu=(0.0, 0.0),
+        use_polarity=False,
+    )
+    assert result.offset_vu[0] == pytest.approx(0.0, abs=0.1)
+    assert result.offset_vu[1] == pytest.approx(0.0, abs=0.1)
+    # Outlier vertices should have zero (or near-zero) Tukey weight.
+    assert float(result.weights[bad].max()) < 1.0e-6
+    # In-lier vertices should retain weight of 1 / sigma**2 = 4 (with sigma=0.5)
+    inlier_idx = np.setdiff1d(np.arange(100), bad)
+    assert float(result.weights[inlier_idx].min()) > 1.0
+
+
+# ---------------------------------------------------------------------------
+# lm_subpixel_refine — translation + rotation
+# ---------------------------------------------------------------------------
+
+
+def test_lm_subpixel_refine_recovers_planted_rotation_and_translation() -> None:
+    shape = (200, 200)
+    cv = shape[0] / 2.0
+    cu = shape[1] / 2.0
+    # Use a four-arm cross template: well-constrained for translation in both
+    # axes and for in-plane rotation about the cross centre.
+    arm_length_px = 60.0
+    arm_density = 60
+    arm_offsets_along = np.linspace(8.0, arm_length_px, arm_density)
+    east_v = np.full_like(arm_offsets_along, cv)
+    east_u = cu + arm_offsets_along
+    west_v = np.full_like(arm_offsets_along, cv)
+    west_u = cu - arm_offsets_along
+    north_v = cv - arm_offsets_along
+    north_u = np.full_like(arm_offsets_along, cu)
+    south_v = cv + arm_offsets_along
+    south_u = np.full_like(arm_offsets_along, cu)
+    vs = np.concatenate([east_v, west_v, north_v, south_v])
+    us = np.concatenate([east_u, west_u, north_u, south_u])
+    vertices = np.stack([vs, us], axis=-1)
+    # The normals are placeholders here (``use_polarity=False`` below).
+    normals = np.zeros_like(vertices)
+    edge_mask = np.zeros(shape, dtype=bool)
+    iv = np.rint(vs).astype(int)
+    iu = np.rint(us).astype(int)
+    edge_mask[iv, iu] = True
+    dt = distance_transform_edt(~edge_mask).astype(np.float64)
+    theta_true = 0.04
+    dv_true = -1.2
+    du_true = 0.7
+    pivot = (cv, cu)
+    cos_t = math.cos(theta_true)
+    sin_t = math.sin(theta_true)
+    rot_v = pivot[0] + cos_t * (vertices[:, 0] - pivot[0]) - sin_t * (vertices[:, 1] - pivot[1])
+    rot_u = pivot[1] + sin_t * (vertices[:, 0] - pivot[0]) + cos_t * (vertices[:, 1] - pivot[1])
+    misaligned_vertices = np.stack([rot_v + dv_true, rot_u + du_true], axis=-1)
+    sigmas = np.full(misaligned_vertices.shape[0], 0.5, dtype=np.float64)
+    result = lm_subpixel_refine(
+        vertices_vu=misaligned_vertices,
+        normals_vu=normals,
+        sigma_normal_per_vertex_px=sigmas,
+        image_edge_dt=dt,
+        initial_offset_vu=(0.0, 0.0),
+        initial_rotation_rad=0.0,
+        fit_rotation=True,
+        pivot_vu=pivot,
+        pivot_distance_px=arm_length_px,
+        use_polarity=False,
+    )
+    # The undoing parameters: dtheta_lm = -theta_true; the LM translation is
+    # ``-R(dtheta_lm) (dv_true, du_true)``.
+    expected_dtheta = -theta_true
+    expected_cos = math.cos(expected_dtheta)
+    expected_sin = math.sin(expected_dtheta)
+    expected_dv_lm = -(expected_cos * dv_true - expected_sin * du_true)
+    expected_du_lm = -(expected_sin * dv_true + expected_cos * du_true)
+    assert result.offset_vu[0] == pytest.approx(expected_dv_lm, abs=0.05)
+    assert result.offset_vu[1] == pytest.approx(expected_du_lm, abs=0.05)
+    assert result.rotation_rad == pytest.approx(expected_dtheta, abs=2.0e-3)
+
+
+def test_lm_subpixel_refine_rejects_misaligned_inputs() -> None:
+    with pytest.raises(ValueError, match='must have shape'):
+        lm_subpixel_refine(
+            vertices_vu=np.zeros((4,)),
+            normals_vu=np.zeros((4, 2)),
+            sigma_normal_per_vertex_px=np.ones(4),
+            image_edge_dt=np.zeros((8, 8)),
+        )
+
+
+def test_lm_subpixel_refine_rejects_non_positive_sigma() -> None:
+    with pytest.raises(ValueError, match='must be finite and > 0'):
+        lm_subpixel_refine(
+            vertices_vu=np.zeros((1, 2)),
+            normals_vu=np.zeros((1, 2)),
+            sigma_normal_per_vertex_px=np.array([0.0]),
+            image_edge_dt=np.zeros((4, 4)),
+        )
+
+
+def test_lm_subpixel_refine_requires_pivot_distance_for_rotation() -> None:
+    with pytest.raises(ValueError, match='pivot_distance_px > 0'):
+        lm_subpixel_refine(
+            vertices_vu=np.zeros((1, 2)),
+            normals_vu=np.zeros((1, 2)),
+            sigma_normal_per_vertex_px=np.array([1.0]),
+            image_edge_dt=np.zeros((4, 4)),
+            fit_rotation=True,
+        )
+
+
+def test_lm_refine_result_freezes_arrays() -> None:
+    shape = (32, 32)
+    dt = np.full(shape, 5.0, dtype=np.float64)
+    vertices = np.array([[16.0, 16.0]], dtype=np.float64)
+    normals = np.array([[1.0, 0.0]], dtype=np.float64)
+    sigmas = np.array([1.0], dtype=np.float64)
+    result = lm_subpixel_refine(
+        vertices_vu=vertices,
+        normals_vu=normals,
+        sigma_normal_per_vertex_px=sigmas,
+        image_edge_dt=dt,
+        use_polarity=False,
+    )
+    assert isinstance(result, LMRefineResult)
+    assert not result.covariance.flags.writeable
+    assert not result.weights.flags.writeable
+    assert not result.residuals_px.flags.writeable
+
+
+# ---------------------------------------------------------------------------
+# Coverage-completion tests for dt_fitting helpers
+# ---------------------------------------------------------------------------
+
+
+def test_tukey_biweight_weights_zero_at_exact_cutoff() -> None:
+    """Holland-Welsch is half-open: ``|r| == c`` evaluates to weight zero.
+
+    The implementation uses ``np.abs(scaled) <= 1.0`` to gate the
+    polynomial, so the boundary itself is *kept* but the polynomial
+    ``(1 - 1**2) ** 2`` is exactly zero.  Verify both halves of the
+    statement: weight is zero, no off-by-one excludes the boundary.
+    """
+    c = DEFAULT_TUKEY_C
+    weights = tukey_biweight_weights(np.array([c, -c]), c=c)
+    assert float(weights[0]) == 0.0
+    assert float(weights[1]) == 0.0
+
+
+def test_coarse_ncc_search_zero_window_returns_origin() -> None:
+    """A search window of ``(0, 0)`` means only the origin shift is scanned.
+
+    Off-by-one safety: the implementation iterates
+    ``range(-margin_v, margin_v + 1)`` which yields a single ``0`` step.
+    The function must return ``(0, 0)`` for any inputs without raising.
+    """
+    edge_mask = np.zeros((8, 8), dtype=bool)
+    edge_mask[3, 3] = True
+    polyline_mask = np.zeros((8, 8), dtype=bool)
+    polyline_mask[3, 3] = True
+    dv, du = coarse_ncc_search(edge_mask, polyline_mask, (0, 0))
+    assert (dv, du) == (0, 0)
+
+
+def test_coarse_ncc_search_unit_window_visits_each_axis_step() -> None:
+    """A window of ``(1, 1)`` must cover -1, 0, +1 in each axis.
+
+    Plant a single edge pixel at the boundary of the (1, 1) window and
+    verify the function reports that exact integer offset (which means
+    the iteration scanned all nine cells, not just the eight non-origin
+    ones).
+    """
+    edge_mask = np.zeros((8, 8), dtype=bool)
+    edge_mask[4, 4] = True
+    polyline_mask = np.zeros((8, 8), dtype=bool)
+    polyline_mask[3, 3] = True
+    dv, du = coarse_ncc_search(edge_mask, polyline_mask, (1, 1))
+    assert (dv, du) == (1, 1)
+
+
+def test_lm_subpixel_refine_requires_image_gradient_when_polarity_enabled() -> None:
+    """Polarity-enabled LM must reject a ``None`` gradient input.
+
+    The validation path returns a clear ``ValueError`` so a caller that
+    forgot to populate ``NavContext.image_gradient_vu_ext`` learns about
+    the omission immediately rather than via a silent NoneType crash
+    inside the polarity filter.
+    """
+    with pytest.raises(ValueError, match='use_polarity=True requires image_gradient_vu'):
+        lm_subpixel_refine(
+            vertices_vu=np.zeros((1, 2)),
+            normals_vu=np.zeros((1, 2)),
+            sigma_normal_per_vertex_px=np.array([1.0]),
+            image_edge_dt=np.zeros((4, 4)),
+            use_polarity=True,
+            image_gradient_vu=None,
+        )
+
+
+def test_lm_subpixel_refine_bails_out_when_damping_saturates() -> None:
+    """The LM loop has an early exit when ``lambda`` saturates at ``1.0e6``.
+
+    With a flat (constant-valued) DT the cost function has zero gradient
+    and zero Hessian; every trial step fails to reduce cost; the damping
+    factor ramps up multiplicatively until it crosses ``1.0e6`` and the
+    loop terminates without convergence.  This exercise covers the
+    ``if lambda_ >= 1.0e6: break`` branch in the LM iteration body.
+    """
+    shape = (16, 16)
+    flat_dt = np.full(shape, 5.0, dtype=np.float64)
+    vertices = np.array([[8.0, 8.0]], dtype=np.float64)
+    normals = np.array([[1.0, 0.0]], dtype=np.float64)
+    sigmas = np.array([1.0], dtype=np.float64)
+    result = lm_subpixel_refine(
+        vertices_vu=vertices,
+        normals_vu=normals,
+        sigma_normal_per_vertex_px=sigmas,
+        image_edge_dt=flat_dt,
+        use_polarity=False,
+        max_iterations=50,
+    )
+    # The loop terminates without converging on a flat DT.
+    assert result.converged is False
+    # The offset stays at the initial value (no successful step reduced cost).
+    assert result.offset_vu == (0.0, 0.0)

--- a/tests/nav/nav_technique/test_dt_fitting.py
+++ b/tests/nav/nav_technique/test_dt_fitting.py
@@ -216,16 +216,46 @@ def test_coarse_ncc_search_returns_zero_with_empty_polyline() -> None:
             (1, -1),
             'must be non-negative',
         ),
+        # Wrong-length window: caught by the length-2 guard.
+        (
+            np.zeros((4, 4), bool),
+            np.zeros((4, 4), bool),
+            (1, 2, 3),
+            'length-2 sequence of ints',
+        ),
+        (
+            np.zeros((4, 4), bool),
+            np.zeros((4, 4), bool),
+            (1,),
+            'length-2 sequence of ints',
+        ),
     ],
 )
 def test_coarse_ncc_search_rejects_invalid_inputs(
     edge_mask: np.ndarray,
     polyline_mask: np.ndarray,
-    window: tuple[int, int],
+    window: tuple[int, ...],
     message: str,
 ) -> None:
+    """Invalid mask shapes or window tuples are rejected with a named message."""
     with pytest.raises(ValueError, match=message):
-        coarse_ncc_search(edge_mask, polyline_mask, window)
+        coarse_ncc_search(edge_mask, polyline_mask, window)  # type: ignore[arg-type]
+
+
+def test_coarse_ncc_search_rejects_float_window_entry() -> None:
+    """A float window entry is rejected with TypeError instead of being truncated."""
+    edge_mask = np.zeros((4, 4), bool)
+    polyline_mask = np.zeros((4, 4), bool)
+    with pytest.raises(TypeError, match='search_window_vu\\[0\\] must be int'):
+        coarse_ncc_search(edge_mask, polyline_mask, (1.5, 1))  # type: ignore[arg-type]
+
+
+def test_coarse_ncc_search_rejects_non_sequence_window() -> None:
+    """A non-tuple/list window is rejected by the length-2 sequence guard."""
+    edge_mask = np.zeros((4, 4), bool)
+    polyline_mask = np.zeros((4, 4), bool)
+    with pytest.raises(ValueError, match='length-2 sequence of ints'):
+        coarse_ncc_search(edge_mask, polyline_mask, np.array([1, 1]))  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/nav/nav_technique/test_nav_technique_body_limb.py
+++ b/tests/nav/nav_technique/test_nav_technique_body_limb.py
@@ -1,0 +1,239 @@
+"""End-to-end tests for ``BodyLimbNav``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from tests.nav.nav_technique.conftest import (
+    ArcPolylineFactory,
+    CirclePolylineFactory,
+    DiscImageFactory,
+    NavContextFactory,
+    NavFeatureFactory,
+)
+
+from nav.feature.feature import NavFeature
+from nav.nav_orchestrator.nav_context import NavContext
+from nav.nav_technique.diagnostics import BodyLimbDiagnostics
+from nav.nav_technique.nav_technique_body_limb import (
+    LIMB_MIN_ARC_PX,
+    BodyLimbNav,
+)
+
+
+def test_body_limb_nav_recovers_planted_offset_single_body(
+    disc_image: DiscImageFactory,
+    circle_polyline: CirclePolylineFactory,
+    make_limb_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    shape = (200, 200)
+    image_center = (100.0, 100.0)
+    radius = 30.0
+    image = disc_image(shape, image_center, radius)
+    # Plant the model 1.5 px below and 2.5 px right of the actual disc:
+    # the technique should report offset_px = (1.5, 2.5) so the model
+    # gets shifted onto the image disc.
+    model_center = (image_center[0] - 1.5, image_center[1] - 2.5)
+    vertices, outward = circle_polyline(model_center, radius, 120)
+    feature = make_limb_feature('moonA', vertices=vertices, outward_normals=outward)
+    technique = BodyLimbNav()
+    context = make_nav_context(image)
+    feasibility = technique.is_feasible([feature])
+    assert feasibility.feasible is True
+    result = technique.navigate([feature], context)
+    assert result.offset_px[0] == pytest.approx(1.5, abs=0.05)
+    assert result.offset_px[1] == pytest.approx(2.5, abs=0.05)
+    assert result.spurious is False
+    assert result.at_edge is False
+    assert isinstance(result.diagnostics, BodyLimbDiagnostics)
+    assert result.diagnostics.tukey_inlier_count == 120
+    assert result.diagnostics.lm_iterations >= 1
+
+
+def test_body_limb_nav_recovers_partial_arc(
+    disc_image: DiscImageFactory,
+    arc_polyline: ArcPolylineFactory,
+    make_limb_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    shape = (200, 200)
+    image_center = (100.0, 100.0)
+    radius = 30.0
+    image = disc_image(shape, image_center, radius)
+    # 50 % visible arc starting at the right side of the body (angles
+    # [-pi/2, pi/2]).
+    model_center = (image_center[0] - 0.5, image_center[1] - 1.5)
+    vertices, outward = arc_polyline(model_center, radius, 60, -np.pi / 2, np.pi / 2)
+    feature = make_limb_feature(
+        'moonB', vertices=vertices, outward_normals=outward, visible_arc_fraction=0.5
+    )
+    technique = BodyLimbNav()
+    context = make_nav_context(image)
+    result = technique.navigate([feature], context)
+    assert result.offset_px[0] == pytest.approx(0.5, abs=0.1)
+    assert result.offset_px[1] == pytest.approx(1.5, abs=0.1)
+    assert result.confidence > 0.0
+
+
+def test_body_limb_nav_recovers_multi_body_offset(
+    disc_image: DiscImageFactory,
+    circle_polyline: CirclePolylineFactory,
+    make_limb_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    shape = (240, 240)
+    radius = 22.0
+    centres = [(80.0, 80.0), (160.0, 90.0), (130.0, 170.0)]
+    image = np.zeros(shape, dtype=np.float64)
+    for cv, cu in centres:
+        image += disc_image(shape, (cv, cu), radius)
+    image = np.clip(image, 0.0, 100.0)
+    planted_dv, planted_du = 1.0, -1.5
+    features: list[NavFeature] = []
+    for idx, (cv, cu) in enumerate(centres):
+        model_center = (cv - planted_dv, cu - planted_du)
+        vertices, outward = circle_polyline(model_center, radius, 80)
+        features.append(
+            make_limb_feature(f'moon_{idx}', vertices=vertices, outward_normals=outward)
+        )
+    technique = BodyLimbNav()
+    context = make_nav_context(image)
+    result = technique.navigate(features, context)
+    assert result.offset_px[0] == pytest.approx(planted_dv, abs=0.05)
+    assert result.offset_px[1] == pytest.approx(planted_du, abs=0.05)
+    # Single-body result on the same image, for covariance comparison.
+    single_result = technique.navigate([features[0]], context)
+    multi_diag_max = float(np.linalg.eigvalsh(result.covariance_px2).max())
+    single_diag_max = float(np.linalg.eigvalsh(single_result.covariance_px2).max())
+    assert multi_diag_max < single_diag_max
+
+
+def test_body_limb_nav_infeasible_on_empty_input() -> None:
+    technique = BodyLimbNav()
+    report = technique.is_feasible([])
+    assert report.feasible is False
+    assert 'no_limb_arc_features' in report.reason
+
+
+def test_body_limb_nav_infeasible_on_short_arc(
+    circle_polyline: CirclePolylineFactory,
+    make_limb_feature: NavFeatureFactory,
+) -> None:
+    short_n = int(LIMB_MIN_ARC_PX) - 1
+    vertices, outward = circle_polyline((50.0, 50.0), 12.0, short_n)
+    feature = make_limb_feature('tiny_moon', vertices=vertices, outward_normals=outward)
+    technique = BodyLimbNav()
+    report = technique.is_feasible([feature])
+    assert report.feasible is False
+    assert 'sufficient_visible_arc' in report.reason
+
+
+def test_body_limb_nav_at_edge_when_offset_hits_search_window(
+    disc_image: DiscImageFactory,
+    circle_polyline: CirclePolylineFactory,
+    make_limb_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    shape = (160, 160)
+    image_center = (80.0, 80.0)
+    radius = 25.0
+    image = disc_image(shape, image_center, radius)
+    margin_v, margin_u = 6, 6
+    # Plant the model at exactly the search window boundary so LM can
+    # only converge at the edge.
+    model_center = (image_center[0] - float(margin_v), image_center[1] - float(margin_u))
+    vertices, outward = circle_polyline(model_center, radius, 120)
+    feature = make_limb_feature('atedge_moon', vertices=vertices, outward_normals=outward)
+    technique = BodyLimbNav()
+    context = make_nav_context(image, extfov_margin_vu=(margin_v, margin_u))
+    result = technique.navigate([feature], context)
+    assert result.at_edge is True
+    # Hard-zero gate via ``at_edge`` forces confidence to 0 per the spec.
+    assert result.confidence == pytest.approx(0.0, abs=1e-12)
+
+
+def test_body_limb_nav_marks_spurious_when_image_lacks_limb(
+    circle_polyline: CirclePolylineFactory,
+    make_limb_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    shape = (200, 200)
+    image = np.zeros(shape, dtype=np.float64)  # No edge anywhere.
+    image[10:20, 10:20] = 100.0  # a small unrelated bright square far from the model
+    vertices, outward = circle_polyline((100.0, 100.0), 30.0, 120)
+    feature = make_limb_feature('lonely_moon', vertices=vertices, outward_normals=outward)
+    technique = BodyLimbNav()
+    context = make_nav_context(image)
+    result = technique.navigate([feature], context)
+    assert result.spurious is True
+
+
+def test_body_limb_nav_polarity_filters_wrong_polarity_vertices(
+    disc_image: DiscImageFactory,
+    circle_polyline: CirclePolylineFactory,
+    make_limb_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    shape = (200, 200)
+    image_center = (100.0, 100.0)
+    radius = 30.0
+    image = disc_image(shape, image_center, radius)
+    model_center = (image_center[0] - 1.0, image_center[1] - 2.0)
+    n_vertices = 120
+    vertices, outward_normals = circle_polyline(model_center, radius, n_vertices)
+    # Plant exactly half (60 of 120) the vertices with inverted outward
+    # normals; the polarity filter must reject every one of them.  The
+    # exact count is the load-bearing assertion: any silent change to the
+    # polarity-rejection wiring (sign convention, Tukey constant,
+    # ``_INFINITY_DT_PENALTY_PX`` substitute) shifts it.
+    bad_indices = np.arange(0, n_vertices, 2)
+    n_bad = int(bad_indices.size)
+    n_good = n_vertices - n_bad
+    outward_normals[bad_indices] *= -1.0
+    feature = make_limb_feature('mixed_moon', vertices=vertices, outward_normals=outward_normals)
+    technique = BodyLimbNav()
+    context = make_nav_context(image)
+    result = technique.navigate([feature], context)
+    assert result.offset_px[0] == pytest.approx(1.0, abs=0.1)
+    assert result.offset_px[1] == pytest.approx(2.0, abs=0.1)
+    assert isinstance(result.diagnostics, BodyLimbDiagnostics)
+    # Two complementary assertions so a failure points at which side broke:
+    # the count must equal the planted ``n_good`` (no extra rejections from
+    # convergence-tolerance drift, no extra acceptances from polarity-check
+    # weakening).
+    assert result.diagnostics.tukey_inlier_count <= n_good
+    assert result.diagnostics.tukey_inlier_count == n_good
+
+
+def test_body_limb_nav_registered_with_navtechnique_registry() -> None:
+    from nav.nav_technique.nav_technique import NavTechnique
+
+    assert BodyLimbNav in NavTechnique._registry
+
+
+def test_body_limb_nav_raises_when_navcontext_lacks_derivatives(
+    disc_image: DiscImageFactory,
+    circle_polyline: CirclePolylineFactory,
+    make_limb_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    shape = (160, 160)
+    image = disc_image(shape, (80.0, 80.0), 25.0)
+    vertices, outward = circle_polyline((80.0, 80.0), 25.0, 120)
+    feature = make_limb_feature('moon', vertices=vertices, outward_normals=outward)
+    technique = BodyLimbNav()
+    context = make_nav_context(image)
+    # Build a fresh context without the gradient / DT fields populated.
+    bare_context = NavContext(
+        obs=context.obs,
+        image_ext=context.image_ext,
+        sensor_mask_ext=context.sensor_mask_ext,
+        image_noise_sigma=context.image_noise_sigma,
+        saturation_mask_ext=context.saturation_mask_ext,
+        cosmic_ray_mask_ext=context.cosmic_ray_mask_ext,
+        image_classifier=context.image_classifier,
+        provenance=context.provenance,
+    )
+    with pytest.raises(RuntimeError, match='image_edge_dt_ext'):
+        technique.navigate([feature], bare_context)

--- a/tests/nav/nav_technique/test_nav_technique_body_terminator.py
+++ b/tests/nav/nav_technique/test_nav_technique_body_terminator.py
@@ -1,0 +1,227 @@
+"""End-to-end tests for ``BodyTerminatorNav``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from tests.nav.nav_technique.conftest import (
+    ArcPolylineFactory,
+    DiscImageFactory,
+    NavContextFactory,
+    NavFeatureFactory,
+)
+
+from nav.feature.feature import NavFeature, NavReliabilityBreakdown
+from nav.feature.feature_type import NavFeatureType
+from nav.feature.flags import TerminatorArcFlags
+from nav.feature.geometry import TerminatorPolyline
+from nav.nav_orchestrator.nav_context import NavContext
+from nav.nav_technique.diagnostics import BodyTerminatorDiagnostics
+from nav.nav_technique.nav_technique_body_terminator import (
+    TERMINATOR_MIN_ARC_PX,
+    BodyTerminatorNav,
+    _aggregate_terminator_features,
+)
+from nav.support.filters import NavFilterKind, NavFilterSpec
+
+# Terminator tests always use a right-side crescent: a half-arc spanning
+# [-pi/2, pi/2] around the body centre.  Other techniques use different
+# angle ranges, so the bounds are a per-test parameter rather than a
+# shared fixture default.
+_TERMINATOR_ANGLE_START: float = -np.pi / 2.0
+_TERMINATOR_ANGLE_END: float = np.pi / 2.0
+
+
+def test_body_terminator_nav_recovers_planted_offset(
+    disc_image: DiscImageFactory,
+    arc_polyline: ArcPolylineFactory,
+    make_terminator_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    shape = (200, 200)
+    image_center = (100.0, 100.0)
+    radius = 30.0
+    image = disc_image(shape, image_center, radius)
+    model_center = (image_center[0] - 0.7, image_center[1] - 1.3)
+    vertices, outward = arc_polyline(
+        model_center, radius, 80, _TERMINATOR_ANGLE_START, _TERMINATOR_ANGLE_END
+    )
+    feature = make_terminator_feature('moonA', vertices=vertices, outward_normals=outward)
+    technique = BodyTerminatorNav()
+    context = make_nav_context(image)
+    feasibility = technique.is_feasible([feature])
+    assert feasibility.feasible is True
+    result = technique.navigate([feature], context)
+    assert result.offset_px[0] == pytest.approx(0.7, abs=0.1)
+    assert result.offset_px[1] == pytest.approx(1.3, abs=0.1)
+    assert isinstance(result.diagnostics, BodyTerminatorDiagnostics)
+    assert result.diagnostics.lm_iterations >= 1
+
+
+def test_body_terminator_nav_per_body_uniform_weighting() -> None:
+    """Two bodies with very different sigma means must each carry uniform weight.
+
+    The technique must collapse each body's per-vertex sigmas to a single
+    per-body scalar via the body's mean — that's the design's
+    "per-body uniform weight" rule (cross-body weighting reflects albedo
+    variation; intra-body weighting is uniform).
+    """
+    angles = np.linspace(-np.pi / 4, np.pi / 4, 30)
+    body_a_vs = 50.0 + 20.0 * np.sin(angles)
+    body_a_us = 50.0 + 20.0 * np.cos(angles)
+    body_a_vertices = np.stack([body_a_vs, body_a_us], axis=-1)
+    body_a_normals = np.stack([np.sin(angles), np.cos(angles)], axis=-1)
+    n = 30
+    feature_a = NavFeature(
+        feature_id='terminator_arc:bodyA',
+        feature_type=NavFeatureType.TERMINATOR_ARC,
+        source_model='body',
+        geometry=TerminatorPolyline(
+            vertices_vu=body_a_vertices,
+            normals_vu=body_a_normals,
+            sigma_normal_per_vertex_px=np.linspace(0.5, 2.5, n).astype(np.float64),
+            sigma_tangent_per_vertex_px=np.full(n, 0.5, dtype=np.float64),
+            bbox_extfov_vu=(40, 40, 80, 80),
+        ),
+        subject_range_km=1.0e6,
+        position_cov_px=None,
+        intensity_sigma_rel=0.0,
+        preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
+        reliability=0.7,
+        reliability_reasons=NavReliabilityBreakdown(visible_arc_fraction=1.0, albedo_penalty=0.05),
+        usable_types=frozenset({NavFeatureType.TERMINATOR_ARC}),
+        flags=TerminatorArcFlags(
+            body_name='bodyA', visible_arc_fraction=1.0, phase_angle_factor=0.8
+        ),
+    )
+    body_b_vs = 110.0 + 20.0 * np.sin(angles)
+    body_b_us = 110.0 + 20.0 * np.cos(angles)
+    body_b_vertices = np.stack([body_b_vs, body_b_us], axis=-1)
+    body_b_normals = np.stack([np.sin(angles), np.cos(angles)], axis=-1)
+    feature_b = NavFeature(
+        feature_id='terminator_arc:bodyB',
+        feature_type=NavFeatureType.TERMINATOR_ARC,
+        source_model='body',
+        geometry=TerminatorPolyline(
+            vertices_vu=body_b_vertices,
+            normals_vu=body_b_normals,
+            sigma_normal_per_vertex_px=np.full(n, 5.0, dtype=np.float64),
+            sigma_tangent_per_vertex_px=np.full(n, 0.5, dtype=np.float64),
+            bbox_extfov_vu=(100, 100, 140, 140),
+        ),
+        subject_range_km=1.0e6,
+        position_cov_px=None,
+        intensity_sigma_rel=0.0,
+        preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
+        reliability=0.4,
+        reliability_reasons=NavReliabilityBreakdown(visible_arc_fraction=1.0, albedo_penalty=0.6),
+        usable_types=frozenset({NavFeatureType.TERMINATOR_ARC}),
+        flags=TerminatorArcFlags(
+            body_name='bodyB', visible_arc_fraction=1.0, phase_angle_factor=0.4
+        ),
+    )
+    _, _, sigmas, ids, _, _ = _aggregate_terminator_features([feature_a, feature_b])
+    # bodyA's per-body sigma is the mean of its per-vertex sigmas (1.5);
+    # bodyB's is the constant 5.0.  The aggregator must use each body's
+    # mean uniformly across its own vertices.
+    assert ids == ['terminator_arc:bodyA', 'terminator_arc:bodyB']
+    assert np.allclose(sigmas[:n], np.full(n, 1.5))
+    assert np.allclose(sigmas[n:], np.full(n, 5.0))
+
+
+def test_body_terminator_nav_infeasible_on_empty_input() -> None:
+    technique = BodyTerminatorNav()
+    report = technique.is_feasible([])
+    assert report.feasible is False
+    assert 'no_terminator_arc_features' in report.reason
+
+
+def test_body_terminator_nav_infeasible_on_short_arc(
+    make_terminator_feature: NavFeatureFactory,
+) -> None:
+    short_n = int(TERMINATOR_MIN_ARC_PX) - 1
+    angles = np.linspace(-np.pi / 4, np.pi / 4, short_n)
+    vs = 50.0 + 20.0 * np.sin(angles)
+    us = 50.0 + 20.0 * np.cos(angles)
+    vertices = np.stack([vs, us], axis=-1)
+    outward = np.stack([np.sin(angles), np.cos(angles)], axis=-1)
+    feature = make_terminator_feature('shortmoon', vertices=vertices, outward_normals=outward)
+    technique = BodyTerminatorNav()
+    report = technique.is_feasible([feature])
+    assert report.feasible is False
+
+
+def test_body_terminator_nav_marks_spurious_when_image_lacks_terminator(
+    make_terminator_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    shape = (200, 200)
+    image = np.zeros(shape, dtype=np.float64)
+    image[5:15, 5:15] = 100.0
+    angles = np.linspace(-np.pi / 4, np.pi / 4, 80)
+    vs = 100.0 + 30.0 * np.sin(angles)
+    us = 100.0 + 30.0 * np.cos(angles)
+    vertices = np.stack([vs, us], axis=-1)
+    outward = np.stack([np.sin(angles), np.cos(angles)], axis=-1)
+    feature = make_terminator_feature('lonely', vertices=vertices, outward_normals=outward)
+    technique = BodyTerminatorNav()
+    context = make_nav_context(image)
+    result = technique.navigate([feature], context)
+    assert result.spurious is True
+
+
+def test_body_terminator_nav_at_edge_when_offset_hits_search_window(
+    disc_image: DiscImageFactory,
+    arc_polyline: ArcPolylineFactory,
+    make_terminator_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    shape = (160, 160)
+    image_center = (80.0, 80.0)
+    radius = 25.0
+    image = disc_image(shape, image_center, radius)
+    margin_v, margin_u = 6, 6
+    model_center = (image_center[0] - float(margin_v), image_center[1] - float(margin_u))
+    vertices, outward = arc_polyline(
+        model_center, radius, 80, _TERMINATOR_ANGLE_START, _TERMINATOR_ANGLE_END
+    )
+    feature = make_terminator_feature('atedge', vertices=vertices, outward_normals=outward)
+    technique = BodyTerminatorNav()
+    context = make_nav_context(image, extfov_margin_vu=(margin_v, margin_u))
+    result = technique.navigate([feature], context)
+    assert result.at_edge is True
+    assert result.confidence == pytest.approx(0.0, abs=1.0e-12)
+
+
+def test_body_terminator_nav_registered_with_navtechnique_registry() -> None:
+    from nav.nav_technique.nav_technique import NavTechnique
+
+    assert BodyTerminatorNav in NavTechnique._registry
+
+
+def test_body_terminator_nav_raises_when_navcontext_lacks_derivatives(
+    disc_image: DiscImageFactory,
+    arc_polyline: ArcPolylineFactory,
+    make_terminator_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    shape = (160, 160)
+    image = disc_image(shape, (80.0, 80.0), 25.0)
+    vertices, outward = arc_polyline(
+        (80.0, 80.0), 25.0, 80, _TERMINATOR_ANGLE_START, _TERMINATOR_ANGLE_END
+    )
+    feature = make_terminator_feature('moon', vertices=vertices, outward_normals=outward)
+    technique = BodyTerminatorNav()
+    context = make_nav_context(image)
+    bare_context = NavContext(
+        obs=context.obs,
+        image_ext=context.image_ext,
+        sensor_mask_ext=context.sensor_mask_ext,
+        image_noise_sigma=context.image_noise_sigma,
+        saturation_mask_ext=context.saturation_mask_ext,
+        cosmic_ray_mask_ext=context.cosmic_ray_mask_ext,
+        image_classifier=context.image_classifier,
+        provenance=context.provenance,
+    )
+    with pytest.raises(RuntimeError, match='image_edge_dt_ext'):
+        technique.navigate([feature], bare_context)

--- a/tests/nav/nav_technique/test_nav_technique_ring_edge.py
+++ b/tests/nav/nav_technique/test_nav_technique_ring_edge.py
@@ -1,0 +1,165 @@
+"""End-to-end tests for ``RingEdgeNav``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from tests.nav.nav_technique.conftest import (
+    CirclePolylineFactory,
+    DiscImageFactory,
+    FlatPolylineFactory,
+    HorizontalStepImageFactory,
+    NavContextFactory,
+    NavFeatureFactory,
+)
+
+from nav.nav_orchestrator.nav_context import NavContext
+from nav.nav_technique.diagnostics import RingEdgeDiagnostics
+from nav.nav_technique.nav_technique_ring_edge import (
+    _RANK1_NULL_RELATIVE_THRESHOLD,
+    RingEdgeNav,
+)
+
+
+def test_ring_edge_nav_recovers_planted_offset_curved(
+    disc_image: DiscImageFactory,
+    circle_polyline: CirclePolylineFactory,
+    make_ring_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    shape = (200, 200)
+    cv = 100.0
+    cu = 100.0
+    radius = 32.0
+    image = disc_image(shape, (cv, cu), radius)
+    # Plant model 0.7 v-down, 1.3 u-right.
+    vertices, outward = circle_polyline((cv - 0.7, cu - 1.3), radius, 120)
+    feature = make_ring_feature(
+        'outer', vertices=vertices, outward_normals=outward, is_straight_line=False
+    )
+    technique = RingEdgeNav()
+    context = make_nav_context(image)
+    feasibility = technique.is_feasible([feature])
+    assert feasibility.feasible is True
+    result = technique.navigate([feature], context)
+    assert result.offset_px[0] == pytest.approx(0.7, abs=0.3)
+    assert result.offset_px[1] == pytest.approx(1.3, abs=0.3)
+    assert isinstance(result.diagnostics, RingEdgeDiagnostics)
+    assert result.diagnostics.is_rank_1 is False
+    eigvals = np.linalg.eigvalsh(result.covariance_px2)
+    assert float(eigvals.min()) > 1.0e-12
+
+
+def test_ring_edge_nav_returns_rank_1_for_all_flat_input(
+    horizontal_step_image: HorizontalStepImageFactory,
+    flat_polyline: FlatPolylineFactory,
+    make_ring_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    shape = (200, 200)
+    # A simple half-image step: bright above row 100, dark below.  The
+    # gradient peak (one pixel wide) sits at row 100, giving a clean,
+    # single minimum that the LM can converge to.
+    image = horizontal_step_image(shape, 100.0)
+    # Polyline sits 1.5 px off the actual edge.  The LM should drive
+    # the offset back to ~ -1.5 in v but only along the radial axis;
+    # along the edge tangent (u) the cost has no slope, so the
+    # information matrix is rank-1.
+    vertices, outward = flat_polyline(101.5, 20.0, 180.0, 120)
+    feature = make_ring_feature(
+        'flat', vertices=vertices, outward_normals=outward, is_straight_line=True
+    )
+    technique = RingEdgeNav()
+    context = make_nav_context(image)
+    result = technique.navigate([feature], context)
+    assert isinstance(result.diagnostics, RingEdgeDiagnostics)
+    assert result.diagnostics.is_rank_1 is True
+    eigvals = np.linalg.eigvalsh(result.covariance_px2)
+    null_eigval = float(eigvals.min())
+    observed_eigval = float(eigvals.max())
+    assert observed_eigval > 0.0
+    # Null direction is along the edge tangent (u axis); rank-deficient
+    # covariance is expressed via the eigenvalue ratio.  Use the same
+    # threshold the production code's ``_is_rank_1`` classifier uses, so
+    # this test exercises the same boundary the technique itself draws
+    # rather than a looser independent constant.
+    assert (
+        null_eigval == pytest.approx(0.0, abs=1.0e-9)
+        or null_eigval / observed_eigval < _RANK1_NULL_RELATIVE_THRESHOLD
+    )
+
+
+def test_ring_edge_nav_mixed_curved_and_flat_full_rank(
+    disc_image: DiscImageFactory,
+    circle_polyline: CirclePolylineFactory,
+    flat_polyline: FlatPolylineFactory,
+    make_ring_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    shape = (220, 220)
+    cv_disc, cu_disc = 60.0, 110.0
+    image = disc_image(shape, (cv_disc, cu_disc), 24.0)
+    # Add a horizontal step below the disc so the two image features do
+    # not overlap; the disc occupies rows 36..84 and the step lives at
+    # row 150.
+    bar_image = np.zeros(shape, dtype=np.float64)
+    bar_image[150:152, 30:190] = 100.0
+    image = np.clip(image + bar_image, 0.0, 100.0)
+    # Both polylines share offset (-1.5, 0): curved centre at
+    # (cv_disc + 1.5, cu_disc) and flat polyline at v = 151 + 1.5.
+    curved_v, curved_n = circle_polyline((cv_disc + 1.5, cu_disc), 24.0, 120)
+    flat_v, flat_n = flat_polyline(152.5, 40.0, 180.0, 80)
+    curved_feature = make_ring_feature(
+        'curved', vertices=curved_v, outward_normals=curved_n, is_straight_line=False
+    )
+    flat_feature = make_ring_feature(
+        'flat', vertices=flat_v, outward_normals=flat_n, is_straight_line=True
+    )
+    technique = RingEdgeNav()
+    context = make_nav_context(image)
+    result = technique.navigate([curved_feature, flat_feature], context)
+    assert isinstance(result.diagnostics, RingEdgeDiagnostics)
+    assert result.diagnostics.is_rank_1 is False
+    eigvals = np.linalg.eigvalsh(result.covariance_px2)
+    assert float(eigvals.min()) > 1.0e-12
+
+
+def test_ring_edge_nav_infeasible_on_empty_input() -> None:
+    technique = RingEdgeNav()
+    report = technique.is_feasible([])
+    assert report.feasible is False
+    assert 'no_ring_edge_features' in report.reason
+
+
+def test_ring_edge_nav_registered_with_navtechnique_registry() -> None:
+    from nav.nav_technique.nav_technique import NavTechnique
+
+    assert RingEdgeNav in NavTechnique._registry
+
+
+def test_ring_edge_nav_raises_when_navcontext_lacks_derivatives(
+    disc_image: DiscImageFactory,
+    circle_polyline: CirclePolylineFactory,
+    make_ring_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    shape = (160, 160)
+    image = disc_image(shape, (80.0, 80.0), 25.0)
+    vertices, outward = circle_polyline((80.0, 80.0), 25.0, 80)
+    feature = make_ring_feature(
+        'mid', vertices=vertices, outward_normals=outward, is_straight_line=False
+    )
+    technique = RingEdgeNav()
+    context = make_nav_context(image)
+    bare_context = NavContext(
+        obs=context.obs,
+        image_ext=context.image_ext,
+        sensor_mask_ext=context.sensor_mask_ext,
+        image_noise_sigma=context.image_noise_sigma,
+        saturation_mask_ext=context.saturation_mask_ext,
+        cosmic_ray_mask_ext=context.cosmic_ray_mask_ext,
+        image_classifier=context.image_classifier,
+        provenance=context.provenance,
+    )
+    with pytest.raises(RuntimeError, match='image_edge_dt_ext'):
+        technique.navigate([feature], bare_context)


### PR DESCRIPTION
## Summary

Implements the first wave of stage-2 concrete `NavTechnique` subclasses plus the shared image-side derivatives and DT-fitting machinery they consume. All work passes `ruff`, `ruff format`, `mypy --strict` (251 source files), `pytest -n auto --dist=loadfile` (1009 passed), `sphinx-build -W`, and `pymarkdown scan` on the documented standard set.

## Concrete NavTechniques

- **`BodyLimbNav`** — joint translation fit on every `LIMB_ARC` feature via coarse-NCC + Levenberg-Marquardt with polarity filtering and Tukey biweight reweighting.
- **`BodyTerminatorNav`** — same shape with terminator-specific per-body uniform weighting (each body's vertices share the body's mean `sigma_normal_per_vertex_px`) and an albedo / phase-angle confidence spec.
- **`RingEdgeNav`** — DT fit on every `RING_EDGE` feature; reports honest rank-1 covariance when every input edge is straight-line. Polarity prediction is intentionally disabled (deferred per Part 13b).

## Shared infrastructure

- **`nav.nav_technique.dt_fitting`** — pure-numerical helpers shared by every DT technique: `coarse_ncc_search` (binary-mask cross-correlation with Manhattan-distance tie-breaking), `polarity_filter` (strict dot-product-greater-than-zero gate), `tukey_biweight_weights` (Holland-Welsch redescender at c = 4.685), `lm_subpixel_refine` (translation, optionally with rotation, with IRLS Tukey reweighting, lambda_start = 1e-3, max 30 iterations, step-norm tolerance 1e-3 px), and `information_matrix_to_covariance` (`pinvh` with rtol = 1e-9).
- **`nav.nav_orchestrator.image_derivatives`** — shared Sobel-of-Gaussian gradient + Canny-style directional NMS + truncated distance transform. `build_image_edge_dt` returns `(image_gradient_ext, image_edge_dt_ext)` and `compute_image_gradient_vu` returns the `(g_v, g_u)` vector consumed by the polarity filter. The orchestrator's `_make_context` populates all three `NavContext` fields.

## Logging convention

The codebase no longer uses the stdlib `logging` module anywhere in the cutover-tier source tree; `pdslogger` via `IMAGE_LOGGER` is the only logger. Every `NavTechnique.navigate` body opens a section via `self.logger.open(f'TECHNIQUE: {self.name}')` so per-image logs delimit each technique's contribution. The accompanying `.cursor/rules/logging_best_practices.mdc` skill documents the convention; a follow-up commit trims the rule to match (no more `NullHandler` carve-out, since the pattern has been removed everywhere).

## Test infrastructure

- `tests/nav/nav_technique/conftest.py` centralises the shared scaffolding (`FakeObs`, anti-aliased disc / horizontal-step image factories, circle / arc / flat polyline factories, `NavContext` factory, three feature factories) so the per-technique end-to-end tests stay focused on assertions rather than setup. Public type aliases on the conftest keep the test tree mypy-strict-clean.
- `@pytest.mark.parametrize` consolidates the `dt_fitting` validation suites; new boundary tests cover exact-c Tukey biweight, zero-window / unit-window NCC, polarity-without-gradient `ValueError`, LM divergence early exit, 4x4 image, and exact-threshold Sobel.

## Documentation

- New `developer_guide_techniques.rst` describes the DT pipeline and per-technique sub-sections. New `developer_guide_uncertainty.rst` derives the M-estimator information-matrix to covariance step. Cross-references between the two pages, plus into the `api_reference` auto-doc tree.
- `user_guide_navigation.rst` refreshed: removes references to the deleted `correlate_all` technique, lists the three DT techniques and the pending ones, adds `--nav-techniques` filtering examples.
- `AUTONAV_PLAN.md` gains a "Stage 2 status" section reflecting what shipped here and what still owes (full-disc / blob / ring-annulus / star techniques; static-data YAMLs; per-instrument `ImageQualityThresholds`; `STATUS_REASON_INFO_TEMPLATE` wiring; provenance population; integration suite; calibration).
- The dead `CartographicDiagnostics` dataclass is removed; it returns alongside `CartographicNav` when the technique itself lands (deferred per Part 13b).

## Coverage on new modules

| Module | Coverage |
|---|---|
| `nav_orchestrator/image_derivatives` | 100% |
| `nav_technique/dt_fitting` | 93% |
| `nav_technique/nav_technique_body_limb` | 90% |
| `nav_technique/nav_technique_body_terminator` | 90% |
| `nav_technique/nav_technique_ring_edge` | 89% |

## Test plan

- [x] `ruff check src tests`
- [x] `ruff format --check src tests`
- [x] `mypy src tests` (strict, 251 source files)
- [x] `pytest -n auto --dist=loadfile` (1009 passed)
- [x] `sphinx-build -W -b html docs docs/_build`
- [x] `pymarkdown scan docs/ .cursor/ README.md CONTRIBUTING.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Three DT-based navigation techniques added (BodyLimb, BodyTerminator, RingEdge); orchestrator now computes and exposes shared image-derivatives and accepts a derivatives config; new DT-fitting and robust subpixel refinement utilities.

* **Documentation**
  * Expanded user/developer guides, uncertainty/observability docs, API reference updates, and a logging best-practices guide.

* **Tests**
  * Comprehensive unit and end-to-end tests for image derivatives, DT fitting, and the new techniques.

* **Chores**
  * Removed legacy module-level logging setup and standardized logging conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->