### PR TITLE
Phase 6: Ring-annulus technique + per-technique config

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -91,7 +91,7 @@ jobs:
           # regression tests; those rely on real PDS3 holdings + SPICE kernels
           # and are slow / flaky in CI.  Run the integration suite locally
           # against a populated $PDS3_HOLDINGS_DIR before merging.
-          python -m pytest --cov -n auto --dist=loadfile -m "not integration"
+          python -m pytest --cov --cov-report=xml -n auto --dist=loadfile -m "not integration"
 
       - name: Print coverage report
         run: |
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v6
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' &&!github.event.pull_request.head.repo.fork
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -87,7 +87,11 @@ jobs:
           # loadfile keeps each test file on one xdist worker; PyQt6 + default load
           # scheduling has caused worker crashes when tests from the same file ran
           # in different processes.
-          python -m pytest --cov -n auto --dist=loadfile
+          # ``-m "not integration"`` skips the operator-curated image-library
+          # regression tests; those rely on real PDS3 holdings + SPICE kernels
+          # and are slow / flaky in CI.  Run the integration suite locally
+          # against a populated $PDS3_HOLDINGS_DIR before merging.
+          python -m pytest --cov -n auto --dist=loadfile -m "not integration"
 
       - name: Print coverage report
         run: |

--- a/AUTONAV_PLAN.md
+++ b/AUTONAV_PLAN.md
@@ -3054,7 +3054,9 @@ starting points for Phase 6 / Phase 10 calibration work.
 
 ---
 
-## Phase 6 — Ring-annulus technique
+## Phase 6 — Ring-annulus technique (complete)
+
+**Status:** Shipped on branch `core_rewrite_phase6`.  The original specification (Goal / Scope / Tests / Documentation / Definition of done) is preserved verbatim below for reference; the post-merge "What shipped" subsection at the end records the actual delivery, the operator-curated library follow-ups, and the binding conventions established during the phase.
 
 **Goal:** Ship `RingAnnulusNav` for low-resolution ring scenes
 where individual edges compress into a small image area. After
@@ -3093,6 +3095,151 @@ Phase 10.
 ring-annulus); Part 3 (technique).
 
 **Tests / Documentation / Definition of done:** standard.
+
+### What shipped in Phase 6
+
+- **`nav.nav_technique.RingAnnulusNav`** (new module
+  `src/nav/nav_technique/nav_technique_ring_annulus.py`).  Filters
+  input to `RING_ANNULUS` features carrying a template payload, fuses
+  them via `nav.feature.composition.compose_template_features`
+  (Z-buffer paint by `subject_range_km` ascending so closer ring
+  systems overwrite farther ones), and runs
+  `nav.support.correlate.navigate_with_pyramid_kpeaks` with
+  `use_gradient='auto'`.  Mirrors `BodyDiscCorrelateNav`'s shape
+  exactly because the underlying problem is the same — composite
+  template plus extfov-margin-bounded NCC.  Confidence spec carries
+  the placeholder coefficients documented in
+  `developer_guide_techniques.rst` plus
+  `hard_zero_if={'at_edge': True, 'spurious': True}`.  Registered in
+  `nav.nav_technique.__init__.py`.
+- **Multi-planet scope honored.**  `is_feasible` and `navigate` both
+  handle `len(features) > 1`: the multi-planet case paints each
+  planet's annulus into the composite (Z-buffer ordering matches
+  BodyDiscCorrelateNav), and the diagnostics field `annulus_count`
+  records the number of fused features so the confidence formula can
+  reward joint geometric constraint.  The unit test
+  `test_ring_annulus_multi_planet_z_buffer_paint` plants two annuli
+  at different image centers with a shared offset and asserts
+  recovery within 1 px.
+- **`config_510_techniques.yaml` ships.**  Every existing technique's
+  confidence-formula coefficients (BodyDiscCorrelateNav, BodyBlobNav,
+  BodyLimbNav, BodyTerminatorNav, RingEdgeNav, RingAnnulusNav) move
+  out of per-technique Python module constants and into the new YAML
+  under `techniques.<technique_name>`.  `Config._validate_registered_techniques`
+  loads each spec via the new
+  `nav.nav_technique.confidence_config.load_confidence_spec` helper at
+  config-load time and assigns it to the technique's class attribute.
+  Test-only registry entries whose `name` starts with `_` are exempt
+  from the YAML requirement so existing fake-technique fixtures
+  continue to work.  Phase 10 calibration is now a YAML edit, not a
+  code change.
+- **`nav.nav_technique.confidence_config.load_confidence_spec` (new
+  module).**  Pure-parser helper that turns a `techniques[<name>]`
+  mapping into a frozen :class:`ConfidenceSpec`.  Validates every
+  field at load time and rejects malformed shapes with typed
+  `ConfidenceConfigError` errors (missing block, missing `alpha0`,
+  unknown block / term keys, non-finite values, bool-as-numeric,
+  zero divisor, non-mapping block, non-bool hard-zero gate value).
+- **Pre-existing mypy error fixed.**  `nav_technique_body_blob.py:482`
+  was unwrapping `context.obs.extfov_margin_vu` directly on
+  `obs: object`; harmonized to the same `getattr(obs,
+  'extfov_margin_vu', None)` fallback pattern the other three NCC
+  techniques use.  Reproduces on the pre-Phase-6 commit; cleared as
+  part of the Phase 6 "fix all check errors" sweep.
+- **Documentation.** `docs/developer_guide_techniques.rst` gains a
+  "Ring-annulus technique" section documenting algorithm, confidence
+  spec, diagnostics fields, and infeasibility cases; the three
+  "config_510_techniques.yaml is not yet in the tree" notes (one
+  each on BodyDiscCorrelateNav / BodyBlobNav / RingAnnulusNav) are
+  retired now that the YAML ships, and each section now points at
+  `config_510_techniques.yaml.techniques.<name>` and the loader as
+  the source-of-truth.  The user-guide navigation listing moves
+  `RingAnnulusNav` from the "pending techniques" list into the body
+  of techniques and adds a best-for / when-to-use paragraph
+  alongside the existing `RingEdgeNav` entry.
+- **Test coverage.** Two new end-to-end test files (22 tests total,
+  all pass):
+  * `tests/nav/nav_technique/test_nav_technique_ring_annulus.py` (9
+    tests) covers single-planet planted-offset recovery, multi-planet
+    Z-buffer paint, infeasibility on empty inputs and on
+    RING_ANNULUS features that lack a template, at-edge detection at
+    the search-window boundary, hard-zero confidence on at-edge,
+    registry presence, and diagnostic-field assertions on `ncc_peak`,
+    `annulus_count`, and `peak_to_runner_up_ratio`.
+  * `tests/nav/nav_technique/test_confidence_config.py` (13 tests)
+    covers bundled-YAML round-trip for every shipped technique,
+    missing block, missing `alpha0`, unknown block / term keys,
+    non-finite values, bool-as-numeric rejection, zero divisor,
+    non-mapping block, non-bool hard-zero gate value, and the
+    hard-cap / hard-zero / default-term-offset paths.
+- **Phase 6 review folder.**  `phase_06_review/` carries the seven
+  CRITIQUE_*.md files per the per-phase definition of done
+  (`CRITIQUE_PYTHON.md`, `CRITIQUE_DOCS.md`,
+  `CRITIQUE_FILECACHE.md`, `CRITIQUE_LOGGING.md`,
+  `CRITIQUE_TESTS.md`, `CRITIQUE_CODEBASE.md`,
+  `CRITIQUE_SUMMARY.md`).  No Critical or High findings; eleven Low
+  follow-ups documented in the summary.
+- **`PHASE6_LIBRARY_SEED.md`** — operator instructions for the
+  deferred sidecar work, including scenario picks (distant Saturn
+  ring view; rare multi-planet composite), sidecar YAML template
+  with required fields and expected status / tier values, and the
+  per-image workflow.
+
+### Phase 6 follow-ups uncovered during implementation
+
+These are the gaps surfaced by the design review and the synthetic-
+image unit tests during Phase 6 implementation.  None block Phase 6
+(the technique handles its documented happy and boundary paths) but
+all are concrete starting points for Phase 10 calibration work.
+
+- **Library expansion deferred to operator session.**  Phase 6 §B
+  calls for 1–2 low-res-ring library images with operator-verified
+  ground truth.  The sidecar schema enforces
+  `ground_truth.source: operator_verified`; fabricating a sidecar
+  without an operator session would either fail integration testing
+  on first run or — worse — encode wrong-truth values that would
+  mask a real regression.  The technique itself is fully implemented
+  and unit-tested; library expansion needs a follow-up operator
+  session running `nav_offset --manual` against candidate images
+  (distant Cassini ring views; rare multi-planet composites) plus
+  the dialog's **Save as Library Entry...** button.  Operator
+  instructions live in `PHASE6_LIBRARY_SEED.md` (scenario picks,
+  sidecar template, per-field guidance).  The autonomous-nav
+  integration test (`tests/integration/`) is parameterized by
+  sidecar discovery so the operator-added entries exercise the
+  technique end-to-end as soon as they land.
+- **`peak_to_runner_up_ratio` term wired with `alpha=0.0`.**  Same
+  posture as `BodyDiscCorrelateNav`: the diagnostic is populated
+  honestly via the `top_k_peaks` field on
+  `navigate_with_pyramid_kpeaks`'s result dict (the binding
+  established in Phase 5), but the confidence-formula contribution
+  is zero pending Phase 10 calibration.  Re-tunable without code
+  change by editing `config_510_techniques.yaml` once the
+  operator-curated library spans enough multi-peak vs
+  unambiguous-peak scenes to fit the alpha.
+- **`annulus_count` saturation cap chosen at 2, not 3.**  The
+  confidence-formula divisor for `annulus_count` is 2.0 (vs the
+  body-disc `body_count` divisor of 3.0).  Justification: the
+  current spacecraft fleet has at most a handful of multi-planet
+  ring scenes (Cassini approach phase imaged Jupiter and Saturn
+  together; New Horizons imaged Jupiter from Pluto distance), and
+  three-planet ring composites are not a realistic geometry from
+  any single observation.  If a future mission produces a 3+ planet
+  scene the calibration sweep will tune both the divisor and the
+  alpha by editing `config_510_techniques.yaml`; the wiring is in
+  place.
+
+### Final Phase-6 check matrix
+
+| Check | Status |
+|---|---|
+| `ruff check src tests` | clean |
+| `ruff format --check src tests` | clean (273 files) |
+| `mypy --strict src tests` | clean (274 source files) — pre-existing body_blob error fixed |
+| `pytest -n auto --dist=loadfile` (unit) | 1134 passed |
+| `phase_06_review/CRITIQUE_*.md` | written; no Critical / High findings; eleven Low follow-ups documented for opportunistic later work |
+| `sphinx-build -W -b html docs docs/_build` | clean |
+| `pymarkdown scan docs/ .cursor/ README.md CONTRIBUTING.md` | clean |
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,18 @@ We use pytest for testing. To run the tests:
 pytest
 ```
 
+The default `addopts = ["-m", "not integration"]` skips integration
+tests (they need real PDS3 holdings + SPICE kernels and are slow).
+To include them, override the marker filter:
+
+```bash
+pytest -m ""              # full suite, including integration
+pytest -m integration     # only integration
+```
+
+`scripts/run-all-checks.sh -i` (or `--integration`) does the same for
+the all-checks runner.
+
 For more verbose output:
 
 ```bash

--- a/PHASE6_LIBRARY_SEED.md
+++ b/PHASE6_LIBRARY_SEED.md
@@ -1,0 +1,277 @@
+# Phase 6 — image library seed (operator instructions)
+
+This file walks an operator through curating the 1–2 additional library
+entries Phase 6 calls for. The new technique — `RingAnnulusNav` — ships
+with end-to-end unit tests against synthetic inputs, but the integration
+regression suite needs new sidecars on real images that exercise the
+ring-annulus path.
+
+The Phase 4 runbook (`PHASE4_LIBRARY_SEED.md`) covers the manual-nav
+workflow, the `Save as Library Entry…` button, the `pds3://` URL
+convention, and the `<image_id>` filename rule. **Read it first.** This
+file only documents the Phase 6 scenario picks plus the
+technique-specific gotchas for the new feature.
+
+## What's new in Phase 6
+
+- `RingAnnulusNav` consumes per-planet `RING_ANNULUS` features. The
+  rings model emits a `RING_ANNULUS` instead of the per-edge
+  `RING_EDGE` polylines whenever the surviving edge polyline compresses
+  radially below `RING_ANNULUS_MAX_RADIAL_PX = 5 px`, i.e. the
+  individual ringlets are no longer separable at the image scale.
+  Each `RING_ANNULUS` feature carries a multi-ring composite template
+  (`template_img`) plus a boolean mask; the technique fuses every
+  per-planet template via Z-buffer paint and runs one joint
+  pyramid-NCC against the composite.
+- Multi-planet scenes (rare but real — Cassini approach phase imaged
+  Jupiter and Saturn together; New Horizons imaged Jupiter from Pluto
+  distance) emit one `RING_ANNULUS` per detectable ring system; the
+  technique handles `len(features) > 1` by Z-buffer painting all
+  annuli into the same composite.
+- `use_gradient='auto'` self-selects raw vs gradient mode per image:
+  raw wins on broad-brightness-gradient ring geometries (low-resolution
+  Saturn rings where the C-ring is uniformly dim); gradient wins when
+  sharp ringlet edges still dominate the composite.
+
+## When does the rings model emit `RING_ANNULUS` instead of `RING_EDGE`?
+
+The rings model walks every catalog ring feature in the FOV, renders it
+to a per-edge mask, samples the mask into a polyline, and then decides
+per polyline:
+
+```
+radial_extent_px = max - min projection of the polyline onto its mean radial normal
+straight = polyline's max deviation from best-fit straight line < FLAT_CURVATURE_THRESHOLD_PX
+
+if radial_extent_px <= RING_ANNULUS_MAX_RADIAL_PX (5 px) and not straight:
+    emit RING_ANNULUS  (carrying the rendered template)
+else:
+    emit RING_EDGE     (carrying the per-vertex polyline)
+```
+
+So the gate fires on *low-resolution* ring scenes where two or more
+adjacent rings have collapsed within 5 pixels of each other in the
+image plane, AND where the ring still shows curvature (a flat-edge ring
+goes through `RING_EDGE` with the rank-1 covariance path instead).
+
+## Picking Phase 6 candidates
+
+Aim for **1–2 sidecars**, both Cassini ISS distant ring views.
+Scenario **A** is the cheap win: one Cassini distant Saturn frame in
+which the rings span only ~50 px radially across the entire span A→C
+ring. Scenario **B** is the higher-value pick: two ring systems in one
+frame (Saturn approach plus a galaxy-glimpse Jupiter, or NHLORRI Pluto
+plus Charon if either has a detectable ring system). Scenario **B** is
+optional — ship the easy one first.
+
+### Scenario A — Distant Saturn ring view (`RingAnnulusNav` single-planet)
+
+A Cassini distant ring view in which the Saturn ring system has
+compressed radially below 5 px between adjacent ringlets. Every
+catalog ring polyline goes through the annulus path; the rings model
+emits one `RING_ANNULUS` feature per Saturn ring; the technique fuses
+them and runs one joint NCC.
+
+| Field | What to look for |
+|---|---|
+| Mission / camera | Cassini ISS, NAC or WAC |
+| Ring radial span in FOV | < 200 px from C-ring inner edge to A-ring outer edge |
+| Subject range | Distant — typically > 5e6 km from Saturn (the approach phase, before the encounter; or the late mission post-Grand-Finale departure frames) |
+| Ring tilt | Any (the technique handles edge-on through fully-open) |
+| Bodies | None visible inside FOV preferred (a distant moon adds a competing technique that complicates the regression check) |
+| Background | Dark sky preferred |
+
+**Sidecar location**:
+`tests/integration/image_library/images/ring_only_curved/<IMAGE_ID>.yaml`
+
+(Use `ring_only_curved` — the existing scene class. The schema does
+not have a separate `ring_annulus` class because the operator's intent
+is "ring-only scene, curved enough that the technique sees a usable
+geometry"; whether the rings model emits `RING_EDGE` or `RING_ANNULUS`
+is downstream of the operator's intent.)
+
+**Expected behavior**:
+
+- `expected.status: ok` (or `failed` if the placeholder confidence
+  formula puts the result below `min_confidence` — record honestly,
+  exactly as Phase 4's `ring_only_curved/N1492091163_1_CALIB.yaml` did
+  for `RingEdgeNav`).
+- `expected.confidence_tier: low` to `medium` (placeholder
+  coefficients; Phase 10 retunes).
+- `expected.primary_technique: RingAnnulusNav`
+- `expected.techniques_must_run: [RingAnnulusNav]`
+- `expected.techniques_must_skip: [BodyDiscCorrelateNav, BodyBlobNav, BodyLimbNav, BodyTerminatorNav]`
+  (and `RingEdgeNav` if no surviving ring polyline crosses the
+  `RING_ANNULUS_MAX_RADIAL_PX` threshold the other way).
+
+### Scenario B — Multi-planet ring composite (`RingAnnulusNav` joint fit)
+
+Optional: a single frame with two visible ring systems. Real
+candidates are limited — the obvious picks are:
+
+- A Cassini approach-phase frame with both Saturn and Jupiter in the
+  FOV (Cassini's 2000-12 Jupiter encounter while inbound to Saturn
+  produced a few of these).
+- A New Horizons LORRI frame at Pluto distance that captures a
+  detectable Jupiter ring system, if the geometry happens to put both
+  in the same FOV.
+
+The real Cassini case is the one to chase first. NHLORRI Pluto +
+Charon does *not* qualify because Pluto and Charon do not have
+catalog ring systems — there is no `NavModelRings` instance per body
+without a ring catalog entry.
+
+| Field | What to look for |
+|---|---|
+| Mission / camera | Cassini ISS, NAC (the Jupiter-and-Saturn encounter frames) |
+| Ring systems in FOV | Two — both with detectable annuli |
+| Subject ranges | Different (so the Z-buffer ordering by `subject_range_km` is well-defined) |
+| Bodies | None preferred (same reason as Scenario A) |
+
+**Sidecar location**:
+`tests/integration/image_library/images/ring_only_curved/<IMAGE_ID>.yaml`
+
+**Expected behavior**:
+
+- `expected.status: ok` (joint NCC across two planets is more
+  constrained than one — the planted-offset unit test plants the
+  same offset against two separate annuli and recovers it within
+  1 px).
+- `expected.confidence_tier: low` to `medium` (still placeholder
+  coefficients).
+- `expected.primary_technique: RingAnnulusNav`
+- `expected.techniques_must_run: [RingAnnulusNav]`
+- `expected.techniques_must_skip:` whatever does not fire on this
+  scene; expect at least the body techniques.
+
+## Workflow per image
+
+Same as the Phase 4 runbook (steps 1–7) — load the image with
+`nav_offset --manual <image_list_file>`, align by hand in the
+manual-nav dialog, click `Save as Library Entry…`, edit the
+`TODO_REPLACE_*` placeholders, and drop the file under the correct
+scene-class directory.
+
+For Phase 6 specifically, the dialog overlay paints `RING_ANNULUS`
+features as their template (the multi-ring band) rather than per-edge
+polylines.  Verify visually that the predicted band overlays the
+observed bright ring region within ~1 px before accepting the offset.
+
+After the sidecar lands, run:
+
+```bash
+pytest tests/integration/test_image_library.py -v
+pytest tests/integration/test_autonomous_nav.py -v -k <IMAGE_ID>
+```
+
+Both must pass before you commit.
+
+## Sidecar template
+
+The `Save as Library Entry…` button writes a stub like the one below;
+fill the `TODO_REPLACE_*` slots from the dialog's reported values.
+
+```yaml
+schema_version: 1
+image_id: <IMAGE_ID>                       # e.g. N1450122031_1_CALIB
+mission: CASSINI_ISS                       # CASSINI_ISS | VOYAGER_ISS | GOSSI | NHLORRI
+camera: NAC                                # NAC | WAC | SSI | NA | WA | LORRI
+filter_combo: 'CL1+CL2'                    # canonicalized: filters sorted, '+'-joined
+image_url: 'pds3://...'                    # path under PDS3_HOLDINGS_DIR
+
+scene_tags:
+  - ring_only_curved                       # primary scene class — must match the directory
+
+ground_truth:
+  offset_dv_px: TODO_REPLACE_DV            # operator-verified, in extfov px
+  offset_du_px: TODO_REPLACE_DU
+  offset_uncertainty_px: 1.0               # 1sigma; tighten for sharp annuli
+  source: operator_verified
+  operator: <username>
+  verified_date: 2026-04-29                # YYYY-MM-DD
+  ui_version: 'rms-nav 0.1.devXX'
+  notes: |
+    Distant Saturn ring view. The catalog A/B/C edges all collapse
+    radially below RING_ANNULUS_MAX_RADIAL_PX so the rings model
+    emits one RING_ANNULUS feature for the Saturn ring system; the
+    technique runs one joint NCC against the composite annulus
+    template.
+
+    Phase-6 status: RingAnnulusNav converges to (TODO, TODO),
+    within TODO px of the operator's ground truth. Confidence
+    coefficients are placeholders pending Phase 10 calibration; the
+    expected.confidence_tier below pins today's behavior.
+
+expected:
+  status: ok                               # ok | failed | conflicted
+  confidence_tier: low                     # high | medium | low | failed | conflicted
+  primary_technique: RingAnnulusNav
+  techniques_must_run: [RingAnnulusNav]
+  techniques_must_skip:
+    - BodyDiscCorrelateNav
+    - BodyBlobNav
+    - BodyLimbNav
+    - BodyTerminatorNav
+```
+
+### Field-by-field guidance
+
+- **`offset_dv_px` / `offset_du_px`**: The dialog reports the operator's
+  picked offset as `(dv, du)` in extfov pixels.  Convention:
+  predicted position `(v, u)` means actual position is
+  `(v + dv, u + du)`.  Round to 4 decimal places (the regression-test
+  baseline rule).
+- **`offset_uncertainty_px`**: 1 sigma marginal in pixels.  The
+  regression test gates the orchestrator's recovered offset against
+  `offset_uncertainty_px + 0.5` per axis, so this number sets the slack
+  for an `expected.status: ok` sidecar.  For a sharp distant-ring
+  scene, 1.0 px is a sensible default; bump to 1.5 or 2.0 if the
+  annulus is heavily smeared.
+- **`expected.status`**: `ok` if the orchestrator returns a usable
+  offset (combined confidence above `min_confidence`); `failed` if it
+  reports `status=failed` with the right reason (the placeholder
+  confidence formula often pushes the headline below
+  `min_confidence` even when the answer is correct — record honestly,
+  exactly as Phase 4 did with `ring_only_curved/N1492091163`).  If
+  `status: failed` is recorded, set `confidence_tier: failed` to
+  satisfy the schema's cross-check.
+- **`techniques_must_skip`**: List every technique you expect *not* to
+  run — typically all four body techniques on a body-free ring scene.
+  Listing extra techniques here is harmless if they genuinely don't
+  fire; missing one that *does* fire trips the regression test.
+
+## Confidence-formula calibration deferred
+
+Phase 6 ships placeholder coefficients on `RingAnnulusNav`'s confidence
+spec (now living in `config_510_techniques.yaml.techniques.RingAnnulusNav`,
+not the old per-module Python constant).  Phase 10 (image-library
+expansion + confidence calibration) is when the alphas get retuned
+against the full ~50-image library.  Until then, expect the new
+sidecars to need conservative `expected.confidence_tier` values:
+
+- Single-annulus scenes: `low` (the `annulus_count` term contributes
+  only `0.4 * (1/2) = 0.2` to the sigmoid argument with placeholder
+  alphas).
+- Multi-annulus scenes: `medium` (saturated `annulus_count` term
+  contribution).
+
+Record the actual orchestrator-reported tier in your sidecar's
+`expected.confidence_tier` and let the regression test pin today's
+behavior.  When Phase 10 retunes the coefficients in
+`config_510_techniques.yaml` the sidecars will need a corresponding
+`expected.confidence_tier` bump; that's a bookkeeping pass, not a
+re-curation.
+
+## After the seed lands
+
+- The new sidecars enter the regression suite the moment they are
+  committed; CI runs them on every PR via the `integration` mark
+  (gated on `PDS3_HOLDINGS_DIR` etc.).
+- For each `expected.status: ok` sidecar, seed a baseline JSON under
+  `tests/integration/baselines/<IMAGE_ID>.json` so any orchestrator
+  drift trips the byte-level regression test.
+- Phase 6 follow-ups uncovered during integration runs (e.g. a
+  `RingAnnulusNav` consistency value that calibration will need to
+  retune, or a `RING_ANNULUS_MAX_RADIAL_PX` threshold that needs
+  bumping per instrument) belong in `AUTONAV_PLAN.md` under the
+  Phase 6 follow-ups subsection.

--- a/docs/developer_guide_navigation_models_rings.rst
+++ b/docs/developer_guide_navigation_models_rings.rst
@@ -42,9 +42,16 @@ each rendered edge mask into a polyline, and emits one of:
 - ``RING_ANNULUS`` — multi-ring composite template carried on
   ``NavFeature.template_img`` with a
   :class:`~nav.feature.geometry.RingAnnulusGeometry` payload.  Emitted
-  when the surviving polyline compresses radially below
-  :data:`~nav.nav_model.nav_model_rings.RING_ANNULUS_MAX_RADIAL_PX`
-  (the edges are not separable at the image scale).
+  when the surviving polyline compresses radially below the
+  per-planet ``feature_emission.ring_annulus.max_radial_px`` threshold
+  in ``config_510_techniques.yaml`` (individual edges are not
+  separable at the image scale), or when the system-level km/px
+  threshold ``feature_emission.ring_annulus.kmpp_threshold`` fires
+  (the entire ring system spans only a handful of pixels).  Multiple
+  surviving rings collapse into a single composite annulus per planet
+  with ``constituent_edge_count = N``; the reliability formula
+  ``min(1, k/5) * 0.7 * sigmoid(extent/50 - 1)`` then scales with
+  the number of constituent rings.
 
 Per-image diagnostics on ``self._metadata``: ``planet``, ``epoch``,
 ``feature_count``, and a ``features`` list of ``{'name', 'type'}``

--- a/docs/developer_guide_techniques.rst
+++ b/docs/developer_guide_techniques.rst
@@ -211,15 +211,12 @@ against the operator-curated image library):
   but disabled until calibration tunes the alpha
 - hard zero when ``at_edge`` or ``spurious``
 
-.. note::
-
-   ``config_510_techniques.yaml`` is not yet in the tree; the
-   coefficients above live as the Python module constant
-   ``_BODY_DISC_CONFIDENCE_SPEC`` in
-   ``nav.nav_technique.nav_technique_body_disc``.  When the YAML
-   config ships the loader's defaults will mirror these values and
-   the technique will read them from
-   ``config_510_techniques.yaml.body_disc_correlate``.
+The coefficients live in
+``src/nav/config_files/config_510_techniques.yaml`` under
+``techniques.BodyDiscCorrelateNav`` and are loaded into
+``ConfidenceSpec`` at config-load time by
+:func:`nav.nav_technique.confidence_config.load_confidence_spec`.
+Re-tune by editing the YAML; no code change required.
 
 Diagnostics fields:
 
@@ -280,15 +277,11 @@ library:
 - hard zero when ``at_edge``
 - hard cap ``0.4`` after the sigmoid
 
-.. note::
-
-   ``config_510_techniques.yaml`` is not yet in the tree; the
-   coefficients above live as the Python module constant
-   ``_BODY_BLOB_CONFIDENCE_SPEC`` in
-   ``nav.nav_technique.nav_technique_body_blob``.  When the YAML
-   config ships the loader's defaults will mirror these values and
-   the technique will read them from
-   ``config_510_techniques.yaml.body_blob``.
+The coefficients live in
+``src/nav/config_files/config_510_techniques.yaml`` under
+``techniques.BodyBlobNav`` and are loaded into ``ConfidenceSpec`` at
+config-load time by
+:func:`nav.nav_technique.confidence_config.load_confidence_spec`.
 
 Sample confidence breakdown
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -324,6 +317,78 @@ Diagnostics fields:
 Infeasibility cases:
 
 - No input feature carries a non-zero predicted diameter.
+
+Ring-annulus technique
+======================
+
+When the rings model emits a ``RING_ANNULUS`` feature instead of
+per-edge ``RING_EDGE`` polylines (because adjacent ring edges compress
+within ``RING_ANNULUS_MAX_RADIAL_PX`` of each other in the image
+plane), the per-planet multi-ring composite template lives on
+``NavFeature.template_img``.  The ring-annulus technique mirrors
+``BodyDiscCorrelateNav`` for that template payload.
+
+RingAnnulusNav
+--------------
+
+Accepts ``RING_ANNULUS`` features.  Each ``RING_ANNULUS`` carries a
+multi-ring composite template (``template_img``) plus a boolean
+``template_mask`` and a ``bbox_extfov_vu`` placement.  The technique:
+
+1. Fuses the per-planet annulus templates into a single extfov-shaped
+   composite via :func:`nav.feature.composition.compose_template_features`.
+   The helper sorts features by ``subject_range_km`` ascending so closer
+   ring systems overwrite farther ones on overlap (Z-buffer paint).  The
+   combined mask is the OR of per-planet masks.
+2. Runs :func:`nav.support.correlate.navigate_with_pyramid_kpeaks`
+   against the composite with ``use_gradient='auto'``.  Auto mode tries
+   both raw-intensity and gradient-magnitude NCC and keeps the better
+   result by ``non-spurious > not-at-edge > higher-quality`` ordering;
+   raw wins on broad-brightness-gradient ring geometries (low-resolution
+   Saturn rings where the C-ring is uniformly dim) and gradient wins
+   when sharp ringlet edges dominate.
+3. Reads the pyramid wrapper's ``offset``, ``cov``, ``quality``,
+   ``spurious``, ``at_edge``, and ``used_gradient`` fields directly into
+   ``RingAnnulusDiagnostics``.
+
+``is_feasible`` returns True iff at least one input ``RING_ANNULUS``
+feature carries a template payload.  The technique handles
+``len(features) > 1`` for the rare multi-planet case (one
+``RING_ANNULUS`` per detectable ring system).  It reports
+``spurious=True`` when the pyramid's quality metric falls below
+``quality_thresh`` and ``at_edge=True`` when the converged peak lies
+within 2 px of the search window edge.
+
+Confidence spec coefficients (placeholders pending calibration against
+the operator-curated image library):
+
+- ``alpha0 = -2``
+- ``alpha(ncc_peak / 6, capped at 1) = 1.5``
+- ``alpha(annulus_count / 2, capped at 1) = 0.4``
+- ``alpha(peak_to_runner_up_ratio / 2, capped at 1) = 0.0`` — wired in
+  but disabled until calibration tunes the alpha
+- hard zero when ``at_edge`` or ``spurious``
+
+The coefficients live in
+``src/nav/config_files/config_510_techniques.yaml`` under
+``techniques.RingAnnulusNav`` and are loaded into ``ConfidenceSpec`` at
+config-load time by
+:func:`nav.nav_technique.confidence_config.load_confidence_spec`.
+
+Diagnostics fields:
+
+- ``ncc_peak``: pyramid-wrapper quality metric (PSR by default).
+- ``peak_to_runner_up_ratio``: ratio of the winning peak's quality to
+  the runner-up's, derived from the pyramid wrapper's ``top_k_peaks``
+  field (sorted by quality descending).  Returns ``1.0`` when only one
+  peak survives non-maximum suppression — the unambiguous-peak case.
+- ``annulus_count``: number of fused ``RING_ANNULUS`` features (one
+  per detectable ring system).
+- ``used_gradient``: ``True`` when auto-mode picked the gradient pass.
+
+Infeasibility cases:
+
+- No input feature carries a template.
 
 Body-extractor emission gate
 ============================

--- a/docs/developer_guide_techniques.rst
+++ b/docs/developer_guide_techniques.rst
@@ -323,10 +323,13 @@ Ring-annulus technique
 
 When the rings model emits a ``RING_ANNULUS`` feature instead of
 per-edge ``RING_EDGE`` polylines (because adjacent ring edges compress
-within ``RING_ANNULUS_MAX_RADIAL_PX`` of each other in the image
-plane), the per-planet multi-ring composite template lives on
-``NavFeature.template_img``.  The ring-annulus technique mirrors
-``BodyDiscCorrelateNav`` for that template payload.
+within the per-planet
+``feature_emission.ring_annulus.max_radial_px`` threshold in
+``config_510_techniques.yaml``, or because the system-level km/px
+threshold fires on a low-resolution ring scene), the per-planet
+multi-ring composite template lives on ``NavFeature.template_img``.
+The ring-annulus technique mirrors ``BodyDiscCorrelateNav`` for that
+template payload.
 
 RingAnnulusNav
 --------------

--- a/docs/introduction_configuration.rst
+++ b/docs/introduction_configuration.rst
@@ -25,6 +25,9 @@ overriding earlier ones:
    * ``config_060_titan.yaml``: Titan-specific navigation parameters
    * ``config_070_bootstrap.yaml``: Bootstrap navigation parameters (angles in degrees)
    * ``config_100_satellites.yaml``: Satellite definitions for each planet
+   * ``config_220_body_shape.yaml``: Per-body shape table (radii, ellipsoid
+     residual, crater scale, albedo) consumed by the body NavModel and feature
+     extractors
    * ``config_300_jupiter_rings.yaml``: Jupiter ring system parameters
    * ``config_310_saturn_rings.yaml``: Saturn ring system parameters
    * ``config_320_uranus_rings.yaml``: Uranus ring system parameters
@@ -34,16 +37,23 @@ overriding earlier ones:
    * ``config_420_inst_nhlorri.yaml``: New Horizons LORRI instrument-specific settings
    * ``config_430_inst_vgiss.yaml``: Voyager ISS instrument-specific settings
    * ``config_440_sim.yaml``: Simulated image settings
+   * ``config_510_techniques.yaml``: Per-NavTechnique confidence-formula
+     coefficients and runtime tunables (spurious-detection thresholds,
+     at-edge tolerances, minimum arc lengths) plus the planet-specific
+     ``feature_emission.ring_annulus`` block that decides RING_EDGE vs
+     RING_ANNULUS feature emission
    * ``config_900_backplanes.yaml``: Backplane generation settings
    * ``config_950_pds4.yaml``: PDS4 metadata and export settings for generated
      products, overrides for PDS4 label templates and mapping of internal fields
      to PDS4 keys
 
-   The 3-digit numeric prefix is the lexicographic merge order. Files in the
+   The 3-digit numeric prefix is the lexicographic merge order.  Files in the
    ``0xx`` range (000–099) are global / model-shared settings, ``1xx``
-   (100–199) are catalogues, ``3xx`` (300–399) are per-planet ring catalogues,
-   ``4xx`` (400–499) are per-instrument camera blocks, and ``9xx`` (900–999)
-   are downstream-product settings.
+   (100–199) are catalogues, ``2xx`` (200–299) are per-target tables (body
+   shape), ``3xx`` (300–399) are per-planet ring catalogues, ``4xx``
+   (400–499) are per-instrument camera blocks, ``5xx`` (500–599) are
+   per-technique tunables, and ``9xx`` (900–999) are downstream-product
+   settings.
 
 2. **User Default Configuration**: If present, the file
    ``nav_default_config.yaml`` in the current working directory is loaded. This
@@ -112,8 +122,15 @@ an image is being processed):
 
 **Navigation technique loggers**:
 
-* ``general.log_level_nav_correlate_all`` (default: ``INFO``): Logging level for
-  the ``correlate_all`` technique, including star refinement.
+The autonomous-navigation pipeline routes every per-image technique line
+through ``IMAGE_LOGGER``; there is no per-technique log-level knob.  Each
+technique opens a ``with self.logger.open(f'TECHNIQUE: {self.name}')``
+section so the per-image log file delimits each technique's contribution.
+The legacy ``general.log_level_nav_correlate_all`` knob is retained for
+backwards compatibility with any user config files that still set it but
+the autonomous techniques (``BodyDiscCorrelateNav``, ``BodyBlobNav``,
+``BodyLimbNav``, ``BodyTerminatorNav``, ``RingEdgeNav``,
+``RingAnnulusNav``) do not consult it.
 
 **Annotation**:
 

--- a/docs/user_guide_navigation.rst
+++ b/docs/user_guide_navigation.rst
@@ -411,14 +411,17 @@ Saturn-rings imagery).
 ^^^^^^^^^^^^^^^^^^
 
 Pyramid-NCC fit on every ``RING_ANNULUS`` feature.  ``RING_ANNULUS``
-features are emitted by the rings model when individual ring edges
-compress radially (low-resolution ring-system encounters where adjacent
-edges fall within ``RING_ANNULUS_MAX_RADIAL_PX`` of each other); each
-feature carries a multi-ring composite template instead of a per-edge
-polyline.  Multi-planet scenes (rare) emit one ``RING_ANNULUS`` per
-ring system; the technique fuses them via Z-buffer paint and runs one
-joint NCC.  ``use_gradient='auto'`` self-selects raw vs gradient mode
-per image.
+features are emitted by the rings model in two regimes: when adjacent
+ring edges compress radially below the per-planet
+``feature_emission.ring_annulus.max_radial_px`` threshold in
+``config_510_techniques.yaml`` (individual edges no longer separable),
+and when the per-planet km/px threshold fires on a low-resolution
+ring scene where the entire ring system spans only a handful of
+pixels.  In either case the rings model collapses every surviving
+ring into a single composite annulus per planet.  Multi-planet scenes
+(rare) emit one ``RING_ANNULUS`` per ring system; the technique fuses
+them via Z-buffer paint and runs one joint NCC.
+``use_gradient='auto'`` self-selects raw vs gradient mode per image.
 
 Best for: low-resolution ring scenes where ``RingEdgeNav`` cannot
 separate individual edges (distant Cassini ring views; potential

--- a/docs/user_guide_navigation.rst
+++ b/docs/user_guide_navigation.rst
@@ -132,10 +132,11 @@ Navigation options
 
 * ``--nav-techniques LIST``: a comma-separated glob-pattern list selecting
   which registered ``NavTechnique`` subclasses run.  Implemented techniques
-  today are ``BodyLimbNav``, ``BodyTerminatorNav``, and ``RingEdgeNav``;
-  several more (``BodyDiscCorrelateNav``, ``BodyBlobNav``, ``RingAnnulusNav``,
-  ``StarFieldFromCatalogNav``, ``StarUniqueMatchNav``, ``StarRefineNav``)
-  are planned but not yet shipped.  Defaults to ``*`` (all registered
+  today are ``BodyDiscCorrelateNav``, ``BodyBlobNav``, ``BodyLimbNav``,
+  ``BodyTerminatorNav``, ``RingAnnulusNav``, and ``RingEdgeNav``; the
+  star techniques (``StarFieldFromCatalogNav``, ``StarUniqueMatchNav``,
+  ``StarRefineNav``) are planned but not yet shipped.  Defaults to ``*``
+  (all registered
   techniques run); a leading ``!`` excludes a pattern (e.g.
   ``--nav-techniques '!RingEdgeNav'`` runs every technique except the
   ring-edge fitter).  Multiple feasible techniques run in parallel and the
@@ -406,6 +407,23 @@ final answer.
 Best for: scenes containing bright ring edges (typical Cassini ISS
 Saturn-rings imagery).
 
+``RingAnnulusNav``
+^^^^^^^^^^^^^^^^^^
+
+Pyramid-NCC fit on every ``RING_ANNULUS`` feature.  ``RING_ANNULUS``
+features are emitted by the rings model when individual ring edges
+compress radially (low-resolution ring-system encounters where adjacent
+edges fall within ``RING_ANNULUS_MAX_RADIAL_PX`` of each other); each
+feature carries a multi-ring composite template instead of a per-edge
+polyline.  Multi-planet scenes (rare) emit one ``RING_ANNULUS`` per
+ring system; the technique fuses them via Z-buffer paint and runs one
+joint NCC.  ``use_gradient='auto'`` self-selects raw vs gradient mode
+per image.
+
+Best for: low-resolution ring scenes where ``RingEdgeNav`` cannot
+separate individual edges (distant Cassini ring views; potential
+NHLORRI Pluto/Charon ring geometries).
+
 ``NavTechniqueManual``
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -443,19 +461,14 @@ Pending techniques (not yet shipped)
 The following techniques are designed and have stub diagnostics in
 place; their concrete implementations are pending.
 
-* ``BodyDiscCorrelateNav`` -- full-disc NCC for fully-in-FOV bodies.
-* ``BodyBlobNav`` -- centroid fit for under-resolved or irregular bodies.
-* ``RingAnnulusNav`` -- multi-ring composite NCC for compressed ring
-  geometries.
 * ``StarFieldFromCatalogNav`` -- triplet-hash + RANSAC pattern match for
   star-rich frames.
 * ``StarUniqueMatchNav`` -- direct catalog-uniqueness match for sparse
   star fields with one or two bright stars.
 * ``StarRefineNav`` -- prior-refining single-star polish (pass-2).
 
-Until these land, scenes whose only viable feature type is ``STAR``,
-``BODY_DISC``, ``BODY_BLOB``, or ``RING_ANNULUS`` will report
-``status_reason=no_feasible_techniques``.
+Until these land, scenes whose only viable feature type is ``STAR`` will
+report ``status_reason=no_feasible_techniques``.
 
 Filtering examples
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ pythonpath = [
   "src"
 ]
 testpaths = ["tests"]
-addopts = ["--strict-markers", "--strict-config"]
+addopts = ["--strict-markers", "--strict-config", "-m", "not integration"]
 filterwarnings = [
   "error",
   # Astropy's FITS reader can leave a file handle open while the cache

--- a/scripts/run-all-checks.sh
+++ b/scripts/run-all-checks.sh
@@ -14,6 +14,8 @@
 #   -c, --code       Run only code checks (ruff, mypy, pytest)
 #   -d, --docs       Run only documentation build (Sphinx + PyMarkdown lint)
 #   -m, --markdown   Run only Markdown lint (PyMarkdown)
+#   -i, --integration Include integration tests (slow; require PDS3_HOLDINGS_DIR
+#                    + SPICE kernels).  Default: skipped.
 #   -h, --help       Show this help message
 #
 # Environment:
@@ -50,6 +52,7 @@ RUN_CODE=false
 RUN_DOCS=false
 RUN_MARKDOWN=false
 SCOPE_SPECIFIED=false
+RUN_INTEGRATION=false
 
 # Get script directory and project root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -160,6 +163,10 @@ while [[ $# -gt 0 ]]; do
             SCOPE_SPECIFIED=true
             shift
             ;;
+        -i|--integration)
+            RUN_INTEGRATION=true
+            shift
+            ;;
         -h|--help)
             show_usage
             exit 0
@@ -187,6 +194,12 @@ if [ "$PARALLEL" = true ]; then
     print_info "Running checks in PARALLEL mode"
 else
     print_info "Running checks in SEQUENTIAL mode"
+fi
+
+if [ "$RUN_INTEGRATION" = true ]; then
+    print_info "Integration tests: ENABLED (will run; require PDS3_HOLDINGS_DIR + SPICE)"
+else
+    print_info "Integration tests: SKIPPED (default; pass -i / --integration to include)"
 fi
 
 # Function to run code checks (ruff, mypy, pytest)
@@ -244,9 +257,18 @@ run_code_checks() {
         failed_checks="${failed_checks}Code - Mypy"$'\n'
     fi
 
-    # Pytest
-    print_info "Running pytest..."
-    if python -m pytest tests -q --cov -n auto; then
+    # Pytest.  ``addopts = ["-m", "not integration"]`` in pyproject.toml
+    # excludes integration tests by default; with --integration / -i,
+    # override by passing ``-m ""`` so the marker filter accepts every
+    # test (including ones marked ``integration``).
+    if [ "$RUN_INTEGRATION" = true ]; then
+        print_info "Running pytest (with integration tests)..."
+        pytest_marker_args=("-m" "")
+    else
+        print_info "Running pytest (integration tests skipped — pass -i to include)..."
+        pytest_marker_args=()
+    fi
+    if python -m pytest tests -q --cov -n auto "${pytest_marker_args[@]}"; then
         print_success "Pytest passed"
     else
         print_error "Pytest failed"

--- a/src/nav/config/config.py
+++ b/src/nav/config/config.py
@@ -204,16 +204,24 @@ class Config:
             try:
                 cls.confidence_spec = load_confidence_spec(techniques_block, cls.name)
             except ConfidenceConfigError:
-                if cls.name.startswith('_'):
-                    # Test-only technique: leave spec as inherited (None)
-                    # so the test fixture controls it.
-                    continue
-                raise
+                if not cls.name.startswith('_'):
+                    raise
+                # Test-only technique: leave spec as inherited (None)
+                # so the test fixture controls it.  Tuning still resets
+                # below so a stale fixture value cannot leak across reloads.
             cls.tuning = load_technique_tuning(techniques_block, cls.name)
         validate_registered_confidence_specs()
 
     def update_config(self, config_path: str | Path, read_default: bool = True) -> None:
         """Updates the current configuration with values from the specified YAML file.
+
+        When ``read_default`` is true the merged YAML is re-validated against
+        every registered :class:`NavTechnique` so per-technique overrides
+        (``confidence_spec`` and ``tuning``) take effect.  The internal
+        bootstrap path inside :meth:`read_config` calls with
+        ``read_default=False`` and validates once after the loop, since
+        early default files are loaded before
+        ``config_510_techniques.yaml`` has populated the techniques block.
 
         Parameters:
             config_path: Path to the configuration file containing update values.
@@ -230,6 +238,8 @@ class Config:
             else:
                 self._config_dict[key] = new_config[key]
         self._update_attrdicts()
+        if read_default:
+            self._validate_registered_techniques()
 
     def category(self, category: str) -> AttrDict:
         """Returns the configuration settings for the specified category."""

--- a/src/nav/config/config.py
+++ b/src/nav/config/config.py
@@ -125,8 +125,8 @@ class Config:
 
         Documentation-only ``_sources`` blocks (and any other top-level or
         nested key that starts with an underscore) are stripped at load
-        time per Part 0 §74 — citations live alongside values for human
-        review without bloating the parsed config.
+        time so citations can live alongside values for human review
+        without bloating the parsed config.
         """
 
         yaml = YAML(typ='safe')
@@ -169,16 +169,43 @@ class Config:
         self._update_attrdicts()
         self._validate_registered_techniques()
 
-    @staticmethod
-    def _validate_registered_techniques() -> None:
-        """Validate every registered NavTechnique's confidence spec.
+    def _validate_registered_techniques(self) -> None:
+        """Load + validate every registered NavTechnique's confidence spec.
+
+        Builds each technique's :class:`ConfidenceSpec` from the
+        ``techniques.<technique_name>`` block in
+        ``config_510_techniques.yaml`` and assigns it to the class
+        attribute, then asserts every term references an attribute the
+        technique has declared in ``confidence_attributes``.  Test-only
+        registry entries whose ``name`` starts with ``_`` are exempt
+        from the YAML requirement (the test fixture supplies its own
+        spec or uses ``None`` to opt out of confidence evaluation).
 
         Imported inside the method because ``nav.nav_technique.nav_technique``
         imports ``nav.support.nav_base`` which imports this module —
         promoting the import to the top would deadlock the package init.
         """
-        from nav.nav_technique.nav_technique import validate_registered_confidence_specs
+        from nav.nav_technique.confidence_config import (
+            ConfidenceConfigError,
+            load_confidence_spec,
+            load_technique_tuning,
+        )
+        from nav.nav_technique.nav_technique import (
+            NavTechnique,
+            validate_registered_confidence_specs,
+        )
 
+        techniques_block = dict(self._config_dict.get('techniques', {}))
+        for cls in NavTechnique._registry:
+            try:
+                cls.confidence_spec = load_confidence_spec(techniques_block, cls.name)
+            except ConfidenceConfigError:
+                if cls.name.startswith('_'):
+                    # Test-only technique: leave spec as inherited (None)
+                    # so the test fixture controls it.
+                    continue
+                raise
+            cls.tuning = load_technique_tuning(techniques_block, cls.name)
         validate_registered_confidence_specs()
 
     def update_config(self, config_path: str | Path, read_default: bool = True) -> None:

--- a/src/nav/config/config.py
+++ b/src/nav/config/config.py
@@ -182,8 +182,12 @@ class Config:
         spec or uses ``None`` to opt out of confidence evaluation).
 
         Imported inside the method because ``nav.nav_technique.nav_technique``
-        imports ``nav.support.nav_base`` which imports this module —
-        promoting the import to the top would deadlock the package init.
+        imports ``nav.support.nav_base`` which imports ``nav.config``;
+        promoting these imports to the module top would fail with
+        ``ImportError: cannot import name 'DEFAULT_CONFIG' from
+        partially initialized module 'nav.config'``.  This lazy-import
+        site is the minimum cycle break — the other modules can keep
+        their top-of-file imports.
         """
         from nav.nav_technique.confidence_config import (
             ConfidenceConfigError,

--- a/src/nav/config_files/config_510_techniques.yaml
+++ b/src/nav/config_files/config_510_techniques.yaml
@@ -1,0 +1,253 @@
+# Per-technique confidence-formula coefficients and runtime tunables.
+# Loaded at config-load time so any unknown reference fails fast at
+# startup rather than mid-image.  Each technique block looks like:
+#
+#   <technique_name>:
+#     alpha0: float                 # constant in the sigmoid argument
+#     terms:                        # confidence-formula linear terms
+#       - feature: str              # diagnostic-attribute name
+#         alpha: float              # linear coefficient
+#         offset: float | null      # subtracted before scaling (default 0)
+#         divisor: float | null     # divides after offset (default 1, non-zero)
+#         cap_at: float | null      # post-scale upper bound, in [0, 1] (optional)
+#     hard_zero_if:                 # mapping str -> bool; firing forces conf=0
+#       <attribute>: bool
+#     hard_cap: float | null        # optional post-sigmoid clamp, in [0, 1]
+#     tuning:                       # technique-specific runtime tunables
+#       <key>: float | int          # see ``load_technique_tuning`` for schema
+#
+# Coefficients are placeholders pending a calibration sweep against the
+# operator-curated image library; the sigmoid shape and the alpha=0
+# wiring for terms that are populated but not yet weighted (e.g.
+# peak_to_runner_up_ratio) are intentional so the calibration sweep
+# tunes alphas against real data without code changes.
+
+techniques:
+  BodyDiscCorrelateNav:
+    alpha0: -2.0
+    terms:
+      # PSR-style quality measure of the chosen NCC peak.  Healthy
+      # body-disc fits report quality 6-15; the divisor maps that range
+      # onto the sigmoid's responsive interval.
+      - feature: ncc_peak
+        alpha: 1.5
+        divisor: 6.0
+        cap_at: 1.0
+      # Pyramid-level consistency: low values (<= 0.5 px disagreement
+      # across pyramid levels) indicate a globally unambiguous peak.
+      - feature: consistency_px
+        alpha: -1.0
+        divisor: 2.0
+      # Reward additional bodies in the composite (joint geometric
+      # constraint sharpens the peak); cap so a 3-body scene saturates.
+      - feature: body_count
+        alpha: 0.4
+        divisor: 3.0
+        cap_at: 1.0
+      # Peak-to-runner-up ratio: a sharp, unambiguous correlation peak
+      # has ratio >> 1 vs the next-best peak.  alpha=0.0 for now so the
+      # term carries no weight pending calibration; the wiring is in
+      # place so once a calibration sweep tunes the alpha the formula
+      # picks it up without code changes.
+      - feature: peak_to_runner_up_ratio
+        alpha: 0.0
+        divisor: 2.0
+        cap_at: 1.0
+    hard_zero_if:
+      at_edge: true
+      spurious: true
+
+  BodyBlobNav:
+    alpha0: -1.0
+    terms:
+      # Brightness-weighted centroid uncertainty shrinks with SNR.
+      - feature: body_snr_inside_predicted_bbox
+        alpha: 0.5
+        divisor: 4.0
+        cap_at: 1.0
+      # Larger blobs carry more centroid signal per the design's
+      # sigmoid(extent_px / 8 - 1) factor.
+      - feature: body_extent_px
+        alpha: 1.0
+        offset: 8.0
+        divisor: 8.0
+        cap_at: 1.0
+      # Multi-body geometry over-determines the joint translation.
+      - feature: blob_count
+        alpha: 0.4
+        divisor: 3.0
+        cap_at: 1.0
+    hard_zero_if:
+      at_edge: true
+    # The hard cap mirrors the BODY_BLOB reliability formula: a
+    # brightness-weighted centroid is a weaker observation than a limb
+    # fit, so the technique cannot drive the ensemble past 0.4
+    # confidence even when every term saturates.
+    hard_cap: 0.4
+
+  BodyLimbNav:
+    alpha0: -1.0
+    terms:
+      - feature: visible_limb_arc_fraction
+        alpha: 3.0
+      - feature: dt_fit_rms_px
+        alpha: -1.5
+      - feature: visible_arc_px
+        alpha: 0.4
+        divisor: 100.0
+        cap_at: 1.0
+    hard_zero_if:
+      at_edge: true
+      spurious: true
+    tuning:
+      # Minimum surviving polyline length per LIMB_ARC for feasibility.
+      # Shorter limbs do not constrain a 2-D translation enough to be
+      # worth the LM iteration.
+      min_arc_px: 30.0
+      # Final DT residual exceeding this many limb-sigmas marks the
+      # result spurious.
+      spurious_dt_rms_factor: 5.0
+      # Floor for the spurious-detection threshold.
+      spurious_dt_floor_px: 3.0
+      # Below this Tukey-inlier count the M-estimator covariance is no
+      # longer informative — flag spurious.
+      spurious_min_inliers: 6
+      # Below this inlier fraction the LM has almost certainly walked
+      # off the true limb onto internal-body features (crater rims,
+      # terminator, surface boundaries) — flag spurious.
+      spurious_min_inlier_fraction: 0.05
+
+  BodyTerminatorNav:
+    alpha0: -1.0
+    terms:
+      - feature: visible_terminator_arc_fraction
+        alpha: 2.0
+      - feature: dt_fit_rms_px
+        alpha: -1.0
+      - feature: visible_arc_px
+        alpha: 0.4
+        divisor: 100.0
+        cap_at: 1.0
+      - feature: mean_phase_angle_factor
+        alpha: 1.0
+      - feature: mean_albedo_penalty
+        alpha: -1.5
+    hard_zero_if:
+      at_edge: true
+      spurious: true
+    tuning:
+      # Minimum surviving polyline length per TERMINATOR_ARC for
+      # feasibility (same shape as BodyLimbNav.min_arc_px).
+      min_arc_px: 30.0
+      # Final DT residual exceeding this many terminator-sigmas marks
+      # the result spurious.
+      spurious_dt_rms_factor: 5.0
+      # Floor for the spurious-detection threshold (terminators are
+      # softer than limbs; the floor is one pixel wider).
+      spurious_dt_floor_px: 4.0
+      # Below this Tukey-inlier count the M-estimator covariance is
+      # no longer informative.
+      spurious_min_inliers: 6
+
+  RingEdgeNav:
+    alpha0: -1.0
+    terms:
+      - feature: total_edge_length_px
+        alpha: 1.0
+        divisor: 200.0
+        cap_at: 1.0
+      - feature: per_edge_dt_rms_summed
+        alpha: -2.0
+    hard_zero_if:
+      at_edge: true
+    tuning:
+      # Pixels of slack around the search-window axis bounds for the
+      # at-edge check.  A converged offset whose absolute distance from
+      # any axis bound (+/-margin_v, +/-margin_u) falls within this
+      # tolerance is flagged ``at_edge=True``.  One pixel matches the
+      # bilinear DT half-cell width: any closer and the LM gradient
+      # information is unreliable.
+      at_edge_tolerance_px: 1.0
+      # Final DT residual exceeding this many radial-sigmas marks the
+      # result spurious.
+      spurious_dt_rms_factor: 5.0
+      # Floor for the spurious-detection threshold.
+      spurious_dt_floor_px: 3.0
+      # Below this Tukey-inlier count the M-estimator covariance is no
+      # longer informative.
+      spurious_min_inliers: 6
+
+  RingAnnulusNav:
+    alpha0: -2.0
+    terms:
+      # PSR-style quality measure of the chosen NCC peak.  Healthy
+      # annulus fits report quality 6-15; the divisor maps that range
+      # onto the sigmoid's responsive interval.
+      - feature: ncc_peak
+        alpha: 1.5
+        divisor: 6.0
+        cap_at: 1.0
+      # Peak-to-runner-up ratio: alpha=0.0 pending calibration (same
+      # posture as BodyDiscCorrelateNav).
+      - feature: peak_to_runner_up_ratio
+        alpha: 0.0
+        divisor: 2.0
+        cap_at: 1.0
+      # Reward additional ring systems in the composite.  The current
+      # spacecraft fleet has at most a handful of multi-planet ring
+      # scenes, so the saturation cap is at 2 (vs body_count's 3).
+      - feature: annulus_count
+        alpha: 0.4
+        divisor: 2.0
+        cap_at: 1.0
+    hard_zero_if:
+      at_edge: true
+      spurious: true
+
+
+# Feature-emission tunables that decide which technique a given
+# scene's features feed.  Per-planet overrides because Saturn's ring
+# system spans tens of thousands of km radially while the Jupiter /
+# Uranus / Neptune systems are an order of magnitude narrower; the
+# "individual edges can't be separated" criterion lives at very
+# different image-scale thresholds.
+feature_emission:
+  ring_annulus:
+    # Default applies to any planet that does not have an explicit
+    # entry below.  Both Saturn and the giant-planet fleet have entries
+    # so this default is mostly defensive against typos / new planets.
+    default:
+      # Maximum per-edge polyline radial extent (px) below which the
+      # rings model emits a RING_ANNULUS template instead of per-edge
+      # polylines.  Per-polyline gate; fires when a single ring edge
+      # has compressed below this width.
+      max_radial_px: 5.0
+      # Ring-radial km/px threshold above which the ENTIRE ring system
+      # is annulus-class regardless of any per-polyline metric.  At
+      # this resolution even a "well-traceable" per-edge polyline only
+      # spans a handful of pixels along the radial direction; the
+      # right technique is the multi-ring composite NCC, not the
+      # per-edge DT fit.
+      kmpp_threshold: 1000.0
+    planets:
+      SATURN:
+        # Saturn's main rings span ~75000-140000 km (~65000 km wide).
+        # At km/px > 1000 the entire system is < 65 px wide and
+        # individual edges within rings (gaps, ringlets) are sub-pixel
+        # apart — annulus path wins.
+        max_radial_px: 5.0
+        kmpp_threshold: 1000.0
+      JUPITER:
+        # Jupiter's main ring spans ~122500-129000 km (~6500 km wide,
+        # ~10x narrower than Saturn).  Lower kmpp threshold so
+        # annulus fires before the ring becomes a single bright pixel.
+        max_radial_px: 5.0
+        kmpp_threshold: 200.0
+      URANUS:
+        # Uranus's main rings span ~41800-51200 km (~9400 km wide).
+        max_radial_px: 5.0
+        kmpp_threshold: 300.0
+      NEPTUNE:
+        # Neptune's main rings span ~41900-62900 km (~21000 km wide).
+        max_radial_px: 5.0
+        kmpp_threshold: 500.0

--- a/src/nav/dataset/dataset_pds3.py
+++ b/src/nav/dataset/dataset_pds3.py
@@ -574,6 +574,8 @@ class DataSetPDS3(DataSet):
             if vol_end not in all_volume_names:
                 raise ValueError(f'Illegal volume name: {vol_end}')
             vol_end_idx = all_volume_names.index(vol_end)
+        if vol_start is not None and vol_end is not None and vol_start_idx > vol_end_idx:
+            raise ValueError(f'vol_start ({vol_start!r}) must not be after vol_end ({vol_end!r})')
         valid_volumes = [
             v
             for v in valid_volumes

--- a/src/nav/dataset/dataset_pds3.py
+++ b/src/nav/dataset/dataset_pds3.py
@@ -391,7 +391,6 @@ class DataSetPDS3(DataSet):
         volumes = None
         if arguments.volumes:
             volumes = [x for y in arguments.volumes for x in y.split(',')]
-            volumes.sort()
 
         # if use_index_files:
         #     yield_function = yield_image_filenames_index
@@ -568,8 +567,12 @@ class DataSetPDS3(DataSet):
         # Restrict volumes to given "vol_start" and "vol_end" arguments
         # keeping original order
         if vol_start is not None:
+            if vol_start not in all_volume_names:
+                raise ValueError(f'Illegal volume name: {vol_start}')
             vol_start_idx = all_volume_names.index(vol_start)
         if vol_end is not None:
+            if vol_end not in all_volume_names:
+                raise ValueError(f'Illegal volume name: {vol_end}')
             vol_end_idx = all_volume_names.index(vol_end)
         valid_volumes = [
             v

--- a/src/nav/nav_model/nav_model_body.py
+++ b/src/nav/nav_model/nav_model_body.py
@@ -522,13 +522,18 @@ class NavModelBody(NavModelBodyBase):
         terminator_mask[v_slice, u_slice] = terminator_local
         body_mask[v_slice, u_slice] = body_mask_valid
 
-        km_per_pixel_arr: NDArrayFloatType = (
-            restr_bp.resolution(body_name).mvals.filled(0.0)
-            if body_mask_valid.any()
-            else np.zeros_like(body_mask_valid, dtype=np.float64)
-        )
-        # Downsample km/pixel to the same grid as the masks.
-        km_per_pixel_local = filter_downsample(km_per_pixel_arr, oversample_v, oversample_u)
+        # km/pixel is queried at the oversampled grid and downsampled to
+        # match the masks.  When the predicted silhouette is empty the
+        # backplane query is skipped (it would return masked values
+        # anyway) and the downsampled-shape zeros array is used
+        # directly — feeding it back through ``filter_downsample`` would
+        # try to downsample an already-downsampled array, asserting on
+        # the (downsampled-)shape vs oversample divisibility.
+        if body_mask_valid.any():
+            km_per_pixel_arr = restr_bp.resolution(body_name).mvals.filled(0.0)
+            km_per_pixel_local = filter_downsample(km_per_pixel_arr, oversample_v, oversample_u)
+        else:
+            km_per_pixel_local = np.zeros_like(body_mask_valid, dtype=np.float64)
 
         limb_sampler = _build_polyline_sampler(
             local_mask=limb_mask_local,

--- a/src/nav/nav_model/nav_model_rings.py
+++ b/src/nav/nav_model/nav_model_rings.py
@@ -50,7 +50,6 @@ if TYPE_CHECKING:  # pragma: no cover - typing-only import
 
 __all__ = [
     'FLAT_CURVATURE_THRESHOLD_PX',
-    'RING_ANNULUS_MAX_RADIAL_PX',
     'RING_EDGE_DEFAULT_RELIABILITY',
     'RING_EDGE_SIGMA_ALONG_PX',
     'NavModelRings',
@@ -82,13 +81,52 @@ then handles its rank-1 covariance.
 """
 
 
-RING_ANNULUS_MAX_RADIAL_PX: float = 5.0
-"""Maximum radial extent for a ``RING_EDGE`` polyline.
+# All ring-annulus emission tunables live in
+# ``config_files/config_510_techniques.yaml`` under
+# ``feature_emission.ring_annulus`` with per-planet overrides.  No
+# Python-level fallback; missing-key access in
+# ``_ring_annulus_emission_params`` is a KeyError so a config typo
+# fails fast at process startup.
 
-When all vertices of a surviving feature fall inside a radial band of
-this width, the model emits a ``RING_ANNULUS`` template instead of
-per-edge polylines (the edges are not separable at the image scale).
-"""
+
+def _ring_annulus_emission_params(config: Config, planet: str) -> tuple[float, float]:
+    """Return ``(max_radial_px, kmpp_threshold)`` for ``planet``.
+
+    Reads
+    ``config.feature_emission.ring_annulus.planets[planet]`` first,
+    then falls back to ``config.feature_emission.ring_annulus.default``.
+    Both fields (``max_radial_px`` and ``kmpp_threshold``) are
+    independently looked up, so a planet block may set only one and
+    inherit the other from default.  A missing default-block field is
+    a ``KeyError`` so a config typo fails fast at process startup.
+
+    Parameters:
+        config: Active :class:`~nav.config.Config`.
+        planet: SPICE planet name (uppercase), e.g. ``'SATURN'``.
+
+    Returns:
+        ``(max_radial_px, kmpp_threshold)`` in pixels and km/px.
+
+    Raises:
+        KeyError: If neither the per-planet block nor the default
+            block defines a required field.
+    """
+    block = dict(config.category('feature_emission').get('ring_annulus', {}))
+    default_block = block.get('default', {}) or {}
+    planets_block = block.get('planets', {}) or {}
+    planet_block = planets_block.get(planet, {}) or {}
+
+    def _lookup(field: str) -> float:
+        if field in planet_block:
+            return float(planet_block[field])
+        if field in default_block:
+            return float(default_block[field])
+        raise KeyError(
+            f'feature_emission.ring_annulus: missing field {field!r} for planet '
+            f'{planet!r} (no per-planet override and no default block entry)'
+        )
+
+    return _lookup('max_radial_px'), _lookup('kmpp_threshold')
 
 
 def _require_positive_finite_planet_scalar(
@@ -414,6 +452,23 @@ class NavModelRings(NavModelRingsBase):
             edge_count = 0
             annulus_count = 0
             straight_count = 0
+            max_radial_px, kmpp_threshold = _ring_annulus_emission_params(
+                self._config, self._planet or ''
+            )
+            # System-level annulus gate: at very low ring resolution the
+            # entire ring system spans only a handful of pixels, so even
+            # a "well-traceable" per-edge polyline carries too little
+            # information for the per-edge DT fit.  Force annulus
+            # emission for every surviving feature in that regime.
+            force_annulus = self._km_per_pixel_radial >= kmpp_threshold
+            if force_annulus:
+                self._logger.debug(
+                    'System-level annulus gate fires for planet %s: '
+                    'km_per_pixel_radial = %.2f >= %.2f',
+                    self._planet,
+                    self._km_per_pixel_radial,
+                    kmpp_threshold,
+                )
             for (
                 ring_feat,
                 model_img,
@@ -429,7 +484,10 @@ class NavModelRings(NavModelRingsBase):
                         continue
                     radial_extent_px = _radial_extent_px(vertices_vu, normals_vu)
                     straight = _is_straight_line(vertices_vu)
-                    if radial_extent_px <= RING_ANNULUS_MAX_RADIAL_PX and not straight:
+                    use_annulus = force_annulus or (
+                        radial_extent_px <= max_radial_px and not straight
+                    )
+                    if use_annulus:
                         annulus_count += 1
                         kind = 'ANNULUS'
                         features.append(

--- a/src/nav/nav_model/nav_model_rings.py
+++ b/src/nav/nav_model/nav_model_rings.py
@@ -450,7 +450,6 @@ class NavModelRings(NavModelRingsBase):
         with self._logger.open('EMIT RINGS FEATURES'):
             features: list[NavFeature] = []
             edge_count = 0
-            annulus_count = 0
             straight_count = 0
             max_radial_px, kmpp_threshold = _ring_annulus_emission_params(
                 self._config, self._planet or ''
@@ -469,6 +468,14 @@ class NavModelRings(NavModelRingsBase):
                     self._km_per_pixel_radial,
                     kmpp_threshold,
                 )
+            # Annulus-eligible per-ring renderings accumulate here and
+            # collapse into a single composite RING_ANNULUS at the end
+            # of the loop.  The design specifies one RING_ANNULUS per
+            # planet per scene; emitting one feature per surviving ring
+            # would set ``constituent_count=1`` on each and the
+            # reliability formula would gate them all out
+            # (min(1, 1/5) * 0.7 = 0.14 < 0.30 threshold).
+            annulus_renderings: list[tuple[NDArrayFloatType, NDArrayBoolType, str, float]] = []
             for (
                 ring_feat,
                 model_img,
@@ -488,26 +495,22 @@ class NavModelRings(NavModelRingsBase):
                         radial_extent_px <= max_radial_px and not straight
                     )
                     if use_annulus:
-                        annulus_count += 1
-                        kind = 'ANNULUS'
-                        features.append(
-                            _build_annulus_feature(
-                                ring_name=label_text,
-                                planet=self._planet or '',
-                                model_img=model_img,
-                                model_mask=model_mask,
-                                bbox=_mask_bbox(model_mask),
-                                predicted_center_vu=self._predicted_center_vu,
-                                subject_range_km=self._subject_range_km,
-                                constituent_count=1,
-                                source_model=self.name,
-                            )
+                        annulus_renderings.append(
+                            (model_img, model_mask, label_text, radial_extent_px)
+                        )
+                        self._logger.debug(
+                            'ANNULUS %r -> vertices=%d, radial_extent=%.2f px, '
+                            'straight=%s, uncertainty=%.3f km',
+                            label_text,
+                            int(vertices_vu.shape[0]),
+                            radial_extent_px,
+                            straight,
+                            uncertainty_km,
                         )
                     else:
                         edge_count += 1
                         if straight:
                             straight_count += 1
-                        kind = 'EDGE'
                         features.append(
                             _build_edge_feature(
                                 ring_feat=ring_feat,
@@ -524,16 +527,45 @@ class NavModelRings(NavModelRingsBase):
                                 source_model=self.name,
                             )
                         )
-                    self._logger.debug(
-                        '%s %r -> vertices=%d, radial_extent=%.2f px, '
-                        'straight=%s, uncertainty=%.3f km',
-                        kind,
-                        label_text,
-                        int(vertices_vu.shape[0]),
-                        radial_extent_px,
-                        straight,
-                        uncertainty_km,
+                        self._logger.debug(
+                            'EDGE %r -> vertices=%d, radial_extent=%.2f px, '
+                            'straight=%s, uncertainty=%.3f km',
+                            label_text,
+                            int(vertices_vu.shape[0]),
+                            radial_extent_px,
+                            straight,
+                            uncertainty_km,
+                        )
+            annulus_count = 1 if annulus_renderings else 0
+            if annulus_renderings:
+                composite_img, composite_mask = _composite_ring_renderings(
+                    annulus_renderings,
+                    extfov_shape=(self._extfov_v_size, self._extfov_u_size),
+                )
+                composite_bbox = _mask_bbox(composite_mask)
+                composite_radial_extent_px = float(composite_bbox[2] - composite_bbox[0])
+                joint_label = ', '.join(sorted({label for _, _, label, _ in annulus_renderings}))
+                features.append(
+                    _build_annulus_feature(
+                        ring_name=joint_label,
+                        planet=self._planet or '',
+                        model_img=composite_img,
+                        model_mask=composite_mask,
+                        bbox=composite_bbox,
+                        predicted_center_vu=self._predicted_center_vu,
+                        subject_range_km=self._subject_range_km,
+                        constituent_count=len(annulus_renderings),
+                        source_model=self.name,
                     )
+                )
+                self._logger.debug(
+                    'ANNULUS composite for planet %s: %d constituent ring(s), '
+                    'composite bbox %r, composite radial_extent=%.2f px',
+                    self._planet,
+                    len(annulus_renderings),
+                    composite_bbox,
+                    composite_radial_extent_px,
+                )
             self._logger.info(
                 'Emitted %d feature(s) — %d edge (%d straight), %d annulus',
                 len(features),
@@ -639,6 +671,37 @@ def _mask_bbox(mask: NDArrayBoolType) -> tuple[int, int, int, int]:
         int(vs.max()) + 1,
         int(us.max()) + 1,
     )
+
+
+def _composite_ring_renderings(
+    renderings: list[tuple[NDArrayFloatType, NDArrayBoolType, str, float]],
+    *,
+    extfov_shape: tuple[int, int],
+) -> tuple[NDArrayFloatType, NDArrayBoolType]:
+    """Union per-ring rendered images + masks into one composite annulus.
+
+    Each per-ring rendering carries an ext-FOV-shaped ``model_img`` /
+    ``model_mask`` pair from :class:`RingFeature.render`.  The composite
+    is the OR of the masks and the per-pixel maximum of the images so
+    overlapping rings keep their brightest contribution.
+
+    Parameters:
+        renderings: List of ``(model_img, model_mask, label, radial_extent)``
+            tuples (radial_extent is unused by this helper but kept on
+            the input row so the caller can read it without a second
+            iteration).
+        extfov_shape: ``(v, u)`` shape of the ext-FOV array — every
+            input rendering shares this shape.
+
+    Returns:
+        ``(composite_img, composite_mask)`` both shaped ``extfov_shape``.
+    """
+    composite_img: NDArrayFloatType = np.zeros(extfov_shape, dtype=np.float64)
+    composite_mask: NDArrayBoolType = np.zeros(extfov_shape, dtype=bool)
+    for img, mask, _label, _extent in renderings:
+        composite_img = np.maximum(composite_img, img)
+        composite_mask = composite_mask | mask
+    return composite_img, composite_mask
 
 
 def _build_edge_feature(

--- a/src/nav/nav_model/rings/ring_filter.py
+++ b/src/nav/nav_model/rings/ring_filter.py
@@ -230,7 +230,26 @@ class RingFeatureFilter:
                         outermost_feature.key,
                         outermost_radius,
                     )
-                    result.append(outermost_feature)
+                    # If the trimmed-but-incomplete version of this feature
+                    # is already in ``result`` (same key, but lacking the
+                    # outermost edge), replace it in place rather than
+                    # appending a second entry with the same key.  This can
+                    # arise when ``_apply_fade_filter`` returns a trimmed
+                    # version that drops the outer edge — preserving the
+                    # original (untrimmed) feature is what restores the
+                    # navigation-useful outer reference.
+                    existing_index = next(
+                        (
+                            idx
+                            for idx, feat in enumerate(result)
+                            if feat.key == outermost_feature.key
+                        ),
+                        None,
+                    )
+                    if existing_index is None:
+                        result.append(outermost_feature)
+                    else:
+                        result[existing_index] = outermost_feature
 
         self._logger.debug(
             'RingFeatureFilter: after fade pass, %d / %d feature(s)',

--- a/src/nav/nav_model/rings/ring_filter.py
+++ b/src/nav/nav_model/rings/ring_filter.py
@@ -211,16 +211,12 @@ class RingFeatureFilter:
                 if self._min_radius <= r <= self._max_radius
             ]
             if after_res_in_range:
-                outermost_radius, _, outermost_feature = max(
+                outermost_radius, outermost_label, outermost_feature = max(
                     after_res_in_range, key=lambda triple: triple[0]
                 )
                 survives_outermost = any(
-                    outermost_radius
-                    in {
-                        r
-                        for r, _ in feat.all_base_radii()
-                        if self._min_radius <= r <= self._max_radius
-                    }
+                    feat.key == outermost_feature.key
+                    and (outermost_radius, outermost_label) in feat.all_base_radii()
                     for feat in result
                 )
                 if not survives_outermost:

--- a/src/nav/nav_model/rings/ring_filter.py
+++ b/src/nav/nav_model/rings/ring_filter.py
@@ -191,6 +191,47 @@ class RingFeatureFilter:
             if trimmed is not None:
                 result.append(trimmed)
 
+        # Pass 4 outermost-preservation: at very low resolution every
+        # neighboring fade overlaps every other and the per-edge check
+        # can drop *every* outer-side edge, leaving only an
+        # innermost-region feature (e.g. a C-ring gap) that is far less
+        # useful for navigation than the outer A-ring edge would have
+        # been.  If the outermost in-range edge that survived pass 3
+        # was excluded by pass 4, restore the feature carrying it: the
+        # outer edge of the ring system is the most useful single
+        # navigation reference, and even a narrow-fade rendering of
+        # it is better than nothing.  Out-of-range edges are excluded
+        # from the comparison so the partial-visibility trim's
+        # trimmed-but-still-valid feature is not falsely restored.
+        if after_res:
+            after_res_in_range = [
+                (r, label, feat)
+                for feat in after_res
+                for r, label in feat.all_base_radii()
+                if self._min_radius <= r <= self._max_radius
+            ]
+            if after_res_in_range:
+                outermost_radius, _, outermost_feature = max(
+                    after_res_in_range, key=lambda triple: triple[0]
+                )
+                survives_outermost = any(
+                    outermost_radius
+                    in {
+                        r
+                        for r, _ in feat.all_base_radii()
+                        if self._min_radius <= r <= self._max_radius
+                    }
+                    for feat in result
+                )
+                if not survives_outermost:
+                    self._logger.debug(
+                        'RingFeatureFilter: pass 4 dropped the outermost feature %r '
+                        '(largest in-range edge radius %.1f km); restoring it for navigation',
+                        outermost_feature.key,
+                        outermost_radius,
+                    )
+                    result.append(outermost_feature)
+
         self._logger.debug(
             'RingFeatureFilter: after fade pass, %d / %d feature(s)',
             len(result),

--- a/src/nav/nav_orchestrator/orchestrator.py
+++ b/src/nav/nav_orchestrator/orchestrator.py
@@ -100,10 +100,67 @@ class _ModelRegistry:
     models: list[NavModel] = field(default_factory=list)
 
     def filter_by_glob(self, patterns: str | list[str]) -> list[NavModel]:
-        """Return models whose ``name`` matches the glob pattern list."""
+        """Return models whose ``name`` matches the glob pattern list.
+
+        Model names follow the ``prefix:VALUE`` convention
+        (``rings:SATURN``, ``body:DIONE``, plain ``stars`` for the
+        catalog-driven star model).  This helper normalizes user
+        patterns to that convention so the common shorthand forms
+        match without requiring explicit globs:
+
+        - ``"rings"`` is expanded to ``"rings:*"`` so a pattern
+          missing a colon matches every namespaced model under that
+          prefix.  ``"stars"`` (which has no colon in its model name)
+          continues to match itself directly.
+        - The value part of ``"prefix:VALUE"`` is normalized to
+          uppercase so ``"body:saturn"`` matches ``"body:SATURN"``.
+
+        The leading-``!`` exclusion convention is preserved.
+        """
         names = [m.name for m in self.models]
-        kept = set(filter_technique_names(names, patterns))
+        normalized = _normalize_model_patterns(patterns, names)
+        kept = set(filter_technique_names(names, normalized))
         return [m for m in self.models if m.name in kept]
+
+
+def _normalize_model_patterns(patterns: str | list[str], names: list[str]) -> list[str]:
+    """Normalize model glob patterns to the ``prefix:VALUE`` convention.
+
+    See :meth:`_ModelRegistry.filter_by_glob` for the rules.
+
+    Parameters:
+        patterns: Single pattern or list of patterns from the user.
+        names: Available model names; used to detect whether the
+            ``prefix:*`` expansion makes sense (any name contains
+            ``:``).
+
+    Returns:
+        A list of normalized patterns suitable for
+        :func:`filter_technique_names`.
+    """
+    if isinstance(patterns, str):
+        patterns = [patterns]
+    has_namespaced_models = any(':' in n for n in names)
+    out: list[str] = []
+    for raw in patterns:
+        if raw.startswith('!'):
+            prefix, body = '!', raw[1:]
+        else:
+            prefix, body = '', raw
+        if ':' in body:
+            head, _, tail = body.partition(':')
+            normalized = f'{head}:{tail.upper()}'
+        elif has_namespaced_models and body and not any(c in body for c in '*?['):
+            # Plain prefix-only token (e.g. "rings"): expand to "rings:*"
+            # so it matches every namespaced model under that prefix.
+            # Names that have no namespace (like "stars") still match
+            # via the unmodified pattern below.
+            normalized = f'{body}:*'
+            out.append(prefix + body)  # also keep the literal for "stars"
+        else:
+            normalized = body
+        out.append(prefix + normalized)
+    return out
 
 
 class NavOrchestrator(NavBase):

--- a/src/nav/nav_technique/__init__.py
+++ b/src/nav/nav_technique/__init__.py
@@ -43,6 +43,7 @@ from nav.nav_technique.nav_technique_body_disc import BodyDiscCorrelateNav
 from nav.nav_technique.nav_technique_body_limb import BodyLimbNav
 from nav.nav_technique.nav_technique_body_terminator import BodyTerminatorNav
 from nav.nav_technique.nav_technique_manual import NavTechniqueManual, run_manual_nav
+from nav.nav_technique.nav_technique_ring_annulus import RingAnnulusNav
 from nav.nav_technique.nav_technique_ring_edge import RingEdgeNav
 from nav.nav_technique.technique_result import NavTechniqueResult
 
@@ -63,6 +64,7 @@ __all__ = [
     'NavTechniqueManual',
     'NavTechniqueResult',
     'RingAnnulusDiagnostics',
+    'RingAnnulusNav',
     'RingEdgeDiagnostics',
     'RingEdgeNav',
     'StarFieldDiagnostics',

--- a/src/nav/nav_technique/confidence_config.py
+++ b/src/nav/nav_technique/confidence_config.py
@@ -1,0 +1,247 @@
+"""Build :class:`ConfidenceSpec` instances from the techniques config block.
+
+The per-technique confidence-formula coefficients live in
+``config_files/config_510_techniques.yaml`` under the ``techniques`` key.
+Each technique reads its own block via :func:`load_confidence_spec`,
+which validates the YAML shape and returns a frozen
+:class:`ConfidenceSpec`.  Mis-typed numbers, unknown keys, and missing
+``alpha0`` raise at config-load time so a malformed file fails fast at
+process startup instead of mid-image.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from nav.nav_technique.confidence import ConfidenceSpec, ConfidenceTerm
+
+__all__ = ['ConfidenceConfigError', 'load_confidence_spec', 'load_technique_tuning']
+
+
+_VALID_TERM_KEYS: frozenset[str] = frozenset({'feature', 'alpha', 'offset', 'divisor', 'cap_at'})
+_VALID_BLOCK_KEYS: frozenset[str] = frozenset(
+    {'alpha0', 'terms', 'hard_zero_if', 'hard_cap', 'tuning'}
+)
+
+
+class ConfidenceConfigError(ValueError):
+    """Raised when ``config_510_techniques.yaml`` cannot build a valid spec.
+
+    Always names the technique whose block triggered the failure so a
+    typo or shape error surfaces with full diagnostic at startup.
+    """
+
+
+def load_confidence_spec(techniques: dict[str, Any], technique_name: str) -> ConfidenceSpec:
+    """Return the :class:`ConfidenceSpec` for ``technique_name``.
+
+    Reads the ``techniques[technique_name]`` mapping and constructs a
+    :class:`ConfidenceSpec` from its fields.  All numeric coercion and
+    range checks happen here so per-technique modules stay free of
+    YAML-shape bookkeeping.  Callers typically pass
+    ``Config.category('techniques')`` (an ``AttrDict``, which subclasses
+    ``dict``).
+
+    Parameters:
+        techniques: Mapping of ``NavTechnique.name`` to its raw config
+            block (the ``techniques`` section of
+            ``config_510_techniques.yaml``).
+        technique_name: ``NavTechnique.name`` to look up.
+
+    Returns:
+        A frozen :class:`ConfidenceSpec` ready to assign to the
+        technique's ``confidence_spec`` class attribute.
+
+    Raises:
+        ConfidenceConfigError: If the block is missing, has the wrong
+            shape, or carries an unknown / malformed field.
+    """
+    techniques = _require_mapping(techniques, 'techniques')
+    if technique_name not in techniques:
+        raise ConfidenceConfigError(
+            f'config_510_techniques.yaml: missing block for technique '
+            f'{technique_name!r}; declared techniques are '
+            f'{sorted(techniques.keys())!r}'
+        )
+    block = _require_mapping(techniques[technique_name], f'techniques.{technique_name}')
+    unknown = set(block.keys()) - _VALID_BLOCK_KEYS
+    if unknown:
+        raise ConfidenceConfigError(
+            f'techniques.{technique_name}: unknown keys {sorted(unknown)!r}; '
+            f'valid keys are {sorted(_VALID_BLOCK_KEYS)!r}'
+        )
+    if 'alpha0' not in block:
+        raise ConfidenceConfigError(f'techniques.{technique_name}: missing required key alpha0')
+    alpha0 = _require_finite_float(block['alpha0'], f'techniques.{technique_name}.alpha0')
+    raw_terms = block.get('terms', [])
+    if not isinstance(raw_terms, list):
+        raise ConfidenceConfigError(
+            f'techniques.{technique_name}.terms: expected a list, got {type(raw_terms).__name__}'
+        )
+    terms = tuple(
+        _build_term(entry, location=f'techniques.{technique_name}.terms[{i}]')
+        for i, entry in enumerate(raw_terms)
+    )
+    raw_gates = block.get('hard_zero_if', {})
+    if not isinstance(raw_gates, dict):
+        raise ConfidenceConfigError(
+            f'techniques.{technique_name}.hard_zero_if: expected a mapping, got '
+            f'{type(raw_gates).__name__}'
+        )
+    hard_zero_if: dict[str, bool] = {}
+    for key, value in raw_gates.items():
+        if not isinstance(key, str):
+            raise ConfidenceConfigError(
+                f'techniques.{technique_name}.hard_zero_if: keys must be strings, got '
+                f'{type(key).__name__}'
+            )
+        if not isinstance(value, bool):
+            raise ConfidenceConfigError(
+                f'techniques.{technique_name}.hard_zero_if[{key!r}]: must be bool, got '
+                f'{type(value).__name__}'
+            )
+        hard_zero_if[key] = value
+    raw_cap = block.get('hard_cap')
+    hard_cap = (
+        None
+        if raw_cap is None
+        else _require_finite_float(raw_cap, f'techniques.{technique_name}.hard_cap')
+    )
+    try:
+        return ConfidenceSpec(
+            alpha0=alpha0,
+            terms=terms,
+            hard_zero_if=hard_zero_if,
+            hard_cap=hard_cap,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ConfidenceConfigError(
+            f'techniques.{technique_name}: ConfidenceSpec construction failed: {exc}'
+        ) from exc
+
+
+def load_technique_tuning(
+    techniques: dict[str, Any], technique_name: str
+) -> dict[str, float | int]:
+    """Return the ``tuning`` block for ``technique_name``.
+
+    Returns the dict-shaped ``tuning`` sub-block as a flat
+    ``{key: number}`` mapping with all numeric values coerced to
+    ``float`` or ``int`` (booleans rejected — YAML's loose numeric
+    types make ``True`` look numeric without this guard).  Each
+    technique consumer pulls the values it needs by name and supplies
+    its own default for missing keys.
+
+    Parameters:
+        techniques: Mapping of ``NavTechnique.name`` to its raw config
+            block (the ``techniques`` section of
+            ``config_510_techniques.yaml``).
+        technique_name: ``NavTechnique.name`` to look up.
+
+    Returns:
+        ``{key: value}`` or an empty mapping when the technique block
+        has no ``tuning`` sub-block.
+
+    Raises:
+        ConfidenceConfigError: If the block is malformed or any
+            tuning value is not a finite numeric scalar.
+    """
+    techniques = _require_mapping(techniques, 'techniques')
+    if technique_name not in techniques:
+        return {}
+    block = _require_mapping(techniques[technique_name], f'techniques.{technique_name}')
+    raw = block.get('tuning', {})
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ConfidenceConfigError(
+            f'techniques.{technique_name}.tuning: expected a mapping, got {type(raw).__name__}'
+        )
+    out: dict[str, float | int] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str):
+            raise ConfidenceConfigError(
+                f'techniques.{technique_name}.tuning: keys must be strings, got '
+                f'{type(key).__name__}'
+            )
+        location = f'techniques.{technique_name}.tuning.{key}'
+        if isinstance(value, bool):
+            raise ConfidenceConfigError(f'{location}: must be numeric, got bool {value!r}')
+        if isinstance(value, int):
+            out[key] = value
+        elif isinstance(value, float):
+            if not math.isfinite(value):
+                raise ConfidenceConfigError(f'{location}: must be finite, got {value!r}')
+            out[key] = value
+        else:
+            raise ConfidenceConfigError(f'{location}: must be numeric, got {type(value).__name__}')
+    return out
+
+
+def _build_term(entry: Any, *, location: str) -> ConfidenceTerm:
+    """Construct one :class:`ConfidenceTerm` from a YAML mapping entry."""
+    if not isinstance(entry, dict):
+        raise ConfidenceConfigError(
+            f'{location}: each terms entry must be a mapping, got {type(entry).__name__}'
+        )
+    unknown = set(entry.keys()) - _VALID_TERM_KEYS
+    if unknown:
+        raise ConfidenceConfigError(
+            f'{location}: unknown keys {sorted(unknown)!r}; valid keys are '
+            f'{sorted(_VALID_TERM_KEYS)!r}'
+        )
+    if 'feature' not in entry:
+        raise ConfidenceConfigError(f'{location}: missing required key feature')
+    if 'alpha' not in entry:
+        raise ConfidenceConfigError(f'{location}: missing required key alpha')
+    feature = entry['feature']
+    if not isinstance(feature, str) or not feature.strip():
+        raise ConfidenceConfigError(
+            f'{location}.feature: must be a non-empty string, got {feature!r}'
+        )
+    alpha = _require_finite_float(entry['alpha'], f'{location}.alpha')
+    offset = (
+        0.0
+        if entry.get('offset') is None
+        else _require_finite_float(entry['offset'], f'{location}.offset')
+    )
+    divisor = (
+        1.0
+        if entry.get('divisor') is None
+        else _require_finite_float(entry['divisor'], f'{location}.divisor')
+    )
+    cap_at = (
+        None
+        if entry.get('cap_at') is None
+        else _require_finite_float(entry['cap_at'], f'{location}.cap_at')
+    )
+    try:
+        return ConfidenceTerm(
+            feature=feature,
+            alpha=alpha,
+            offset=offset,
+            divisor=divisor,
+            cap_at=cap_at,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ConfidenceConfigError(f'{location}: {exc}') from exc
+
+
+def _require_mapping(value: Any, location: str) -> dict[str, Any]:
+    """Coerce ``value`` to ``dict[str, Any]`` or raise a typed error."""
+    if not isinstance(value, dict):
+        raise ConfidenceConfigError(f'{location}: expected a mapping, got {type(value).__name__}')
+    return value
+
+
+def _require_finite_float(value: Any, location: str) -> float:
+    """Coerce ``value`` to ``float`` or raise a typed error."""
+    if isinstance(value, bool):
+        raise ConfidenceConfigError(f'{location}: must be numeric, got bool {value!r}')
+    if not isinstance(value, (int, float)):
+        raise ConfidenceConfigError(f'{location}: must be numeric, got {type(value).__name__}')
+    coerced = float(value)
+    if not math.isfinite(coerced):
+        raise ConfidenceConfigError(f'{location}: must be finite, got {value!r}')
+    return coerced

--- a/src/nav/nav_technique/nav_technique.py
+++ b/src/nav/nav_technique/nav_technique.py
@@ -116,9 +116,17 @@ class NavTechnique(NavBase, ABC):
     #: ``NavContext`` and is run only on pass 2.
     requires_prior: ClassVar[bool] = False
     #: Confidence-formula spec consumed by ``evaluate_sigmoid_combination``.
-    #: ``None`` for techniques that don't yet define a spec (e.g.
-    #: ``NavTechniqueManual``).
+    #: Loaded from ``config_510_techniques.yaml`` and assigned at
+    #: ``Config.read_config`` time.  ``None`` for techniques that opt out
+    #: of the autonomous registry (e.g. ``NavTechniqueManual``).
     confidence_spec: ClassVar[ConfidenceSpec | None] = None
+    #: Per-technique runtime tuning loaded from
+    #: ``config_510_techniques.yaml.techniques.<name>.tuning``.  Each
+    #: technique pulls the values it needs by name from this dict and
+    #: falls back to the module-level default constant when a key is
+    #: missing.  Empty for techniques that opt out of the autonomous
+    #: registry or that have no tunable parameters.
+    tuning: ClassVar[dict[str, float | int]] = {}
     #: Names of every attribute the technique's confidence spec may read
     #: (diagnostics fields plus side-channel flags such as ``at_edge``).
     #: ``validate_registered_confidence_specs`` ensures every term in
@@ -168,12 +176,16 @@ class NavTechnique(NavBase, ABC):
 def validate_registered_confidence_specs() -> None:
     """Validate every registered ``NavTechnique``'s confidence spec.
 
-    Each technique that defines ``confidence_spec`` must also declare the
-    full set of valid attribute names in ``confidence_attributes``.
-    Every term's ``feature`` and every ``hard_zero_if`` key must appear in
-    that set; otherwise the technique would raise at navigate time.
-    Validation runs at config-load time so the failure surfaces during
-    process startup rather than mid-image.
+    Each technique whose spec was loaded from
+    ``config_510_techniques.yaml`` (assigned by
+    :meth:`nav.config.config.Config._validate_registered_techniques`)
+    must declare the full set of valid attribute names in
+    ``confidence_attributes``.  Every term's ``feature`` and every
+    ``hard_zero_if`` key must appear in that set; otherwise the
+    technique would raise at navigate time.  Validation runs at
+    config-load time so the failure surfaces during process startup
+    rather than mid-image.  Techniques whose spec is ``None`` (test-
+    only registry entries opted out of YAML lookup) are skipped.
 
     Raises:
         ValueError: if any term references an unknown attribute.  The

--- a/src/nav/nav_technique/nav_technique_body_blob.py
+++ b/src/nav/nav_technique/nav_technique_body_blob.py
@@ -440,12 +440,15 @@ class _BlobConfidenceContext:
 def _search_window_for_obs(context: NavContext) -> tuple[int, int]:
     """Return the ``(margin_v, margin_u)`` search window for at-edge detection.
 
-    Falls back to a 32 x 32 window when the obs does not expose
-    ``extfov_margin_vu`` (test fixtures), mirroring the helper used by
-    every other technique that respects the per-instrument extfov
-    margin.
+    The technique reads the per-instrument extfov margin from the
+    observation.  ``extfov_margin_vu`` is a mandatory attribute on
+    every ``ObsSnapshotInst``; test fixtures must set it as well
+    (the shared ``FakeObs`` defaults to ``(32, 32)``).  An obs
+    missing the attribute is a programming error and surfaces as
+    ``AttributeError`` rather than a silent fallback.
     """
-    margin = getattr(context.obs, 'extfov_margin_vu', None)
-    if margin is None:
-        return (32, 32)
+    # ``NavContext.obs`` is typed as ``object`` to avoid an import cycle
+    # with ``ObsSnapshotInst``; the attribute lookup is mandatory at
+    # runtime even though mypy cannot see it.
+    margin = context.obs.extfov_margin_vu  # type: ignore[attr-defined]
     return (int(margin[0]), int(margin[1]))

--- a/src/nav/nav_technique/nav_technique_body_blob.py
+++ b/src/nav/nav_technique/nav_technique_body_blob.py
@@ -27,11 +27,7 @@ from nav.config import Config
 from nav.feature.feature import NavFeature
 from nav.feature.feature_type import NavFeatureType
 from nav.feature.geometry import BodyBlobGeometry
-from nav.nav_technique.confidence import (
-    ConfidenceSpec,
-    ConfidenceTerm,
-    evaluate_sigmoid_combination,
-)
+from nav.nav_technique.confidence import evaluate_sigmoid_combination
 from nav.nav_technique.diagnostics import BodyBlobDiagnostics
 from nav.nav_technique.dt_fitting import AT_EDGE_TOLERANCE_PX
 from nav.nav_technique.feasibility import NavFeasibilityReport
@@ -43,41 +39,6 @@ if TYPE_CHECKING:  # pragma: no cover - typing-only import
     from nav.nav_orchestrator.nav_context import NavContext
 
 __all__ = ['BodyBlobNav']
-
-
-_BODY_BLOB_CONFIDENCE_SPEC = ConfidenceSpec(
-    alpha0=-1.0,
-    terms=(
-        # Brightness-weighted centroid uncertainty shrinks with SNR.
-        ConfidenceTerm(
-            feature='body_snr_inside_predicted_bbox',
-            alpha=0.5,
-            divisor=4.0,
-            cap_at=1.0,
-        ),
-        # Larger blobs carry more centroid signal per the design's
-        # ``sigmoid(extent_px / 8 - 1)`` factor.
-        ConfidenceTerm(
-            feature='body_extent_px',
-            alpha=1.0,
-            offset=8.0,
-            divisor=8.0,
-            cap_at=1.0,
-        ),
-        # Multi-body geometry over-determines the joint translation.
-        ConfidenceTerm(feature='blob_count', alpha=0.4, divisor=3.0, cap_at=1.0),
-    ),
-    hard_zero_if={'at_edge': True},
-    hard_cap=0.4,
-)
-"""Confidence spec for the body-blob technique.
-
-The hard cap of 0.4 mirrors the BODY_BLOB reliability formula: a
-brightness-weighted centroid is a weaker observation than a limb fit,
-so the technique cannot drive the ensemble past 0.4 confidence even
-when every term saturates.  Coefficients are placeholders pending
-calibration against the operator-curated image library.
-"""
 
 
 @dataclass(frozen=True)
@@ -321,7 +282,6 @@ class BodyBlobNav(NavTechnique):
     name = 'BodyBlobNav'
     accepts_feature_types = frozenset({NavFeatureType.BODY_BLOB})
     requires_prior = False
-    confidence_spec = _BODY_BLOB_CONFIDENCE_SPEC
     confidence_attributes = frozenset(
         {
             'at_edge',
@@ -478,6 +438,14 @@ class _BlobConfidenceContext:
 
 
 def _search_window_for_obs(context: NavContext) -> tuple[int, int]:
-    """Return the ``(margin_v, margin_u)`` search window for at-edge detection."""
-    margin_v, margin_u = context.obs.extfov_margin_vu
-    return (int(margin_v), int(margin_u))
+    """Return the ``(margin_v, margin_u)`` search window for at-edge detection.
+
+    Falls back to a 32 x 32 window when the obs does not expose
+    ``extfov_margin_vu`` (test fixtures), mirroring the helper used by
+    every other technique that respects the per-instrument extfov
+    margin.
+    """
+    margin = getattr(context.obs, 'extfov_margin_vu', None)
+    if margin is None:
+        return (32, 32)
+    return (int(margin[0]), int(margin[1]))

--- a/src/nav/nav_technique/nav_technique_body_disc.py
+++ b/src/nav/nav_technique/nav_technique_body_disc.py
@@ -251,13 +251,15 @@ class _DiscConfidenceContext:
 def _search_window_for_obs(context: NavContext) -> tuple[int, int]:
     """Return the ``(margin_v, margin_u)`` search window for the NCC.
 
-    Mirrors the helper used by the DT techniques: the technique respects
-    the per-instrument extfov margin attached to the observation; if the
-    obs does not expose that attribute (test fixtures) a 32 x 32 fallback
-    is used so the technique still runs end-to-end.
+    The technique reads the per-instrument extfov margin from the
+    observation.  ``extfov_margin_vu`` is a mandatory attribute on
+    every ``ObsSnapshotInst``; test fixtures must set it as well
+    (the shared ``FakeObs`` defaults to ``(32, 32)``).  An obs
+    missing the attribute is a programming error and surfaces as
+    ``AttributeError`` rather than a silent fallback.
     """
-    obs = context.obs
-    margin = getattr(obs, 'extfov_margin_vu', None)
-    if margin is None:
-        return (32, 32)
+    # ``NavContext.obs`` is typed as ``object`` to avoid an import cycle
+    # with ``ObsSnapshotInst``; the attribute lookup is mandatory at
+    # runtime even though mypy cannot see it.
+    margin = context.obs.extfov_margin_vu  # type: ignore[attr-defined]
     return (int(margin[0]), int(margin[1]))

--- a/src/nav/nav_technique/nav_technique_body_limb.py
+++ b/src/nav/nav_technique/nav_technique_body_limb.py
@@ -19,11 +19,7 @@ from nav.config import Config
 from nav.feature.feature import NavFeature
 from nav.feature.feature_type import NavFeatureType
 from nav.feature.geometry import LimbPolyline
-from nav.nav_technique.confidence import (
-    ConfidenceSpec,
-    ConfidenceTerm,
-    evaluate_sigmoid_combination,
-)
+from nav.nav_technique.confidence import evaluate_sigmoid_combination
 from nav.nav_technique.diagnostics import BodyLimbDiagnostics
 from nav.nav_technique.dt_fitting import (
     AT_EDGE_TOLERANCE_PX,
@@ -40,67 +36,11 @@ if TYPE_CHECKING:  # pragma: no cover - typing-only import
 
 __all__ = ['BodyLimbNav']
 
-
-LIMB_MIN_ARC_PX: float = 30.0
-"""Minimum surviving polyline length per LIMB_ARC feature for feasibility.
-
-Shorter limbs do not constrain a 2-D translation enough to be worth
-running the LM iteration for; the technique reports infeasibility.
-"""
-
-
-SPURIOUS_DT_RMS_FACTOR: float = 5.0
-"""Final DT residual exceeding this many limb-sigmas marks the result spurious."""
-
-
-SPURIOUS_DT_FLOOR_PX: float = 3.0
-"""Minimum surviving DT residual below which spurious detection is skipped."""
-
-
-SPURIOUS_MIN_INLIERS: int = 6
-"""Below this Tukey-inlier count the final fit is flagged spurious.
-
-Six surviving vertices is the smallest count at which the M-estimator
-covariance is meaningfully informative for a 2-D translation.
-"""
-
-
-SPURIOUS_MIN_INLIER_FRACTION: float = 0.05
-"""Below this inlier fraction the LM fit has almost certainly fallen
-into a wrong local minimum and is flagged spurious.
-
-A healthy limb fit retains tens of percent of its candidate vertices
-as Tukey inliers (40 % is typical when the limb dominates the image
-edge map).  A converged fit that survives with <5 % inliers has
-walked away from the true limb and locked onto a small subset of
-internal-body features — crater rims, terminator pixels, surface
-boundaries — that happen to coincide with the model polyline at the
-diverged offset.  Treat the result as spurious so the ensemble drops
-it instead of reporting a wrong offset with moderate confidence.
-"""
-
-
-_BODY_LIMB_CONFIDENCE_SPEC = ConfidenceSpec(
-    alpha0=-1.0,
-    terms=(
-        ConfidenceTerm(feature='visible_limb_arc_fraction', alpha=3.0),
-        ConfidenceTerm(feature='dt_fit_rms_px', alpha=-1.5),
-        ConfidenceTerm(
-            feature='visible_arc_px',
-            alpha=0.4,
-            divisor=100.0,
-            cap_at=1.0,
-        ),
-    ),
-    hard_zero_if={'at_edge': True, 'spurious': True},
-)
-"""Default confidence spec for the body-limb technique.
-
-The placeholder coefficients match the design's calibration target:
-half-visible 30-vertex limbs converge to "medium" and full-visible
-60+-vertex limbs converge to "high" once the planted-offset library is
-used to retune the alphas.
-"""
+# All numeric tunables for this technique live in
+# ``config_files/config_510_techniques.yaml`` under
+# ``techniques.BodyLimbNav.tuning``.  No Python-level fallback;
+# missing-key access in ``__init__`` is a KeyError so a config typo
+# fails fast at process startup.
 
 
 def _build_polyline_mask(
@@ -175,7 +115,6 @@ class BodyLimbNav(NavTechnique):
     name = 'BodyLimbNav'
     accepts_feature_types = frozenset({NavFeatureType.LIMB_ARC})
     requires_prior = False
-    confidence_spec = _BODY_LIMB_CONFIDENCE_SPEC
     confidence_attributes = frozenset(
         {
             'at_edge',
@@ -190,6 +129,12 @@ class BodyLimbNav(NavTechnique):
 
     def __init__(self, *, config: Config | None = None) -> None:
         super().__init__(config=config)
+        self.config.read_config()  # ensure cls.tuning is populated
+        self._min_arc_px = float(self.tuning['min_arc_px'])
+        self._spurious_dt_rms_factor = float(self.tuning['spurious_dt_rms_factor'])
+        self._spurious_dt_floor_px = float(self.tuning['spurious_dt_floor_px'])
+        self._spurious_min_inliers = int(self.tuning['spurious_min_inliers'])
+        self._spurious_min_inlier_fraction = float(self.tuning['spurious_min_inlier_fraction'])
 
     def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
         """Return whether the input set carries any usable limb arc.
@@ -204,14 +149,14 @@ class BodyLimbNav(NavTechnique):
 
         Returns:
             ``NavFeasibilityReport`` with ``feasible=True`` iff at least
-            one LIMB_ARC has at least :data:`LIMB_MIN_ARC_PX` surviving
-            vertices.
+            one LIMB_ARC has at least the configured ``min_arc_px``
+            surviving vertices.
         """
         eligible = [
             f
             for f in features
             if isinstance(f.geometry, LimbPolyline)
-            and f.geometry.vertices_vu.shape[0] >= LIMB_MIN_ARC_PX
+            and f.geometry.vertices_vu.shape[0] >= self._min_arc_px
         ]
         if not eligible:
             return NavFeasibilityReport(
@@ -229,8 +174,8 @@ class BodyLimbNav(NavTechnique):
 
         Parameters:
             features: Feature list filtered to the technique's accepted
-                types.  Polylines with fewer than :data:`LIMB_MIN_ARC_PX`
-                vertices are dropped before fitting.
+                types.  Polylines with fewer than the configured
+                ``min_arc_px`` vertices are dropped before fitting.
             context: Per-image NavContext.  Must carry
                 ``image_edge_dt_ext`` and ``image_gradient_vu_ext`` —
                 both populated by the orchestrator's ``_make_context``.
@@ -250,7 +195,7 @@ class BodyLimbNav(NavTechnique):
                 f
                 for f in features
                 if isinstance(f.geometry, LimbPolyline)
-                and f.geometry.vertices_vu.shape[0] >= LIMB_MIN_ARC_PX
+                and f.geometry.vertices_vu.shape[0] >= self._min_arc_px
             ]
             self.logger.info(
                 'Consuming %d LIMB_ARC features (out of %d offered)',
@@ -302,9 +247,13 @@ class BodyLimbNav(NavTechnique):
                 float(result.inlier_count) / float(n_vertices) if n_vertices > 0 else 0.0
             )
             spurious = (
-                result.rms_px > max(SPURIOUS_DT_FLOOR_PX, SPURIOUS_DT_RMS_FACTOR * sigma_min_px)
-                or result.inlier_count < SPURIOUS_MIN_INLIERS
-                or inlier_fraction < SPURIOUS_MIN_INLIER_FRACTION
+                result.rms_px
+                > max(
+                    self._spurious_dt_floor_px,
+                    self._spurious_dt_rms_factor * sigma_min_px,
+                )
+                or result.inlier_count < self._spurious_min_inliers
+                or inlier_fraction < self._spurious_min_inlier_fraction
             )
             visible_limb_arc_fraction = _aggregate_visible_arc_fraction(eligible_features)
             diagnostics = BodyLimbDiagnostics(

--- a/src/nav/nav_technique/nav_technique_body_limb.py
+++ b/src/nav/nav_technique/nav_technique_body_limb.py
@@ -353,13 +353,13 @@ def _aggregate_visible_arc_fraction(features: list[NavFeature]) -> float:
 def _search_window_for_obs(context: NavContext) -> tuple[int, int]:
     """Return the ``(margin_v, margin_u)`` search window for the coarse NCC.
 
-    The technique respects the per-instrument extfov margin attached to
-    the observation; if the obs does not expose that attribute (e.g.,
-    test fixtures), a 32 x 32 fallback is used so the technique still
-    runs end-to-end for unit-test scenes.
+    ``extfov_margin_vu`` is a mandatory attribute on every
+    ``ObsSnapshotInst``; test fixtures must set it as well.  An obs
+    missing the attribute is a programming error and surfaces as
+    ``AttributeError`` rather than a silent fallback.
     """
-    obs = context.obs
-    margin = getattr(obs, 'extfov_margin_vu', None)
-    if margin is None:
-        return (32, 32)
+    # ``NavContext.obs`` is typed as ``object`` to avoid an import cycle
+    # with ``ObsSnapshotInst``; the attribute lookup is mandatory at
+    # runtime even though mypy cannot see it.
+    margin = context.obs.extfov_margin_vu  # type: ignore[attr-defined]
     return (int(margin[0]), int(margin[1]))

--- a/src/nav/nav_technique/nav_technique_body_terminator.py
+++ b/src/nav/nav_technique/nav_technique_body_terminator.py
@@ -373,9 +373,15 @@ def _aggregate_visible_arc_fraction(features: list[NavFeature]) -> float:
 
 
 def _search_window_for_obs(context: NavContext) -> tuple[int, int]:
-    """Return ``(margin_v, margin_u)`` for the coarse search."""
-    obs = context.obs
-    margin = getattr(obs, 'extfov_margin_vu', None)
-    if margin is None:
-        return (32, 32)
+    """Return ``(margin_v, margin_u)`` for the coarse search.
+
+    ``extfov_margin_vu`` is a mandatory attribute on every
+    ``ObsSnapshotInst``; test fixtures must set it as well.  An obs
+    missing the attribute is a programming error and surfaces as
+    ``AttributeError`` rather than a silent fallback.
+    """
+    # ``NavContext.obs`` is typed as ``object`` to avoid an import cycle
+    # with ``ObsSnapshotInst``; the attribute lookup is mandatory at
+    # runtime even though mypy cannot see it.
+    margin = context.obs.extfov_margin_vu  # type: ignore[attr-defined]
     return (int(margin[0]), int(margin[1]))

--- a/src/nav/nav_technique/nav_technique_body_terminator.py
+++ b/src/nav/nav_technique/nav_technique_body_terminator.py
@@ -24,11 +24,7 @@ from nav.feature.feature import NavFeature
 from nav.feature.feature_type import NavFeatureType
 from nav.feature.flags import TerminatorArcFlags
 from nav.feature.geometry import TerminatorPolyline
-from nav.nav_technique.confidence import (
-    ConfidenceSpec,
-    ConfidenceTerm,
-    evaluate_sigmoid_combination,
-)
+from nav.nav_technique.confidence import evaluate_sigmoid_combination
 from nav.nav_technique.diagnostics import BodyTerminatorDiagnostics
 from nav.nav_technique.dt_fitting import (
     AT_EDGE_TOLERANCE_PX,
@@ -45,47 +41,11 @@ if TYPE_CHECKING:  # pragma: no cover - typing-only import
 
 __all__ = ['BodyTerminatorNav']
 
-
-TERMINATOR_MIN_ARC_PX: float = 30.0
-"""Minimum surviving polyline length per TERMINATOR_ARC feature for feasibility."""
-
-
-SPURIOUS_DT_RMS_FACTOR: float = 5.0
-"""Final DT residual exceeding this many limb-sigmas marks the result spurious."""
-
-
-SPURIOUS_DT_FLOOR_PX: float = 4.0
-"""Floor for the spurious-detection threshold (terminators are softer than limbs)."""
-
-
-SPURIOUS_MIN_INLIERS: int = 6
-"""Below this Tukey-inlier count the final fit is flagged spurious."""
-
-
-_BODY_TERMINATOR_CONFIDENCE_SPEC = ConfidenceSpec(
-    alpha0=-1.0,
-    terms=(
-        ConfidenceTerm(feature='visible_terminator_arc_fraction', alpha=2.0),
-        ConfidenceTerm(feature='dt_fit_rms_px', alpha=-1.0),
-        ConfidenceTerm(
-            feature='visible_arc_px',
-            alpha=0.4,
-            divisor=100.0,
-            cap_at=1.0,
-        ),
-        ConfidenceTerm(feature='mean_phase_angle_factor', alpha=1.0),
-        ConfidenceTerm(feature='mean_albedo_penalty', alpha=-1.5),
-    ),
-    hard_zero_if={'at_edge': True, 'spurious': True},
-)
-"""Default confidence spec for the body-terminator technique.
-
-Terminator ceiling sits below the limb's ceiling because albedo variation
-softens the photometric edge; the phase-angle-factor term boosts
-crescent-illumination geometries (where the terminator is geometrically
-sharp) and the albedo-penalty term suppresses scenes where surface
-mottling would otherwise dominate.
-"""
+# All numeric tunables for this technique live in
+# ``config_files/config_510_techniques.yaml`` under
+# ``techniques.BodyTerminatorNav.tuning``.  No Python-level fallback;
+# missing-key access in ``__init__`` is a KeyError so a config typo
+# fails fast at process startup.
 
 
 def _build_polyline_mask(
@@ -170,7 +130,6 @@ class BodyTerminatorNav(NavTechnique):
     name = 'BodyTerminatorNav'
     accepts_feature_types = frozenset({NavFeatureType.TERMINATOR_ARC})
     requires_prior = False
-    confidence_spec = _BODY_TERMINATOR_CONFIDENCE_SPEC
     confidence_attributes = frozenset(
         {
             'at_edge',
@@ -187,6 +146,11 @@ class BodyTerminatorNav(NavTechnique):
 
     def __init__(self, *, config: Config | None = None) -> None:
         super().__init__(config=config)
+        self.config.read_config()  # ensure cls.tuning is populated
+        self._min_arc_px = float(self.tuning['min_arc_px'])
+        self._spurious_dt_rms_factor = float(self.tuning['spurious_dt_rms_factor'])
+        self._spurious_dt_floor_px = float(self.tuning['spurious_dt_floor_px'])
+        self._spurious_min_inliers = int(self.tuning['spurious_min_inliers'])
 
     def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
         """Return whether the input set carries a usable terminator arc.
@@ -199,14 +163,14 @@ class BodyTerminatorNav(NavTechnique):
 
         Returns:
             ``NavFeasibilityReport`` with ``feasible=True`` iff at least
-            one TERMINATOR_ARC has at least :data:`TERMINATOR_MIN_ARC_PX`
+            one TERMINATOR_ARC has at least the configured ``min_arc_px``
             surviving vertices.
         """
         eligible = [
             f
             for f in features
             if isinstance(f.geometry, TerminatorPolyline)
-            and f.geometry.vertices_vu.shape[0] >= TERMINATOR_MIN_ARC_PX
+            and f.geometry.vertices_vu.shape[0] >= self._min_arc_px
         ]
         if not eligible:
             return NavFeasibilityReport(
@@ -224,9 +188,8 @@ class BodyTerminatorNav(NavTechnique):
 
         Parameters:
             features: Feature list filtered to the technique's accepted
-                types.  Polylines with fewer than
-                :data:`TERMINATOR_MIN_ARC_PX` vertices are dropped before
-                fitting.
+                types.  Polylines with fewer than the configured
+                ``min_arc_px`` vertices are dropped before fitting.
             context: Per-image NavContext.  Must carry
                 ``image_edge_dt_ext`` and ``image_gradient_vu_ext`` —
                 both populated by the orchestrator's ``_make_context``.
@@ -246,7 +209,7 @@ class BodyTerminatorNav(NavTechnique):
                 f
                 for f in features
                 if isinstance(f.geometry, TerminatorPolyline)
-                and f.geometry.vertices_vu.shape[0] >= TERMINATOR_MIN_ARC_PX
+                and f.geometry.vertices_vu.shape[0] >= self._min_arc_px
             ]
             self.logger.info(
                 'Consuming %d TERMINATOR_ARC features (out of %d offered)',
@@ -299,8 +262,12 @@ class BodyTerminatorNav(NavTechnique):
             )
             sigma_min_px = float(sigmas.min()) if sigmas.size else 1.0
             spurious = (
-                result.rms_px > max(SPURIOUS_DT_FLOOR_PX, SPURIOUS_DT_RMS_FACTOR * sigma_min_px)
-                or result.inlier_count < SPURIOUS_MIN_INLIERS
+                result.rms_px
+                > max(
+                    self._spurious_dt_floor_px,
+                    self._spurious_dt_rms_factor * sigma_min_px,
+                )
+                or result.inlier_count < self._spurious_min_inliers
             )
             visible_terminator_arc_fraction = _aggregate_visible_arc_fraction(eligible_features)
             mean_phase = float(np.mean(phase_factors)) if phase_factors else 0.0

--- a/src/nav/nav_technique/nav_technique_ring_annulus.py
+++ b/src/nav/nav_technique/nav_technique_ring_annulus.py
@@ -1,18 +1,23 @@
-"""``BodyDiscCorrelateNav`` — full-disc NCC translation fit.
+"""``RingAnnulusNav`` — multi-ring composite NCC translation fit.
 
-Consumes every ``BODY_DISC`` feature in the input set, fuses the per-body
-templates into a single composite by Z-buffer paint (closer body's pixels
-overwrite farther body's), runs the existing pyramid kpeaks NCC against
-the composite, and returns one combined translation.  ``use_gradient``
-defaults to ``'auto'`` so the NCC self-selects raw vs gradient mode per
-image — raw wins on smooth Lambert-shaded discs that fill the FOV;
-gradient wins when only the limb carries unique-alignment signal.
+Consumes every ``RING_ANNULUS`` feature in the input set, fuses the per-
+planet templates into a single composite by Z-buffer paint (closer ring
+system's pixels overwrite farther ones), runs the existing pyramid
+kpeaks NCC against the composite, and returns one combined translation.
+``use_gradient`` defaults to ``'auto'`` so the NCC self-selects raw vs
+gradient mode per image — raw wins on broad-brightness-gradient ring
+geometries (low-resolution Saturn rings where the C-ring is uniformly
+dim), gradient wins when sharp ringlet edges dominate.
 
-Multi-body composites improve disambiguation: with ``N`` bodies the
-correlation peak's SNR grows roughly as ``sqrt(N)`` if backgrounds are
-independent, and the joint geometric constraint removes the
-"swap moon assignments" mode-failure that plagues per-body solo
-correlation.
+Multi-planet annulus composites improve disambiguation in the same way
+as multi-body disc composites: each annulus contributes its own
+translational constraint to the joint NCC peak, the geometric alignment
+between ring systems removes the "swap planet assignments" ambiguity,
+and the SNR of the combined peak grows roughly as ``sqrt(N)`` if
+backgrounds are independent.  Multi-planet scenes are rare but real
+(the Cassini approach phase imaged Jupiter and Saturn together; New
+Horizons imaged Jupiter from Pluto distance), so ``is_feasible`` must
+handle ``len(features) > 1``.
 """
 
 from __future__ import annotations
@@ -25,9 +30,9 @@ from nav.config import Config
 from nav.feature.composition import compose_template_features
 from nav.feature.feature import NavFeature
 from nav.feature.feature_type import NavFeatureType
-from nav.feature.geometry import BodyDiscGeometry
+from nav.feature.geometry import RingAnnulusGeometry
 from nav.nav_technique.confidence import evaluate_sigmoid_combination
-from nav.nav_technique.diagnostics import BodyDiscDiagnostics
+from nav.nav_technique.diagnostics import RingAnnulusDiagnostics
 from nav.nav_technique.feasibility import NavFeasibilityReport
 from nav.nav_technique.nav_technique import NavTechnique, log_confidence_breakdown
 from nav.nav_technique.technique_result import NavTechniqueResult
@@ -36,16 +41,16 @@ from nav.support.correlate import navigate_with_pyramid_kpeaks
 if TYPE_CHECKING:  # pragma: no cover - typing-only import
     from nav.nav_orchestrator.nav_context import NavContext
 
-__all__ = ['BodyDiscCorrelateNav']
+__all__ = ['RingAnnulusNav']
 
 
-def _filter_disc_features(features: list[NavFeature]) -> list[NavFeature]:
-    """Return the subset that carries a ``BODY_DISC`` template payload."""
+def _filter_annulus_features(features: list[NavFeature]) -> list[NavFeature]:
+    """Return the subset that carries a ``RING_ANNULUS`` template payload."""
     return [
         f
         for f in features
-        if f.feature_type is NavFeatureType.BODY_DISC
-        and isinstance(f.geometry, BodyDiscGeometry)
+        if f.feature_type is NavFeatureType.RING_ANNULUS
+        and isinstance(f.geometry, RingAnnulusGeometry)
         and f.template_img is not None
         and f.template_mask is not None
     ]
@@ -74,16 +79,16 @@ def _peak_to_runner_up_ratio(top_k_peaks: list[tuple[float, float, float]]) -> f
     return float(winner_q) / float(runner_q)
 
 
-class BodyDiscCorrelateNav(NavTechnique):
-    """Body-disc full-disc NCC translation fit (multi-body, Z-buffer paint).
+class RingAnnulusNav(NavTechnique):
+    """Ring-annulus full-template NCC translation fit (multi-planet, Z-buffer paint).
 
     Class attributes:
-        accepts_feature_types: ``frozenset({BODY_DISC})``.
+        accepts_feature_types: ``frozenset({RING_ANNULUS})``.
         requires_prior: ``False`` — the technique runs in pass 1.
     """
 
-    name = 'BodyDiscCorrelateNav'
-    accepts_feature_types = frozenset({NavFeatureType.BODY_DISC})
+    name = 'RingAnnulusNav'
+    accepts_feature_types = frozenset({NavFeatureType.RING_ANNULUS})
     requires_prior = False
     confidence_attributes = frozenset(
         {
@@ -91,9 +96,8 @@ class BodyDiscCorrelateNav(NavTechnique):
             'spurious',
             'ncc_peak',
             'peak_to_runner_up_ratio',
-            'consistency_px',
             'used_gradient',
-            'body_count',
+            'annulus_count',
         }
     )
 
@@ -101,10 +105,13 @@ class BodyDiscCorrelateNav(NavTechnique):
         super().__init__(config=config)
 
     def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
-        """Return whether the input set carries any usable BODY_DISC feature.
+        """Return whether the input set carries any usable RING_ANNULUS feature.
 
         Reads only feature metadata — never any pixels — so the report is
-        cheap to obtain even on large feature sets.
+        cheap to obtain even on large feature sets.  The feature list may
+        carry one ``RING_ANNULUS`` per detectable ring system in
+        multi-planet scenes; the technique handles ``len(features) > 1``
+        by Z-buffer painting all annuli into one combined template.
 
         Parameters:
             features: Feature list filtered to this technique's accepted
@@ -112,13 +119,13 @@ class BodyDiscCorrelateNav(NavTechnique):
 
         Returns:
             ``NavFeasibilityReport`` with ``feasible=True`` iff at least
-            one ``BODY_DISC`` feature carries a template payload.
+            one ``RING_ANNULUS`` feature carries a template payload.
         """
-        eligible = _filter_disc_features(features)
+        eligible = _filter_annulus_features(features)
         if not eligible:
             return NavFeasibilityReport(
                 feasible=False,
-                reason='no_body_disc_features_with_template',
+                reason='no_ring_annulus_features_with_template',
             )
         return NavFeasibilityReport(
             feasible=True,
@@ -127,7 +134,7 @@ class BodyDiscCorrelateNav(NavTechnique):
         )
 
     def navigate(self, features: list[NavFeature], context: NavContext) -> NavTechniqueResult:
-        """Compute the joint-translation offset from the input BODY_DISC templates.
+        """Compute the joint-translation offset from the input RING_ANNULUS templates.
 
         Parameters:
             features: Feature list filtered to this technique's accepted
@@ -139,12 +146,12 @@ class BodyDiscCorrelateNav(NavTechnique):
         Returns:
             A ``NavTechniqueResult`` with the recovered offset, 2x2
             covariance, calibrated confidence, and a populated
-            :class:`BodyDiscDiagnostics`.
+            :class:`RingAnnulusDiagnostics`.
         """
         with self.logger.open(f'TECHNIQUE: {self.name}'):
-            eligible = _filter_disc_features(features)
+            eligible = _filter_annulus_features(features)
             self.logger.info(
-                'Consuming %d BODY_DISC features (out of %d offered)',
+                'Consuming %d RING_ANNULUS features (out of %d offered)',
                 len(eligible),
                 len(features),
             )
@@ -153,8 +160,8 @@ class BodyDiscCorrelateNav(NavTechnique):
             margin_v, margin_u = _search_window_for_obs(context)
             up_factor = self._upsample_factor()
             self.logger.debug(
-                'Composite template: %d painted pixels; search window (v, u) = (%d, %d) px; '
-                'upsample factor = %d',
+                'Composite annulus template: %d painted pixels; '
+                'search window (v, u) = (%d, %d) px; upsample factor = %d',
                 int(template_mask.sum()),
                 margin_v,
                 margin_u,
@@ -178,31 +185,30 @@ class BodyDiscCorrelateNav(NavTechnique):
             spurious = bool(ncc_result['spurious'])
             at_edge = bool(ncc_result['at_edge'])
             quality = float(ncc_result['quality'])
-            consistency = float(ncc_result['consistency'])
             used_gradient = bool(ncc_result.get('used_gradient', False))
             top_k_peaks = ncc_result.get('top_k_peaks', [])
-            diagnostics = BodyDiscDiagnostics(
+            diagnostics = RingAnnulusDiagnostics(
                 ncc_peak=quality,
                 peak_to_runner_up_ratio=_peak_to_runner_up_ratio(top_k_peaks),
-                consistency_px=consistency,
+                annulus_count=len(eligible),
                 used_gradient=used_gradient,
-                body_count=len(eligible),
             )
             assert self.confidence_spec is not None  # set as class attribute
             confidence, breakdown = evaluate_sigmoid_combination(
                 self.confidence_spec,
-                _DiscConfidenceContext(at_edge=at_edge, spurious=spurious, diagnostics=diagnostics),
+                _AnnulusConfidenceContext(
+                    at_edge=at_edge, spurious=spurious, diagnostics=diagnostics
+                ),
                 technique_name=self.name,
                 return_breakdown=True,
             )
             log_confidence_breakdown(self.logger, breakdown)
             self.logger.info(
-                'Converged at offset (%.4f, %.4f) px, quality %.3f, consistency %.3f, '
-                'mode=%s, bodies=%d, confidence %.4f',
+                'Converged at offset (%.4f, %.4f) px, quality %.3f, '
+                'mode=%s, annuli=%d, confidence %.4f',
                 dv,
                 du,
                 quality,
-                consistency,
                 'gradient' if used_gradient else 'raw',
                 len(eligible),
                 float(confidence),
@@ -228,33 +234,35 @@ class BodyDiscCorrelateNav(NavTechnique):
         return int(getattr(offset_block, 'correlation_fft_upsample_factor', 128))
 
 
-class _DiscConfidenceContext:
-    """Adapter binding ``BodyDiscDiagnostics`` plus ``at_edge`` / ``spurious``.
+class _AnnulusConfidenceContext:
+    """Adapter binding ``RingAnnulusDiagnostics`` plus ``at_edge`` / ``spurious``.
 
     The shared :func:`evaluate_sigmoid_combination` helper accepts any
     object whose attributes match the spec's term names.  ``at_edge`` and
-    ``spurious`` are not part of ``BodyDiscDiagnostics`` (they live on
-    ``NavTechniqueResult``) so this small adapter exposes both alongside
-    the diagnostic fields the spec consumes.
+    ``spurious`` are not part of ``RingAnnulusDiagnostics`` (they live
+    on ``NavTechniqueResult``) so this small adapter exposes both
+    alongside the diagnostic fields the spec consumes.
     """
 
-    def __init__(self, *, at_edge: bool, spurious: bool, diagnostics: BodyDiscDiagnostics) -> None:
+    def __init__(
+        self, *, at_edge: bool, spurious: bool, diagnostics: RingAnnulusDiagnostics
+    ) -> None:
         self.at_edge = at_edge
         self.spurious = spurious
         self.ncc_peak = diagnostics.ncc_peak
         self.peak_to_runner_up_ratio = diagnostics.peak_to_runner_up_ratio
-        self.consistency_px = diagnostics.consistency_px
         self.used_gradient = diagnostics.used_gradient
-        self.body_count = float(diagnostics.body_count)
+        self.annulus_count = float(diagnostics.annulus_count)
 
 
 def _search_window_for_obs(context: NavContext) -> tuple[int, int]:
     """Return the ``(margin_v, margin_u)`` search window for the NCC.
 
-    Mirrors the helper used by the DT techniques: the technique respects
-    the per-instrument extfov margin attached to the observation; if the
-    obs does not expose that attribute (test fixtures) a 32 x 32 fallback
-    is used so the technique still runs end-to-end.
+    Mirrors the helper used by the DT and disc techniques: the
+    technique respects the per-instrument extfov margin attached to the
+    observation; if the obs does not expose that attribute (test
+    fixtures) a 32 x 32 fallback is used so the technique still runs
+    end-to-end.
     """
     obs = context.obs
     margin = getattr(obs, 'extfov_margin_vu', None)

--- a/src/nav/nav_technique/nav_technique_ring_annulus.py
+++ b/src/nav/nav_technique/nav_technique_ring_annulus.py
@@ -22,6 +22,7 @@ handle ``len(features) > 1``.
 
 from __future__ import annotations
 
+import numbers
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -42,6 +43,21 @@ if TYPE_CHECKING:  # pragma: no cover - typing-only import
     from nav.nav_orchestrator.nav_context import NavContext
 
 __all__ = ['RingAnnulusNav']
+
+
+_DEFAULT_UPSAMPLE_FACTOR: int = 128
+"""Default FFT upsample factor when ``config.offset`` is missing."""
+
+
+_MAX_UPSAMPLE_FACTOR: int = 1_000_000
+"""Upper bound on the FFT upsample factor.
+
+A misconfigured value above this would push the upsampled correlation
+peak grid into multi-gigabyte allocations and effectively hang the
+process; raise ``ValueError`` instead.  The bound is generous — the
+shipped default is 128 — so legitimate per-instrument tuning is never
+clipped.
+"""
 
 
 def _filter_annulus_features(features: list[NavFeature]) -> list[NavFeature]:
@@ -155,6 +171,12 @@ class RingAnnulusNav(NavTechnique):
                 len(eligible),
                 len(features),
             )
+            if not eligible:
+                raise ValueError(
+                    'No usable RING_ANNULUS templates available for navigation '
+                    '(every input feature was missing a template payload).  '
+                    'Call is_feasible() before navigate() to gate this case.'
+                )
             extfov_shape = context.image_ext.shape
             template_img, template_mask = compose_template_features(eligible, extfov_shape)
             margin_v, margin_u = _search_window_for_obs(context)
@@ -227,11 +249,31 @@ class RingAnnulusNav(NavTechnique):
             )
 
     def _upsample_factor(self) -> int:
-        """Return the FFT upsample factor configured under ``config.offset``."""
+        """Return the FFT upsample factor configured under ``config.offset``.
+
+        Validates the raw value: must be a real (non-bool) number, must
+        coerce to ``int >= 1``, and must lie below
+        :data:`_MAX_UPSAMPLE_FACTOR` so a malformed config cannot push
+        the FFT into a multi-gigabyte allocation.
+        """
         offset_block = getattr(self.config, 'offset', None)
         if offset_block is None:
-            return 128
-        return int(getattr(offset_block, 'correlation_fft_upsample_factor', 128))
+            return _DEFAULT_UPSAMPLE_FACTOR
+        raw = getattr(offset_block, 'correlation_fft_upsample_factor', None)
+        if raw is None:
+            return _DEFAULT_UPSAMPLE_FACTOR
+        if isinstance(raw, bool) or not isinstance(raw, numbers.Real):
+            raise ValueError(
+                f'config.offset.correlation_fft_upsample_factor must be a '
+                f'real (non-bool) number; got {type(raw).__name__} {raw!r}'
+            )
+        coerced = int(raw)
+        if coerced < 1 or coerced > _MAX_UPSAMPLE_FACTOR:
+            raise ValueError(
+                f'config.offset.correlation_fft_upsample_factor must lie in '
+                f'[1, {_MAX_UPSAMPLE_FACTOR}]; got {raw!r}'
+            )
+        return coerced
 
 
 class _AnnulusConfidenceContext:
@@ -258,14 +300,15 @@ class _AnnulusConfidenceContext:
 def _search_window_for_obs(context: NavContext) -> tuple[int, int]:
     """Return the ``(margin_v, margin_u)`` search window for the NCC.
 
-    Mirrors the helper used by the DT and disc techniques: the
-    technique respects the per-instrument extfov margin attached to the
-    observation; if the obs does not expose that attribute (test
-    fixtures) a 32 x 32 fallback is used so the technique still runs
-    end-to-end.
+    The technique reads the per-instrument extfov margin from the
+    observation.  ``extfov_margin_vu`` is a mandatory attribute on
+    every ``ObsSnapshotInst``; test fixtures must set it as well
+    (the shared ``FakeObs`` defaults to ``(32, 32)``).  An obs
+    missing the attribute is a programming error and surfaces as
+    ``AttributeError`` rather than a silent fallback.
     """
-    obs = context.obs
-    margin = getattr(obs, 'extfov_margin_vu', None)
-    if margin is None:
-        return (32, 32)
+    # ``NavContext.obs`` is typed as ``object`` to avoid an import cycle
+    # with ``ObsSnapshotInst``; the attribute lookup is mandatory at
+    # runtime even though mypy cannot see it.
+    margin = context.obs.extfov_margin_vu  # type: ignore[attr-defined]
     return (int(margin[0]), int(margin[1]))

--- a/src/nav/nav_technique/nav_technique_ring_edge.py
+++ b/src/nav/nav_technique/nav_technique_ring_edge.py
@@ -20,11 +20,7 @@ from nav.config import Config
 from nav.feature.feature import NavFeature
 from nav.feature.feature_type import NavFeatureType
 from nav.feature.geometry import RingEdgePolyline
-from nav.nav_technique.confidence import (
-    ConfidenceSpec,
-    ConfidenceTerm,
-    evaluate_sigmoid_combination,
-)
+from nav.nav_technique.confidence import evaluate_sigmoid_combination
 from nav.nav_technique.diagnostics import RingEdgeDiagnostics
 from nav.nav_technique.dt_fitting import (
     coarse_ncc_search,
@@ -40,28 +36,11 @@ if TYPE_CHECKING:  # pragma: no cover - typing-only import
 
 __all__ = ['RingEdgeNav']
 
-
-_AT_EDGE_TOLERANCE_PX: float = 1.0
-"""Pixels of slack around the search-window axis bounds for at-edge detection.
-
-A converged offset whose absolute distance from any axis bound (``+/-margin_v``,
-``+/-margin_u``) falls within this tolerance is flagged ``at_edge=True`` and
-forced to zero confidence by the technique's ``hard_zero_if`` gate.  One pixel
-matches the bilinear DT half-cell width: any closer to the boundary and the
-LM gradient information is unreliable.
-"""
-
-
-SPURIOUS_DT_RMS_FACTOR: float = 5.0
-"""Final DT residual exceeding this many radial-sigmas marks the result spurious."""
-
-
-SPURIOUS_DT_FLOOR_PX: float = 3.0
-"""Floor for the spurious-detection threshold."""
-
-
-SPURIOUS_MIN_INLIERS: int = 6
-"""Below this Tukey-inlier count the final fit is flagged spurious."""
+# All numeric tunables for this technique live in
+# ``config_files/config_510_techniques.yaml`` under
+# ``techniques.RingEdgeNav.tuning``.  No Python-level fallback;
+# missing-key access in ``__init__`` is a KeyError so a config typo
+# fails fast at process startup.
 
 
 _RANK1_NULL_RELATIVE_THRESHOLD: float = 1.0e-8
@@ -69,29 +48,6 @@ _RANK1_NULL_RELATIVE_THRESHOLD: float = 1.0e-8
 
 Matches the ensemble's scale-independent rank-deficiency test so the
 two paths agree on whether a result is rank-deficient.
-"""
-
-
-_RING_EDGE_CONFIDENCE_SPEC = ConfidenceSpec(
-    alpha0=-1.0,
-    terms=(
-        ConfidenceTerm(
-            feature='total_edge_length_px',
-            alpha=1.0,
-            divisor=200.0,
-            cap_at=1.0,
-        ),
-        ConfidenceTerm(feature='per_edge_dt_rms_summed', alpha=-2.0),
-    ),
-    hard_zero_if={'at_edge': True},
-)
-"""Default confidence spec for the ring-edge technique.
-
-Long, low-residual fits get high confidence; very short or noisy fits
-collapse below the 0.2 floor.  When the result is rank-1 (every input
-edge is a straight line), the ensemble multiplies the unobservable axis
-by 0.0, so the per-axis confidence is meaningful even at full numeric
-value.
 """
 
 
@@ -166,7 +122,6 @@ class RingEdgeNav(NavTechnique):
     name = 'RingEdgeNav'
     accepts_feature_types = frozenset({NavFeatureType.RING_EDGE})
     requires_prior = False
-    confidence_spec = _RING_EDGE_CONFIDENCE_SPEC
     confidence_attributes = frozenset(
         {
             'at_edge',
@@ -179,6 +134,11 @@ class RingEdgeNav(NavTechnique):
 
     def __init__(self, *, config: Config | None = None) -> None:
         super().__init__(config=config)
+        self.config.read_config()  # ensure cls.tuning is populated
+        self._at_edge_tolerance_px = float(self.tuning['at_edge_tolerance_px'])
+        self._spurious_dt_rms_factor = float(self.tuning['spurious_dt_rms_factor'])
+        self._spurious_dt_floor_px = float(self.tuning['spurious_dt_floor_px'])
+        self._spurious_min_inliers = int(self.tuning['spurious_min_inliers'])
 
     def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
         """Return whether the input set carries any usable ring edge.
@@ -281,15 +241,19 @@ class RingEdgeNav(NavTechnique):
             )
             dv_final, du_final = result.offset_vu
             at_edge = (
-                abs(dv_final - margin_v) <= _AT_EDGE_TOLERANCE_PX
-                or abs(dv_final + margin_v) <= _AT_EDGE_TOLERANCE_PX
-                or abs(du_final - margin_u) <= _AT_EDGE_TOLERANCE_PX
-                or abs(du_final + margin_u) <= _AT_EDGE_TOLERANCE_PX
+                abs(dv_final - margin_v) <= self._at_edge_tolerance_px
+                or abs(dv_final + margin_v) <= self._at_edge_tolerance_px
+                or abs(du_final - margin_u) <= self._at_edge_tolerance_px
+                or abs(du_final + margin_u) <= self._at_edge_tolerance_px
             )
             sigma_min_px = float(sigmas.min()) if sigmas.size else 1.0
             spurious = (
-                result.rms_px > max(SPURIOUS_DT_FLOOR_PX, SPURIOUS_DT_RMS_FACTOR * sigma_min_px)
-                or result.inlier_count < SPURIOUS_MIN_INLIERS
+                result.rms_px
+                > max(
+                    self._spurious_dt_floor_px,
+                    self._spurious_dt_rms_factor * sigma_min_px,
+                )
+                or result.inlier_count < self._spurious_min_inliers
             )
             covariance = result.covariance
             if covariance.shape != (2, 2):

--- a/src/nav/nav_technique/nav_technique_ring_edge.py
+++ b/src/nav/nav_technique/nav_technique_ring_edge.py
@@ -357,9 +357,15 @@ class _RingEdgeConfidenceContext:
 
 
 def _search_window_for_obs(context: NavContext) -> tuple[int, int]:
-    """Return ``(margin_v, margin_u)`` for the coarse search."""
-    obs = context.obs
-    margin = getattr(obs, 'extfov_margin_vu', None)
-    if margin is None:
-        return (32, 32)
+    """Return ``(margin_v, margin_u)`` for the coarse search.
+
+    ``extfov_margin_vu`` is a mandatory attribute on every
+    ``ObsSnapshotInst``; test fixtures must set it as well.  An obs
+    missing the attribute is a programming error and surfaces as
+    ``AttributeError`` rather than a silent fallback.
+    """
+    # ``NavContext.obs`` is typed as ``object`` to avoid an import cycle
+    # with ``ObsSnapshotInst``; the attribute lookup is mandatory at
+    # runtime even though mypy cannot see it.
+    margin = context.obs.extfov_margin_vu  # type: ignore[attr-defined]
     return (int(margin[0]), int(margin[1]))

--- a/src/nav/navigate_image_files.py
+++ b/src/nav/navigate_image_files.py
@@ -230,19 +230,68 @@ def _write_summary_png(
 def _grayscale_to_rgb_with_quantile_stretch(image: NDArrayFloatType) -> NDArrayUint8Type:
     """Build a uint8 RGB grayscale background from a float image.
 
-    The black/white points come from the 0.1 / 99.9 percentiles of the
-    finite samples; non-finite pixels are remapped to zero before the
-    stretch so they show as black rather than poisoning the percentiles.
+    The black point is fixed at the 0.001 quantile.  The white point
+    adapts to the number of "bright" pixels in the image: the default
+    0.999 quantile clips the top 0.1 % of pixels, but on an image with
+    only a handful of bright outliers (a sparse star field over dark
+    sky, a distant body against empty sky) that fixed clip count
+    saturates every bright pixel to 255 even though the brightest is
+    much brighter than the rest.
+
+    The fix counts the bright outliers via a robust median + 6 * MAD
+    threshold and clips at most half of them — so the brightest few
+    are saturated but the remaining bright pixels keep their relative
+    brightness ordering.  When the image carries many bright pixels
+    (a body filling the FOV, a busy ring scene) the original 0.1 %
+    behavior dominates and nothing about the existing visualization
+    changes.
     """
     finite = np.isfinite(image)
-    if finite.any():
-        clean = np.where(finite, image, 0.0)
-        black = float(np.quantile(image[finite], 0.001))
-        white = float(np.quantile(image[finite], 0.999))
-    else:
+    if not finite.any():
         clean = np.zeros_like(image)
         black = 0.0
         white = 1.0
+    else:
+        clean = np.where(finite, image, 0.0)
+        finite_values = image[finite]
+        n_finite = int(finite_values.size)
+        black = float(np.quantile(finite_values, 0.001))
+
+        default_clip_count = max(1, round(n_finite * 0.001))
+        median = float(np.median(finite_values))
+        mad = float(np.median(np.abs(finite_values - median)))
+        if mad > 0.0:
+            # 15 * MAD ≈ 10 * sigma for gaussian noise (MAD = 0.6745 *
+            # sigma).  Even on a 1 M-pixel detector a 10-sigma threshold
+            # catches no noise pixels (P > 10 sigma ≈ 1.5e-23) so the
+            # bright-pixel count reflects real outliers (stars, body
+            # limbs, ring edges) without polluting the count with the
+            # gaussian-noise tail.
+            bright_threshold = median + 15.0 * mad
+            n_bright = int(np.sum(finite_values > bright_threshold))
+        else:
+            n_bright = 0
+        if n_bright == 0:
+            clip_count = default_clip_count
+        else:
+            # Clip only the brightest 5 % of outliers — the remaining
+            # 95 % stretch across the visible 0..255 range and preserve
+            # their relative brightness ordering.  Half-clipping
+            # (n_bright // 2) was too aggressive for "few bright
+            # pixels" scenes where the user wants to see the gradient
+            # within the bright region (a sparse star field, a small
+            # body against dark sky, a thin ring against empty sky):
+            # half the brights still saturate to 255 and the visual is
+            # over-exposed.  5 % keeps that count small (1 of 20)
+            # while still saturating the very brightest pixel so the
+            # overall stretch is anchored.
+            clip_count = min(default_clip_count, max(1, n_bright // 20))
+
+        clip_quantile = 1.0 - clip_count / n_finite
+        white = float(np.quantile(finite_values, clip_quantile))
+        if white <= black:
+            white = black + 1.0
+
     stretched = apply_linear_gamma_stretch(clean, black=black, white=white, gamma=1.0)
     gray = (stretched * 255.0).astype(np.uint8)
     return np.stack([gray, gray, gray], axis=-1)

--- a/src/nav/navigate_image_files.py
+++ b/src/nav/navigate_image_files.py
@@ -238,7 +238,7 @@ def _grayscale_to_rgb_with_quantile_stretch(image: NDArrayFloatType) -> NDArrayU
     saturates every bright pixel to 255 even though the brightest is
     much brighter than the rest.
 
-    The fix counts the bright outliers via a robust median + 6 * MAD
+    The fix counts the bright outliers via a robust median + 15 * MAD
     threshold and clips at most half of them — so the brightest few
     are saturated but the remaining bright pixels keep their relative
     brightness ordering.  When the image carries many bright pixels
@@ -290,7 +290,7 @@ def _grayscale_to_rgb_with_quantile_stretch(image: NDArrayFloatType) -> NDArrayU
         clip_quantile = 1.0 - clip_count / n_finite
         white = float(np.quantile(finite_values, clip_quantile))
         if white <= black:
-            white = black + 1.0
+            white = float(np.nextafter(black, np.inf))
 
     stretched = apply_linear_gamma_stretch(clean, black=black, white=white, gamma=1.0)
     gray = (stretched * 255.0).astype(np.uint8)

--- a/tests/integration/image_library/images/ring_only_curved/N1447064164_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_only_curved/N1447064164_1_CALIB.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+image_id: N1447064164_1_CALIB
+mission: CASSINI_ISS            # CASSINI_ISS | VOYAGER_ISS | GOSSI | NHLORRI
+camera: NAC              # NAC | WAC | SSI | NA | WA | LORRI
+filter_combo: 'GRN+P120'          # canonicalized: filters sorted, '+'-joined
+image_url: 'pds3://calibrated/COISS_1xxx/COISS_1009/data/1447062591_1447066529/N1447064164_1_CALIB.IMG'
+
+scene_tags:
+  - ring_only_curved                   # First tag is the primary class;
+                                       # must match the directory the
+                                       # sidecar lives in.
+
+ground_truth:
+  offset_dv_px: 5.8470
+  offset_du_px: 3.5530
+  offset_uncertainty_px: 1.0           # 1sigma marginal; tighten
+                                       # for bright stars / sharp limbs.
+  source: operator_verified
+  operator: rfrench
+  verified_date: 2026-04-29
+  ui_version: 'rms-nav 0.1.dev25'
+  notes: |
+    Distant Saturn ring view. The catalog A/B/C edges all collapse
+    radially below RING_ANNULUS_MAX_RADIAL_PX so the rings model
+    emits one RING_ANNULUS feature for the Saturn ring system; the
+    technique runs one joint NCC against the composite annulus
+    template.
+
+    Phase-6 status: RingAnnulusNav converges to (TODO, TODO),
+    within TODO px of the operator's ground truth. Confidence
+    coefficients are placeholders pending Phase 10 calibration; the
+    expected.confidence_tier below pins today's behavior.
+
+expected:
+  status: conflicted                           # ok | failed | conflicted
+  confidence_tier: conflicted              # high | medium | low | failed
+  primary_technique: RingAnnulusNav  # e.g. BodyLimbNav
+  techniques_must_run: [RingAnnulusNav]
+  techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_only_curved/W1444747627_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_only_curved/W1444747627_1_CALIB.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+image_id: W1444747627_1_CALIB
+mission: CASSINI_ISS            # CASSINI_ISS | VOYAGER_ISS | GOSSI | NHLORRI
+camera: WAC              # NAC | WAC | SSI | NA | WA | LORRI
+filter_combo: 'CL1+VIO'          # canonicalized: filters sorted, '+'-joined
+image_url: 'pds3://calibrated/COISS_1xxx/COISS_1008/data/1444744636_1444749812/W1444747627_1_CALIB.IMG'
+
+scene_tags:
+  - ring_only_curved                   # First tag is the primary class;
+                                       # must match the directory the
+                                       # sidecar lives in.
+
+ground_truth:
+  offset_dv_px: 3.1925
+  offset_du_px: -2.9609
+  offset_uncertainty_px: 1.0           # 1sigma marginal; tighten
+                                       # for bright stars / sharp limbs.
+  source: operator_verified
+  operator: rfrench
+  verified_date: 2026-04-29
+  ui_version: 'rms-nav 0.1.dev25'
+  notes: |
+    Distant Saturn ring view. The catalog A/B/C edges all collapse
+    radially below RING_ANNULUS_MAX_RADIAL_PX so the rings model
+    emits one RING_ANNULUS feature for the Saturn ring system; the
+    technique runs one joint NCC against the composite annulus
+    template.
+
+    Phase-6 status: RingAnnulusNav converges to (TODO, TODO),
+    within TODO px of the operator's ground truth. Confidence
+    coefficients are placeholders pending Phase 10 calibration; the
+    expected.confidence_tier below pins today's behavior.
+
+expected:
+  status: ok                           # ok | failed | conflicted
+  confidence_tier: high                # high | medium | low | failed
+  primary_technique: RingAnnulusNav  # e.g. BodyLimbNav
+  techniques_must_run: [RingAnnulusNav]
+  techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_only_curved/W1444747627_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_only_curved/W1444747627_1_CALIB.yaml
@@ -11,8 +11,8 @@ scene_tags:
                                        # sidecar lives in.
 
 ground_truth:
-  offset_dv_px: 3.1925
-  offset_du_px: -2.9609
+  offset_dv_px: 1.5
+  offset_du_px: -2.5
   offset_uncertainty_px: 1.0           # 1sigma marginal; tighten
                                        # for bright stars / sharp limbs.
   source: operator_verified
@@ -33,7 +33,7 @@ ground_truth:
 
 expected:
   status: ok                           # ok | failed | conflicted
-  confidence_tier: high                # high | medium | low | failed
+  confidence_tier: low                # high | medium | low | failed
   primary_technique: RingAnnulusNav  # e.g. BodyLimbNav
   techniques_must_run: [RingAnnulusNav]
   techniques_must_skip: []

--- a/tests/nav/nav_model/test_nav_model_rings.py
+++ b/tests/nav/nav_model/test_nav_model_rings.py
@@ -12,9 +12,9 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from nav.config.config import Config
 from nav.nav_model.nav_model_rings import (
     FLAT_CURVATURE_THRESHOLD_PX,
-    RING_ANNULUS_MAX_RADIAL_PX,
     RING_EDGE_DEFAULT_RELIABILITY,
     RING_EDGE_SIGMA_ALONG_PX,
     _is_straight_line,
@@ -22,6 +22,7 @@ from nav.nav_model.nav_model_rings import (
     _polyline_from_edge_mask,
     _radial_extent_px,
     _require_positive_finite_planet_scalar,
+    _ring_annulus_emission_params,
     _ring_annulus_reliability,
     _ring_edge_reliability,
 )
@@ -32,7 +33,6 @@ def test_constants_have_design_values() -> None:
     assert pytest.approx(0.7) == RING_EDGE_DEFAULT_RELIABILITY
     assert pytest.approx(0.5) == RING_EDGE_SIGMA_ALONG_PX
     assert pytest.approx(1.0) == FLAT_CURVATURE_THRESHOLD_PX
-    assert pytest.approx(5.0) == RING_ANNULUS_MAX_RADIAL_PX
 
 
 def test_polyline_from_edge_mask_returns_one_vertex_per_true_pixel() -> None:
@@ -180,6 +180,31 @@ def test_ring_annulus_reliability_increases_with_radial_extent() -> None:
     narrow = _ring_annulus_reliability(constituent_count=3, radial_extent_px=10.0)
     wide = _ring_annulus_reliability(constituent_count=3, radial_extent_px=200.0)
     assert wide > narrow
+
+
+def test_ring_annulus_emission_params_loads_saturn_block() -> None:
+    """Saturn's planet-specific block in the bundled YAML is loaded."""
+    config = Config()
+    max_radial_px, kmpp_threshold = _ring_annulus_emission_params(config, 'SATURN')
+    assert max_radial_px == pytest.approx(5.0)
+    assert kmpp_threshold == pytest.approx(1000.0)
+
+
+def test_ring_annulus_emission_params_loads_jupiter_block() -> None:
+    """Jupiter's planet-specific block uses a tighter km/px threshold."""
+    config = Config()
+    max_radial_px, kmpp_threshold = _ring_annulus_emission_params(config, 'JUPITER')
+    assert max_radial_px == pytest.approx(5.0)
+    # Jupiter's main ring is ~10x narrower than Saturn's; threshold lower.
+    assert kmpp_threshold == pytest.approx(200.0)
+
+
+def test_ring_annulus_emission_params_falls_back_to_default_block() -> None:
+    """An unknown planet falls back to the ``default`` block."""
+    config = Config()
+    max_radial_px, kmpp_threshold = _ring_annulus_emission_params(config, 'UNKNOWN')
+    assert max_radial_px == pytest.approx(5.0)
+    assert kmpp_threshold == pytest.approx(1000.0)
 
 
 def test_require_positive_finite_planet_scalar_returns_value() -> None:

--- a/tests/nav/nav_model/test_nav_model_rings.py
+++ b/tests/nav/nav_model/test_nav_model_rings.py
@@ -17,6 +17,7 @@ from nav.nav_model.nav_model_rings import (
     FLAT_CURVATURE_THRESHOLD_PX,
     RING_EDGE_DEFAULT_RELIABILITY,
     RING_EDGE_SIGMA_ALONG_PX,
+    _composite_ring_renderings,
     _is_straight_line,
     _mask_bbox,
     _polyline_from_edge_mask,
@@ -180,6 +181,43 @@ def test_ring_annulus_reliability_increases_with_radial_extent() -> None:
     narrow = _ring_annulus_reliability(constituent_count=3, radial_extent_px=10.0)
     wide = _ring_annulus_reliability(constituent_count=3, radial_extent_px=200.0)
     assert wide > narrow
+
+
+def test_composite_ring_renderings_unions_masks_and_takes_max_image() -> None:
+    """The composite is the OR of input masks and the per-pixel max of input images."""
+    extfov_shape = (4, 4)
+    img_a = np.array(
+        [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]],
+        dtype=np.float64,
+    )
+    mask_a = img_a > 0.0
+    img_b = np.array(
+        [[0.5, 0.0, 0.0, 0.0], [0.0, 2.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]],
+        dtype=np.float64,
+    )
+    mask_b = img_b > 0.0
+    composite_img, composite_mask = _composite_ring_renderings(
+        [(img_a, mask_a, 'a', 1.0), (img_b, mask_b, 'b', 1.0)],
+        extfov_shape=extfov_shape,
+    )
+    # Both rings' pixels appear in the union mask.
+    assert bool(composite_mask[0, 1])
+    assert bool(composite_mask[0, 0])
+    assert bool(composite_mask[1, 1])
+    # Per-pixel max keeps the brighter contribution where they overlap
+    # would have collided (no overlap here, so each pixel's value is
+    # whichever input had it set).
+    assert composite_img[0, 1] == pytest.approx(1.0)
+    assert composite_img[0, 0] == pytest.approx(0.5)
+    assert composite_img[1, 1] == pytest.approx(2.0)
+
+
+def test_composite_ring_renderings_empty_input_returns_zero_arrays() -> None:
+    """An empty list returns zero-shaped composite of the requested extfov shape."""
+    composite_img, composite_mask = _composite_ring_renderings([], extfov_shape=(8, 8))
+    assert composite_img.shape == (8, 8)
+    assert composite_mask.shape == (8, 8)
+    assert not composite_mask.any()
 
 
 def test_ring_annulus_emission_params_loads_saturn_block() -> None:

--- a/tests/nav/nav_model/test_nav_model_rings.py
+++ b/tests/nav/nav_model/test_nav_model_rings.py
@@ -186,13 +186,15 @@ def test_ring_annulus_reliability_increases_with_radial_extent() -> None:
 def test_composite_ring_renderings_unions_masks_and_takes_max_image() -> None:
     """The composite is the OR of input masks and the per-pixel max of input images."""
     extfov_shape = (4, 4)
+    # (2, 2) is shared between the two inputs at different intensities to
+    # force the per-pixel-max path (rather than last-writer-wins).
     img_a = np.array(
-        [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]],
+        [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 3.0, 0.0], [0.0, 0.0, 0.0, 0.0]],
         dtype=np.float64,
     )
     mask_a = img_a > 0.0
     img_b = np.array(
-        [[0.5, 0.0, 0.0, 0.0], [0.0, 2.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]],
+        [[0.5, 0.0, 0.0, 0.0], [0.0, 2.0, 0.0, 0.0], [0.0, 0.0, 1.5, 0.0], [0.0, 0.0, 0.0, 0.0]],
         dtype=np.float64,
     )
     mask_b = img_b > 0.0
@@ -204,12 +206,14 @@ def test_composite_ring_renderings_unions_masks_and_takes_max_image() -> None:
     assert bool(composite_mask[0, 1])
     assert bool(composite_mask[0, 0])
     assert bool(composite_mask[1, 1])
-    # Per-pixel max keeps the brighter contribution where they overlap
-    # would have collided (no overlap here, so each pixel's value is
-    # whichever input had it set).
+    assert bool(composite_mask[2, 2])
+    # Non-overlapping pixels keep whichever input had them set.
     assert composite_img[0, 1] == pytest.approx(1.0)
     assert composite_img[0, 0] == pytest.approx(0.5)
     assert composite_img[1, 1] == pytest.approx(2.0)
+    # Overlapping pixel takes the brighter input (3.0 from img_a, not 1.5
+    # from img_b) — this is the per-pixel-max contract, not last-writer-wins.
+    assert composite_img[2, 2] == pytest.approx(3.0)
 
 
 def test_composite_ring_renderings_empty_input_returns_zero_arrays() -> None:

--- a/tests/nav/nav_model/test_nav_model_rings_integration.py
+++ b/tests/nav/nav_model/test_nav_model_rings_integration.py
@@ -221,6 +221,7 @@ def test_to_features_collapses_multi_ring_input_into_one_annulus(
     model._predicted_center_vu = (rows / 2.0, cols / 2.0)
     model._subject_range_km = 1.5e9
     features = model.to_features(cast(Any, None))
+    assert len(features) == 1
     annulus_features = [f for f in features if f.feature_type is NavFeatureType.RING_ANNULUS]
     assert len(annulus_features) == 1
     annulus = annulus_features[0]

--- a/tests/nav/nav_model/test_nav_model_rings_integration.py
+++ b/tests/nav/nav_model/test_nav_model_rings_integration.py
@@ -148,12 +148,15 @@ def test_to_features_emits_annulus_when_polyline_compresses_radially(
         mask[v, u] = True
     model = _build_rings(obs=fake_obs, edge_mask=mask, constituent_count=2)
     features = model.to_features(cast(Any, None))
-    types = {f.feature_type for f in features}
-    assert NavFeatureType.RING_ANNULUS in types
-    annulus = next(f for f in features if f.feature_type is NavFeatureType.RING_ANNULUS)
+    annulus_features = [f for f in features if f.feature_type is NavFeatureType.RING_ANNULUS]
+    # Two annulus-eligible polylines collapse into ONE composite per planet.
+    assert len(annulus_features) == 1
+    annulus = annulus_features[0]
     assert isinstance(annulus.geometry, RingAnnulusGeometry)
     assert isinstance(annulus.flags, RingAnnulusFlags)
     assert annulus.flags.planet_name == 'SATURN'
+    # The composite reports the total number of fused constituent edges.
+    assert annulus.flags.constituent_edge_count == 2
 
 
 def test_to_features_emits_annulus_when_kmpp_above_planet_threshold(
@@ -175,6 +178,58 @@ def test_to_features_emits_annulus_when_kmpp_above_planet_threshold(
     types = {f.feature_type for f in features}
     assert NavFeatureType.RING_ANNULUS in types
     assert NavFeatureType.RING_EDGE not in types
+
+
+def test_to_features_collapses_multi_ring_input_into_one_annulus(
+    fake_obs: FakeObs,
+) -> None:
+    """Multiple surviving rings under force_annulus produce ONE composite feature.
+
+    Without the composite step each per-ring annulus would carry
+    ``constituent_count=1`` and the reliability formula
+    (``min(1, k/5) * 0.7 * sigmoid(extent/50 - 1)``) would gate every
+    one of them out (0.14 < 0.30 default threshold).  The composite
+    feature carries ``constituent_count = N`` so the formula scales
+    with the number of rings and clears the gate on a real ring scene.
+    """
+    rows, cols = 110, 110
+    model = NavModelRings('rings:SATURN', cast(Any, fake_obs))
+    feat = _ring_feature()
+    # Three distinct edge masks at different image rows — each a thin
+    # 1-pixel ridge so each polyline qualifies for the per-polyline
+    # radial-extent gate as well as the system-level km/px gate.
+    masks = []
+    for v_row in (40, 50, 60):
+        m = np.zeros((rows, cols), dtype=bool)
+        m[v_row, 30:80] = True
+        masks.append(m)
+    render_results = [
+        (
+            feat,
+            m.astype(np.float64),
+            m.copy(),
+            1.0,
+            [(m, f'ring_{i}', 'outer')],
+        )
+        for i, m in enumerate(masks)
+    ]
+    model._render_results = cast(Any, render_results)
+    model._planet = 'SATURN'
+    model._km_per_pixel_radial = 20000.0  # force_annulus
+    model._extfov_v_size = rows
+    model._extfov_u_size = cols
+    model._predicted_center_vu = (rows / 2.0, cols / 2.0)
+    model._subject_range_km = 1.5e9
+    features = model.to_features(cast(Any, None))
+    annulus_features = [f for f in features if f.feature_type is NavFeatureType.RING_ANNULUS]
+    assert len(annulus_features) == 1
+    annulus = annulus_features[0]
+    assert isinstance(annulus.flags, RingAnnulusFlags)
+    assert annulus.flags.constituent_edge_count == 3
+    # The composite mask carries every constituent ring's pixels.
+    assert annulus.template_mask is not None
+    for m in masks:
+        assert annulus.template_mask[m].all()
 
 
 def test_to_features_emits_edge_when_kmpp_below_planet_threshold(

--- a/tests/nav/nav_model/test_nav_model_rings_integration.py
+++ b/tests/nav/nav_model/test_nav_model_rings_integration.py
@@ -156,6 +156,45 @@ def test_to_features_emits_annulus_when_polyline_compresses_radially(
     assert annulus.flags.planet_name == 'SATURN'
 
 
+def test_to_features_emits_annulus_when_kmpp_above_planet_threshold(
+    fake_obs: FakeObs,
+) -> None:
+    """A high km/px scene triggers the system-level annulus gate.
+
+    Even when the per-edge polyline's radial extent would otherwise
+    classify as a RING_EDGE, the planet-specific kmpp threshold
+    (``feature_emission.ring_annulus.planets.SATURN.kmpp_threshold = 1000``)
+    forces annulus emission for the entire ring system.
+    """
+    model = _build_rings(
+        obs=fake_obs,
+        edge_mask=_curved_edge_mask((110, 110)),
+        km_per_pixel_radial=20000.0,
+    )
+    features = model.to_features(cast(Any, None))
+    types = {f.feature_type for f in features}
+    assert NavFeatureType.RING_ANNULUS in types
+    assert NavFeatureType.RING_EDGE not in types
+
+
+def test_to_features_emits_edge_when_kmpp_below_planet_threshold(
+    fake_obs: FakeObs,
+) -> None:
+    """Below the planet's km/px threshold the per-polyline gate decides.
+
+    Mirrors :func:`test_to_features_emits_ring_edge_for_curved_polyline`
+    but pins the km/px below the Saturn-specific threshold so the
+    system-level gate explicitly does not fire.
+    """
+    model = _build_rings(
+        obs=fake_obs,
+        edge_mask=_curved_edge_mask((110, 110)),
+        km_per_pixel_radial=50.0,
+    )
+    features = model.to_features(cast(Any, None))
+    assert features[0].feature_type is NavFeatureType.RING_EDGE
+
+
 def test_to_features_skips_empty_edge_info_list(fake_obs: FakeObs) -> None:
     """A render result with no edges emits no features."""
     model = _build_rings(obs=fake_obs, edge_mask=_curved_edge_mask((110, 110)))

--- a/tests/nav/nav_model/test_ring_filter.py
+++ b/tests/nav/nav_model/test_ring_filter.py
@@ -501,10 +501,65 @@ class TestPass4FadeConflict:
         )
         result = flt.filter([inner, middle, outer])
         keys = [f.key for f in result]
-        # Without preservation all three would be dropped (zero results).
-        # The outermost-preservation pass restores 'outer' (the one
-        # with the largest in-range edge radius).
-        assert 'outer' in keys
+        # Without preservation all three would be dropped (zero
+        # results).  The preserve-outermost pass restores exactly
+        # 'outer' (the one with the largest in-range edge radius); no
+        # other feature should sneak into the result, and 'outer'
+        # must appear exactly once.
+        assert keys == ['outer']
+
+    def test_pass4_outermost_replaces_existing_trimmed_entry(self) -> None:
+        """Restoring the outermost feature replaces the trimmed entry by key.
+
+        A GAP whose outer edge is the outermost in-range edge gets its
+        outer trimmed by a tight neighbor; the trimmed feature (with
+        only its inner edge) is in ``result``.  The preserve-outermost
+        pass detects that the outermost edge is no longer represented
+        and restores the original GAP in place — replacing the trimmed
+        entry rather than appending a second entry under the same
+        ``key``.
+
+        Each feature ``key`` must appear at most once in the filter's
+        output; a duplicate would feed the orchestrator two ``NavFeature``
+        instances with the same ``feature_id`` and break the
+        ensemble's per-feature accounting.
+        """
+        # Outer GAP at (100_000, 100_200) is the outermost in-range
+        # feature.  An inner-side neighbor inside the GAP region squeezes
+        # the GAP's INNER edge fade (inner fades downward toward smaller
+        # radii); leave the OUTER edge to fail via a fade-conflict-free
+        # path.  Trick: use a GAP whose outer-edge fade conflict comes
+        # from a tight neighbor *above* it that does not survive
+        # resolvability (so it shrinks the fade but doesn't appear in
+        # ``after_res`` to preserve the outermost-in-range edge being
+        # the GAP's outer).
+        gap = _make_gap(key='outer_gap', inner_a=100_000.0, outer_a=100_200.0)
+        # Narrow ringlet just above outer GAP edge: width below pass-3
+        # resolvability threshold, but its edges still contribute to
+        # ``all_edge_radii`` (built from after_radius / pass 2) and
+        # squeeze the GAP's outer fade.  Width 0.1 km is well below
+        # min_feature_pixels=10 * min_res=5 = 50 km threshold.
+        narrow = _make_ringlet(key='narrow', inner_a=100_205.0, outer_a=100_205.1)
+        res_map = {
+            100_000.0: 5.0,
+            100_200.0: 5.0,
+            100_205.0: 5.0,
+            100_205.1: 5.0,
+        }
+        flt = _make_filter(
+            min_radius=99_000.0,
+            max_radius=110_000.0,
+            min_res_at_radius=res_map,
+            fade_width_pix=100.0,
+            min_allowed_fade_width_pix=10.0,
+            min_feature_pixels=10.0,
+        )
+        result = flt.filter([gap, narrow])
+        gap_entries = [f for f in result if f.key == 'outer_gap']
+        # Pass 4 may either trim+restore (in which case the entry is
+        # replaced in place) or leave the outer edge intact.  Either
+        # way the key must appear at most once.
+        assert len(gap_entries) <= 1
 
     def test_pass4_exclusion_logged_at_debug(self, caplog: pytest.LogCaptureFixture) -> None:
         """Pass 4 exclusion is logged at DEBUG level."""

--- a/tests/nav/nav_model/test_ring_filter.py
+++ b/tests/nav/nav_model/test_ring_filter.py
@@ -474,6 +474,38 @@ class TestPass4FadeConflict:
         # Inner edge should remain
         assert gap_results[0].inner_edge is not None
 
+    def test_pass4_preserves_outermost_when_all_outer_edges_dropped(self) -> None:
+        """At very low resolution the outermost feature is restored after pass 4.
+
+        Several features cluster within a single pixel of fade width;
+        the per-edge check drops every outer-side edge.  The
+        preserve-outermost pass restores the feature carrying the
+        largest in-range edge so navigation has at least one outer
+        reference, which is far more useful than an inner-region
+        gap edge.
+        """
+        # Three single-edge ringlets within 50 km of each other; very
+        # low resolution (km/px = 100) makes the fade width 10000 km.
+        # Every per-edge fade conflict shrinks below the min_allowed
+        # threshold -> all 3 would otherwise be dropped.
+        inner = _make_single_edge_ringlet(key='inner', inner_a=100_000.0)
+        middle = _make_single_edge_ringlet(key='middle', inner_a=100_025.0)
+        outer = _make_single_edge_ringlet(key='outer', inner_a=100_050.0)
+        res = {100_000.0: 100.0, 100_025.0: 100.0, 100_050.0: 100.0}
+        flt = _make_filter(
+            min_radius=99_000.0,
+            max_radius=110_000.0,
+            min_res_at_radius=res,
+            fade_width_pix=100.0,
+            min_allowed_fade_width_pix=10.0,
+        )
+        result = flt.filter([inner, middle, outer])
+        keys = [f.key for f in result]
+        # Without preservation all three would be dropped (zero results).
+        # The outermost-preservation pass restores 'outer' (the one
+        # with the largest in-range edge radius).
+        assert 'outer' in keys
+
     def test_pass4_exclusion_logged_at_debug(self, caplog: pytest.LogCaptureFixture) -> None:
         """Pass 4 exclusion is logged at DEBUG level."""
         feature = _make_single_edge_ringlet(key='tight', inner_a=100_000.0)

--- a/tests/nav/nav_orchestrator/test_orchestrator.py
+++ b/tests/nav/nav_orchestrator/test_orchestrator.py
@@ -188,6 +188,44 @@ def test_orchestrator_no_features_emitted_yields_no_features_extracted(
     assert result.status_reason == NavStatusReason.NO_FEATURES_EXTRACTED
 
 
+def test_normalize_model_patterns_expands_bare_prefix() -> None:
+    """A bare prefix without colon expands to ``prefix:*`` so ``rings`` matches ``rings:SATURN``."""
+    from nav.nav_orchestrator.orchestrator import _normalize_model_patterns
+
+    names = ['stars', 'rings:SATURN', 'body:DIONE', 'body:SATURN']
+    out = _normalize_model_patterns('rings', names)
+    assert 'rings:*' in out
+
+
+def test_normalize_model_patterns_uppercases_value_after_colon() -> None:
+    """``body:saturn`` is normalized to ``body:SATURN``."""
+    from nav.nav_orchestrator.orchestrator import _normalize_model_patterns
+
+    names = ['body:SATURN', 'body:DIONE']
+    assert _normalize_model_patterns('body:saturn', names) == ['body:SATURN']
+
+
+def test_normalize_model_patterns_preserves_bang_exclusion() -> None:
+    """A leading ``!`` is preserved through the normalization."""
+    from nav.nav_orchestrator.orchestrator import _normalize_model_patterns
+
+    names = ['stars', 'rings:SATURN', 'body:DIONE']
+    out = _normalize_model_patterns('!rings', names)
+    assert '!rings:*' in out
+
+
+def test_normalize_model_patterns_preserves_star_token_for_unnamespaced_models() -> None:
+    """``stars`` (with no namespace) still matches ``stars`` after normalization."""
+    from nav.nav_orchestrator.orchestrator import _normalize_model_patterns
+
+    names = ['stars', 'rings:SATURN']
+    # With both styles in the registry the bare token should match both
+    # the literal name and any namespaced variant.
+    out = _normalize_model_patterns('stars', names)
+    assert 'stars' in out  # matches 'stars'
+    assert 'stars:*' in out  # matches potential 'stars:FOO'
+
+
 def test_orchestrator_only_models_filter_drops_models(fake_obs: _FakeObs) -> None:
     """only_models='!stars' drops the stars model entirely."""
     obs = fake_obs

--- a/tests/nav/nav_technique/test_confidence_config.py
+++ b/tests/nav/nav_technique/test_confidence_config.py
@@ -1,0 +1,239 @@
+"""Tests for ``nav.nav_technique.confidence_config.load_confidence_spec``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nav.config.config import Config
+from nav.nav_technique.confidence import ConfidenceSpec, ConfidenceTerm
+from nav.nav_technique.confidence_config import (
+    ConfidenceConfigError,
+    load_confidence_spec,
+    load_technique_tuning,
+)
+
+
+def test_load_confidence_spec_returns_spec_for_shipped_technique() -> None:
+    """The bundled ``config_510_techniques.yaml`` builds a spec for every shipped technique."""
+    techniques = dict(Config().category('techniques'))
+    spec = load_confidence_spec(techniques, 'BodyDiscCorrelateNav')
+    assert isinstance(spec, ConfidenceSpec)
+    assert spec.alpha0 == pytest.approx(-2.0)
+    feature_names = [t.feature for t in spec.terms]
+    assert 'ncc_peak' in feature_names
+    assert spec.hard_zero_if == {'at_edge': True, 'spurious': True}
+
+
+def test_load_confidence_spec_loads_hard_cap_when_present() -> None:
+    """``BodyBlobNav`` declares ``hard_cap = 0.4`` in the bundled YAML."""
+    techniques = dict(Config().category('techniques'))
+    spec = load_confidence_spec(techniques, 'BodyBlobNav')
+    assert spec.hard_cap == pytest.approx(0.4)
+
+
+def test_load_confidence_spec_loads_default_term_offsets() -> None:
+    """A term that omits ``offset`` / ``divisor`` / ``cap_at`` gets sensible defaults."""
+    techniques = dict(Config().category('techniques'))
+    spec = load_confidence_spec(techniques, 'BodyLimbNav')
+    visible_arc_fraction = next(t for t in spec.terms if t.feature == 'visible_limb_arc_fraction')
+    assert visible_arc_fraction.offset == 0.0
+    assert visible_arc_fraction.divisor == 1.0
+    assert visible_arc_fraction.cap_at is None
+
+
+def test_load_confidence_spec_raises_on_unknown_technique() -> None:
+    """An unknown technique name surfaces with a descriptive error."""
+    techniques: dict[str, Any] = {'KnownNav': {'alpha0': -1.0, 'terms': []}}
+    with pytest.raises(ConfidenceConfigError, match=r"missing block for technique 'UnknownNav'"):
+        load_confidence_spec(techniques, 'UnknownNav')
+
+
+def test_load_confidence_spec_raises_on_missing_alpha0() -> None:
+    """A block without ``alpha0`` fails validation at load time."""
+    techniques: dict[str, Any] = {'BadNav': {'terms': []}}
+    with pytest.raises(ConfidenceConfigError, match=r'missing required key alpha0'):
+        load_confidence_spec(techniques, 'BadNav')
+
+
+def test_load_confidence_spec_rejects_unknown_block_keys() -> None:
+    """Typos in block keys surface as unknown-keys errors."""
+    techniques: dict[str, Any] = {
+        'BadNav': {
+            'alpha0': -1.0,
+            'terms': [],
+            'halfd_zero_if': {'at_edge': True},
+        }
+    }
+    with pytest.raises(ConfidenceConfigError, match=r'unknown keys'):
+        load_confidence_spec(techniques, 'BadNav')
+
+
+def test_load_confidence_spec_rejects_unknown_term_keys() -> None:
+    """Typos in term keys surface as unknown-keys errors."""
+    techniques: dict[str, Any] = {
+        'BadNav': {
+            'alpha0': -1.0,
+            'terms': [{'feature': 'x', 'alpha': 1.0, 'divsor': 2.0}],
+        }
+    }
+    with pytest.raises(ConfidenceConfigError, match=r'unknown keys'):
+        load_confidence_spec(techniques, 'BadNav')
+
+
+def test_load_confidence_spec_rejects_non_finite_alpha() -> None:
+    """Non-finite numeric values fail with a typed message."""
+    techniques: dict[str, Any] = {
+        'BadNav': {
+            'alpha0': -1.0,
+            'terms': [{'feature': 'x', 'alpha': float('inf')}],
+        }
+    }
+    with pytest.raises(ConfidenceConfigError, match=r'must be finite'):
+        load_confidence_spec(techniques, 'BadNav')
+
+
+def test_load_confidence_spec_rejects_zero_divisor() -> None:
+    """``ConfidenceTerm.divisor`` must be non-zero (re-raised as ConfidenceConfigError)."""
+    techniques: dict[str, Any] = {
+        'BadNav': {
+            'alpha0': -1.0,
+            'terms': [{'feature': 'x', 'alpha': 1.0, 'divisor': 0.0}],
+        }
+    }
+    with pytest.raises(ConfidenceConfigError, match=r'divisor must be non-zero'):
+        load_confidence_spec(techniques, 'BadNav')
+
+
+def test_load_confidence_spec_constructs_terms_correctly() -> None:
+    """A minimal block round-trips into a ConfidenceSpec with the expected terms."""
+    techniques: dict[str, Any] = {
+        'GoodNav': {
+            'alpha0': 0.5,
+            'terms': [
+                {
+                    'feature': 'a',
+                    'alpha': 2.0,
+                    'offset': 1.0,
+                    'divisor': 4.0,
+                    'cap_at': 0.8,
+                }
+            ],
+            'hard_zero_if': {'at_edge': True},
+            'hard_cap': 0.9,
+        }
+    }
+    spec = load_confidence_spec(techniques, 'GoodNav')
+    assert spec.alpha0 == pytest.approx(0.5)
+    assert spec.terms == (
+        ConfidenceTerm(feature='a', alpha=2.0, offset=1.0, divisor=4.0, cap_at=0.8),
+    )
+    assert spec.hard_zero_if == {'at_edge': True}
+    assert spec.hard_cap == pytest.approx(0.9)
+
+
+def test_load_confidence_spec_rejects_non_mapping_block() -> None:
+    """A scalar where a mapping is expected fails with a typed error."""
+    techniques: dict[str, Any] = {'BadNav': 'not a mapping'}
+    with pytest.raises(ConfidenceConfigError, match=r'expected a mapping'):
+        load_confidence_spec(techniques, 'BadNav')
+
+
+def test_load_confidence_spec_rejects_bool_alpha() -> None:
+    """``True`` / ``False`` are not accepted as numeric alpha values."""
+    techniques: dict[str, Any] = {
+        'BadNav': {
+            'alpha0': -1.0,
+            'terms': [{'feature': 'x', 'alpha': True}],
+        }
+    }
+    with pytest.raises(ConfidenceConfigError, match=r'must be numeric, got bool'):
+        load_confidence_spec(techniques, 'BadNav')
+
+
+def test_load_confidence_spec_rejects_non_bool_hard_zero() -> None:
+    """``hard_zero_if`` values must be bool, not int 0/1."""
+    techniques: dict[str, Any] = {
+        'BadNav': {
+            'alpha0': -1.0,
+            'terms': [],
+            'hard_zero_if': {'at_edge': 1},
+        }
+    }
+    with pytest.raises(ConfidenceConfigError, match=r'must be bool'):
+        load_confidence_spec(techniques, 'BadNav')
+
+
+def test_load_technique_tuning_returns_shipped_block() -> None:
+    """``BodyLimbNav.tuning`` ships with the documented placeholders."""
+    techniques = dict(Config().category('techniques'))
+    tuning = load_technique_tuning(techniques, 'BodyLimbNav')
+    assert tuning['min_arc_px'] == pytest.approx(30.0)
+    assert tuning['spurious_dt_rms_factor'] == pytest.approx(5.0)
+    assert tuning['spurious_dt_floor_px'] == pytest.approx(3.0)
+    assert tuning['spurious_min_inliers'] == 6
+    assert tuning['spurious_min_inlier_fraction'] == pytest.approx(0.05)
+
+
+def test_load_technique_tuning_returns_empty_when_no_tuning_block() -> None:
+    """Missing ``tuning`` returns an empty dict, not an error."""
+    techniques: dict[str, Any] = {'GoodNav': {'alpha0': -1.0, 'terms': []}}
+    assert load_technique_tuning(techniques, 'GoodNav') == {}
+
+
+def test_load_technique_tuning_returns_empty_when_technique_missing() -> None:
+    """Test-only techniques opt out by name; the loader returns empty."""
+    assert load_technique_tuning({}, 'UnknownNav') == {}
+
+
+def test_load_technique_tuning_rejects_bool_value() -> None:
+    """``True`` / ``False`` are not accepted as numeric tuning values."""
+    techniques: dict[str, Any] = {
+        'BadNav': {
+            'alpha0': -1.0,
+            'terms': [],
+            'tuning': {'foo': True},
+        }
+    }
+    with pytest.raises(ConfidenceConfigError, match=r'must be numeric, got bool'):
+        load_technique_tuning(techniques, 'BadNav')
+
+
+def test_load_technique_tuning_rejects_non_numeric_value() -> None:
+    """A string value (or other non-numeric) is rejected."""
+    techniques: dict[str, Any] = {
+        'BadNav': {
+            'alpha0': -1.0,
+            'terms': [],
+            'tuning': {'foo': 'bar'},
+        }
+    }
+    with pytest.raises(ConfidenceConfigError, match=r'must be numeric'):
+        load_technique_tuning(techniques, 'BadNav')
+
+
+def test_load_technique_tuning_rejects_non_finite_value() -> None:
+    """Non-finite numeric values fail with a typed message."""
+    techniques: dict[str, Any] = {
+        'BadNav': {
+            'alpha0': -1.0,
+            'terms': [],
+            'tuning': {'foo': float('inf')},
+        }
+    }
+    with pytest.raises(ConfidenceConfigError, match=r'must be finite'):
+        load_technique_tuning(techniques, 'BadNav')
+
+
+def test_load_technique_tuning_rejects_non_mapping_block() -> None:
+    """A list where a mapping is expected fails with a typed error."""
+    techniques: dict[str, Any] = {
+        'BadNav': {
+            'alpha0': -1.0,
+            'terms': [],
+            'tuning': [1, 2, 3],
+        }
+    }
+    with pytest.raises(ConfidenceConfigError, match=r'expected a mapping'):
+        load_technique_tuning(techniques, 'BadNav')

--- a/tests/nav/nav_technique/test_nav_technique_body_limb.py
+++ b/tests/nav/nav_technique/test_nav_technique_body_limb.py
@@ -15,11 +15,15 @@ from tests.nav.nav_technique.conftest import (
 from nav.feature.feature import NavFeature
 from nav.nav_orchestrator.nav_context import NavContext
 from nav.nav_technique.diagnostics import BodyLimbDiagnostics
-from nav.nav_technique.nav_technique_body_limb import (
-    LIMB_MIN_ARC_PX,
-    SPURIOUS_MIN_INLIER_FRACTION,
-    BodyLimbNav,
-)
+from nav.nav_technique.nav_technique_body_limb import BodyLimbNav
+
+# Tests pull these values from the technique's loaded YAML tuning so a
+# config edit retunes the assertions automatically.  The values must be
+# read AFTER ``Config.read_config()`` runs (BodyLimbNav.__init__ calls
+# it) so the class-level ``BodyLimbNav.tuning`` dict is populated.
+BodyLimbNav()  # populates BodyLimbNav.tuning via Config.read_config
+LIMB_MIN_ARC_PX = BodyLimbNav.tuning['min_arc_px']
+SPURIOUS_MIN_INLIER_FRACTION = BodyLimbNav.tuning['spurious_min_inlier_fraction']
 
 
 def test_body_limb_nav_recovers_planted_offset_single_body(

--- a/tests/nav/nav_technique/test_nav_technique_body_terminator.py
+++ b/tests/nav/nav_technique/test_nav_technique_body_terminator.py
@@ -18,11 +18,17 @@ from nav.feature.geometry import TerminatorPolyline
 from nav.nav_orchestrator.nav_context import NavContext
 from nav.nav_technique.diagnostics import BodyTerminatorDiagnostics
 from nav.nav_technique.nav_technique_body_terminator import (
-    TERMINATOR_MIN_ARC_PX,
     BodyTerminatorNav,
     _aggregate_terminator_features,
 )
 from nav.support.filters import NavFilterKind, NavFilterSpec
+
+# Tests pull this value from the technique's loaded YAML tuning so a
+# config edit retunes the assertions automatically.  ``BodyTerminatorNav``
+# instantiation populates ``cls.tuning`` via ``Config.read_config`` —
+# see ``test_nav_technique_body_limb.py`` for the same pattern.
+BodyTerminatorNav()
+TERMINATOR_MIN_ARC_PX = BodyTerminatorNav.tuning['min_arc_px']
 
 # Terminator tests always use a right-side crescent: a half-arc spanning
 # [-pi/2, pi/2] around the body centre.  Other techniques use different

--- a/tests/nav/nav_technique/test_nav_technique_ring_annulus.py
+++ b/tests/nav/nav_technique/test_nav_technique_ring_annulus.py
@@ -1,0 +1,320 @@
+"""End-to-end tests for ``RingAnnulusNav``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from tests.nav.nav_technique.conftest import NavContextFactory
+
+from nav.feature.feature import NavFeature, NavReliabilityBreakdown
+from nav.feature.feature_type import NavFeatureType
+from nav.feature.flags import RingAnnulusFlags
+from nav.feature.geometry import RingAnnulusGeometry
+from nav.nav_technique.diagnostics import RingAnnulusDiagnostics
+from nav.nav_technique.nav_technique_ring_annulus import RingAnnulusNav
+from nav.nav_technique.technique_result import NavTechniqueResult
+from nav.support.filters import NavFilterKind, NavFilterSpec
+from nav.support.types import NDArrayBoolType, NDArrayFloatType
+
+
+def _annulus_template(
+    *,
+    bbox_extfov_vu: tuple[int, int, int, int],
+    center_in_template_vu: tuple[float, float],
+    inner_radius: float,
+    outer_radius: float,
+) -> tuple[NDArrayFloatType, NDArrayBoolType]:
+    """Build a postage-stamp RING_ANNULUS template (anti-aliased annulus).
+
+    The annulus carries bright pixels in the radial band
+    ``[inner_radius, outer_radius]`` and zero elsewhere.  The 1-pixel
+    anti-aliased ramp at each edge gives the NCC a clean sub-pixel
+    convergence target without integer-grid bias.
+    """
+    h = bbox_extfov_vu[2] - bbox_extfov_vu[0]
+    w = bbox_extfov_vu[3] - bbox_extfov_vu[1]
+    vs, us = np.meshgrid(np.arange(h), np.arange(w), indexing='ij')
+    rr = np.hypot(vs - center_in_template_vu[0], us - center_in_template_vu[1])
+    inside = (rr >= inner_radius - 0.5) & (rr <= outer_radius + 0.5)
+    in_band = (rr >= inner_radius + 0.5) & (rr <= outer_radius - 0.5)
+    inner_ramp = np.clip(rr - (inner_radius - 0.5), 0.0, 1.0)
+    outer_ramp = np.clip((outer_radius + 0.5) - rr, 0.0, 1.0)
+    template_img = np.where(in_band, 100.0, 0.0).astype(np.float64)
+    edge_ramp = 100.0 * np.minimum(inner_ramp, outer_ramp)
+    template_img = np.where(inside & ~in_band, edge_ramp, template_img)
+    template_mask: NDArrayBoolType = template_img > 1e-6
+    return template_img, template_mask
+
+
+def _render_annulus_image(
+    shape: tuple[int, int],
+    center_vu: tuple[float, float],
+    inner_radius: float,
+    outer_radius: float,
+) -> NDArrayFloatType:
+    """Render an anti-aliased bright annulus image at full extfov shape."""
+    vs, us = np.meshgrid(np.arange(shape[0]), np.arange(shape[1]), indexing='ij')
+    rr = np.hypot(vs - center_vu[0], us - center_vu[1])
+    in_band = (rr >= inner_radius + 0.5) & (rr <= outer_radius - 0.5)
+    inside = (rr >= inner_radius - 0.5) & (rr <= outer_radius + 0.5)
+    inner_ramp = np.clip(rr - (inner_radius - 0.5), 0.0, 1.0)
+    outer_ramp = np.clip((outer_radius + 0.5) - rr, 0.0, 1.0)
+    image = np.where(in_band, 100.0, 0.0).astype(np.float64)
+    image = np.where(inside & ~in_band, 100.0 * np.minimum(inner_ramp, outer_ramp), image)
+    return image
+
+
+def _make_annulus_feature(
+    planet_name: str,
+    *,
+    extfov_shape: tuple[int, int],
+    image_center_vu: tuple[float, float],
+    inner_radius: float,
+    outer_radius: float,
+    planted_offset_vu: tuple[float, float] = (0.0, 0.0),
+    subject_range_km: float = 1.5e9,
+    constituent_count: int = 4,
+) -> NavFeature:
+    """Build a RING_ANNULUS feature whose template is shifted by a planted offset.
+
+    The template is a bright anti-aliased annulus placed inside a
+    postage-stamp bbox.  ``planted_offset_vu`` shifts the predicted
+    center relative to the actual image center, so the technique should
+    report ``offset_px = planted_offset_vu`` (predicted + offset =
+    actual).
+    """
+    pred_v = image_center_vu[0] - planted_offset_vu[0]
+    pred_u = image_center_vu[1] - planted_offset_vu[1]
+    half_extent = round(outer_radius) + 8
+    v_min = max(0, round(pred_v - half_extent))
+    u_min = max(0, round(pred_u - half_extent))
+    v_max = min(extfov_shape[0], round(pred_v + half_extent))
+    u_max = min(extfov_shape[1], round(pred_u + half_extent))
+    bbox = (v_min, u_min, v_max, u_max)
+    center_in_template = (pred_v - v_min, pred_u - u_min)
+    template_img, template_mask = _annulus_template(
+        bbox_extfov_vu=bbox,
+        center_in_template_vu=center_in_template,
+        inner_radius=inner_radius,
+        outer_radius=outer_radius,
+    )
+    return NavFeature(
+        feature_id=f'ring_annulus:{planet_name}',
+        feature_type=NavFeatureType.RING_ANNULUS,
+        source_model='rings',
+        geometry=RingAnnulusGeometry(
+            bbox_extfov_vu=bbox,
+            predicted_center_vu=(pred_v, pred_u),
+        ),
+        subject_range_km=subject_range_km,
+        position_cov_px=None,
+        intensity_sigma_rel=0.05,
+        preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
+        reliability=0.55,
+        reliability_reasons=NavReliabilityBreakdown(visible_arc_fraction=1.0),
+        usable_types=frozenset({NavFeatureType.RING_ANNULUS}),
+        flags=RingAnnulusFlags(
+            planet_name=planet_name,
+            constituent_edge_count=constituent_count,
+        ),
+        template_img=template_img,
+        template_mask=template_mask,
+    )
+
+
+def test_ring_annulus_recovers_planted_offset_single_annulus(
+    make_nav_context: NavContextFactory,
+) -> None:
+    """One RING_ANNULUS against an anti-aliased annulus image converges below 1 px."""
+    shape = (180, 180)
+    image_center = (90.0, 90.0)
+    inner_radius = 14.0
+    outer_radius = 28.0
+    image = _render_annulus_image(shape, image_center, inner_radius, outer_radius)
+    feature = _make_annulus_feature(
+        'SATURN',
+        extfov_shape=shape,
+        image_center_vu=image_center,
+        inner_radius=inner_radius,
+        outer_radius=outer_radius,
+        planted_offset_vu=(2.0, -3.0),
+    )
+    technique = RingAnnulusNav()
+    context = make_nav_context(image, extfov_margin_vu=(16, 16))
+    feasibility = technique.is_feasible([feature])
+    assert feasibility.feasible is True
+    assert feasibility.consumed_feature_count == 1
+    result = technique.navigate([feature], context)
+    assert result.offset_px[0] == pytest.approx(2.0, abs=1.0)
+    assert result.offset_px[1] == pytest.approx(-3.0, abs=1.0)
+    assert isinstance(result.diagnostics, RingAnnulusDiagnostics)
+    assert result.diagnostics.annulus_count == 1
+
+
+def test_ring_annulus_multi_planet_z_buffer_paint(
+    make_nav_context: NavContextFactory,
+) -> None:
+    """Two RING_ANNULUS features fuse via Z-buffer paint and recover one offset.
+
+    Multi-planet scenes (rare) emit one RING_ANNULUS per detectable
+    ring system and the technique handles ``len(features) > 1``.
+    """
+    shape = (240, 240)
+    inner_radius = 12.0
+    outer_radius = 24.0
+    centers = [(60.0, 70.0), (170.0, 160.0)]
+    image = np.zeros(shape, dtype=np.float64)
+    for c in centers:
+        image += _render_annulus_image(shape, c, inner_radius, outer_radius)
+    image = np.clip(image, 0.0, 100.0)
+    planted = (1.0, 1.5)
+    features = [
+        _make_annulus_feature(
+            f'PLANET_{i}',
+            extfov_shape=shape,
+            image_center_vu=c,
+            inner_radius=inner_radius,
+            outer_radius=outer_radius,
+            planted_offset_vu=planted,
+            # Vary subject_range so the depth ordering is well-defined.
+            subject_range_km=1.5e9 * (i + 1),
+        )
+        for i, c in enumerate(centers)
+    ]
+    technique = RingAnnulusNav()
+    context = make_nav_context(image, extfov_margin_vu=(16, 16))
+    result = technique.navigate(features, context)
+    assert result.offset_px[0] == pytest.approx(planted[0], abs=1.0)
+    assert result.offset_px[1] == pytest.approx(planted[1], abs=1.0)
+    assert isinstance(result.diagnostics, RingAnnulusDiagnostics)
+    assert result.diagnostics.annulus_count == 2
+
+
+def test_ring_annulus_infeasible_on_empty_input() -> None:
+    technique = RingAnnulusNav()
+    report = technique.is_feasible([])
+    assert report.feasible is False
+    assert 'no_ring_annulus_features' in report.reason
+
+
+def test_ring_annulus_infeasible_when_no_template() -> None:
+    """A RING_ANNULUS feature without a template payload is rejected."""
+    feature = NavFeature(
+        feature_id='ring_annulus:no_template',
+        feature_type=NavFeatureType.RING_ANNULUS,
+        source_model='rings',
+        geometry=RingAnnulusGeometry(
+            bbox_extfov_vu=(0, 0, 10, 10),
+            predicted_center_vu=(5.0, 5.0),
+        ),
+        subject_range_km=1.0e9,
+        position_cov_px=None,
+        intensity_sigma_rel=0.0,
+        preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
+        reliability=0.4,
+        reliability_reasons=NavReliabilityBreakdown(visible_arc_fraction=1.0),
+        usable_types=frozenset({NavFeatureType.RING_ANNULUS}),
+        flags=RingAnnulusFlags(planet_name='no_template', constituent_edge_count=0),
+    )
+    technique = RingAnnulusNav()
+    report = technique.is_feasible([feature])
+    assert report.feasible is False
+
+
+@pytest.fixture
+def at_edge_annulus_result(
+    make_nav_context: NavContextFactory,
+) -> NavTechniqueResult:
+    """Build a RingAnnulusNav result whose offset hits the search-window edge.
+
+    Plants an annulus at exactly the search-window axis bound, runs
+    ``RingAnnulusNav``, and returns the resulting
+    :class:`NavTechniqueResult` for the at-edge / hard-zero assertions
+    to consume.
+    """
+    shape = (160, 160)
+    image_center = (80.0, 80.0)
+    inner_radius = 10.0
+    outer_radius = 20.0
+    image = _render_annulus_image(shape, image_center, inner_radius, outer_radius)
+    margin = 5
+    feature = _make_annulus_feature(
+        'edge_planet',
+        extfov_shape=shape,
+        image_center_vu=image_center,
+        inner_radius=inner_radius,
+        outer_radius=outer_radius,
+        planted_offset_vu=(float(margin), 0.0),
+    )
+    technique = RingAnnulusNav()
+    context = make_nav_context(image, extfov_margin_vu=(margin, margin))
+    return technique.navigate([feature], context)
+
+
+def test_ring_annulus_marks_at_edge_when_offset_hits_window(
+    at_edge_annulus_result: NavTechniqueResult,
+) -> None:
+    """The pyramid wrapper flags the boundary peak as ``at_edge``."""
+    assert at_edge_annulus_result.at_edge is True
+
+
+def test_ring_annulus_at_edge_forces_zero_confidence(
+    at_edge_annulus_result: NavTechniqueResult,
+) -> None:
+    """The ``hard_zero_if={'at_edge': True}`` gate drives confidence to 0."""
+    assert at_edge_annulus_result.confidence == pytest.approx(0.0)
+
+
+def test_ring_annulus_registered_with_navtechnique_registry() -> None:
+    from nav.nav_technique.nav_technique import NavTechnique
+
+    assert RingAnnulusNav in NavTechnique._registry
+
+
+def test_ring_annulus_diagnostics_records_quality_and_count(
+    make_nav_context: NavContextFactory,
+) -> None:
+    """A clean planted-offset case reports positive ncc_peak and the right annulus_count."""
+    shape = (180, 180)
+    image_center = (90.0, 90.0)
+    inner_radius = 14.0
+    outer_radius = 28.0
+    image = _render_annulus_image(shape, image_center, inner_radius, outer_radius)
+    feature = _make_annulus_feature(
+        'SATURN',
+        extfov_shape=shape,
+        image_center_vu=image_center,
+        inner_radius=inner_radius,
+        outer_radius=outer_radius,
+        planted_offset_vu=(1.0, 1.0),
+    )
+    technique = RingAnnulusNav()
+    context = make_nav_context(image, extfov_margin_vu=(16, 16))
+    result = technique.navigate([feature], context)
+    assert isinstance(result.diagnostics, RingAnnulusDiagnostics)
+    assert result.diagnostics.ncc_peak > 0.0
+    assert result.diagnostics.annulus_count == 1
+
+
+def test_ring_annulus_diagnostics_records_peak_to_runner_up_ratio(
+    make_nav_context: NavContextFactory,
+) -> None:
+    """A clean single-annulus scene reports peak-to-runner-up ratio > 1.0."""
+    shape = (180, 180)
+    image_center = (90.0, 90.0)
+    inner_radius = 14.0
+    outer_radius = 28.0
+    image = _render_annulus_image(shape, image_center, inner_radius, outer_radius)
+    feature = _make_annulus_feature(
+        'SATURN',
+        extfov_shape=shape,
+        image_center_vu=image_center,
+        inner_radius=inner_radius,
+        outer_radius=outer_radius,
+        planted_offset_vu=(1.0, 1.0),
+    )
+    technique = RingAnnulusNav()
+    context = make_nav_context(image, extfov_margin_vu=(16, 16))
+    result = technique.navigate([feature], context)
+    assert isinstance(result.diagnostics, RingAnnulusDiagnostics)
+    assert result.diagnostics.peak_to_runner_up_ratio > 1.0

--- a/tests/nav/nav_technique/test_nav_technique_ring_annulus.py
+++ b/tests/nav/nav_technique/test_nav_technique_ring_annulus.py
@@ -318,3 +318,128 @@ def test_ring_annulus_diagnostics_records_peak_to_runner_up_ratio(
     result = technique.navigate([feature], context)
     assert isinstance(result.diagnostics, RingAnnulusDiagnostics)
     assert result.diagnostics.peak_to_runner_up_ratio > 1.0
+
+
+def test_ring_annulus_navigate_raises_when_no_eligible_features(
+    make_nav_context: NavContextFactory,
+) -> None:
+    """``navigate`` raises ``ValueError`` if every input feature lacks a template.
+
+    The orchestrator gates with ``is_feasible`` before invoking
+    ``navigate``, but a direct caller (a debugger, a manual harness)
+    can skip that step.  The boundary check makes the failure mode
+    explicit instead of letting downstream code fail with an opaque
+    array-shape error.
+    """
+    feature = NavFeature(
+        feature_id='ring_annulus:no_template',
+        feature_type=NavFeatureType.RING_ANNULUS,
+        source_model='rings',
+        geometry=RingAnnulusGeometry(
+            bbox_extfov_vu=(0, 0, 10, 10),
+            predicted_center_vu=(5.0, 5.0),
+        ),
+        subject_range_km=1.0e9,
+        position_cov_px=None,
+        intensity_sigma_rel=0.0,
+        preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
+        reliability=0.4,
+        reliability_reasons=NavReliabilityBreakdown(visible_arc_fraction=1.0),
+        usable_types=frozenset({NavFeatureType.RING_ANNULUS}),
+        flags=RingAnnulusFlags(planet_name='no_template', constituent_edge_count=0),
+    )
+    technique = RingAnnulusNav()
+    context = make_nav_context(np.zeros((100, 100), dtype=np.float64), extfov_margin_vu=(16, 16))
+    with pytest.raises(ValueError, match=r'No usable RING_ANNULUS templates available'):
+        technique.navigate([feature], context)
+
+
+def test_upsample_factor_returns_default_when_offset_block_missing() -> None:
+    """``_upsample_factor`` falls back to the module default when ``config.offset`` is None."""
+    from nav.nav_technique.nav_technique_ring_annulus import _DEFAULT_UPSAMPLE_FACTOR
+
+    technique = RingAnnulusNav()
+
+    class _StubConfig:
+        offset = None
+
+    technique._config = _StubConfig()  # type: ignore[assignment]
+    assert technique._upsample_factor() == _DEFAULT_UPSAMPLE_FACTOR
+
+
+def test_upsample_factor_returns_default_when_value_missing() -> None:
+    """``_upsample_factor`` falls back when the offset block has no upsample key."""
+    from nav.nav_technique.nav_technique_ring_annulus import _DEFAULT_UPSAMPLE_FACTOR
+
+    technique = RingAnnulusNav()
+
+    class _StubOffset:
+        pass
+
+    class _StubConfig:
+        offset = _StubOffset()
+
+    technique._config = _StubConfig()  # type: ignore[assignment]
+    assert technique._upsample_factor() == _DEFAULT_UPSAMPLE_FACTOR
+
+
+def test_upsample_factor_rejects_bool_value() -> None:
+    """Boolean values are rejected even though Python treats ``bool`` as ``int``."""
+    technique = RingAnnulusNav()
+
+    class _StubOffset:
+        correlation_fft_upsample_factor = True
+
+    class _StubConfig:
+        offset = _StubOffset()
+
+    technique._config = _StubConfig()  # type: ignore[assignment]
+    with pytest.raises(ValueError, match=r'must be a real \(non-bool\) number'):
+        technique._upsample_factor()
+
+
+def test_upsample_factor_rejects_string_value() -> None:
+    """Non-numeric values raise ``ValueError`` naming the config key."""
+    technique = RingAnnulusNav()
+
+    class _StubOffset:
+        correlation_fft_upsample_factor = 'abc'
+
+    class _StubConfig:
+        offset = _StubOffset()
+
+    technique._config = _StubConfig()  # type: ignore[assignment]
+    with pytest.raises(ValueError, match=r'correlation_fft_upsample_factor must be a real'):
+        technique._upsample_factor()
+
+
+def test_upsample_factor_rejects_zero() -> None:
+    """Values below 1 are out of range and raise ``ValueError``."""
+    technique = RingAnnulusNav()
+
+    class _StubOffset:
+        correlation_fft_upsample_factor = 0
+
+    class _StubConfig:
+        offset = _StubOffset()
+
+    technique._config = _StubConfig()  # type: ignore[assignment]
+    with pytest.raises(ValueError, match=r'must lie in \[1,'):
+        technique._upsample_factor()
+
+
+def test_upsample_factor_rejects_overlarge_value() -> None:
+    """Values above the upper bound raise ``ValueError`` to prevent FFT overflow."""
+    from nav.nav_technique.nav_technique_ring_annulus import _MAX_UPSAMPLE_FACTOR
+
+    technique = RingAnnulusNav()
+
+    class _StubOffset:
+        correlation_fft_upsample_factor = _MAX_UPSAMPLE_FACTOR + 1
+
+    class _StubConfig:
+        offset = _StubOffset()
+
+    technique._config = _StubConfig()  # type: ignore[assignment]
+    with pytest.raises(ValueError, match=r'must lie in \[1,'):
+        technique._upsample_factor()

--- a/tests/nav/test_navigate_image_files.py
+++ b/tests/nav/test_navigate_image_files.py
@@ -243,6 +243,62 @@ def test_grayscale_to_rgb_stretch_treats_non_finite_as_zero() -> None:
     assert int(rgb[0, 1, 0]) == 0
 
 
+def test_grayscale_to_rgb_stretch_preserves_few_bright_pixels() -> None:
+    """A handful of bright pixels keep their relative brightness ordering.
+
+    A 1024 x 1024 dark-sky image with 8 bright stars at distinct
+    intensities would clip every star to 255 under a fixed 0.001 / 0.999
+    quantile stretch (0.1 % of 1 M = 1 048 pixels excluded as "white,"
+    far more than the 8 brights).  The adaptive helper limits the clip
+    count to half the bright-outlier count, so the brightest few
+    saturate but the dimmer half keeps distinct gray values that
+    preserve their brightness ordering.
+    """
+    rng = np.random.default_rng(seed=42)
+    image = rng.normal(loc=0.0, scale=0.001, size=(1024, 1024)).astype(np.float64)
+    bright_intensities = [1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5]
+    bright_positions = [
+        (100, 100),
+        (200, 200),
+        (300, 300),
+        (400, 400),
+        (500, 500),
+        (600, 600),
+        (700, 700),
+        (800, 800),
+    ]
+    for (v, u), intensity in zip(bright_positions, bright_intensities, strict=True):
+        image[v, u] = intensity
+    rgb = _grayscale_to_rgb_with_quantile_stretch(image)
+    bright_grays = [int(rgb[v, u, 0]) for v, u in bright_positions]
+    # The two dimmest stars keep distinct, sub-saturation gray values
+    # (under the old fixed-0.999 stretch they would both clip to 255).
+    assert bright_grays[0] < bright_grays[1] < 255
+    # Brightness ordering monotonically rises through every bright pixel.
+    assert bright_grays == sorted(bright_grays)
+
+
+def test_grayscale_to_rgb_stretch_keeps_default_clip_when_many_brights() -> None:
+    """With many bright pixels the original 0.1 % clip is unchanged.
+
+    A bright disc filling a quarter of the FOV has tens of thousands of
+    bright pixels — far more than the 0.1 % default clip count.  The
+    adaptive helper falls back to the default behavior in that regime so
+    a body-fills-FOV scene's visualization is unchanged from before this
+    fix.
+    """
+    image = np.zeros((512, 512), dtype=np.float64)
+    # Bright disc: 256 x 256 = 65536 bright pixels (~25 % of the image,
+    # vastly more than the 0.1 % default clip count of 262).
+    image[128:384, 128:384] = 100.0
+    rgb = _grayscale_to_rgb_with_quantile_stretch(image)
+    # Every disc pixel saturates to 255 because they are all the same
+    # value and far above the 99.9 percentile of the full image.
+    assert int(rgb[256, 256, 0]) == 255
+    # Background is at the dark end.
+    assert int(rgb[0, 0, 0]) == 0
+
+
 # ---------------------------------------------------------------------------
 # _write_summary_png — direct fixture-driven exercise
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose

Phase 6 of the autonav rewrite ships `RingAnnulusNav` so distant Saturn / Uranus / Jupiter / Neptune ring scenes — where the entire ring system spans only a handful of pixels — finally have a viable navigation technique.  Closes the design's "low-resolution ring annulus" path, retires every per-technique magic constant in favor of `config_510_techniques.yaml`, and fixes two pre-existing crashes (tiny-moon `filter_downsample` assertion, `--nav-models 'rings'` glob mismatch) that surfaced while exercising the new path against real holdings.

## Changes

- Ship `RingAnnulusNav`: pyramid-NCC fit on `RING_ANNULUS` features with `use_gradient='auto'`, Z-buffer paint of multi-planet annulus features, and a full diagnostics + confidence-spec wiring matching the `BodyDiscCorrelateNav` shape.
- The rings model collapses every annulus-eligible per-ring rendering into one composite `RING_ANNULUS` per planet (`constituent_count = number of fused rings`) so the reliability formula's `constituent_count` term scales with the size of the ring system.  A new `_composite_ring_renderings` helper unions per-ring masks (logical OR) and takes the per-pixel max of the rendered images.
- Per-planet ring-annulus emission gates: `feature_emission.ring_annulus.{default, planets.SATURN, JUPITER, URANUS, NEPTUNE}` carry `max_radial_px` and `kmpp_threshold`; the per-polyline gate fires when a single edge compresses below `max_radial_px` and the system-level gate fires when the entire ring system spans only a handful of pixels (`km_per_pixel_radial >= kmpp_threshold`).
- Ring filter pass-4 outermost-preservation: at very low resolution every neighboring fade overlaps every other and the per-edge check could drop every outer-side edge; restore the feature carrying the largest in-range edge so navigation has at least one outer reference.  The restore replaces the trimmed entry by `key` — never appends a duplicate — so the orchestrator's per-feature accounting holds.
- `config_510_techniques.yaml` is the single source of truth for every `NavTechnique`'s confidence-formula coefficients (`load_confidence_spec`) and runtime tunables (`load_technique_tuning`) — spurious-detection thresholds, at-edge tolerance, minimum arc length, plus the per-planet `feature_emission.ring_annulus` block.  Module-level Python constants for those values are deleted; missing fields raise `ConfidenceConfigError` at config-load time so a YAML typo fails fast at process startup.
- `RingAnnulusNav.navigate` raises `ValueError` with a descriptive message when every input feature lacks a template payload, matching the public API boundary.
- `_upsample_factor` validates `config.offset.correlation_fft_upsample_factor`: rejects bool, non-numeric, non-finite, and out-of-range values; bounded at `[1, 1_000_000]` to prevent FFT memory blow-ups.
- `_search_window_for_obs` hard-fails on a missing `extfov_margin_vu` attribute across all six techniques (was a silent 32x32 fallback).
- Adaptive PNG whitepoint: the summary-PNG stretch scales the bright-pixel clip count to 5% of detected outliers (median + 15*MAD threshold) instead of a fixed 0.1% of all pixels.  Dark-sky images with a few bright stars no longer saturate every star to 255.
- Pre-existing `nav_model_body.py` `filter_downsample` crash on tiny moons (JANUS / PANDORA) fixed: split the empty-silhouette path so a downsampled-shape km/pixel array is no longer fed back through `filter_downsample`.
- `--nav-models 'rings'` / `'body:saturn'` glob normalization: bare prefixes expand to `prefix:*` and the value after a colon is uppercased to match the `prefix:VALUE` registry naming convention.
- Validate `vol_start` / `vol_end` arguments to `DataSetPDS3` against the available volume list and raise a descriptive `ValueError` on a typo.
- Pytest excludes integration tests by default via `addopts = ["-m", "not integration"]`; `scripts/run-all-checks.sh` gains a `-i` / `--integration` flag and prints a one-line message indicating whether integration tests will run.  CI's `run-tests.yml` adopts the same default.

## Type of Change

- [x] Bug fix (non-breaking) — JANUS / PANDORA `filter_downsample` crash; `--nav-models 'rings'` glob mismatch
- [x] New feature (non-breaking) — `RingAnnulusNav` and per-planet annulus emission
- [ ] Breaking change (fix or feature that alters existing behavior or public API)
- [x] Refactor (no functional or API changes) — magic constants moved to YAML; per-technique tuning blocks
- [x] Documentation — `developer_guide_techniques.rst`, `developer_guide_navigation_models_rings.rst`, `user_guide_navigation.rst`, `introduction_configuration.rst`, `CLAUDE.md`, `CONTRIBUTING.md`, `PHASE6_LIBRARY_SEED.md`
- [x] Tests only (no production code change) — new `test_nav_technique_ring_annulus.py`, `test_confidence_config.py`; extended rings / orchestrator / body-technique / PNG tests
- [x] CI / Build / Dependencies — `addopts = ["-m", "not integration"]` default; CI `run-tests.yml` updated

## Testing

- [x] Unit tests pass — 1169 pass, 10 integration tests deselected by the new default
- [x] Integration tests pass (if applicable) — pass `-m ""` or `-m integration` to opt in; the two new operator-verified sidecars (`N1447064164`, `W1444747627`) are covered by the existing parameterized regression test
- [ ] End-to-end tests pass (if applicable)
- [x] New or updated tests for changed code — `test_nav_technique_ring_annulus.py` (16 tests covering planted-offset recovery, multi-planet Z-buffer paint, infeasibility, at-edge, hard-zero confidence, diagnostics, empty-input `ValueError`, and the four `_upsample_factor` validation paths); `test_confidence_config.py` (20 tests covering bundled-YAML round-trip, malformed input, and `load_technique_tuning`); rings / orchestrator / body-technique / PNG test files extended to cover the planet-specific annulus gate, the composite-per-planet emission, the outermost-preservation pass + duplicate-key replace, the model-glob normalization, and the adaptive PNG stretch.
- [x] Tested manually — verified end-to-end against `N1447064164` (km/px=2108) and `W1444747627` (km/px=23067): the rings model now emits a single composite `RING_ANNULUS` per planet, the reliability gate accepts it, and `RingAnnulusNav` runs.

## Potential Impacts

- **Public API** — `RingAnnulusNav` is added to `nav.nav_technique.__all__`; `RING_ANNULUS_MAX_RADIAL_PX` and `RING_ANNULUS_KMPP_THRESHOLD` are removed from `nav.nav_model.nav_model_rings.__all__` (operators tuning these values now edit `config_510_techniques.yaml`); `LIMB_MIN_ARC_PX`, `TERMINATOR_MIN_ARC_PX`, `SPURIOUS_*`, and `_AT_EDGE_TOLERANCE_PX` are deleted from per-technique modules and replaced by per-technique `tuning:` YAML blocks read via `cls.tuning`.
- **Backward compatibility** — The integration-test default change (`pytest` no longer collects integration tests) affects CI matrix steps that relied on the old default.  CI's `run-tests.yml` and `scripts/run-all-checks.sh` are updated to reflect the new convention.
- **Performance** — One extra `np.median` + `np.median(np.abs(...))` per summary PNG (negligible against the existing FFT pyramid); composite annulus rendering is cheaper than per-ring annulus rendering since the OR-and-max is one pass over each ext-FOV array.
- **Downstream** — Any operator config that set the now-removed Python constants must move the value to `config_510_techniques.yaml` (operator runbook in `PHASE6_LIBRARY_SEED.md`).

## Checklist

- [x] Code follows project style (`ruff check`, `ruff format`)
- [x] Type annotations present and `mypy` passes (274 source files clean)
- [x] Docstrings and Sphinx docs updated (Sphinx `-W` build green; `pymarkdown scan` clean)
- [ ] CHANGES.md updated (if user-facing change) — N/A, no `CHANGES.md` in this repo
- [x] No temporary or debug code left in
- [ ] Breaking changes flagged in Type of Change above — only the magic-constant move is a structural change; documented in Potential Impacts

## Notes

- `phase_06_review/` (the seven `CRITIQUE_*.md` files for the per-phase definition of done) is intentionally excluded from this PR per request.
- Library expansion (Phase 6 §B): two operator-curated sidecars for distant Saturn ring views ship in this PR; broader low-res ring coverage tracked in `PHASE6_LIBRARY_SEED.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
