### PR TITLE
Phase 7+8 star techniques + manual-nav + body cleanup

### DIFF
--- a/.cursor/rules/pull_request.mdc
+++ b/.cursor/rules/pull_request.mdc
@@ -7,7 +7,7 @@ alwaysApply: false
 
 ## Scope of review
 
-Treat the PR as a **single unit of change**. The diff to review is the set of all commits on the current branch back to its **immediate root** (the merge-base with the target branch). Consider the net result of those commits together; do **not** comment on differences that exist only between commits within the PR (e.g. "you fixed X in a later commit" or "commit 2 undid part of commit 1"). Review the final state of the branch against the base.
+Treat the PR as a **single unit of change**. The diff to review is the set of all commits on the current branch back to its **immediate root** (the merge-base with the target branch). Consider the net result of those commits together; do **not** comment on differences that exist only between commits within the PR (e.g. "you fixed X in a later commit" or "commit 2 undid part of commit 1"). Review the final state of the branch against the base. Do not explicitly word wrap lines.
 
 ## Principles
 

--- a/AUTONAV_PLAN.md
+++ b/AUTONAV_PLAN.md
@@ -1027,9 +1027,9 @@ techniques broaden coverage.
 | **3** | Foundation completion + per-instrument config wiring | **Complete** (branch `core_rewrite_catchup`) |
 | **4** | First navigable image (end-to-end DT-only) | **Complete** (branch `core_rewrite_phase4`) |
 | **5** | Body disc + body blob techniques | **Complete** (branch `core_rewrite_phase5`) |
-| **6** | Ring-annulus technique | Pending |
-| **7** | Star techniques part 1 (unique-match + refine) | Pending |
-| **8** | `StarFieldFromCatalogNav` (multi-star RANSAC) | Pending |
+| **6** | Ring-annulus technique | **Complete** (branch `core_rewrite_phase6`) |
+| **7** | Star techniques part 1 (unique-match + refine) | **Complete** (branch `core_rewrite_phase7`) |
+| **8** | `StarFieldFromCatalogNav` (multi-star RANSAC) | **Complete** (branch `core_rewrite_phase7`) |
 | **9** | Camera rotation correction (per instrument) | Pending |
 | **10** | Image library expansion + confidence-formula calibration | Pending |
 | **11** | Cleanup + documentation finalization + breadth comparison | Pending |
@@ -3243,7 +3243,12 @@ all are concrete starting points for Phase 10 calibration work.
 
 ---
 
-## Phase 7 — Star techniques part 1 (unique-match + refine)
+## Phase 7 — Star techniques part 1 (unique-match + refine) (complete)
+
+Phase 7 ("star techniques part 1" branch `core_rewrite_phase7`) ships
+the two simpler star techniques that do not require multi-star
+pattern matching: `StarUniqueMatchNav` (pass-1, 1- or 2-star paths)
+and `StarRefineNav` (pass-2 refine on the pass-1 prior).
 
 **Goal:** Ship `StarUniqueMatchNav` and `StarRefineNav` — the two
 simpler star techniques that do not require multi-star pattern
@@ -3271,22 +3276,76 @@ A. **`StarUniqueMatchNav`.**
    - On `fit_camera_rotation = True` instruments the 3×3
      covariance is rank-2 in the 1-star case (translation
      observable, rotation unobservable); ensemble combine handles
-     via `pinvh`.
+     via `pinvh`.  Phase 7 currently ships the 2-D translation-only
+     covariance; the rank-2 3×3 path lights up in Phase 9 when
+     rotation fitting is enabled per instrument.
    - Diagnostics via the existing `StarUniqueMatchDiagnostics`
      dataclass.
 
 B. **`StarRefineNav`.**
-   - Port the existing star-refinement pass forward; consumes a
-     prior offset (typically the pass-1 ensemble result) and
-     refines via local PSF fit on detected stars near each
-     predicted catalog star. Confidence per the refinement formula.
+   - Pass-2 technique that consumes the pass-1 ensemble's prior
+     offset and refines via local centroid fits on every predicted
+     catalog star.  Per-star inverse-variance weighting; outliers
+     (detection more than `max_per_star_residual_px` from the
+     prior-shifted prediction) are dropped before the joint
+     average.  Confidence per the per-star scatter / inlier-count
+     formula.
    - Diagnostics via `StarRefineDiagnostics`.
 
 C. **Library expansion.**
-   - 2–3 star-rich library images: 1 Cassini star-cal frame, 1
-     NHLORRI scene with detectable stars, 1 multi-feature scene
-     with stars + body where the refine pass matters. Sidecars +
-     ground truth + baselines.
+   - **Deferred to operator session (same posture as Phase 6 §B).**
+     The sidecar schema enforces `ground_truth.source: operator_verified`;
+     fabricating sidecars without an operator session would either
+     fail integration testing on first run or — worse — encode
+     wrong-truth values that mask a real regression.  The two
+     techniques are fully implemented and unit-tested; library
+     expansion needs a follow-up operator session running
+     `nav_offset --manual` against star-rich Cassini star-cal,
+     NHLORRI deep-sky, and multi-feature stars+body scenes plus
+     the dialog's **Save as Library Entry...** button.  The
+     autonomous-nav integration test is parameterized by sidecar
+     discovery so the operator-added entries exercise the
+     techniques end-to-end as soon as they land.
+
+### Implementation notes
+
+- **`StarFlags` extended.** `predicted_snr` (raw, uncapped SNR) and
+  `vmag` were added to `StarFlags` so `StarUniqueMatchNav` can rank
+  stars by predicted brightness and compute the magnitude margin
+  to the next-brightest predictable star.  Both fields are
+  populated by `NavModelStars._emit_features` and default to
+  zero / `None` so existing test fixtures and other code paths
+  remain unaffected.
+- **Per-mode confidence cap.** The YAML `confidence_spec` for
+  `StarUniqueMatchNav` ships a single shape; the per-mode caps
+  (0.7 one-star, 0.8 two-star) are applied post-sigmoid inside
+  `StarUniqueMatchNav.navigate`.  This keeps the spec evaluator
+  schema-stable while still respecting the design's mode-driven
+  ceiling.
+- **Local-window detection.** Both techniques use a localised
+  brightness-peak + brightness-weighted-moment centroid inside a
+  per-prediction window (no global `detect_sources` call).  This
+  keeps the techniques feasible on images where the global DAOPHOT
+  pipeline would fail (mostly-empty FOV, very faint secondary
+  stars).
+- **Tunables.** Every numeric tunable for both techniques lives in
+  `config_files/config_510_techniques.yaml` under
+  `techniques.<TechniqueName>.tuning` (search-window size,
+  centroid-box half-width, residual / detection thresholds,
+  per-mode caps, refine-window size, minimum inlier count).
+  No Python-level fallback; missing-key access in `__init__` is a
+  KeyError so a config typo fails fast at process startup.
+
+### Final Phase-7 check matrix
+
+| Check | Status |
+|---|---|
+| `ruff check src tests` | clean |
+| `ruff format --check src tests` | clean (277 files) |
+| `mypy --strict src tests` | clean (278 source files) |
+| `pytest -n auto --dist=loadfile` (unit) | 1183 passed |
+| `sphinx-build -W -b html docs docs/_build` | clean |
+| `pymarkdown scan docs/ .cursor/ README.md CONTRIBUTING.md` | clean |
 
 **Scope (out):** `StarFieldFromCatalogNav` — Phase 8. Camera
 rotation — Phase 9.
@@ -3297,7 +3356,15 @@ rotation — Phase 9.
 
 ---
 
-## Phase 8 — `StarFieldFromCatalogNav`
+## Phase 8 — `StarFieldFromCatalogNav` (complete)
+
+Phase 8 ("star techniques part 2" branch `core_rewrite_phase7`,
+piggy-backing on the same branch as Phase 7) ships the multi-star
+RANSAC pattern matcher. After this phase every star scene
+navigates: 1- and 2-star scenes via Phase 7's `StarUniqueMatchNav`,
+≥ 3-star scenes via the new `StarFieldFromCatalogNav`, and any
+star-bearing scene with a usable pass-1 prior via Phase 7's
+`StarRefineNav`.
 
 **Goal:** Ship the multi-star RANSAC pattern matcher — the long
 pole of the star side. After this phase all star scenes navigate
@@ -3327,15 +3394,68 @@ C. **Sub-piece 3 — RANSAC.** Deterministic seeding (seed from
    RANSAC"). Inlier count + median residual reported in
    `StarFieldDiagnostics`.
 
-D. **Sub-piece 4 — verification.** Procrustes fit
-   (translation + rotation when `fit_camera_rotation` is true;
-   translation-only otherwise). Tukey biweight reweighting
-   (reuse `nav.nav_technique.dt_fitting.tukey_biweight_weights`).
-   Diagnostics via `StarFieldDiagnostics`.
+D. **Sub-piece 4 — verification.** Procrustes fit, translation-only
+   in Phase 8.  Tukey biweight reweighting (reuse
+   `nav.nav_technique.dt_fitting.tukey_biweight_weights`).
+   Diagnostics via `StarFieldDiagnostics`.  The rotation-enabled
+   3-DoF Procrustes path lights up in Phase 9 when
+   `fit_camera_rotation` is enabled per instrument.
 
 E. **Library expansion.** 2–3 dense star fields: Cassini star
    calibration scenes, NHLORRI deep sky. Sidecars + ground truth +
    baselines.
+
+### Implementation notes
+
+- **Self-contained matched-filter detector.** Phase 8 wires a
+  technique-internal source detector that reuses
+  `nav.nav_model.stars.detection.matched_filter_image` plus a
+  Gaussian PSF kernel sized by the
+  `techniques.StarFieldFromCatalogNav.tuning.psf_sigma_px` /
+  `.centroid_box_half_px` knobs.  The richer DAOPHOT-style
+  shape-and-saturation cuts in `detection.detect_sources` stay
+  unused for now: pulling them in requires a `psfmodel.PSF` object
+  and a smear-aware kernel from the obs, which the existing
+  technique-test scaffolding (`FakeObs`) does not expose.  Phase
+  11's cleanup sweep is the natural place to unify the two paths
+  once the integration library exercises the smear / saturated /
+  CCD-bloom regimes that the richer detector handles.
+- **Translation-only Procrustes.**  Phase 8 ships translation-only
+  fitting; the rotation-enabled 3-DoF Procrustes path lights up
+  in Phase 9 when `fit_camera_rotation` is enabled per instrument.
+  The plan-level "Procrustes fit (translation + rotation when
+  `fit_camera_rotation` is true; translation-only otherwise)"
+  wording is therefore implemented as the translation-only branch
+  only; the technique's covariance is a 2x2 per-axis variance
+  derived from the surviving Tukey-weighted residuals.
+- **Determinism by sort.**  Per Part 3 §"Determinism in RANSAC",
+  candidate (det_triplet, cat_triplet) pairs are evaluated
+  exhaustively in sorted order — `(hash_distance ascending,
+  sorted detection-source indices ascending, catalog-triplet index
+  ascending)` — and the matcher's choice of winner is therefore
+  bit-identical across back-to-back invocations on the same obs.
+  The seed derived from `obs.midtime` (via
+  `_seed_from_image_et`) is logged for traceability but the
+  exhaustive sorted iteration means the seed is not load-bearing
+  in Phase 8.
+- **Tunables.** Every numeric tunable for the technique lives in
+  `config_files/config_510_techniques.yaml` under
+  `techniques.StarFieldFromCatalogNav.tuning` (search caps,
+  detection threshold, hash-metric weights, hash match radius,
+  inlier tolerance, min-inlier count).  Missing-key access in
+  `__init__` is a KeyError so a config typo fails fast at process
+  startup.
+
+### Final Phase-7 + Phase-8 check matrix
+
+| Check | Status |
+|---|---|
+| `ruff check src tests` | clean |
+| `ruff format --check src tests` | clean |
+| `mypy --strict src tests` | clean |
+| `pytest -n auto --dist=loadfile` (unit) | passing |
+| `sphinx-build -W -b html docs docs/_build` | clean |
+| `pymarkdown scan docs/ .cursor/ README.md CONTRIBUTING.md` | clean |
 
 **Scope (out):** Camera rotation full enablement — Phase 9.
 Calibration — Phase 10.
@@ -3452,6 +3572,51 @@ D. **Regression baselines for every library image.**
 E. **Manual-nav UI polish.** Save-as-library-entry button shipped
    in Phase 4; finalize any remaining workflow rough edges
    discovered during the bulk library curation.
+
+F. **STAR predicted-SNR unit handling for calibrated images
+   (filed during Phase 7+8 curation, 2026-04-30).**
+   ``nav.nav_model.stars.predicted_snr.integrated_signal_dn`` returns
+   ``2.512 ** -(in_band_mag - 4.0)``, treating the result as a "DN"
+   quantity — but the same number is then plugged into
+
+   ::
+
+       SNR = sig / sqrt(sig + image_noise_sigma**2 * N_aperture)
+
+   where ``image_noise_sigma`` is the per-pixel noise on the
+   ``NavContext`` image (in whatever units the obs returned).  For
+   raw-DN images (e.g. ``_RAW.IMG``) the units agree and SNR is
+   sensible.  For calibrated I/F images
+   (Cassini ISS ``_CALIB.IMG``, NHLORRI ``_red.fit`` post-pipeline,
+   etc.) ``image_noise_sigma`` is in I/F (``~1e-7``) while the
+   "signal" is still DN-equivalent, so SNR collapses to ``√sig`` and
+   every catalog star comes in below the reliability gate's STAR
+   threshold (0.20).  Worked example: W1580760393_1_CALIB
+   (Pleiades, 100 catalog stars in FOV) — autonomous nav fails with
+   ``status=failed / Every feature dropped by the reliability gate``
+   even on a textbook Scenario C frame.
+
+   **Why this lands in Phase 10:** the calibration sweep depends on
+   running ``nav_offset`` autonomously over the library; the library
+   contains both ``_RAW.IMG`` and ``_CALIB.IMG`` entries.  Without
+   the fix, the calibration sweep silently drops every calibrated
+   image and tunes against an unrepresentative subset.
+
+   **Direction.**  Add a per-instrument-per-processing-level
+   ``signal_dn_to_image_unit_scale`` constant (or equivalent —
+   convert ``image_noise_sigma`` to DN-equivalent at NavContext
+   build time) so ``predicted_snr`` operates on a single unit
+   system regardless of whether the obs delivered raw DN or
+   calibrated I/F.  The per-camera ``mag_offset`` knob is for
+   catalog-band → instrument-band correction and is **not** the
+   right knob for this fix.
+
+   **Workaround pre-fix.**  Manual-nav curation
+   (``run_manual_nav`` / ``--manual``) bypasses the reliability
+   gate (``apply_gate=False``) so library sidecars can be created
+   from calibrated images even before the fix lands.  Operator
+   curation per ``PHASE7_LIBRARY_SEED.md`` Scenario C uses this
+   path.
 
 **Scope (out):** Cleanup — Phase 11. Deferred items — Phase 12+.
 

--- a/PHASE7_LIBRARY_SEED.md
+++ b/PHASE7_LIBRARY_SEED.md
@@ -1,0 +1,366 @@
+# Phase 7 + 8 — image library seed (operator instructions)
+
+This file walks an operator through curating the additional library
+entries Phases 7 and 8 call for. The new techniques —
+`StarUniqueMatchNav` (1- or 2-star unique match), `StarRefineNav`
+(pass-2 refinement on the pass-1 prior), and `StarFieldFromCatalogNav`
+(multi-star RANSAC pattern matcher) — ship with end-to-end unit tests
+against synthetic inputs, but the integration regression suite needs
+new sidecars on real images that exercise each star technique against
+real spacecraft data.
+
+The Phase 4 runbook (`PHASE4_LIBRARY_SEED.md`) covers the manual-nav
+workflow, the `Save as Library Entry…` button, the `pds3://` URL
+convention, and the `<image_id>` filename rule. **Read it first.** This
+file only documents the Phase 7 / 8 scenario picks plus the
+technique-specific gotchas for each new feature.
+
+## What's new in Phases 7 + 8
+
+- `StarUniqueMatchNav` consumes 1 or 2 STAR features. The 1-star path
+  fires when the brightest predictable star is at least
+  `brightness_margin_to_next_catalog_star_mag` (default 1.5 mag)
+  brighter than the next-brightest predictable star inside extfov.
+  The 2-star path fires when two predictable stars are present; the
+  technique tries both detection-to-prediction assignments and picks
+  the one whose joint residual is smaller. Confidence is capped at
+  0.7 (1-star) or 0.8 (2-star).
+- `StarRefineNav` runs in pass 2 with the pass-1 ensemble's prior
+  offset attached to `NavContext`. For each predicted catalog star it
+  (i) shifts the prediction by the prior, (ii) finds the brightest
+  peak in a small refinement window, and (iii) returns the
+  inverse-variance-weighted mean of per-star residuals. Stars whose
+  detection sits more than `max_per_star_residual_px` (default 4 px)
+  from the shifted prediction are dropped before the joint average.
+- `StarFieldFromCatalogNav` requires ≥ 3 STAR features. It detects
+  bright sources globally, builds similarity-invariant triplet hashes
+  for both the detection and catalog cohorts, and iterates
+  (det_triplet, cat_triplet) candidate pairs in deterministic order
+  (hash distance ascending → sorted detection-source indices
+  ascending). Each candidate proposes a translation; the winner is the
+  one that scores the most inliers under a per-correspondence
+  tolerance. With the inlier set, the technique refits translation by
+  Tukey-biweight-reweighted least squares.
+
+## What images do these techniques need?
+
+Each technique has a different feasibility envelope, so the curated
+sidecars span four canonical scenarios.
+
+| Scenario | Primary technique | Stars in extfov | Other features | Why |
+|---|---|---|---|---|
+| **A** — Bright single star | `StarUniqueMatchNav` (1-star) | 1 unique-bright (≥ 1.5 mag margin) | None | Simplest path; should hit confidence cap 0.7. |
+| **B** *(optional)* — Two-star translation | `StarUniqueMatchNav` (2-star) | 2 unambiguous | None | Cross-checks the assignment via residual; confidence cap 0.8. |
+| **C** — Star-rich field | `StarFieldFromCatalogNav` | ≥ 6 detectable | None | Triplet matcher should converge to ≥ 6 inliers. |
+| **D** — Stars + body | `StarRefineNav` (pass 2) | ≥ 1 detectable | Body limb (or disc) | A body-fed pass-1 prior lets the refiner sharpen on the lone star. |
+
+**Required sidecars: A, C, D** (one per technique that has a unique
+feasibility envelope).  Scenario A is the cheapest win; Scenario C is
+the highest-value pick because `StarFieldFromCatalogNav` cannot be
+exercised by either of the other two star techniques.
+
+**Scenario B is optional** — see the rationale at the head of its
+section below.  Skipping it does not weaken the regression suite; the
+2-star path is structurally identical to the 1-star path with a
+residual cross-check, and the unit test
+``test_star_unique_match_two_star_recovers_planted_offset`` exercises
+the algorithm end-to-end against a synthetic two-Gaussian fixture.
+
+### Scenario A — Bright single star (`StarUniqueMatchNav` 1-star path)
+
+A Cassini ISS or NHLORRI star-cal frame in which exactly one bright
+catalog star (V ~ 5–7 mag) sits inside the FOV with no body or ring
+in sight. The pointing-error envelope must be small enough that the
+predicted star's `(v, u)` falls within the per-instrument
+`search_window_px` of its planted position (default 30 px on the
+unique-match technique).
+
+| Field | What to look for |
+|---|---|
+| Mission / camera | Cassini ISS NAC; NHLORRI; VGISS (where pointing reconstruction allows) |
+| Star count in FOV | Exactly 1 detectable (catalog-predicted), ≥ 1.5 mag brighter than the next-brightest predictable star |
+| Subject | Star calibration target — Cassini "STAR_CAL" or "BORESIGHT" sequence frames are ideal |
+| Filter | Clear preferred (CL1+CL2 on Cassini); broadband filter on other instruments |
+
+**Sidecar location**:
+`tests/integration/image_library/images/one_bright_star_no_body/<IMAGE_ID>.yaml`
+
+**Expected behavior**:
+
+- `expected.status: ok`
+- `expected.confidence_tier: medium` (placeholder coefficients clamp
+  the 1-star path at 0.7 by design)
+- `expected.primary_technique: StarUniqueMatchNav`
+- `expected.techniques_must_run: [StarUniqueMatchNav]`
+- `expected.techniques_must_skip:` every body / ring / star-field
+  technique on a body-free, single-star scene
+
+### Scenario B *(optional)* — Two-star translation (`StarUniqueMatchNav` 2-star path)
+
+**Why this is optional.**  Real spacecraft frames with **exactly two**
+detectable catalog stars in extfov (and no third predictable star
+within reach of the SNR floor) are surprisingly rare:
+
+- Cassini ISS NAC has a 0.35° FOV; star-cal targets are deliberately
+  one bright star (Vega, Canopus, Spica) so the field around them is
+  usually too sparse to find a second predictable star at all.
+- Cassini ISS WAC has a 3.5° FOV; fields with 2 catalog stars almost
+  always have a third within reach, which kicks the orchestrator over
+  to ``StarFieldFromCatalogNav`` and makes the scene a Scenario C
+  rather than Scenario B.
+- NHLORRI and VGISS narrow-angle deep-sky frames are better hunting
+  grounds, but the search is still mostly manual.
+
+The 2-star path is structurally **identical to the 1-star path with a
+residual cross-check**.  The unit test
+``test_star_unique_match_two_star_recovers_planted_offset`` plants
+two synthetic Gaussian PSFs at known positions, runs the technique,
+and verifies the planted offset is recovered to within 0.4 px.  An
+integration sidecar would re-test the same algorithm against a real
+image — useful for breadth, but not essential when synthetic-fixture
+coverage already exists and the placeholder confidence coefficients
+are a Phase-10 retune target anyway.
+
+**If you do find a real 2-star frame**, the rest of this section
+documents the sidecar shape.  If not, skip it; Scenarios A, C, and D
+are sufficient for the Phase 7 + 8 library seed.
+
+Same posture as Scenario A but with two detectable catalog stars
+inside extfov.  The 2-star path tries both detection-to-prediction
+assignments and picks the smaller-residual fit.
+
+| Field | What to look for |
+|---|---|
+| Mission / camera | Cassini ISS NAC star calibration; NHLORRI deep-sky pointing |
+| Star count in FOV | Exactly 2 detectable; SNRs need not be equal but both must clear the per-instrument detection threshold |
+| Subject | A short or pre-encounter star-cal frame |
+| Filter | Clear |
+
+**Sidecar location**:
+`tests/integration/image_library/images/two_bright_stars_no_body/<IMAGE_ID>.yaml`
+
+**Expected behavior**:
+
+- `expected.status: ok`
+- `expected.confidence_tier: medium` (2-star cap at 0.8)
+- `expected.primary_technique: StarUniqueMatchNav`
+- `expected.techniques_must_run: [StarUniqueMatchNav]`
+- `expected.techniques_must_skip: [StarFieldFromCatalogNav, ...]`
+  (`StarFieldFromCatalogNav` is mutually exclusive at feasibility time;
+  it returns infeasible for fewer than 3 predictable stars).
+
+### Scenario C — Star-rich field (`StarFieldFromCatalogNav`)
+
+A dense star field — typically a Cassini ISS NAC star calibration
+mosaic frame near the galactic plane, or an NHLORRI deep-sky frame
+on the way to Pluto. The matcher needs ≥ 6 inlier correspondences for
+a clean `expected.status: ok`.
+
+| Field | What to look for |
+|---|---|
+| Mission / camera | Cassini ISS NAC (star-cal); NHLORRI; long-exposure VGISS NA |
+| Detectable catalog stars | ≥ 6 inside extfov, with predicted SNRs that clear the detection threshold |
+| Subject | Pure star field — no body or ring visible (a faint distant moon is acceptable but adds a competing technique) |
+| Background | Dark sky |
+| Filter | Clear preferred; long-exposure pointing-cal frames work well |
+
+**Sidecar location**:
+`tests/integration/image_library/images/star_dominated/<IMAGE_ID>.yaml`
+
+(``star_dominated`` is the dense-star-field scene class.  Use
+``faint_stars`` instead if the scene is dominated by 6+ faint
+catalog stars rather than a smaller cohort of bright ones.)
+
+**Expected behavior**:
+
+- `expected.status: ok`
+- `expected.confidence_tier: medium` to `high` (the matcher's
+  `n_inliers` term saturates at 6 inliers in the placeholder
+  coefficients)
+- `expected.primary_technique: StarFieldFromCatalogNav`
+- `expected.techniques_must_run: [StarFieldFromCatalogNav]`
+- `expected.techniques_must_skip: [StarUniqueMatchNav, ...]`
+  (`StarUniqueMatchNav` is mutually exclusive: with ≥ 3 unambiguous
+  catalog stars the brightness-margin gate fails and the technique
+  reports `enough_stars_for_triplet_match`-equivalent infeasibility.)
+
+### Scenario D — Stars + body (`StarRefineNav` pass-2 refinement)
+
+A stars-plus-body scene in which the body fit (limb / terminator /
+disc) supplies the pass-1 prior and `StarRefineNav` sharpens it on the
+1–2 predictable catalog stars also in the FOV. This is the prior-
+required path; `StarRefineNav` cannot run from a zero prior.
+
+| Field | What to look for |
+|---|---|
+| Mission / camera | Cassini ISS NAC (Saturn approach phase frames with a star nearby); NHLORRI Pluto encounter approach |
+| Body | One body in FOV with a fittable limb or disc (favor a sharp lit limb) |
+| Star count | ≥ 1 catalog-predicted star inside extfov, NOT inside the body silhouette |
+| Filter | Whatever the body fit prefers (typically Clear) |
+
+**Sidecar location**: `tests/integration/image_library/images/<scene_class>/<IMAGE_ID>.yaml`
+
+Where `<scene_class>` is the body-side scene class (e.g.
+`body_only_limb_curved`); the sidecar's `expected.techniques_must_run`
+list pins both the body technique AND `StarRefineNav` so the
+regression test verifies pass 2 fires.
+
+**Expected behavior**:
+
+- `expected.status: ok` (the body technique typically wins on
+  confidence; `StarRefineNav` enters the ensemble in pass 2 and
+  cross-validates the body fit).
+- `expected.confidence_tier: medium` to `high`
+- `expected.primary_technique:` whichever body technique wins (limb /
+  terminator / disc)
+- `expected.techniques_must_run:` list both the body technique AND
+  `StarRefineNav` — this is the only sidecar that pins pass 2
+  invocation.
+- `expected.techniques_must_skip:` every technique that does not
+  feasibly fire (e.g. `RingAnnulusNav` on a body-only scene).
+
+## Workflow per image
+
+Same as the Phase 4 runbook (steps 1–7) — load the image with
+`nav_offset --manual <image_list_file>`, align by hand in the
+manual-nav dialog, click `Save as Library Entry…`, edit the
+`TODO_REPLACE_*` placeholders, and drop the file under the correct
+scene-class directory.
+
+For Phases 7 / 8 specifically:
+
+- **Star-only scenes (A, B, C).** The dialog overlay paints predicted
+  catalog stars as small crosses; verify visually that each predicted
+  cross sits within ~1 px of a detectable bright pixel before
+  accepting the offset.
+- **Stars + body scene (D).** The dialog overlays both the body
+  feature (limb polyline / disc template) and the predicted star
+  cross. Align the body first (the body fit dominates the operator's
+  perception of "right"); the predicted star should fall within a
+  pixel of its image position once the body offset is right.
+
+After the sidecar lands, run:
+
+```bash
+pytest tests/integration/test_image_library.py -v
+pytest tests/integration/test_autonomous_nav.py -v -k <IMAGE_ID>
+```
+
+Both must pass before you commit.
+
+## Sidecar template
+
+The `Save as Library Entry…` button writes a stub like the one below;
+fill the `TODO_REPLACE_*` slots from the dialog's reported values.
+The example below is a Scenario C star-rich field; adjust
+`expected.primary_technique` / `expected.techniques_must_run` to match
+the scenario.
+
+```yaml
+schema_version: 1
+image_id: <IMAGE_ID>                       # e.g. N1450122031_1_CALIB
+mission: CASSINI_ISS                       # CASSINI_ISS | VOYAGER_ISS | GOSSI | NHLORRI
+camera: NAC                                # NAC | WAC | SSI | NA | WA | LORRI
+filter_combo: 'CL1+CL2'                    # canonicalized: filters sorted, '+'-joined
+image_url: 'pds3://...'                    # path under PDS3_HOLDINGS_DIR
+
+scene_tags:
+  - star_dominated                         # primary scene class — must match the directory
+
+ground_truth:
+  offset_dv_px: TODO_REPLACE_DV            # operator-verified, in extfov px
+  offset_du_px: TODO_REPLACE_DU
+  offset_uncertainty_px: 1.0               # 1sigma; tighten for star-rich fields
+  source: operator_verified
+  operator: <username>
+  verified_date: 2026-04-30                # YYYY-MM-DD
+  ui_version: 'rms-nav 0.1.devXX'
+  notes: |
+    Star calibration field. Eight detectable catalog stars inside
+    extfov; StarFieldFromCatalogNav recovers the planted offset by
+    triplet pattern matching. Phase-8 status: matcher converges to
+    (TODO, TODO), within TODO px of the operator's ground truth.
+    Confidence coefficients are placeholders pending Phase 10
+    calibration; the expected.confidence_tier below pins today's
+    behavior.
+
+expected:
+  status: ok                               # ok | failed | conflicted
+  confidence_tier: medium                  # high | medium | low | failed | conflicted
+  primary_technique: StarFieldFromCatalogNav
+  techniques_must_run: [StarFieldFromCatalogNav]
+  techniques_must_skip:
+    - BodyDiscCorrelateNav
+    - BodyBlobNav
+    - BodyLimbNav
+    - BodyTerminatorNav
+    - RingAnnulusNav
+    - RingEdgeNav
+    - StarUniqueMatchNav
+```
+
+### Field-by-field guidance
+
+- **`offset_dv_px` / `offset_du_px`**: The dialog reports the operator's
+  picked offset as `(dv, du)` in extfov pixels. Convention: predicted
+  position `(v, u)` means actual position is `(v + dv, u + du)`. Round
+  to 4 decimal places (the regression-test baseline rule).
+- **`offset_uncertainty_px`**: 1 sigma marginal in pixels. Star-rich
+  scenes typically support 0.3–0.5 px uncertainty (per-star centroid
+  uncertainty is ~0.1 px and the joint translation averages many
+  of those); single- or two-star scenes drop to 0.5–1.0 px because
+  the centroid noise floor is larger relative to the constraint.
+- **`expected.status`**: `ok` if the orchestrator returns a usable
+  offset (combined confidence above `min_confidence`); `failed` if it
+  reports `status=failed` with the right reason (the placeholder
+  confidence formula often pushes the headline below
+  `min_confidence` even when the answer is correct — record honestly,
+  exactly as Phase 4 did with `ring_only_curved/N1492091163`). If
+  `status: failed` is recorded, set `confidence_tier: failed` to
+  satisfy the schema's cross-check.
+- **`techniques_must_skip`**: List every technique you expect *not* to
+  run on this scene — typically every body / ring technique on a
+  body-free star scene, plus the mutually-exclusive star technique
+  (`StarUniqueMatchNav` is infeasible when ≥ 3 unambiguous catalog
+  stars are present; `StarFieldFromCatalogNav` is infeasible when <
+  3 predictable stars are inside extfov).
+
+## Confidence-formula calibration deferred
+
+Phases 7 and 8 ship placeholder coefficients on every star
+technique's confidence spec (now living in
+`config_510_techniques.yaml.techniques.<TechniqueName>`, not the old
+per-module Python constants). Phase 10 (image-library expansion +
+confidence calibration) is when the alphas get retuned against the
+full ~50-image library. Until then, expect the new sidecars to need
+conservative `expected.confidence_tier` values:
+
+- `StarUniqueMatchNav` 1-star: capped at 0.7 by design — record `medium`.
+- `StarUniqueMatchNav` 2-star: capped at 0.8 by design — record `medium`.
+- `StarRefineNav`: dominated by `n_stars_used` and `residual_scatter_px`.
+  A clean refinement on 2–3 inliers should land in the `medium` tier;
+  a single-inlier refinement on a soft star may fall to `low`.
+- `StarFieldFromCatalogNav`: dominated by `n_inliers`. The placeholder
+  coefficients saturate the term at 6 inliers; expect `medium` for
+  6–8 inliers and `high` once the technique sees a 10+ inlier match.
+
+Record the actual orchestrator-reported tier in your sidecar's
+`expected.confidence_tier` and let the regression test pin today's
+behavior. When Phase 10 retunes the coefficients in
+`config_510_techniques.yaml` the sidecars will need a corresponding
+`expected.confidence_tier` bump; that's a bookkeeping pass, not a
+re-curation.
+
+## After the seed lands
+
+- The new sidecars enter the regression suite the moment they are
+  committed; CI runs them on every PR via the `integration` mark
+  (gated on `PDS3_HOLDINGS_DIR` etc.).
+- For each `expected.status: ok` sidecar, seed a baseline JSON under
+  `tests/integration/baselines/<IMAGE_ID>.json` so any orchestrator
+  drift trips the byte-level regression test.
+- Phase 7 / 8 follow-ups uncovered during integration runs (e.g. a
+  per-instrument `psf_sigma_px` value that calibration will need to
+  retune, or a `pattern_match_min_inliers` threshold that needs
+  bumping per instrument) belong in `AUTONAV_PLAN.md` under the
+  Phase 7 / 8 follow-ups subsection.

--- a/docs/developer_guide_navigation_models_stars.rst
+++ b/docs/developer_guide_navigation_models_stars.rst
@@ -9,10 +9,11 @@ fall in the extended FOV.  Each feature carries a
 Cramer-Rao centroid covariance, a predicted-SNR-driven reliability
 score, and a :class:`~nav.feature.flags.StarFlags` block with
 ``saturated``, ``smear_length_px``, ``in_body_silhouette``, and
-``in_saturation_or_cosmic_mask`` fields.  Two techniques consume STAR
+``in_saturation_or_cosmic_mask`` fields.  Three techniques consume STAR
 features: ``StarFieldFromCatalogNav`` (similarity-invariant triplet
-pattern match) and ``StarUniqueMatchNav`` (catalog-uniqueness 1- or
-2-star match).
+pattern match for ≥ 3 stars), ``StarUniqueMatchNav`` (catalog-uniqueness
+1- or 2-star match), and ``StarRefineNav`` (pass-2 refinement on a
+prior offset).
 
 The :mod:`nav.nav_model.stars` package is split by responsibility:
 

--- a/docs/developer_guide_techniques.rst
+++ b/docs/developer_guide_techniques.rst
@@ -393,6 +393,139 @@ Infeasibility cases:
 
 - No input feature carries a template.
 
+Star techniques
+===============
+
+Three techniques consume STAR features.  Each runs against a different
+star-count regime, and the orchestrator picks per scene by feasibility
+gates.
+
+StarUniqueMatchNav
+------------------
+
+Accepts ``STAR`` features.  Runs in pass 1 (no prior required).  Two
+paths share one technique:
+
+- **One-star path.** When the catalog reduction yields one star whose
+  predicted SNR is at least
+  ``brightness_margin_to_next_catalog_star_mag`` (default 1.5 mag)
+  brighter than the next-brightest predictable star, the brightest
+  detection inside its search window is unambiguously its match.  The
+  offset is the centroid minus the prediction; confidence is capped
+  at ``one_star_confidence_cap`` (default 0.7).
+- **Two-star path.**  With two predictable stars, the technique tries
+  both detection-to-prediction assignments and picks the one whose
+  joint residual is smaller.  Confidence is capped at
+  ``two_star_confidence_cap`` (default 0.8).
+
+``is_feasible`` returns True when at least one usable STAR feature is
+present (occluded / cosmic-ray-masked stars are filtered out
+upstream).  The technique uses a localised brightness-peak +
+brightness-weighted-moment centroid inside a per-prediction window; no
+global ``detect_sources`` call is needed.
+
+StarRefineNav
+-------------
+
+Accepts ``STAR`` features.  Runs in pass 2 (``requires_prior=True``).
+For each predicted catalog star, the technique:
+
+1. Shifts the prediction by the prior offset.
+2. Looks for a brightness peak in a small refine window around the
+   shifted prediction.
+3. Fits a brightness-weighted moment for the sub-pixel centroid.
+4. Computes per-star residuals and averages them in inverse-variance
+   fashion.
+
+Stars whose detection sits more than ``max_per_star_residual_px`` from
+the shifted prediction are dropped before the joint average.  The
+refined offset is reported as ``delta + prior_offset`` (the ensemble
+combine sees the absolute offset).  The covariance reflects the
+residual scatter across surviving stars; with two or more inliers the
+technique reports the actual scatter, with one inlier the per-feature
+CRLB floor.
+
+StarFieldFromCatalogNav
+-----------------------
+
+Accepts ``STAR`` features.  Runs in pass 1 (no prior required).
+Requires at least three usable STAR features.  Algorithm:
+
+1. **Source detection.** Matched-filter the image against a Gaussian
+   PSF kernel sized by ``psf_sigma_px`` /
+   ``centroid_box_half_px``; pixels that are local maxima above
+   ``detection_sigma * image_noise_sigma`` clear the gate.  Each
+   surviving peak contributes a brightness-weighted moment centroid.
+   The brightest ``max_sources`` (default 30) survivors feed the
+   matcher; the cap keeps the M^3 triplet enumeration bounded.
+2. **Triplet hashing.**  For each unordered triplet of detected
+   sources ``{A, B, C}`` with ``A`` brightest, the hash
+   ``(d_AB / d_AC, d_BC / d_AC, ∠BAC)`` is computed.  The same
+   canonicalisation runs on catalog triplets, ranked by predicted
+   SNR.  All three hash components are similarity-invariant
+   (translation, rotation, uniform scale), so the matcher recovers
+   correspondences without already knowing the transform.
+3. **RANSAC.**  Each (det_triplet, cat_triplet) candidate within
+   ``hash_match_tolerance`` (weighted Euclidean in the hash space)
+   proposes the translation
+   ``mean(detection_vertices) - mean(catalog_vertices)``.  Candidates
+   are evaluated in deterministic sorted order — ``(hash_distance
+   ascending, sorted detection-source indices ascending,
+   catalog-triplet index ascending)`` — so the matcher's choice of
+   winner is bit-identical across two back-to-back invocations on
+   the same obs (Cardinal Principle 3, Part 3 §"Determinism in
+   RANSAC").  Inlier count is the score; the winner needs at least
+   ``pattern_match_min_inliers`` (default 6).
+4. **Verification.**  With the winning inlier correspondences, a
+   Tukey-biweight-reweighted weighted least-squares mean refits the
+   translation; the per-axis variance of the surviving residuals is
+   the reported covariance.
+
+``is_feasible`` returns True when ≥ 3 usable STAR features are
+present (below that the matcher cannot form a triplet).
+``StarUniqueMatchNav`` and ``StarFieldFromCatalogNav`` are mutually
+exclusive at feasibility time: 1–2 predictable stars favour the
+unique-match path, ≥ 3 favour the triplet matcher.
+
+Phase 8 ships translation-only fitting; the rotation-enabled
+3-DoF Procrustes path lights up in Phase 9 when
+``fit_camera_rotation`` is enabled per instrument.
+
+Confidence spec coefficients (placeholders pending Phase 10
+calibration against the operator-curated image library):
+
+- ``alpha0 = -2``
+- ``alpha((n_inliers - 6) / 6, capped at 1) = 1``
+- ``alpha(median_residual_px) = -1``
+- ``alpha(n_detected_sources / 30, capped at 1) = 0`` — wired in but
+  disabled until calibration tunes the alpha
+- ``alpha(n_catalog_predicted / 30, capped at 1) = 0`` — wired in but
+  disabled until calibration tunes the alpha
+- hard zero when ``at_edge`` or ``spurious``
+
+The coefficients live in
+``src/nav/config_files/config_510_techniques.yaml`` under
+``techniques.StarFieldFromCatalogNav`` and are loaded into
+``ConfidenceSpec`` at config-load time by
+:func:`nav.nav_technique.confidence_config.load_confidence_spec`.
+
+Diagnostics fields:
+
+- ``n_inliers``: surviving detection-to-catalog correspondences after
+  the Tukey refit.
+- ``median_residual_px``: median Euclidean residual on the inliers.
+- ``n_detected_sources``: bright peaks the detector kept (capped at
+  ``max_sources``).
+- ``n_catalog_predicted``: catalog stars the matcher considered (also
+  capped at ``max_sources``).
+- ``n_triplets_evaluated``: candidate (det_triplet, cat_triplet)
+  pairs whose hash distance fell within the match tolerance.
+
+Infeasibility cases:
+
+- Fewer than three usable STAR features (the matcher cannot form a
+  triplet).
+
 Body-extractor emission gate
 ============================
 

--- a/docs/introduction_configuration.rst
+++ b/docs/introduction_configuration.rst
@@ -130,7 +130,8 @@ The legacy ``general.log_level_nav_correlate_all`` knob is retained for
 backwards compatibility with any user config files that still set it but
 the autonomous techniques (``BodyDiscCorrelateNav``, ``BodyBlobNav``,
 ``BodyLimbNav``, ``BodyTerminatorNav``, ``RingEdgeNav``,
-``RingAnnulusNav``) do not consult it.
+``RingAnnulusNav``, ``StarUniqueMatchNav``, ``StarRefineNav``,
+``StarFieldFromCatalogNav``) do not consult it.
 
 **Annotation**:
 

--- a/docs/user_guide_navigation.rst
+++ b/docs/user_guide_navigation.rst
@@ -457,21 +457,6 @@ Programmatic equivalent (one obs in, ``NavTechniqueResult`` out):
 
    result = run_manual_nav(obs)
 
-Pending techniques (not yet shipped)
--------------------------------------
-
-The following techniques are designed and have stub diagnostics in
-place; their concrete implementations are pending.
-
-* ``StarFieldFromCatalogNav`` -- triplet-hash + RANSAC pattern match for
-  star-rich frames.
-* ``StarUniqueMatchNav`` -- direct catalog-uniqueness match for sparse
-  star fields with one or two bright stars.
-* ``StarRefineNav`` -- prior-refining single-star polish (pass-2).
-
-Until these land, scenes whose only viable feature type is ``STAR`` will
-report ``status_reason=no_feasible_techniques``.
-
 Filtering examples
 ------------------
 

--- a/docs/user_guide_navigation.rst
+++ b/docs/user_guide_navigation.rst
@@ -133,10 +133,9 @@ Navigation options
 * ``--nav-techniques LIST``: a comma-separated glob-pattern list selecting
   which registered ``NavTechnique`` subclasses run.  Implemented techniques
   today are ``BodyDiscCorrelateNav``, ``BodyBlobNav``, ``BodyLimbNav``,
-  ``BodyTerminatorNav``, ``RingAnnulusNav``, and ``RingEdgeNav``; the
-  star techniques (``StarFieldFromCatalogNav``, ``StarUniqueMatchNav``,
-  ``StarRefineNav``) are planned but not yet shipped.  Defaults to ``*``
-  (all registered
+  ``BodyTerminatorNav``, ``RingAnnulusNav``, ``RingEdgeNav``,
+  ``StarUniqueMatchNav``, ``StarRefineNav``, and
+  ``StarFieldFromCatalogNav``.  Defaults to ``*`` (all registered
   techniques run); a leading ``!`` excludes a pattern (e.g.
   ``--nav-techniques '!RingEdgeNav'`` runs every technique except the
   ring-edge fitter).  Multiple feasible techniques run in parallel and the

--- a/src/nav/config_files/config_510_techniques.yaml
+++ b/src/nav/config_files/config_510_techniques.yaml
@@ -84,6 +84,10 @@ techniques:
     # fit, so the technique cannot drive the ensemble past 0.4
     # confidence even when every term saturates.
     hard_cap: 0.4
+    tuning:
+      # Pixels of slack around the search-window axis bounds for the
+      # at-edge check.  See ``RingEdgeNav.at_edge_tolerance_px``.
+      at_edge_tolerance_px: 1.0
 
   BodyLimbNav:
     alpha0: -1.0
@@ -116,6 +120,9 @@ techniques:
       # off the true limb onto internal-body features (crater rims,
       # terminator, surface boundaries) — flag spurious.
       spurious_min_inlier_fraction: 0.05
+      # Pixels of slack around the search-window axis bounds for the
+      # at-edge check.  See ``RingEdgeNav.at_edge_tolerance_px``.
+      at_edge_tolerance_px: 1.0
 
   BodyTerminatorNav:
     alpha0: -1.0
@@ -148,6 +155,9 @@ techniques:
       # Below this Tukey-inlier count the M-estimator covariance is
       # no longer informative.
       spurious_min_inliers: 6
+      # Pixels of slack around the search-window axis bounds for the
+      # at-edge check.  See ``RingEdgeNav.at_edge_tolerance_px``.
+      at_edge_tolerance_px: 1.0
 
   RingEdgeNav:
     alpha0: -1.0
@@ -176,6 +186,178 @@ techniques:
       # Below this Tukey-inlier count the M-estimator covariance is no
       # longer informative.
       spurious_min_inliers: 6
+
+  StarUniqueMatchNav:
+    # The 1-star path is capped at 0.7 inside the technique (single match
+    # cannot self-check); the 2-star path is capped at 0.8 (residual
+    # cross-checks the assignment).  YAML alpha shape is identical for
+    # both paths; the cap is applied post-sigmoid in
+    # ``StarUniqueMatchNav.navigate``.
+    alpha0: -1.0
+    terms:
+      # Higher predicted SNR shrinks the centroid CRLB and tightens the
+      # match.  Saturate near snr=20 (typical bright catalog star).
+      - feature: predicted_snr
+        alpha: 1.0
+        divisor: 20.0
+        cap_at: 1.0
+      # Magnitude margin to the next-brightest predictable star in the
+      # extfov.  Below the 1.5 mag floor the technique short-circuits
+      # before reaching the formula; above the floor, additional margin
+      # earns confidence up to a 1.5 mag span.
+      - feature: brightness_margin_mag
+        alpha: 1.0
+        offset: 1.5
+        divisor: 1.5
+        cap_at: 1.0
+      # Larger residuals between the matched detection and the prediction
+      # pull confidence down.
+      - feature: residual_px
+        alpha: -1.0
+        divisor: 2.0
+    hard_zero_if:
+      at_edge: true
+      spurious: true
+    tuning:
+      # Minimum magnitude difference to the next-brightest predictable
+      # star for the 1-star path to fire.
+      brightness_margin_to_next_catalog_star_mag: 1.5
+      # Half-width of the search window around each prediction (px).
+      # Should bracket the per-instrument SPICE pointing-error envelope
+      # so the brightest peak in the window is the matched detection.
+      search_window_px: 30.0
+      # Centroid box half-width around the brightness peak (px).
+      centroid_box_half_px: 3
+      # Maximum allowed best-assignment residual in the 2-star path
+      # before falling back to the 1-star path.
+      max_residual_px: 4.0
+      # Detection-threshold multiplier on image_noise_sigma; below this
+      # the brightest pixel inside the search window is considered noise.
+      detection_sigma: 4.0
+      # Per-mode caps applied post-sigmoid; the 1-star path cannot
+      # self-check, so its cap is lower than the 2-star path's.
+      one_star_confidence_cap: 0.7
+      two_star_confidence_cap: 0.8
+      # Pixels of slack around the search-window axis bounds for the
+      # at-edge check.  A converged offset whose absolute distance from
+      # any axis bound (+/-margin_v, +/-margin_u) falls within this
+      # tolerance is flagged ``at_edge=True`` and forced to zero
+      # confidence by the technique's ``hard_zero_if`` gate.  Matches
+      # the bilinear-DT half-cell width used elsewhere in the pipeline.
+      at_edge_tolerance_px: 1.0
+
+  StarRefineNav:
+    # Pass-2 refinement on the pass-1 ensemble's prior offset.  Tighter
+    # alphas than the unique-match path because every surviving inlier
+    # contributes independent evidence.
+    alpha0: -1.0
+    terms:
+      # More inliers => more independent constraints; saturate at 5.
+      - feature: n_stars_used
+        alpha: 1.0
+        divisor: 5.0
+        cap_at: 1.0
+      # Lower median per-star error => tighter refinement.
+      - feature: median_pos_err_px
+        alpha: -1.0
+        divisor: 1.0
+      # Lower per-axis scatter => internally consistent fit.
+      - feature: residual_scatter_px
+        alpha: -1.0
+        divisor: 1.0
+    hard_zero_if:
+      at_edge: true
+      spurious: true
+    tuning:
+      # Half-width of the per-star refine window (px).  Tighter than the
+      # unique-match search window because the pass-1 prior already put
+      # us within a few pixels of the right answer.
+      refine_window_px: 6.0
+      # Centroid box half-width around the brightness peak (px).
+      centroid_box_half_px: 3
+      # Drop a star whose detection sits more than this many pixels from
+      # the prior-shifted prediction; almost certainly a wrong peak.
+      max_per_star_residual_px: 4.0
+      # Detection-threshold multiplier on image_noise_sigma.
+      detection_sigma: 4.0
+      # Below this many surviving inliers the technique reports spurious.
+      min_inliers: 1
+      # Pixels of slack around the search-window axis bounds for the
+      # at-edge check (see StarUniqueMatchNav.at_edge_tolerance_px).
+      at_edge_tolerance_px: 1.0
+      # Post-sigmoid confidence cap when the refine fit had only one
+      # inlier.  A 1-star refine adds no independent cross-check
+      # information beyond the prior it was handed (the same single
+      # observation that drove the pass-1 fit), so its confidence
+      # ceiling is set lower than ``StarUniqueMatchNav``'s 0.7 1-star
+      # cap.  The ensemble's primary-technique selection therefore
+      # cannot promote a 1-star refine over a 1-star unique-match on
+      # the same observation.  Phase 10 calibration may retune the
+      # numeric value; the structural cap stays.
+      single_inlier_confidence_cap: 0.5
+
+  StarFieldFromCatalogNav:
+    # Multi-star RANSAC pattern matcher.  Confidence is dominated by
+    # ``n_inliers`` (more matched stars => stronger constraint) and is
+    # pulled down by residual scatter.  The ``n_detected_sources`` and
+    # ``n_catalog_predicted`` terms ride alpha=0.0 pending Phase 10
+    # calibration; the wiring is in place so a sweep can tune them
+    # without code changes.
+    alpha0: -2.0
+    terms:
+      - feature: n_inliers
+        alpha: 1.0
+        offset: 6.0
+        divisor: 6.0
+        cap_at: 1.0
+      - feature: median_residual_px
+        alpha: -1.0
+        divisor: 1.0
+      - feature: n_detected_sources
+        alpha: 0.0
+        divisor: 30.0
+        cap_at: 1.0
+      - feature: n_catalog_predicted
+        alpha: 0.0
+        divisor: 30.0
+        cap_at: 1.0
+    hard_zero_if:
+      at_edge: true
+      spurious: true
+    tuning:
+      # Maximum number of brightest detected sources / brightest
+      # catalog stars to feed the matcher.  Triplet count is M^3, so
+      # 30 keeps the candidate list bounded (~27K triplets per side).
+      max_sources: 30
+      # Detection-threshold multiplier on image_noise_sigma.
+      detection_sigma: 4.0
+      # Gaussian PSF sigma (px) used for the matched-filter kernel.
+      # Matches the typical ungroomed star PSF; per-instrument
+      # overrides arrive in Phase 9 / 10 once the integration library
+      # exercises the full instrument set.
+      psf_sigma_px: 1.0
+      # Centroid box half-width around each detection peak (px).
+      centroid_box_half_px: 3
+      # KD-tree match radius in the (ratio, ratio, angle_rad) hash
+      # space; weighted Euclidean.  0.05 is the empirical default for
+      # centroid sigma ~0.1 px against typical triplet scales (Part 3
+      # §"Algorithm specifics").
+      hash_match_tolerance: 0.05
+      # Per-axis weights in the hash distance metric.  Radians and
+      # dimensionless ratios are roughly comparable in magnitude over
+      # the typical triplet shapes; both default to 1.0.
+      hash_ratio_weight: 1.0
+      hash_angle_weight: 1.0
+      # Maximum residual (px) for a detection-to-catalog
+      # correspondence to count as an inlier under a candidate
+      # transform.
+      inlier_tolerance_px: 2.0
+      # Minimum inlier count for the matcher to accept a transform;
+      # below this the technique returns spurious.
+      pattern_match_min_inliers: 6
+      # Pixels of slack around the search-window axis bounds for the
+      # at-edge check (see StarUniqueMatchNav.at_edge_tolerance_px).
+      at_edge_tolerance_px: 1.0
 
   RingAnnulusNav:
     alpha0: -2.0

--- a/src/nav/feature/composition.py
+++ b/src/nav/feature/composition.py
@@ -21,11 +21,23 @@ from __future__ import annotations
 import numpy as np
 
 from nav.feature.feature import NavFeature
-from nav.feature.geometry import BodyBlobGeometry
-from nav.support.image import draw_circle
+from nav.feature.geometry import BodyBlobGeometry, StarGeometry
+from nav.support.image import draw_circle, draw_rect
 from nav.support.types import NDArrayBoolType, NDArrayFloatType
 
 __all__ = ['compose_dialog_overlay', 'compose_template_features']
+
+
+_STAR_MARKER_HALFWIDTH_PX_FLOOR: int = 3
+"""Minimum half-width of the rectangle marker drawn around a STAR feature.
+
+The dialog overlay paints a rectangle outline at each STAR's predicted
+position so the operator can see where the catalog says the star sits
+before they click on the actual bright pixel.  The rectangle's
+half-width is the larger of the feature's per-axis bbox half-extent
+and this floor, so a tightly-bbox'd star (e.g. PSF sigma < 1 px) still
+gets a visible 7x7 outline rather than collapsing to a single pixel.
+"""
 
 
 def compose_template_features(
@@ -94,16 +106,24 @@ def compose_dialog_overlay(
 
     Starts from :func:`compose_template_features` (BODY_DISC,
     RING_ANNULUS, CARTOGRAPHIC_MODEL templates) and additionally
-    rasterizes every polyline-bearing feature's ``vertices_vu`` as
-    single-pixel marks so an operator can manually align scenes whose
-    only emitted features are limbs, terminators, or ring edges.  The
-    polyline rasterization is intentionally minimal — it is a visibility
-    aid, not a precise renderer; the autonomous DT pipeline owns the
-    quantitative fit.
+    rasterizes:
 
-    Vertices that fall outside the ext-FOV bounds are silently dropped
-    (the polyline samplers can hand back partially-clipped polylines
-    near the FOV edge).
+    - every polyline-bearing feature's ``vertices_vu`` as single-pixel
+      marks (LIMB_ARC, TERMINATOR_ARC, RING_EDGE);
+    - every BODY_BLOB's predicted-diameter circle outline at the
+      predicted centroid;
+    - every STAR feature's bbox as a rectangle outline at the
+      predicted-vu position so the operator can manually align
+      catalog stars with the observed bright pixels.
+
+    All rasterization is intentionally minimal — it is a visibility
+    aid, not a precise renderer; the autonomous DT / RANSAC pipeline
+    owns the quantitative fit.
+
+    Vertices and markers that fall outside the ext-FOV bounds are
+    silently dropped (the polyline samplers can hand back
+    partially-clipped polylines near the FOV edge; star markers near
+    the FOV edge are clipped to the visible portion).
 
     Parameters:
         features: The feature list (templated + polyline + plain).
@@ -112,7 +132,8 @@ def compose_dialog_overlay(
     Returns:
         Tuple ``(image, mask)`` where ``image`` is float64 in ext-FOV
         coordinates and ``mask`` is a boolean array of the same shape.
-        Every painted pixel (template *or* polyline) is True in the mask.
+        Every painted pixel (template *or* polyline *or* marker) is
+        True in the mask.
     """
     image, mask = compose_template_features(features, extfov_shape_vu)
     h, w = extfov_shape_vu
@@ -146,7 +167,53 @@ def compose_dialog_overlay(
             u_int = round(u_center)
             draw_circle(image, 1.0, u_int, v_int, radius_px)
             draw_circle(mask, True, u_int, v_int, radius_px)
+        # 3) StarGeometry carries only a predicted (v, u) point and a
+        #    PSF-sized bbox.  Render a rectangle outline around the
+        #    bbox so the operator can see where the catalog says the
+        #    star sits before clicking on the actual peak.
+        if isinstance(feature.geometry, StarGeometry):
+            _paint_star_marker(image, mask, feature.geometry, extfov_shape_vu)
     return image, mask
+
+
+def _paint_star_marker(
+    image: NDArrayFloatType,
+    mask: NDArrayBoolType,
+    geometry: StarGeometry,
+    extfov_shape_vu: tuple[int, int],
+) -> None:
+    """Paint a rectangle outline around a STAR feature's predicted bbox.
+
+    ``draw_rect`` does not clip on the array bounds — partial-FOV
+    rectangles get truncated by the slice operations, but a center
+    that is far enough off-image that the rectangle is entirely
+    out-of-bounds is silently a no-op.  A center close enough to an
+    edge that part of the rectangle would index negatively is the
+    risky case; the explicit half-width clamp below keeps every drawn
+    pixel inside the array.
+    """
+    h, w = extfov_shape_vu
+    v_center, u_center = geometry.predicted_vu
+    v_int = round(v_center)
+    u_int = round(u_center)
+    if v_int < 0 or v_int >= h or u_int < 0 or u_int >= w:
+        return  # marker centre off-image; no painting
+    v_min, u_min, v_max, u_max = geometry.bbox_extfov_vu
+    # The bbox is half-open, so its half-extent is one less than the
+    # diff.  Clamp to a visible-marker floor and also to the largest
+    # half-width that keeps every rectangle pixel inside the FOV.
+    v_half = max(_STAR_MARKER_HALFWIDTH_PX_FLOOR, ((v_max - v_min) // 2) - 1)
+    u_half = max(_STAR_MARKER_HALFWIDTH_PX_FLOOR, ((u_max - u_min) // 2) - 1)
+    v_half = min(v_half, v_int, h - 1 - v_int)
+    u_half = min(u_half, u_int, w - 1 - u_int)
+    if v_half <= 0 or u_half <= 0:
+        # Edge-tight: fall back to a single pixel at the predicted
+        # position rather than emit no marker at all.
+        image[v_int, u_int] = 1.0
+        mask[v_int, u_int] = True
+        return
+    draw_rect(image, 1.0, u_int, v_int, u_half, v_half)
+    draw_rect(mask, True, u_int, v_int, u_half, v_half)
 
 
 def _bbox_clamped(

--- a/src/nav/feature/flags.py
+++ b/src/nav/feature/flags.py
@@ -36,17 +36,29 @@ class StarFlags:
             a predicted body silhouette in extfov.
         in_saturation_or_cosmic_mask: True if the predicted star position
             falls inside a saturation or cosmic-ray mask pixel.
+        predicted_snr: Predicted integrated SNR for the catalog star (raw,
+            uncapped).  Consumed by ``StarUniqueMatchNav`` to rank stars
+            by predicted brightness when picking the unique-bright pair.
+            ``0.0`` for fixtures or features whose model did not populate
+            it.  Must be ``>= 0``.
+        vmag: Catalog V-band magnitude of the star, or ``None`` when the
+            catalog entry has no magnitude.  Used by ``StarUniqueMatchNav``
+            to compute the magnitude margin to the next-brightest star.
     """
 
     saturated: bool = False
     smear_length_px: float = 0.0
     in_body_silhouette: bool = False
     in_saturation_or_cosmic_mask: bool = False
+    predicted_snr: float = 0.0
+    vmag: float | None = None
 
     def __post_init__(self) -> None:
-        """Validate that ``smear_length_px`` is non-negative."""
+        """Validate ``smear_length_px`` and ``predicted_snr`` are non-negative."""
         if self.smear_length_px < 0.0:
             raise ValueError(f'smear_length_px must be >= 0; got {self.smear_length_px!r}')
+        if self.predicted_snr < 0.0:
+            raise ValueError(f'predicted_snr must be >= 0; got {self.predicted_snr!r}')
 
 
 @dataclass(frozen=True)

--- a/src/nav/nav_model/stars/nav_model_stars.py
+++ b/src/nav/nav_model/stars/nav_model_stars.py
@@ -280,6 +280,8 @@ class NavModelStars(NavModel):
                         smear_length_px=smear_len,
                         in_body_silhouette=in_body or in_ring,
                         in_saturation_or_cosmic_mask=in_sat_or_cosmic,
+                        predicted_snr=float(snr),
+                        vmag=(None if star.vmag is None else float(star.vmag)),
                     ),
                 )
             )

--- a/src/nav/nav_technique/__init__.py
+++ b/src/nav/nav_technique/__init__.py
@@ -45,6 +45,9 @@ from nav.nav_technique.nav_technique_body_terminator import BodyTerminatorNav
 from nav.nav_technique.nav_technique_manual import NavTechniqueManual, run_manual_nav
 from nav.nav_technique.nav_technique_ring_annulus import RingAnnulusNav
 from nav.nav_technique.nav_technique_ring_edge import RingEdgeNav
+from nav.nav_technique.nav_technique_star_field import StarFieldFromCatalogNav
+from nav.nav_technique.nav_technique_star_refine import StarRefineNav
+from nav.nav_technique.nav_technique_star_unique_match import StarUniqueMatchNav
 from nav.nav_technique.technique_result import NavTechniqueResult
 
 __all__ = [
@@ -68,8 +71,11 @@ __all__ = [
     'RingEdgeDiagnostics',
     'RingEdgeNav',
     'StarFieldDiagnostics',
+    'StarFieldFromCatalogNav',
     'StarRefineDiagnostics',
+    'StarRefineNav',
     'StarUniqueMatchDiagnostics',
+    'StarUniqueMatchNav',
     'evaluate_sigmoid_combination',
     'filter_technique_names',
     'run_manual_nav',

--- a/src/nav/nav_technique/_star_helpers.py
+++ b/src/nav/nav_technique/_star_helpers.py
@@ -1,0 +1,186 @@
+"""Internal helpers shared across the three star NavTechniques.
+
+The three star techniques (`StarUniqueMatchNav`, `StarRefineNav`,
+`StarFieldFromCatalogNav`) all need the same handful of small
+operations on STAR features and image patches: filtering by feature
+type / flags, reading the predicted-SNR off the flags dataclass,
+converting an SNR ratio to a magnitude difference, and pulling a
+sub-pixel centroid from a small image window.  Defining these helpers
+in one place avoids the cross-module private-helper imports that
+otherwise tie three technique modules together through their
+underscore-prefixed surface.
+
+The submodule itself is private (leading underscore on the file
+name); the helpers carry no underscore prefix because they are
+public-but-internal — every star technique imports them, but they
+are not part of the package's public API.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from nav.feature.feature import NavFeature
+from nav.feature.feature_type import NavFeatureType
+from nav.feature.flags import StarFlags
+from nav.feature.geometry import StarGeometry
+from nav.support.types import NDArrayFloatType
+
+__all__ = [
+    'brightness_margin_mag',
+    'local_centroid',
+    'predicted_snr',
+    'predicted_vu',
+    'star_features',
+    'usable_stars',
+]
+
+
+def star_features(features: list[NavFeature]) -> list[NavFeature]:
+    """Return the input subset that carries STAR geometry + StarFlags."""
+    return [
+        f
+        for f in features
+        if f.feature_type is NavFeatureType.STAR
+        and isinstance(f.geometry, StarGeometry)
+        and isinstance(f.flags, StarFlags)
+    ]
+
+
+def usable_stars(features: list[NavFeature]) -> list[NavFeature]:
+    """Return STAR features that are not occluded or saturation-flagged.
+
+    Mirrors the autonomous reliability gate's STAR posture: a star inside a
+    body silhouette, ring annulus, or saturation/cosmic-ray mask is not a
+    candidate for any star technique because the corresponding image pixel
+    is dominated by other signal.
+    """
+    out: list[NavFeature] = []
+    for f in star_features(features):
+        flags = f.flags
+        assert isinstance(flags, StarFlags)
+        if flags.in_body_silhouette:
+            continue
+        if flags.in_saturation_or_cosmic_mask:
+            continue
+        out.append(f)
+    return out
+
+
+def predicted_snr(feature: NavFeature) -> float:
+    """Return the predicted SNR carried on a STAR feature's flags."""
+    flags = feature.flags
+    assert isinstance(flags, StarFlags)
+    return float(flags.predicted_snr)
+
+
+def predicted_vu(feature: NavFeature) -> tuple[float, float]:
+    """Return the predicted (v, u) carried on a STAR feature's geometry."""
+    geometry = feature.geometry
+    assert isinstance(geometry, StarGeometry)
+    return geometry.predicted_vu
+
+
+def brightness_margin_mag(brightest_snr: float, runner_up_snr: float) -> float:
+    """Return the magnitude difference implied by an SNR ratio.
+
+    For background-limited detection the measured SNR scales linearly with
+    flux, so the magnitude difference between two stars whose predicted
+    SNRs are ``s1`` (brighter) and ``s2`` (dimmer) is
+
+    ::
+
+        delta_mag = 2.5 * log10(s1 / s2)
+
+    A ratio of 4 corresponds to ~1.5 mag, the default uniqueness floor.
+    Returns ``+inf`` when ``runner_up_snr`` is non-positive (no other
+    predictable star competes with the brightest).
+    """
+    if runner_up_snr <= 0.0:
+        return float('inf')
+    if brightest_snr <= 0.0:
+        return 0.0
+    return 2.5 * math.log10(brightest_snr / runner_up_snr)
+
+
+def local_centroid(
+    image_ext: NDArrayFloatType,
+    predicted_vu_pos: tuple[float, float],
+    *,
+    search_window_px: float,
+    centroid_box_half_px: int,
+    image_noise_sigma: float,
+    detection_sigma: float,
+) -> tuple[tuple[float, float] | None, float]:
+    """Return the brightest local detection centroid + matched-filter peak.
+
+    Implements a small DAOPHOT-style detection inside a search window
+    centered on the prediction:
+
+    1. Slice the image to a ``(2 * search_window_px + 1)`` half-window
+       around the prediction (clamped to image bounds).
+    2. Take the brightest pixel inside the window — this is the
+       candidate peak.
+    3. Reject the candidate when its DN is below
+       ``detection_sigma * image_noise_sigma``.
+    4. Fit a brightness-weighted moment (Gaussian-equivalent for noise-
+       free fixtures) over a ``(2 * centroid_box_half_px + 1)`` box
+       around the candidate to pull a sub-pixel centroid.
+
+    The star techniques use this purely-local fit rather than a global
+    ``detect_sources`` call so they stay feasible on images where the
+    global DAOPHOT pipeline would fail (mostly-empty FOV, dim secondary
+    stars).
+
+    Parameters:
+        image_ext: 2-D extfov image array.
+        predicted_vu_pos: ``(v, u)`` prediction at the centre of the
+            search window.
+        search_window_px: Half-width of the search window in pixels.
+        centroid_box_half_px: Half-width of the centroid-fit box in
+            pixels.
+        image_noise_sigma: Robust per-pixel noise sigma in DN units.
+        detection_sigma: Threshold multiplier on
+            ``image_noise_sigma``; the brightest peak must clear
+            ``detection_sigma * image_noise_sigma`` to be accepted.
+
+    Returns:
+        ``(centroid, peak_dn)`` where ``centroid`` is the
+        ``(v, u)`` sub-pixel centre or ``None`` if no peak cleared
+        the threshold.  ``peak_dn`` is the brightest DN in the search
+        window regardless of whether the peak was accepted (handy for
+        diagnostics).
+    """
+    v0, u0 = predicted_vu_pos
+    h, w = image_ext.shape
+    v_lo = max(0, math.floor(v0 - search_window_px))
+    u_lo = max(0, math.floor(u0 - search_window_px))
+    v_hi = min(h, math.ceil(v0 + search_window_px) + 1)
+    u_hi = min(w, math.ceil(u0 + search_window_px) + 1)
+    if v_hi <= v_lo or u_hi <= u_lo:
+        return None, 0.0
+    window = image_ext[v_lo:v_hi, u_lo:u_hi]
+    flat_idx = int(np.argmax(window))
+    pv, pu = np.unravel_index(flat_idx, window.shape)
+    peak_dn = float(window[pv, pu])
+    if peak_dn < detection_sigma * image_noise_sigma:
+        return None, peak_dn
+    peak_v = v_lo + int(pv)
+    peak_u = u_lo + int(pu)
+    box_v_lo = max(0, peak_v - centroid_box_half_px)
+    box_u_lo = max(0, peak_u - centroid_box_half_px)
+    box_v_hi = min(h, peak_v + centroid_box_half_px + 1)
+    box_u_hi = min(w, peak_u + centroid_box_half_px + 1)
+    box = image_ext[box_v_lo:box_v_hi, box_u_lo:box_u_hi]
+    bg = float(np.median(box))
+    weights = np.clip(box.astype(np.float64) - bg, 0.0, None)
+    total = float(weights.sum())
+    if total <= 0.0:
+        return None, peak_dn
+    vs = np.arange(box_v_lo, box_v_hi, dtype=np.float64)
+    us = np.arange(box_u_lo, box_u_hi, dtype=np.float64)
+    centroid_v = float(np.sum(vs[:, None] * weights) / total)
+    centroid_u = float(np.sum(us[None, :] * weights) / total)
+    return (centroid_v, centroid_u), peak_dn

--- a/src/nav/nav_technique/_star_helpers.py
+++ b/src/nav/nav_technique/_star_helpers.py
@@ -95,13 +95,18 @@ def brightness_margin_mag(brightest_snr: float, runner_up_snr: float) -> float:
         delta_mag = 2.5 * log10(s1 / s2)
 
     A ratio of 4 corresponds to ~1.5 mag, the default uniqueness floor.
-    Returns ``+inf`` when ``runner_up_snr`` is non-positive (no other
-    predictable star competes with the brightest).
+
+    A non-positive ``brightest_snr`` is unpopulated / garbage input and
+    is checked **first** so a zero-SNR cohort cannot accidentally be
+    treated as "uniquely bright" — it returns ``0.0``.  Only after the
+    brightest is known to carry signal does a non-positive
+    ``runner_up_snr`` mean "no other predictable star competes with the
+    brightest", which is reported as ``+inf``.
     """
-    if runner_up_snr <= 0.0:
-        return float('inf')
     if brightest_snr <= 0.0:
         return 0.0
+    if runner_up_snr <= 0.0:
+        return float('inf')
     return 2.5 * math.log10(brightest_snr / runner_up_snr)
 
 

--- a/src/nav/nav_technique/diagnostics.py
+++ b/src/nav/nav_technique/diagnostics.py
@@ -207,8 +207,10 @@ class StarUniqueMatchDiagnostics:
     Parameters:
         mode: ``'one_star'`` or ``'two_star'``.
         predicted_snr: Predicted SNR of the brightest catalog star.
-        brightness_margin_mag: Mag difference to the next-brightest catalog
-            source predictable in extfov.
+        brightness_margin_mag: Mag difference to the next-brightest *unmatched*
+            catalog source predictable in extfov; ``+inf`` when no unmatched
+            star exists (a 1-star scene with no other predictable star, or a
+            2-star scene with no third predictable star to compare against).
         residual_px: Detection-vs-prediction residual.
     """
 

--- a/src/nav/nav_technique/dt_fitting.py
+++ b/src/nav/nav_technique/dt_fitting.py
@@ -32,7 +32,6 @@ from nav.support.distance_transform import sample_dt_bilinear
 from nav.support.types import NDArrayBoolType, NDArrayFloatType
 
 __all__ = [
-    'AT_EDGE_TOLERANCE_PX',
     'DEFAULT_LM_DAMPING',
     'DEFAULT_LM_MAX_ITERATIONS',
     'DEFAULT_LM_STEP_TOLERANCE',
@@ -45,22 +44,6 @@ __all__ = [
     'polarity_filter',
     'tukey_biweight_weights',
 ]
-
-
-AT_EDGE_TOLERANCE_PX: float = 1.0
-"""Pixels of slack around the search-window axis bounds for at-edge detection.
-
-A converged offset whose absolute distance from any axis bound
-(``+/- margin_v``, ``+/- margin_u``) falls within this tolerance is
-flagged ``at_edge=True`` and forced to zero confidence by the
-technique's ``hard_zero_if`` gate.  One pixel matches the bilinear
-DT half-cell width: any closer to the boundary and the LM gradient
-information is unreliable.
-
-Shared across every translation-fit technique (DT-based limb /
-terminator / ring-edge plus the brightness-weighted-moment blob fit)
-so the at-edge convention stays uniform.
-"""
 
 
 DEFAULT_TUKEY_C: float = 4.685

--- a/src/nav/nav_technique/nav_technique.py
+++ b/src/nav/nav_technique/nav_technique.py
@@ -27,8 +27,23 @@ __all__ = [
     'NavTechnique',
     'filter_technique_names',
     'log_confidence_breakdown',
+    'search_window_for_obs',
     'validate_registered_confidence_specs',
 ]
+
+
+def search_window_for_obs(context: NavContext) -> tuple[int, int]:
+    """Return the ``(margin_v, margin_u)`` extfov margin from the obs.
+
+    Every translation-fit technique reads the per-instrument extfov
+    margin from ``context.obs.extfov_margin_vu`` to bound its at-edge
+    detection.  Centralising the read in one helper keeps the convention
+    uniform: a test obs stand-in that omits the attribute surfaces an
+    ``AttributeError`` rather than silently falling through to a
+    fabricated default.
+    """
+    margin = context.obs.extfov_margin_vu  # type: ignore[attr-defined]
+    return (int(margin[0]), int(margin[1]))
 
 
 def log_confidence_breakdown(

--- a/src/nav/nav_technique/nav_technique_body_blob.py
+++ b/src/nav/nav_technique/nav_technique_body_blob.py
@@ -29,9 +29,12 @@ from nav.feature.feature_type import NavFeatureType
 from nav.feature.geometry import BodyBlobGeometry
 from nav.nav_technique.confidence import evaluate_sigmoid_combination
 from nav.nav_technique.diagnostics import BodyBlobDiagnostics
-from nav.nav_technique.dt_fitting import AT_EDGE_TOLERANCE_PX
 from nav.nav_technique.feasibility import NavFeasibilityReport
-from nav.nav_technique.nav_technique import NavTechnique, log_confidence_breakdown
+from nav.nav_technique.nav_technique import (
+    NavTechnique,
+    log_confidence_breakdown,
+    search_window_for_obs,
+)
 from nav.nav_technique.technique_result import NavTechniqueResult
 from nav.support.types import NDArrayBoolType, NDArrayFloatType
 
@@ -294,6 +297,8 @@ class BodyBlobNav(NavTechnique):
 
     def __init__(self, *, config: Config | None = None) -> None:
         super().__init__(config=config)
+        self.config.read_config()  # ensure cls.tuning is populated
+        self._at_edge_tolerance_px = float(self.tuning['at_edge_tolerance_px'])
 
     def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
         """Return whether the input set carries any usable BODY_BLOB feature.
@@ -336,7 +341,7 @@ class BodyBlobNav(NavTechnique):
                 len(eligible),
                 len(features),
             )
-            margin_v, margin_u = _search_window_for_obs(context)
+            margin_v, margin_u = search_window_for_obs(context)
             self.logger.debug('Search window (v, u) = (%d, %d) px', margin_v, margin_u)
             image_ext = np.asarray(context.image_ext, np.float64)
             noise_sigma = float(max(context.image_noise_sigma, 1e-9))
@@ -345,8 +350,8 @@ class BodyBlobNav(NavTechnique):
                 return self._fail_no_signal(features=eligible, noise_sigma=noise_sigma)
             fit = _joint_offset_from_residuals(residuals)
             at_edge = (
-                abs(fit.dv) >= margin_v - AT_EDGE_TOLERANCE_PX
-                or abs(fit.du) >= margin_u - AT_EDGE_TOLERANCE_PX
+                abs(fit.dv) >= margin_v - self._at_edge_tolerance_px
+                or abs(fit.du) >= margin_u - self._at_edge_tolerance_px
             )
             mean_snr = float(np.mean(residuals.snrs))
             mean_extent = float(np.mean(residuals.extents))
@@ -435,20 +440,3 @@ class _BlobConfidenceContext:
         self.body_extent_px = diagnostics.body_extent_px
         self.blob_count = float(diagnostics.blob_count)
         self.residual_px = diagnostics.residual_px
-
-
-def _search_window_for_obs(context: NavContext) -> tuple[int, int]:
-    """Return the ``(margin_v, margin_u)`` search window for at-edge detection.
-
-    The technique reads the per-instrument extfov margin from the
-    observation.  ``extfov_margin_vu`` is a mandatory attribute on
-    every ``ObsSnapshotInst``; test fixtures must set it as well
-    (the shared ``FakeObs`` defaults to ``(32, 32)``).  An obs
-    missing the attribute is a programming error and surfaces as
-    ``AttributeError`` rather than a silent fallback.
-    """
-    # ``NavContext.obs`` is typed as ``object`` to avoid an import cycle
-    # with ``ObsSnapshotInst``; the attribute lookup is mandatory at
-    # runtime even though mypy cannot see it.
-    margin = context.obs.extfov_margin_vu  # type: ignore[attr-defined]
-    return (int(margin[0]), int(margin[1]))

--- a/src/nav/nav_technique/nav_technique_body_disc.py
+++ b/src/nav/nav_technique/nav_technique_body_disc.py
@@ -29,7 +29,11 @@ from nav.feature.geometry import BodyDiscGeometry
 from nav.nav_technique.confidence import evaluate_sigmoid_combination
 from nav.nav_technique.diagnostics import BodyDiscDiagnostics
 from nav.nav_technique.feasibility import NavFeasibilityReport
-from nav.nav_technique.nav_technique import NavTechnique, log_confidence_breakdown
+from nav.nav_technique.nav_technique import (
+    NavTechnique,
+    log_confidence_breakdown,
+    search_window_for_obs,
+)
 from nav.nav_technique.technique_result import NavTechniqueResult
 from nav.support.correlate import navigate_with_pyramid_kpeaks
 
@@ -150,7 +154,7 @@ class BodyDiscCorrelateNav(NavTechnique):
             )
             extfov_shape = context.image_ext.shape
             template_img, template_mask = compose_template_features(eligible, extfov_shape)
-            margin_v, margin_u = _search_window_for_obs(context)
+            margin_v, margin_u = search_window_for_obs(context)
             up_factor = self._upsample_factor()
             self.logger.debug(
                 'Composite template: %d painted pixels; search window (v, u) = (%d, %d) px; '
@@ -246,20 +250,3 @@ class _DiscConfidenceContext:
         self.consistency_px = diagnostics.consistency_px
         self.used_gradient = diagnostics.used_gradient
         self.body_count = float(diagnostics.body_count)
-
-
-def _search_window_for_obs(context: NavContext) -> tuple[int, int]:
-    """Return the ``(margin_v, margin_u)`` search window for the NCC.
-
-    The technique reads the per-instrument extfov margin from the
-    observation.  ``extfov_margin_vu`` is a mandatory attribute on
-    every ``ObsSnapshotInst``; test fixtures must set it as well
-    (the shared ``FakeObs`` defaults to ``(32, 32)``).  An obs
-    missing the attribute is a programming error and surfaces as
-    ``AttributeError`` rather than a silent fallback.
-    """
-    # ``NavContext.obs`` is typed as ``object`` to avoid an import cycle
-    # with ``ObsSnapshotInst``; the attribute lookup is mandatory at
-    # runtime even though mypy cannot see it.
-    margin = context.obs.extfov_margin_vu  # type: ignore[attr-defined]
-    return (int(margin[0]), int(margin[1]))

--- a/src/nav/nav_technique/nav_technique_body_limb.py
+++ b/src/nav/nav_technique/nav_technique_body_limb.py
@@ -22,12 +22,15 @@ from nav.feature.geometry import LimbPolyline
 from nav.nav_technique.confidence import evaluate_sigmoid_combination
 from nav.nav_technique.diagnostics import BodyLimbDiagnostics
 from nav.nav_technique.dt_fitting import (
-    AT_EDGE_TOLERANCE_PX,
     coarse_ncc_search,
     lm_subpixel_refine,
 )
 from nav.nav_technique.feasibility import NavFeasibilityReport
-from nav.nav_technique.nav_technique import NavTechnique, log_confidence_breakdown
+from nav.nav_technique.nav_technique import (
+    NavTechnique,
+    log_confidence_breakdown,
+    search_window_for_obs,
+)
 from nav.nav_technique.technique_result import NavTechniqueResult
 from nav.support.types import NDArrayBoolType, NDArrayFloatType
 
@@ -135,6 +138,7 @@ class BodyLimbNav(NavTechnique):
         self._spurious_dt_floor_px = float(self.tuning['spurious_dt_floor_px'])
         self._spurious_min_inliers = int(self.tuning['spurious_min_inliers'])
         self._spurious_min_inlier_fraction = float(self.tuning['spurious_min_inlier_fraction'])
+        self._at_edge_tolerance_px = float(self.tuning['at_edge_tolerance_px'])
 
     def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
         """Return whether the input set carries any usable limb arc.
@@ -209,7 +213,7 @@ class BodyLimbNav(NavTechnique):
             gradient_vu = context.image_gradient_vu_ext
             edge_mask = edge_dt <= 0.5
             polyline_mask = _build_polyline_mask(vertices, edge_dt.shape[:2])
-            margin_v, margin_u = _search_window_for_obs(context)
+            margin_v, margin_u = search_window_for_obs(context)
             self.logger.debug(
                 'Aggregated %d limb vertices, sigma_normal range [%.3f, %.3f] px, '
                 'search window (v, u) = (%d, %d) px',
@@ -236,10 +240,10 @@ class BodyLimbNav(NavTechnique):
             )
             dv_final, du_final = result.offset_vu
             at_edge = (
-                abs(dv_final - margin_v) <= AT_EDGE_TOLERANCE_PX
-                or abs(dv_final + margin_v) <= AT_EDGE_TOLERANCE_PX
-                or abs(du_final - margin_u) <= AT_EDGE_TOLERANCE_PX
-                or abs(du_final + margin_u) <= AT_EDGE_TOLERANCE_PX
+                abs(dv_final - margin_v) <= self._at_edge_tolerance_px
+                or abs(dv_final + margin_v) <= self._at_edge_tolerance_px
+                or abs(du_final - margin_u) <= self._at_edge_tolerance_px
+                or abs(du_final + margin_u) <= self._at_edge_tolerance_px
             )
             sigma_min_px = float(sigmas.min()) if sigmas.size else 1.0
             n_vertices = int(vertices.shape[0])
@@ -348,18 +352,3 @@ def _aggregate_visible_arc_fraction(features: list[NavFeature]) -> float:
     if total_count == 0.0:
         return 0.0
     return total_weighted / total_count
-
-
-def _search_window_for_obs(context: NavContext) -> tuple[int, int]:
-    """Return the ``(margin_v, margin_u)`` search window for the coarse NCC.
-
-    ``extfov_margin_vu`` is a mandatory attribute on every
-    ``ObsSnapshotInst``; test fixtures must set it as well.  An obs
-    missing the attribute is a programming error and surfaces as
-    ``AttributeError`` rather than a silent fallback.
-    """
-    # ``NavContext.obs`` is typed as ``object`` to avoid an import cycle
-    # with ``ObsSnapshotInst``; the attribute lookup is mandatory at
-    # runtime even though mypy cannot see it.
-    margin = context.obs.extfov_margin_vu  # type: ignore[attr-defined]
-    return (int(margin[0]), int(margin[1]))

--- a/src/nav/nav_technique/nav_technique_body_terminator.py
+++ b/src/nav/nav_technique/nav_technique_body_terminator.py
@@ -27,12 +27,15 @@ from nav.feature.geometry import TerminatorPolyline
 from nav.nav_technique.confidence import evaluate_sigmoid_combination
 from nav.nav_technique.diagnostics import BodyTerminatorDiagnostics
 from nav.nav_technique.dt_fitting import (
-    AT_EDGE_TOLERANCE_PX,
     coarse_ncc_search,
     lm_subpixel_refine,
 )
 from nav.nav_technique.feasibility import NavFeasibilityReport
-from nav.nav_technique.nav_technique import NavTechnique, log_confidence_breakdown
+from nav.nav_technique.nav_technique import (
+    NavTechnique,
+    log_confidence_breakdown,
+    search_window_for_obs,
+)
 from nav.nav_technique.technique_result import NavTechniqueResult
 from nav.support.types import NDArrayBoolType, NDArrayFloatType
 
@@ -151,6 +154,7 @@ class BodyTerminatorNav(NavTechnique):
         self._spurious_dt_rms_factor = float(self.tuning['spurious_dt_rms_factor'])
         self._spurious_dt_floor_px = float(self.tuning['spurious_dt_floor_px'])
         self._spurious_min_inliers = int(self.tuning['spurious_min_inliers'])
+        self._at_edge_tolerance_px = float(self.tuning['at_edge_tolerance_px'])
 
     def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
         """Return whether the input set carries a usable terminator arc.
@@ -228,7 +232,7 @@ class BodyTerminatorNav(NavTechnique):
             gradient_vu = context.image_gradient_vu_ext
             edge_mask = edge_dt <= 0.5
             polyline_mask = _build_polyline_mask(vertices, edge_dt.shape[:2])
-            margin_v, margin_u = _search_window_for_obs(context)
+            margin_v, margin_u = search_window_for_obs(context)
             self.logger.debug(
                 'Aggregated %d terminator vertices, sigma_normal range [%.3f, %.3f] px, '
                 'search window (v, u) = (%d, %d) px',
@@ -255,10 +259,10 @@ class BodyTerminatorNav(NavTechnique):
             )
             dv_final, du_final = result.offset_vu
             at_edge = (
-                abs(dv_final - margin_v) <= AT_EDGE_TOLERANCE_PX
-                or abs(dv_final + margin_v) <= AT_EDGE_TOLERANCE_PX
-                or abs(du_final - margin_u) <= AT_EDGE_TOLERANCE_PX
-                or abs(du_final + margin_u) <= AT_EDGE_TOLERANCE_PX
+                abs(dv_final - margin_v) <= self._at_edge_tolerance_px
+                or abs(dv_final + margin_v) <= self._at_edge_tolerance_px
+                or abs(du_final - margin_u) <= self._at_edge_tolerance_px
+                or abs(du_final + margin_u) <= self._at_edge_tolerance_px
             )
             sigma_min_px = float(sigmas.min()) if sigmas.size else 1.0
             spurious = (
@@ -370,18 +374,3 @@ def _aggregate_visible_arc_fraction(features: list[NavFeature]) -> float:
     if total_count == 0.0:
         return 0.0
     return total_weighted / total_count
-
-
-def _search_window_for_obs(context: NavContext) -> tuple[int, int]:
-    """Return ``(margin_v, margin_u)`` for the coarse search.
-
-    ``extfov_margin_vu`` is a mandatory attribute on every
-    ``ObsSnapshotInst``; test fixtures must set it as well.  An obs
-    missing the attribute is a programming error and surfaces as
-    ``AttributeError`` rather than a silent fallback.
-    """
-    # ``NavContext.obs`` is typed as ``object`` to avoid an import cycle
-    # with ``ObsSnapshotInst``; the attribute lookup is mandatory at
-    # runtime even though mypy cannot see it.
-    margin = context.obs.extfov_margin_vu  # type: ignore[attr-defined]
-    return (int(margin[0]), int(margin[1]))

--- a/src/nav/nav_technique/nav_technique_manual.py
+++ b/src/nav/nav_technique/nav_technique_manual.py
@@ -72,7 +72,7 @@ class NavTechniqueManual(NavTechnique):
     def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
         """Manual navigation runs whenever there is anything to render.
 
-        Three feature kinds paint into the dialog's composite overlay
+        Four feature kinds paint into the dialog's composite overlay
         (see :func:`~nav.feature.composition.compose_dialog_overlay`):
 
         - template-bearing (``BODY_DISC``, ``RING_ANNULUS``,
@@ -80,11 +80,14 @@ class NavTechniqueManual(NavTechnique):
         - polyline-bearing (``LIMB_ARC``, ``TERMINATOR_ARC``,
           ``RING_EDGE``) — single-pixel marks at every vertex;
         - ``BODY_BLOB`` — 1-pixel circle outline at the predicted
-          centroid with the predicted-diameter radius.
+          centroid with the predicted-diameter radius;
+        - ``STAR`` — rectangle outline at the predicted-vu position
+          sized by the per-feature PSF bbox so the operator can see
+          where the catalog says the star sits.
 
         Without any of them the dialog has nothing to display.
         """
-        from nav.feature.geometry import BodyBlobGeometry
+        from nav.feature.geometry import BodyBlobGeometry, StarGeometry
 
         renderable = 0
         for f in features:
@@ -96,6 +99,9 @@ class NavTechniqueManual(NavTechnique):
                 renderable += 1
                 continue
             if isinstance(f.geometry, BodyBlobGeometry):
+                renderable += 1
+                continue
+            if isinstance(f.geometry, StarGeometry):
                 renderable += 1
         if renderable == 0:
             return NavFeasibilityReport(

--- a/src/nav/nav_technique/nav_technique_manual.py
+++ b/src/nav/nav_technique/nav_technique_manual.py
@@ -47,10 +47,16 @@ _MANUAL_OFFSET_SIGMA_PX = 1.0
 class NavTechniqueManual(NavTechnique):
     """Interactive manual navigation.
 
-    Composes every template-bearing feature into a single ext-FOV image
-    plus mask, hands the result plus the observation to the
-    ``ManualNavDialog``, and packages the operator's choice into a
-    ``NavTechniqueResult``.
+    Composes every renderable feature into a single ext-FOV image plus
+    mask via :func:`~nav.feature.composition.compose_dialog_overlay`,
+    hands the result plus the observation to the ``ManualNavDialog``,
+    and packages the operator's choice into a ``NavTechniqueResult``.
+    Renderable feature kinds are template-bearing (``BODY_DISC``,
+    ``RING_ANNULUS``, ``CARTOGRAPHIC_MODEL``), polyline-bearing
+    (``LIMB_ARC``, ``TERMINATOR_ARC``, ``RING_EDGE``), ``BODY_BLOB``
+    (predicted-diameter circle outline), and ``STAR`` (rectangle
+    outline at the predicted-vu position sized by the per-feature PSF
+    bbox).
 
     Class attributes:
         _abstract: ``True`` — kept out of the auto-discovery registry so
@@ -192,14 +198,17 @@ def run_manual_nav(
     Returns:
         The :class:`NavTechniqueResult` produced by the dialog, or
         ``None`` when no supported overlay features paint any pixels
-        into the ext-FOV composite.  Supported overlay types are
-        template-bearing features (``BODY_DISC`` / ``RING_ANNULUS`` /
+        into the ext-FOV composite.  Supported overlay types match
+        :meth:`NavTechniqueManual.is_feasible`: template-bearing
+        features (``BODY_DISC`` / ``RING_ANNULUS`` /
         ``CARTOGRAPHIC_MODEL``), polyline-bearing features (``LIMB_ARC``
-        / ``TERMINATOR_ARC`` / ``RING_EDGE``), and ``BODY_BLOB`` (which
-        renders as a 1-pixel circle outline).  The dialog is opened
-        only when the composed mask is non-empty; an off-frame blob or
-        a polyline whose vertices all clip out-of-bounds is treated as
-        if no renderable feature were present.
+        / ``TERMINATOR_ARC`` / ``RING_EDGE``), ``BODY_BLOB`` (1-pixel
+        circle outline at the predicted centroid), and ``STAR``
+        (rectangle outline at the predicted-vu position sized by the
+        per-feature PSF bbox).  The dialog is opened only when the
+        composed mask is non-empty; an off-frame blob, an off-image
+        star, or a polyline whose vertices all clip out-of-bounds is
+        treated as if no renderable feature were present.
     """
     # Local imports keep heavyweight dependencies (NavOrchestrator, NavModel
     # registry) out of import-time graphs for callers that only need the

--- a/src/nav/nav_technique/nav_technique_ring_annulus.py
+++ b/src/nav/nav_technique/nav_technique_ring_annulus.py
@@ -35,7 +35,11 @@ from nav.feature.geometry import RingAnnulusGeometry
 from nav.nav_technique.confidence import evaluate_sigmoid_combination
 from nav.nav_technique.diagnostics import RingAnnulusDiagnostics
 from nav.nav_technique.feasibility import NavFeasibilityReport
-from nav.nav_technique.nav_technique import NavTechnique, log_confidence_breakdown
+from nav.nav_technique.nav_technique import (
+    NavTechnique,
+    log_confidence_breakdown,
+    search_window_for_obs,
+)
 from nav.nav_technique.technique_result import NavTechniqueResult
 from nav.support.correlate import navigate_with_pyramid_kpeaks
 
@@ -179,7 +183,7 @@ class RingAnnulusNav(NavTechnique):
                 )
             extfov_shape = context.image_ext.shape
             template_img, template_mask = compose_template_features(eligible, extfov_shape)
-            margin_v, margin_u = _search_window_for_obs(context)
+            margin_v, margin_u = search_window_for_obs(context)
             up_factor = self._upsample_factor()
             self.logger.debug(
                 'Composite annulus template: %d painted pixels; '
@@ -295,20 +299,3 @@ class _AnnulusConfidenceContext:
         self.peak_to_runner_up_ratio = diagnostics.peak_to_runner_up_ratio
         self.used_gradient = diagnostics.used_gradient
         self.annulus_count = float(diagnostics.annulus_count)
-
-
-def _search_window_for_obs(context: NavContext) -> tuple[int, int]:
-    """Return the ``(margin_v, margin_u)`` search window for the NCC.
-
-    The technique reads the per-instrument extfov margin from the
-    observation.  ``extfov_margin_vu`` is a mandatory attribute on
-    every ``ObsSnapshotInst``; test fixtures must set it as well
-    (the shared ``FakeObs`` defaults to ``(32, 32)``).  An obs
-    missing the attribute is a programming error and surfaces as
-    ``AttributeError`` rather than a silent fallback.
-    """
-    # ``NavContext.obs`` is typed as ``object`` to avoid an import cycle
-    # with ``ObsSnapshotInst``; the attribute lookup is mandatory at
-    # runtime even though mypy cannot see it.
-    margin = context.obs.extfov_margin_vu  # type: ignore[attr-defined]
-    return (int(margin[0]), int(margin[1]))

--- a/src/nav/nav_technique/nav_technique_ring_edge.py
+++ b/src/nav/nav_technique/nav_technique_ring_edge.py
@@ -27,7 +27,11 @@ from nav.nav_technique.dt_fitting import (
     lm_subpixel_refine,
 )
 from nav.nav_technique.feasibility import NavFeasibilityReport
-from nav.nav_technique.nav_technique import NavTechnique, log_confidence_breakdown
+from nav.nav_technique.nav_technique import (
+    NavTechnique,
+    log_confidence_breakdown,
+    search_window_for_obs,
+)
 from nav.nav_technique.technique_result import NavTechniqueResult
 from nav.support.types import NDArrayBoolType, NDArrayFloatType
 
@@ -211,7 +215,7 @@ class RingEdgeNav(NavTechnique):
             gradient_vu = context.image_gradient_vu_ext
             edge_mask = edge_dt <= 0.5
             polyline_mask = _build_polyline_mask(vertices, edge_dt.shape[:2])
-            margin_v, margin_u = _search_window_for_obs(context)
+            margin_v, margin_u = search_window_for_obs(context)
             self.logger.debug(
                 'Aggregated %d ring-edge vertices, sigma_radial range [%.3f, %.3f] px, '
                 'search window (v, u) = (%d, %d) px',
@@ -354,18 +358,3 @@ class _RingEdgeConfidenceContext:
         self.per_edge_dt_rms_summed = diagnostics.per_edge_dt_rms_summed
         self.edge_count = diagnostics.edge_count
         self.is_rank_1 = diagnostics.is_rank_1
-
-
-def _search_window_for_obs(context: NavContext) -> tuple[int, int]:
-    """Return ``(margin_v, margin_u)`` for the coarse search.
-
-    ``extfov_margin_vu`` is a mandatory attribute on every
-    ``ObsSnapshotInst``; test fixtures must set it as well.  An obs
-    missing the attribute is a programming error and surfaces as
-    ``AttributeError`` rather than a silent fallback.
-    """
-    # ``NavContext.obs`` is typed as ``object`` to avoid an import cycle
-    # with ``ObsSnapshotInst``; the attribute lookup is mandatory at
-    # runtime even though mypy cannot see it.
-    margin = context.obs.extfov_margin_vu  # type: ignore[attr-defined]
-    return (int(margin[0]), int(margin[1]))

--- a/src/nav/nav_technique/nav_technique_star_field.py
+++ b/src/nav/nav_technique/nav_technique_star_field.py
@@ -1,0 +1,838 @@
+"""``StarFieldFromCatalogNav`` — multi-star RANSAC pattern matcher.
+
+The technique is the long-pole prior-free star fit: it makes no assumption
+about which detection corresponds to which catalog star, and recovers a
+2-D translation purely from the *geometry* of bright sources in the image
+matched against the predicted catalog field.
+
+Algorithm — four sub-pieces:
+
+1. **Source detection.**  The image is matched-filtered against a
+   small Gaussian PSF kernel; pixels that are local maxima above
+   ``detection_sigma * image_noise_sigma`` are accepted; a brightness-
+   weighted centroid pins each peak's sub-pixel position.  The
+   brightest ``max_sources`` survivors (default 30) feed the matcher.
+2. **Triplet hashing.**  For every unordered triplet of detected
+   sources ``{A, B, C}`` with ``A`` brightest, the hash
+   ``(d_AB / d_AC, d_BC / d_AC, ∠BAC)`` is computed.  The same hash is
+   computed for catalog triplets (``A`` = brightest by predicted SNR).
+   The hash is similarity-invariant — translation, rotation, and
+   uniform scale all leave it unchanged — so the matcher recovers
+   correspondences without already knowing the offset.
+3. **RANSAC.**  Each (detection-triplet, catalog-triplet) candidate is
+   scored by counting detection-to-catalog inliers under the
+   translation it implies.  Candidates are iterated in deterministic
+   order — sorted first by hash distance ascending, then by sorted
+   ``(idx_A, idx_B, idx_C)`` ascending — so the matcher's choice of
+   winner is fully reproducible (Cardinal Principle 3, Part 3
+   §"Determinism in RANSAC").
+4. **Verification.**  With the best transform's inlier set, the
+   technique refits the translation by Tukey-biweight-reweighted
+   least squares; the per-axis variance of the surviving residuals
+   becomes the reported covariance.
+
+Phase 8 ships translation-only fitting; the
+``fit_camera_rotation`` rotation upgrade arrives in Phase 9.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+from scipy.ndimage import maximum_filter
+
+from nav.config import Config
+from nav.feature.feature import NavFeature
+from nav.feature.feature_type import NavFeatureType
+from nav.nav_model.stars.detection import matched_filter_image
+from nav.nav_technique._star_helpers import predicted_snr, predicted_vu, usable_stars
+from nav.nav_technique.confidence import evaluate_sigmoid_combination
+from nav.nav_technique.diagnostics import StarFieldDiagnostics
+from nav.nav_technique.dt_fitting import DEFAULT_TUKEY_C, tukey_biweight_weights
+from nav.nav_technique.feasibility import NavFeasibilityReport
+from nav.nav_technique.nav_technique import (
+    NavTechnique,
+    log_confidence_breakdown,
+    search_window_for_obs,
+)
+from nav.nav_technique.technique_result import NavTechniqueResult
+from nav.support.types import NDArrayFloatType
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from nav.nav_orchestrator.nav_context import NavContext
+
+__all__ = ['StarFieldFromCatalogNav']
+
+
+# All numeric tunables for this technique live in
+# ``config_files/config_510_techniques.yaml`` under
+# ``techniques.StarFieldFromCatalogNav.tuning``.  Missing-key access in
+# ``__init__`` is a KeyError so a config typo fails fast at process
+# startup.
+
+
+@dataclass(frozen=True)
+class _DetectedSource:
+    """Internal detection record produced by ``_detect_image_sources``.
+
+    The technique uses only ``(v, u, peak_dn)``; richer DAOPHOT
+    statistics (sharpness / roundness, saturation tag) are not needed
+    for triplet matching and are therefore not surfaced.
+    """
+
+    v: float
+    u: float
+    peak_dn: float
+
+
+def _gaussian_kernel(sigma_px: float, *, size: int) -> NDArrayFloatType:
+    """Return a normalised 2-D isotropic Gaussian matched-filter kernel.
+
+    Parameters:
+        sigma_px: PSF sigma in pixels.  Must be strictly positive.
+        size: Side length of the (odd) square kernel.  Coerced up to
+            the next odd integer when even.
+
+    Returns:
+        ``(size, size)`` float64 array, sum-to-unity.
+    """
+    if sigma_px <= 0.0:
+        raise ValueError(f'sigma_px must be > 0; got {sigma_px!r}')
+    if size % 2 == 0:
+        size += 1
+    half = size // 2
+    coords = np.arange(-half, half + 1, dtype=np.float64)
+    vv, uu = np.meshgrid(coords, coords, indexing='ij')
+    kernel = np.exp(-(vv * vv + uu * uu) / (2.0 * sigma_px * sigma_px))
+    kernel /= float(kernel.sum())
+    return kernel
+
+
+def _detect_image_sources(
+    image: NDArrayFloatType,
+    *,
+    image_noise_sigma: float,
+    sigma_px: float,
+    detection_sigma: float,
+    centroid_box_half_px: int,
+    max_sources: int,
+) -> list[_DetectedSource]:
+    """Detect bright local-max sources in ``image`` and return the brightest set.
+
+    Three-stage pipeline:
+
+    1. Matched-filter the image against a Gaussian kernel sized by
+       ``sigma_px``; the response peak amplitude at each pixel is the
+       maximum-likelihood signal estimate at that location.
+    2. Find pixels that are local maxima within a
+       ``(2 * centroid_box_half_px + 1)`` window AND clear
+       ``detection_sigma * image_noise_sigma``.
+    3. For each surviving peak, fit a brightness-weighted moment in a
+       small box around the peak to pull a sub-pixel centroid.
+
+    Detections are ranked by ``(peak_dn descending, v ascending,
+    u ascending)`` and the first ``max_sources`` are returned — the
+    triplet matcher is M^3 in the input count, so 30 is the typical
+    cap (Part 3 §"Determinism in RANSAC").
+
+    Parameters:
+        image: 2-D float input.
+        image_noise_sigma: Robust per-pixel noise sigma in DN.
+        sigma_px: PSF sigma in pixels for the matched-filter kernel.
+        detection_sigma: Threshold multiplier on
+            ``image_noise_sigma``.
+        centroid_box_half_px: Half-width of the centroid box (and of
+            the local-max window).
+        max_sources: Maximum number of detections to return.
+
+    Returns:
+        List of ``_DetectedSource`` records, ordered by brightness
+        descending.  May be empty when no peak clears the threshold.
+    """
+    kernel_size = 2 * centroid_box_half_px + 1
+    kernel = _gaussian_kernel(sigma_px, size=kernel_size)
+    response = matched_filter_image(image, kernel=kernel)
+    threshold = detection_sigma * image_noise_sigma
+    local_max = maximum_filter(response, size=kernel_size, mode='reflect')
+    candidate_mask = (response == local_max) & (response > threshold)
+    h, w = image.shape
+    out: list[_DetectedSource] = []
+    for v_idx, u_idx in np.argwhere(candidate_mask):
+        v_i = int(v_idx)
+        u_i = int(u_idx)
+        v_lo = max(0, v_i - centroid_box_half_px)
+        u_lo = max(0, u_i - centroid_box_half_px)
+        v_hi = min(h, v_i + centroid_box_half_px + 1)
+        u_hi = min(w, u_i + centroid_box_half_px + 1)
+        box = image[v_lo:v_hi, u_lo:u_hi].astype(np.float64)
+        bg = float(np.median(box))
+        weights = np.clip(box - bg, 0.0, None)
+        total = float(weights.sum())
+        if total <= 0.0:
+            continue
+        vs = np.arange(v_lo, v_hi, dtype=np.float64)
+        us = np.arange(u_lo, u_hi, dtype=np.float64)
+        cv = float(np.sum(vs[:, None] * weights) / total)
+        cu = float(np.sum(us[None, :] * weights) / total)
+        out.append(_DetectedSource(v=cv, u=cu, peak_dn=float(response[v_i, u_i])))
+    out.sort(key=lambda s: (-s.peak_dn, s.v, s.u))
+    return out[:max_sources]
+
+
+def _triplet_hash(
+    pa: tuple[float, float],
+    pb: tuple[float, float],
+    pc: tuple[float, float],
+) -> tuple[float, float, float] | None:
+    """Return the similarity-invariant ``(d_AB / d_AC, d_BC / d_AC, ∠BAC)`` triple.
+
+    Per Part 3 §"Algorithm specifics" the hash is computed with ``A``
+    canonicalised as the brightest of the triplet (the caller is
+    responsible for that canonicalisation); both ratios survive
+    arbitrary rotation, translation, and uniform scale, which is what
+    lets the matcher recover correspondences without knowing the
+    transform.
+
+    Parameters:
+        pa: Brightest vertex of the triplet.
+        pb, pc: The other two vertices, in caller-canonical
+            (sorted-index) order so each unordered triplet hashes
+            once.
+
+    Returns:
+        ``(r1, r2, theta)`` tuple, or ``None`` for degenerate
+        configurations (collinear vertices, coincident points) which
+        are silently dropped.
+    """
+    av, au = pa
+    bv, bu = pb
+    cv, cu = pc
+    ab_v = bv - av
+    ab_u = bu - au
+    ac_v = cv - av
+    ac_u = cu - au
+    bc_v = cv - bv
+    bc_u = cu - bu
+    d_ab = math.hypot(ab_v, ab_u)
+    d_ac = math.hypot(ac_v, ac_u)
+    d_bc = math.hypot(bc_v, bc_u)
+    if d_ab <= 0.0 or d_ac <= 0.0:
+        return None
+    cos_theta = (ab_v * ac_v + ab_u * ac_u) / (d_ab * d_ac)
+    cos_theta = max(-1.0, min(1.0, cos_theta))
+    return (d_ab / d_ac, d_bc / d_ac, math.acos(cos_theta))
+
+
+@dataclass(frozen=True)
+class _Triplet:
+    """One enumerated triplet, hashed in canonical form.
+
+    ``idx_a / idx_b / idx_c`` reference back into the source point
+    list; ``a`` is the brightest of the three and ``(b, c)`` are
+    sorted by index ascending so each unordered triplet appears once.
+    """
+
+    idx_a: int
+    idx_b: int
+    idx_c: int
+    hash_v: tuple[float, float, float]
+
+
+def _enumerate_triplets(
+    points: list[tuple[float, float]],
+    brightness_rank: list[int],
+) -> list[_Triplet]:
+    """Return every canonical ``_Triplet`` over ``points``.
+
+    ``brightness_rank[i]`` is the brightness rank of point ``i``
+    (``0`` = brightest); it picks the ``a`` vertex within each
+    unordered ``(i, j, k)`` triple.  Degenerate triplets (collinear or
+    coincident) are dropped silently.
+    """
+    n = len(points)
+    out: list[_Triplet] = []
+    for i in range(n):
+        for j in range(i + 1, n):
+            for k in range(j + 1, n):
+                triple = (i, j, k)
+                ranks = (brightness_rank[i], brightness_rank[j], brightness_rank[k])
+                a_pos = int(np.argmin(np.asarray(ranks)))
+                idx_a = triple[a_pos]
+                rest = sorted(idx for idx in triple if idx != idx_a)
+                idx_b, idx_c = rest
+                hashed = _triplet_hash(points[idx_a], points[idx_b], points[idx_c])
+                if hashed is None:
+                    continue
+                out.append(_Triplet(idx_a=idx_a, idx_b=idx_b, idx_c=idx_c, hash_v=hashed))
+    return out
+
+
+def _hash_distance_sq(
+    h1: tuple[float, float, float],
+    h2: tuple[float, float, float],
+    *,
+    ratio_weight: float,
+    angle_weight: float,
+) -> float:
+    """Return the weighted squared Euclidean distance between two triplet hashes.
+
+    ``ratio_weight`` scales the two ratio components and
+    ``angle_weight`` scales the angle component.  Both default to 1.0
+    in the YAML — radians and dimensionless ratios end up roughly
+    comparable in magnitude over the typical triplet shapes.
+    """
+    dr1 = h1[0] - h2[0]
+    dr2 = h1[1] - h2[1]
+    da = h1[2] - h2[2]
+    return ratio_weight * (dr1 * dr1 + dr2 * dr2) + angle_weight * da * da
+
+
+def _greedy_inlier_count(
+    detection_pts: NDArrayFloatType,
+    catalog_pts: NDArrayFloatType,
+    offset_vu: tuple[float, float],
+    *,
+    tolerance_px: float,
+) -> tuple[int, list[tuple[int, int]]]:
+    """Greedy nearest-neighbour matching under the proposed translation.
+
+    Each detection is paired with its closest catalog star (after
+    applying the offset to catalog positions) within
+    ``tolerance_px``.  Each catalog star can match at most one
+    detection — once consumed, it is removed from the candidate pool.
+
+    Parameters:
+        detection_pts: ``(N_det, 2)`` array of detection (v, u).
+        catalog_pts: ``(N_cat, 2)`` array of catalog (v, u).
+        offset_vu: Translation applied to catalog positions before
+            matching.
+        tolerance_px: Maximum residual distance for a correspondence.
+
+    Returns:
+        ``(n_inliers, correspondences)`` where ``correspondences`` is a
+        list of ``(det_idx, cat_idx)`` tuples in detection-index
+        ascending order.  ``n_inliers`` equals
+        ``len(correspondences)``.
+    """
+    if detection_pts.size == 0 or catalog_pts.size == 0:
+        return 0, []
+    shifted_catalog = catalog_pts + np.asarray(offset_vu, np.float64)[None, :]
+    n_det = detection_pts.shape[0]
+    n_cat = shifted_catalog.shape[0]
+    available = np.ones(n_cat, dtype=bool)
+    pairs: list[tuple[int, int]] = []
+    tol_sq = tolerance_px * tolerance_px
+    for d_idx in range(n_det):
+        d = detection_pts[d_idx]
+        if not available.any():
+            break
+        diffs = shifted_catalog - d[None, :]
+        dist_sq = np.sum(diffs * diffs, axis=1)
+        dist_sq[~available] = np.inf
+        c_idx = int(np.argmin(dist_sq))
+        if dist_sq[c_idx] <= tol_sq:
+            pairs.append((d_idx, c_idx))
+            available[c_idx] = False
+    return len(pairs), pairs
+
+
+def _triplet_centroid_offset(
+    detection_pts: NDArrayFloatType,
+    catalog_pts: NDArrayFloatType,
+    *,
+    det_indices: tuple[int, int, int],
+    cat_indices: tuple[int, int, int],
+) -> tuple[float, float]:
+    """Return the translation aligning two triplet centroids.
+
+    Centroids are the unweighted mean of three vertex positions.
+    Numerically equivalent to ``mean(detection - catalog)`` over the
+    triplet but expressed centroid-style for clarity.
+    """
+    det_v = (
+        detection_pts[det_indices[0], 0]
+        + detection_pts[det_indices[1], 0]
+        + detection_pts[det_indices[2], 0]
+    ) / 3.0
+    det_u = (
+        detection_pts[det_indices[0], 1]
+        + detection_pts[det_indices[1], 1]
+        + detection_pts[det_indices[2], 1]
+    ) / 3.0
+    cat_v = (
+        catalog_pts[cat_indices[0], 0]
+        + catalog_pts[cat_indices[1], 0]
+        + catalog_pts[cat_indices[2], 0]
+    ) / 3.0
+    cat_u = (
+        catalog_pts[cat_indices[0], 1]
+        + catalog_pts[cat_indices[1], 1]
+        + catalog_pts[cat_indices[2], 1]
+    ) / 3.0
+    return float(det_v - cat_v), float(det_u - cat_u)
+
+
+def _solve_translation(
+    detection_pts: NDArrayFloatType,
+    catalog_pts: NDArrayFloatType,
+    weights: NDArrayFloatType,
+) -> tuple[float, float]:
+    """Return the weighted-mean translation ``mean(d - c)``.
+
+    Returns ``(0.0, 0.0)`` when the total weight is non-positive.
+    """
+    diffs = detection_pts - catalog_pts
+    total = float(weights.sum())
+    if total <= 0.0:
+        return 0.0, 0.0
+    dv = float(np.sum(weights * diffs[:, 0]) / total)
+    du = float(np.sum(weights * diffs[:, 1]) / total)
+    return dv, du
+
+
+def _seed_from_image_et(image_et: float) -> int:
+    """Return a deterministic 64-bit RANSAC seed from the obs midtime ET.
+
+    Per Part 3 §"Determinism in RANSAC" the matcher iterates triplets
+    in sorted order (no random sampling), so the seed is informational
+    rather than load-bearing.  It is logged so that any future
+    tie-breaking RNG can pull from the same value and stay
+    reproducible across two back-to-back invocations on the same obs.
+    """
+    if not math.isfinite(image_et):
+        return 0
+    # Convert seconds-past-J2000 (TDB) to integer nanoseconds, then
+    # mask into the unsigned 64-bit range; ``& 0xFFFFFFFFFFFFFFFF``
+    # makes negative ETs (pre-J2000 obs, e.g. Voyager) wrap cleanly
+    # rather than overflow ``np.random.default_rng``.
+    return round(image_et * 1.0e9) & 0xFFFFFFFFFFFFFFFF
+
+
+class _StarFieldConfidenceContext:
+    """Adapter binding ``StarFieldDiagnostics`` plus side flags."""
+
+    def __init__(
+        self,
+        *,
+        at_edge: bool,
+        spurious: bool,
+        diagnostics: StarFieldDiagnostics,
+    ) -> None:
+        self.at_edge = at_edge
+        self.spurious = spurious
+        self.n_inliers = float(diagnostics.n_inliers)
+        self.median_residual_px = diagnostics.median_residual_px
+        self.n_detected_sources = float(diagnostics.n_detected_sources)
+        self.n_catalog_predicted = float(diagnostics.n_catalog_predicted)
+
+
+class StarFieldFromCatalogNav(NavTechnique):
+    """Multi-star pattern-match translation fit (≥ 3 catalog + image stars).
+
+    Class attributes:
+        accepts_feature_types: ``frozenset({STAR})``.
+        requires_prior: ``False`` — runs in pass 1.
+    """
+
+    name = 'StarFieldFromCatalogNav'
+    accepts_feature_types = frozenset({NavFeatureType.STAR})
+    requires_prior = False
+    confidence_attributes = frozenset(
+        {
+            'at_edge',
+            'spurious',
+            'n_inliers',
+            'median_residual_px',
+            'n_detected_sources',
+            'n_catalog_predicted',
+        }
+    )
+
+    def __init__(self, *, config: Config | None = None) -> None:
+        super().__init__(config=config)
+        self.config.read_config()  # ensure cls.tuning is populated
+        self._max_sources = int(self.tuning['max_sources'])
+        self._detection_sigma = float(self.tuning['detection_sigma'])
+        self._psf_sigma_px = float(self.tuning['psf_sigma_px'])
+        self._centroid_box_half_px = int(self.tuning['centroid_box_half_px'])
+        self._hash_match_tolerance = float(self.tuning['hash_match_tolerance'])
+        self._hash_ratio_weight = float(self.tuning['hash_ratio_weight'])
+        self._hash_angle_weight = float(self.tuning['hash_angle_weight'])
+        self._inlier_tolerance_px = float(self.tuning['inlier_tolerance_px'])
+        self._min_inliers = int(self.tuning['pattern_match_min_inliers'])
+        self._at_edge_tolerance_px = float(self.tuning['at_edge_tolerance_px'])
+        if self._min_inliers < 3:
+            raise ValueError(
+                f'pattern_match_min_inliers must be >= 3 (the matcher needs at '
+                f'least one triplet per side); got {self._min_inliers}'
+            )
+        if self._max_sources < 3:
+            raise ValueError(f'max_sources must be >= 3; got {self._max_sources}')
+
+    def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
+        """Report feasibility based on the predictable-star cohort.
+
+        Reads only feature metadata; never any pixels.  Feasible when
+        at least three usable STAR features are in the input set —
+        below that the matcher cannot form a single triplet.
+        """
+        usable = usable_stars(features)
+        if len(usable) < 3:
+            return NavFeasibilityReport(
+                feasible=False,
+                reason=f'fewer_than_3_predicted_stars (got {len(usable)})',
+            )
+        return NavFeasibilityReport(feasible=True, reason='ok', consumed_feature_count=len(usable))
+
+    def navigate(self, features: list[NavFeature], context: NavContext) -> NavTechniqueResult:
+        """Recover translation from triplet pattern matching against the catalog.
+
+        Parameters:
+            features: STAR features (the orchestrator pre-filters by
+                type).  At least three must survive
+                ``usable_stars``.
+            context: Per-image NavContext.
+
+        Returns:
+            ``NavTechniqueResult`` with the recovered offset, 2x2
+            covariance, calibrated confidence, and a populated
+            :class:`StarFieldDiagnostics`.
+        """
+        with self.logger.open(f'TECHNIQUE: {self.name}'):
+            usable = usable_stars(features)
+            self.logger.info(
+                'Consuming %d usable STAR feature(s) (out of %d offered)',
+                len(usable),
+                len(features),
+            )
+            seed = _seed_from_image_et(float(context.provenance.image_et))
+            self.logger.debug('RANSAC seed (from obs.midtime ns): %d', seed)
+            ranked_catalog = sorted(usable, key=predicted_snr, reverse=True)[: self._max_sources]
+            n_catalog_predicted = len(ranked_catalog)
+            if n_catalog_predicted < 3:
+                return self._fail(
+                    features=features,
+                    reason=f'fewer_than_3_predicted_stars (got {n_catalog_predicted})',
+                    diagnostics=StarFieldDiagnostics(
+                        n_inliers=0,
+                        median_residual_px=0.0,
+                        n_detected_sources=0,
+                        n_catalog_predicted=n_catalog_predicted,
+                        n_triplets_evaluated=0,
+                    ),
+                )
+            image_ext = np.asarray(context.image_ext, np.float64)
+            noise_sigma = float(max(context.image_noise_sigma, 1e-9))
+            detected = _detect_image_sources(
+                image_ext,
+                image_noise_sigma=noise_sigma,
+                sigma_px=self._psf_sigma_px,
+                detection_sigma=self._detection_sigma,
+                centroid_box_half_px=self._centroid_box_half_px,
+                max_sources=self._max_sources,
+            )
+            n_detected_sources = len(detected)
+            self.logger.info(
+                'Detected %d source(s); using up to %d catalog stars',
+                n_detected_sources,
+                n_catalog_predicted,
+            )
+            if n_detected_sources < 3:
+                return self._fail(
+                    features=features,
+                    reason=f'fewer_than_3_detected_sources (got {n_detected_sources})',
+                    diagnostics=StarFieldDiagnostics(
+                        n_inliers=0,
+                        median_residual_px=0.0,
+                        n_detected_sources=n_detected_sources,
+                        n_catalog_predicted=n_catalog_predicted,
+                        n_triplets_evaluated=0,
+                    ),
+                )
+            return self._match_and_fit(
+                features=features,
+                detected=detected,
+                ranked_catalog=ranked_catalog,
+                context=context,
+                n_detected_sources=n_detected_sources,
+                n_catalog_predicted=n_catalog_predicted,
+            )
+
+    def _match_and_fit(
+        self,
+        *,
+        features: list[NavFeature],
+        detected: list[_DetectedSource],
+        ranked_catalog: list[NavFeature],
+        context: NavContext,
+        n_detected_sources: int,
+        n_catalog_predicted: int,
+    ) -> NavTechniqueResult:
+        """RANSAC + Tukey-biweight verification on the prepared cohorts."""
+        det_points = [(s.v, s.u) for s in detected]
+        det_points_arr = np.asarray(det_points, np.float64)
+        det_brightness_rank = list(range(n_detected_sources))  # already sorted
+        cat_points = [predicted_vu(f) for f in ranked_catalog]
+        cat_points_arr = np.asarray(cat_points, np.float64)
+        cat_brightness_rank = list(range(n_catalog_predicted))  # already sorted by SNR
+        det_triplets = _enumerate_triplets(det_points, det_brightness_rank)
+        cat_triplets = _enumerate_triplets(cat_points, cat_brightness_rank)
+        if not det_triplets or not cat_triplets:
+            return self._fail(
+                features=features,
+                reason='no_valid_triplets_after_canonicalisation',
+                diagnostics=StarFieldDiagnostics(
+                    n_inliers=0,
+                    median_residual_px=0.0,
+                    n_detected_sources=n_detected_sources,
+                    n_catalog_predicted=n_catalog_predicted,
+                    n_triplets_evaluated=0,
+                ),
+            )
+        candidates = self._enumerate_candidates(det_triplets, cat_triplets)
+        n_triplets_evaluated = len(candidates)
+        self.logger.debug(
+            '%d detection triplet(s) and %d catalog triplet(s) -> %d hash-distance candidates',
+            len(det_triplets),
+            len(cat_triplets),
+            n_triplets_evaluated,
+        )
+        best = self._score_candidates(
+            candidates=candidates,
+            cat_triplets=cat_triplets,
+            det_points_arr=det_points_arr,
+            cat_points_arr=cat_points_arr,
+        )
+        if best is None or best[0] < self._min_inliers:
+            n_inliers = 0 if best is None else best[0]
+            return self._fail(
+                features=features,
+                reason=(f'too_few_inliers ({n_inliers} < min {self._min_inliers})'),
+                diagnostics=StarFieldDiagnostics(
+                    n_inliers=n_inliers,
+                    median_residual_px=0.0,
+                    n_detected_sources=n_detected_sources,
+                    n_catalog_predicted=n_catalog_predicted,
+                    n_triplets_evaluated=n_triplets_evaluated,
+                ),
+            )
+        n_inliers, correspondences, _coarse_offset = best
+        det_inliers = det_points_arr[[d for d, _ in correspondences]]
+        cat_inliers = cat_points_arr[[c for _, c in correspondences]]
+        offset_vu, weights, residuals = self._tukey_refit(det_inliers, cat_inliers)
+        residual_distances = np.hypot(residuals[:, 0], residuals[:, 1])
+        median_residual_px = float(np.median(residual_distances))
+        cov = self._build_covariance(weights=weights, residuals=residuals)
+        diagnostics = StarFieldDiagnostics(
+            n_inliers=n_inliers,
+            median_residual_px=median_residual_px,
+            n_detected_sources=n_detected_sources,
+            n_catalog_predicted=n_catalog_predicted,
+            n_triplets_evaluated=n_triplets_evaluated,
+        )
+        margin_v, margin_u = search_window_for_obs(context)
+        at_edge = (
+            abs(offset_vu[0]) >= margin_v - self._at_edge_tolerance_px
+            or abs(offset_vu[1]) >= margin_u - self._at_edge_tolerance_px
+        )
+        confidence = self._evaluate_confidence(
+            diagnostics=diagnostics, at_edge=at_edge, spurious=False
+        )
+        consumed_ids = tuple(ranked_catalog[c].feature_id for _, c in correspondences)
+        self.logger.info(
+            'Pattern-match offset (%.4f, %.4f) px; %d inlier(s); median residual %.4f px; '
+            'confidence %.4f',
+            offset_vu[0],
+            offset_vu[1],
+            n_inliers,
+            median_residual_px,
+            confidence,
+        )
+        return NavTechniqueResult(
+            technique_name=self.name,
+            feature_ids=consumed_ids,
+            offset_px=(offset_vu[0], offset_vu[1]),
+            covariance_px2=cov,
+            confidence=confidence,
+            spurious=False,
+            at_edge=at_edge,
+            diagnostics=diagnostics,
+        )
+
+    def _enumerate_candidates(
+        self,
+        det_triplets: list[_Triplet],
+        cat_triplets: list[_Triplet],
+    ) -> list[tuple[float, int, int, int, int, int, int, int]]:
+        """Return surviving ``(dist_sq, sorted_det_idx..., a, b, c, cat_idx)`` candidates.
+
+        Each detection triplet is matched against every catalog triplet
+        whose hash-distance falls within ``hash_match_tolerance``.  The
+        candidate list is sorted by ``(hash_dist_sq, sorted
+        detection-source indices ascending, catalog-triplet index)`` —
+        per AUTONAV_PLAN.md §33 the sorted-ascending detection tuple
+        ``(min, mid, max)`` is the canonical tie-breaker, not the
+        canonical (a=brightest, b<c) order, because the
+        sorted-ascending key is invariant under brightness re-ranking
+        and yields bit-identical iteration across two back-to-back
+        invocations on the same obs (Cardinal Principle 3).
+        """
+        tol_sq = self._hash_match_tolerance * self._hash_match_tolerance
+        out: list[tuple[float, int, int, int, int, int, int, int]] = []
+        for det in det_triplets:
+            sorted_indices = sorted([det.idx_a, det.idx_b, det.idx_c])
+            sort_lo, sort_mid, sort_hi = sorted_indices[0], sorted_indices[1], sorted_indices[2]
+            for ci, cat in enumerate(cat_triplets):
+                dist_sq = _hash_distance_sq(
+                    det.hash_v,
+                    cat.hash_v,
+                    ratio_weight=self._hash_ratio_weight,
+                    angle_weight=self._hash_angle_weight,
+                )
+                if dist_sq <= tol_sq:
+                    out.append(
+                        (
+                            dist_sq,
+                            sort_lo,
+                            sort_mid,
+                            sort_hi,
+                            det.idx_a,
+                            det.idx_b,
+                            det.idx_c,
+                            ci,
+                        )
+                    )
+        out.sort()
+        return out
+
+    def _score_candidates(
+        self,
+        *,
+        candidates: list[tuple[float, int, int, int, int, int, int, int]],
+        cat_triplets: list[_Triplet],
+        det_points_arr: NDArrayFloatType,
+        cat_points_arr: NDArrayFloatType,
+    ) -> tuple[int, list[tuple[int, int]], tuple[float, float]] | None:
+        """Score every candidate; return the (n_inliers, correspondences, offset) winner.
+
+        Each (det_triplet, cat_triplet) candidate proposes the
+        translation that maps the catalog-triplet centroid onto the
+        detection-triplet centroid.  Inliers are counted by greedy
+        nearest-neighbour matching under that translation.  The first
+        candidate (in sorted order) that ties the best inlier count
+        wins, which matches the deterministic-iteration contract.
+        """
+        best: tuple[int, list[tuple[int, int]], tuple[float, float]] | None = None
+        for _dist_sq, _lo, _mid, _hi, det_a, det_b, det_c, cat_pos in candidates:
+            cat = cat_triplets[cat_pos]
+            offset = _triplet_centroid_offset(
+                det_points_arr,
+                cat_points_arr,
+                det_indices=(det_a, det_b, det_c),
+                cat_indices=(cat.idx_a, cat.idx_b, cat.idx_c),
+            )
+            n_inliers, pairs = _greedy_inlier_count(
+                det_points_arr,
+                cat_points_arr,
+                offset_vu=offset,
+                tolerance_px=self._inlier_tolerance_px,
+            )
+            if best is None or n_inliers > best[0]:
+                best = (n_inliers, pairs, offset)
+        return best
+
+    def _tukey_refit(
+        self,
+        det_inliers: NDArrayFloatType,
+        cat_inliers: NDArrayFloatType,
+    ) -> tuple[tuple[float, float], NDArrayFloatType, NDArrayFloatType]:
+        """Refit translation by Tukey-biweight-reweighted least squares.
+
+        Two-pass: (i) unweighted mean to seed residual scale; (ii) one
+        biweight-reweighted mean at the conventional 4.685 breakdown
+        constant.  Returns the final ``(offset, weights, residuals)``
+        triple where ``residuals`` is the per-correspondence
+        ``(d - (c + offset))`` array.
+        """
+        n = det_inliers.shape[0]
+        weights0 = np.ones(n, dtype=np.float64)
+        offset0 = _solve_translation(det_inliers, cat_inliers, weights0)
+        residuals0 = det_inliers - cat_inliers - np.asarray(offset0, np.float64)[None, :]
+        distances0 = np.hypot(residuals0[:, 0], residuals0[:, 1])
+        scale = float(np.median(distances0)) if distances0.size > 0 else 0.0
+        if scale <= 0.0:
+            # Perfect fit — no scatter — biweight weights are unity by
+            # construction (every residual is zero).
+            return offset0, weights0, residuals0
+        scaled = distances0 / scale
+        weights = tukey_biweight_weights(scaled, c=DEFAULT_TUKEY_C)
+        if float(weights.sum()) <= 0.0:
+            return offset0, weights0, residuals0
+        offset = _solve_translation(det_inliers, cat_inliers, weights)
+        residuals = det_inliers - cat_inliers - np.asarray(offset, np.float64)[None, :]
+        return offset, weights, residuals
+
+    def _build_covariance(
+        self, *, weights: NDArrayFloatType, residuals: NDArrayFloatType
+    ) -> NDArrayFloatType:
+        """Return the per-axis covariance of the translation estimate.
+
+        With ``N`` weighted residuals the parameter (mean) covariance is
+        per-axis ``var_axis / sum(weights)``; the variance is computed
+        with the biweight weights so outliers do not inflate it.  A
+        small floor (``1 / sum(weights)``) keeps the covariance
+        positive-definite in the noise-free case where every residual
+        is zero.
+        """
+        total = float(weights.sum())
+        if total <= 0.0:
+            return np.eye(2, dtype=np.float64)
+        var_v = float(np.sum(weights * residuals[:, 0] ** 2)) / total
+        var_u = float(np.sum(weights * residuals[:, 1] ** 2)) / total
+        floor = 1.0 / total
+        cov_v = max(var_v / total, floor)
+        cov_u = max(var_u / total, floor)
+        return np.diag([cov_v, cov_u]).astype(np.float64)
+
+    def _evaluate_confidence(
+        self,
+        *,
+        diagnostics: StarFieldDiagnostics,
+        at_edge: bool,
+        spurious: bool,
+    ) -> float:
+        """Run the YAML confidence formula and emit a per-term breakdown."""
+        assert self.confidence_spec is not None
+        confidence, breakdown = evaluate_sigmoid_combination(
+            self.confidence_spec,
+            _StarFieldConfidenceContext(
+                at_edge=at_edge, spurious=spurious, diagnostics=diagnostics
+            ),
+            technique_name=self.name,
+            return_breakdown=True,
+        )
+        log_confidence_breakdown(self.logger, breakdown)
+        return float(confidence)
+
+    def _fail(
+        self,
+        *,
+        features: list[NavFeature],
+        reason: str,
+        diagnostics: StarFieldDiagnostics,
+    ) -> NavTechniqueResult:
+        """Return a zero-confidence spurious result with the supplied reason."""
+        self.logger.info('Reporting spurious result: %s', reason)
+        return NavTechniqueResult(
+            technique_name=self.name,
+            feature_ids=tuple(f.feature_id for f in features),
+            offset_px=(0.0, 0.0),
+            covariance_px2=1e6 * np.eye(2, dtype=np.float64),
+            confidence=0.0,
+            spurious=True,
+            at_edge=False,
+            diagnostics=diagnostics,
+        )

--- a/src/nav/nav_technique/nav_technique_star_field.py
+++ b/src/nav/nav_technique/nav_technique_star_field.py
@@ -67,6 +67,20 @@ if TYPE_CHECKING:  # pragma: no cover - typing-only import
 __all__ = ['StarFieldFromCatalogNav']
 
 
+_COLLINEAR_REL_EPS: float = 1.0e-6
+"""Relative tolerance for the collinear-triplet rejection in ``_triplet_hash``.
+
+A triplet is treated as collinear (and rejected) when the magnitude of
+its 2-D cross product falls below ``_COLLINEAR_REL_EPS * d_ab * d_ac``.
+The dimensionless ratio survives uniform scaling of the input, so the
+floor expresses "the smaller-angle deviation from a perfect line" in
+the same way a relative-error tolerance does for floating-point
+comparisons.  ``1e-6`` admits numerical jitter on near-degenerate
+real-detection triplets while still catching the geometric
+degeneracy.
+"""
+
+
 # All numeric tunables for this technique live in
 # ``config_files/config_510_techniques.yaml`` under
 # ``techniques.StarFieldFromCatalogNav.tuning``.  Missing-key access in
@@ -220,6 +234,15 @@ def _triplet_hash(
     d_ac = math.hypot(ac_v, ac_u)
     d_bc = math.hypot(bc_v, bc_u)
     if d_ab <= 0.0 or d_ac <= 0.0:
+        return None
+    # Collinear-but-distinct triplets produce ``theta = 0`` or ``pi`` —
+    # a hash that can match any other 0-or-pi hash regardless of scale,
+    # which is a false-match trap for the RANSAC matcher.  Reject when
+    # the 2-D cross product magnitude (``d_ab * d_ac * |sin(theta)|``)
+    # falls below a small fraction of the side-length product, which
+    # is dimensionless and survives uniform scaling of the input.
+    cross = ab_v * ac_u - ab_u * ac_v
+    if abs(cross) <= _COLLINEAR_REL_EPS * d_ab * d_ac:
         return None
     cos_theta = (ab_v * ac_v + ab_u * ac_u) / (d_ab * d_ac)
     cos_theta = max(-1.0, min(1.0, cos_theta))

--- a/src/nav/nav_technique/nav_technique_star_refine.py
+++ b/src/nav/nav_technique/nav_technique_star_refine.py
@@ -1,0 +1,388 @@
+"""``StarRefineNav`` — pass-2 star-refinement technique.
+
+Consumes the pass-1 ensemble's prior offset and refines it via local
+PSF-centroid fits on every predicted catalog star.  For each STAR
+feature, the technique:
+
+1. Shifts the catalog prediction by the prior offset.
+2. Looks for a brightness peak inside a small refinement window
+   centered on that shifted prediction.
+3. Fits a brightness-weighted moment around the peak to get a sub-pixel
+   centroid.
+4. Computes per-star residuals (observed - shifted_prediction) and
+   averages them in inverse-variance fashion.
+
+Per-star inverse variance is the trace of the feature's CRLB
+covariance carried on ``NavFeature.position_cov_px``; stars with low
+predicted SNR get less weight.  Stars whose detection is too far from
+the shifted prediction (likely a wrong peak) are dropped before the
+fit.
+
+The refined offset is reported as a *delta* from the prior — the
+ensemble combine adds it back.  The covariance reflects the residual
+scatter across the surviving stars; with two or more inliers the
+technique reports the actual scatter, with a single inlier the CRLB
+floor.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from nav.config import Config
+from nav.feature.feature import NavFeature
+from nav.feature.feature_type import NavFeatureType
+from nav.feature.flags import StarFlags
+from nav.feature.geometry import StarGeometry
+from nav.nav_technique._star_helpers import local_centroid, usable_stars
+from nav.nav_technique.confidence import evaluate_sigmoid_combination
+from nav.nav_technique.diagnostics import StarRefineDiagnostics
+from nav.nav_technique.feasibility import NavFeasibilityReport
+from nav.nav_technique.nav_technique import (
+    NavTechnique,
+    log_confidence_breakdown,
+    search_window_for_obs,
+)
+from nav.nav_technique.technique_result import NavTechniqueResult
+from nav.support.types import NDArrayFloatType
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from nav.nav_orchestrator.nav_context import NavContext
+
+__all__ = ['StarRefineNav']
+
+
+# All numeric tunables for this technique live in
+# ``config_files/config_510_techniques.yaml`` under
+# ``techniques.StarRefineNav.tuning``.  No Python-level fallback;
+# missing-key access in ``__init__`` is a KeyError so a config typo
+# fails fast at process startup.
+
+
+def _trace_inverse_variance(feature: NavFeature) -> float:
+    """Return the inverse-trace of a feature's position covariance.
+
+    The CRLB covariance carried on ``NavFeature.position_cov_px`` is the
+    per-feature uncertainty floor; its trace is the sum of per-axis
+    variances and ``1 / trace`` is a fast precision-weighted scalar
+    proxy for the feature's worth in a least-squares average.
+    """
+    cov = feature.position_cov_px
+    if cov is None:
+        return 1.0
+    arr = np.asarray(cov, dtype=np.float64)
+    trace = float(np.trace(arr))
+    if trace <= 0.0:
+        return 1.0
+    return 1.0 / trace
+
+
+class _RefineConfidenceContext:
+    """Adapter binding ``StarRefineDiagnostics`` plus side flags."""
+
+    def __init__(
+        self,
+        *,
+        at_edge: bool,
+        spurious: bool,
+        diagnostics: StarRefineDiagnostics,
+    ) -> None:
+        self.at_edge = at_edge
+        self.spurious = spurious
+        self.n_stars_used = float(diagnostics.n_stars_used)
+        self.median_pos_err_px = diagnostics.median_pos_err_px
+        self.residual_scatter_px = diagnostics.residual_scatter_px
+
+
+class StarRefineNav(NavTechnique):
+    """Star-refinement technique consuming the pass-1 prior.
+
+    A 1-inlier refine carries no independent cross-check information
+    beyond the prior it was handed — it is the same single observation
+    that drove the pass-1 fit, just polished.  The post-sigmoid
+    ``single_inlier_confidence_cap`` (default 0.5) prevents the
+    technique from promoting itself above ``StarUniqueMatchNav``'s
+    0.7 1-star cap on the same observation.  With ≥ 2 inliers the per-
+    star residual scatter cross-checks the joint fit and the cap is
+    not applied.
+
+    Class attributes:
+        accepts_feature_types: ``frozenset({STAR})``.
+        requires_prior: ``True`` — runs in pass 2.
+    """
+
+    name = 'StarRefineNav'
+    accepts_feature_types = frozenset({NavFeatureType.STAR})
+    requires_prior = True
+    confidence_attributes = frozenset(
+        {
+            'at_edge',
+            'spurious',
+            'n_stars_used',
+            'median_pos_err_px',
+            'residual_scatter_px',
+        }
+    )
+
+    def __init__(self, *, config: Config | None = None) -> None:
+        super().__init__(config=config)
+        self.config.read_config()  # ensure cls.tuning is populated
+        self._refine_window_px = float(self.tuning['refine_window_px'])
+        self._centroid_box_half_px = int(self.tuning['centroid_box_half_px'])
+        self._max_per_star_residual_px = float(self.tuning['max_per_star_residual_px'])
+        self._detection_sigma = float(self.tuning['detection_sigma'])
+        self._min_inliers = int(self.tuning['min_inliers'])
+        self._at_edge_tolerance_px = float(self.tuning['at_edge_tolerance_px'])
+        self._single_inlier_confidence_cap = float(self.tuning['single_inlier_confidence_cap'])
+        if self._min_inliers < 1:
+            raise ValueError(f'min_inliers must be >= 1; got {self._min_inliers}')
+        if not 0.0 <= self._single_inlier_confidence_cap <= 1.0:
+            raise ValueError(
+                f'single_inlier_confidence_cap must lie in [0, 1]; got '
+                f'{self._single_inlier_confidence_cap!r}'
+            )
+
+    def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
+        """Report feasibility based on the predictable-star cohort."""
+        usable = usable_stars(features)
+        if not usable:
+            return NavFeasibilityReport(feasible=False, reason='no_usable_star_features')
+        return NavFeasibilityReport(feasible=True, reason='ok', consumed_feature_count=len(usable))
+
+    def navigate(self, features: list[NavFeature], context: NavContext) -> NavTechniqueResult:
+        """Refine the pass-1 prior by per-star centroid residuals.
+
+        Parameters:
+            features: STAR features (the orchestrator pre-filters by type).
+            context: Per-image NavContext.  Must carry ``prior_offset_px``;
+                the technique is registered as ``requires_prior=True`` so
+                the orchestrator only invokes it on pass 2.
+
+        Returns:
+            ``NavTechniqueResult`` with the *delta* offset relative to the
+            prior, a 2x2 covariance, calibrated confidence, and a
+            populated :class:`StarRefineDiagnostics`.
+        """
+        with self.logger.open(f'TECHNIQUE: {self.name}'):
+            usable = usable_stars(features)
+            self.logger.info(
+                'Consuming %d usable STAR feature(s) (out of %d offered)',
+                len(usable),
+                len(features),
+            )
+            if context.prior_offset_px is None:
+                return self._fail(
+                    features=features,
+                    reason='no_prior_offset_on_context',
+                    diagnostics=StarRefineDiagnostics(
+                        n_stars_used=0,
+                        median_pos_err_px=0.0,
+                        residual_scatter_px=0.0,
+                    ),
+                )
+            prior_v, prior_u = context.prior_offset_px
+            image_ext = np.asarray(context.image_ext, np.float64)
+            noise_sigma = float(max(context.image_noise_sigma, 1e-9))
+            inliers, per_star_residuals_v, per_star_residuals_u, weights = self._collect_residuals(
+                usable, image_ext, noise_sigma, prior_v, prior_u
+            )
+            if len(inliers) < self._min_inliers:
+                return self._fail(
+                    features=features,
+                    reason=(f'too_few_inliers ({len(inliers)} < min {self._min_inliers})'),
+                    diagnostics=StarRefineDiagnostics(
+                        n_stars_used=len(inliers),
+                        median_pos_err_px=0.0,
+                        residual_scatter_px=0.0,
+                    ),
+                )
+            total_weight = float(weights.sum())
+            delta_v = float(np.sum(weights * per_star_residuals_v) / total_weight)
+            delta_u = float(np.sum(weights * per_star_residuals_u) / total_weight)
+            distances = np.hypot(per_star_residuals_v, per_star_residuals_u)
+            median_pos_err_px = float(np.median(distances))
+            scatter_v = float(
+                math.sqrt(
+                    float(np.sum(weights * (per_star_residuals_v - delta_v) ** 2)) / total_weight
+                )
+            )
+            scatter_u = float(
+                math.sqrt(
+                    float(np.sum(weights * (per_star_residuals_u - delta_u) ** 2)) / total_weight
+                )
+            )
+            residual_scatter_px = math.hypot(scatter_v, scatter_u)
+            diagnostics = StarRefineDiagnostics(
+                n_stars_used=len(inliers),
+                median_pos_err_px=median_pos_err_px,
+                residual_scatter_px=residual_scatter_px,
+            )
+            margin_v, margin_u = search_window_for_obs(context)
+            at_edge = (
+                abs(delta_v + prior_v) >= margin_v - self._at_edge_tolerance_px
+                or abs(delta_u + prior_u) >= margin_u - self._at_edge_tolerance_px
+            )
+            assert self.confidence_spec is not None
+            raw_confidence, breakdown = evaluate_sigmoid_combination(
+                self.confidence_spec,
+                _RefineConfidenceContext(at_edge=at_edge, spurious=False, diagnostics=diagnostics),
+                technique_name=self.name,
+                return_breakdown=True,
+            )
+            log_confidence_breakdown(self.logger, breakdown)
+            # 1-inlier refines carry no independent cross-check beyond the
+            # prior they were handed; cap their confidence so the
+            # ensemble's primary-technique selection cannot promote a
+            # 1-star refine over a 1-star unique-match on the same
+            # observation.
+            confidence = float(raw_confidence)
+            if len(inliers) == 1 and confidence > self._single_inlier_confidence_cap:
+                self.logger.info(
+                    'Single-inlier refine: capping confidence %.4f -> %.4f '
+                    '(no cross-check on a 1-star refine)',
+                    confidence,
+                    self._single_inlier_confidence_cap,
+                )
+                confidence = self._single_inlier_confidence_cap
+            cov = self._build_covariance(
+                inliers=inliers,
+                weights=weights,
+                residuals_v=per_star_residuals_v,
+                residuals_u=per_star_residuals_u,
+                delta_v=delta_v,
+                delta_u=delta_u,
+            )
+            self.logger.info(
+                'Refined %d star(s); delta (%.4f, %.4f) px from prior '
+                '(%.4f, %.4f); median pos err %.4f px; scatter %.4f px; '
+                'confidence %.4f',
+                len(inliers),
+                delta_v,
+                delta_u,
+                prior_v,
+                prior_u,
+                median_pos_err_px,
+                residual_scatter_px,
+                confidence,
+            )
+            return NavTechniqueResult(
+                technique_name=self.name,
+                feature_ids=tuple(f.feature_id for f in inliers),
+                offset_px=(delta_v + prior_v, delta_u + prior_u),
+                covariance_px2=cov,
+                confidence=confidence,
+                spurious=False,
+                at_edge=at_edge,
+                diagnostics=diagnostics,
+            )
+
+    def _collect_residuals(
+        self,
+        stars: list[NavFeature],
+        image_ext: NDArrayFloatType,
+        noise_sigma: float,
+        prior_v: float,
+        prior_u: float,
+    ) -> tuple[
+        list[NavFeature],
+        NDArrayFloatType,
+        NDArrayFloatType,
+        NDArrayFloatType,
+    ]:
+        """Per-star centroid residuals around the shifted predictions."""
+        inliers: list[NavFeature] = []
+        residuals_v: list[float] = []
+        residuals_u: list[float] = []
+        weights: list[float] = []
+        for star in stars:
+            assert isinstance(star.geometry, StarGeometry)
+            assert isinstance(star.flags, StarFlags)
+            pred_v, pred_u = star.geometry.predicted_vu
+            shifted_pred = (pred_v + prior_v, pred_u + prior_u)
+            det, peak = local_centroid(
+                image_ext,
+                shifted_pred,
+                search_window_px=self._refine_window_px,
+                centroid_box_half_px=self._centroid_box_half_px,
+                image_noise_sigma=noise_sigma,
+                detection_sigma=self._detection_sigma,
+            )
+            if det is None:
+                self.logger.debug(
+                    'Star %s: no peak above %.2f sigma in refine window (peak %.3f DN); dropped',
+                    star.feature_id,
+                    self._detection_sigma,
+                    peak,
+                )
+                continue
+            res_v = det[0] - shifted_pred[0]
+            res_u = det[1] - shifted_pred[1]
+            distance = math.hypot(res_v, res_u)
+            if distance > self._max_per_star_residual_px:
+                self.logger.debug(
+                    'Star %s: refine residual %.3f px exceeds max %.3f px; dropped',
+                    star.feature_id,
+                    distance,
+                    self._max_per_star_residual_px,
+                )
+                continue
+            inliers.append(star)
+            residuals_v.append(res_v)
+            residuals_u.append(res_u)
+            weights.append(_trace_inverse_variance(star))
+        return (
+            inliers,
+            np.asarray(residuals_v, dtype=np.float64),
+            np.asarray(residuals_u, dtype=np.float64),
+            np.asarray(weights, dtype=np.float64),
+        )
+
+    def _build_covariance(
+        self,
+        *,
+        inliers: list[NavFeature],
+        weights: NDArrayFloatType,
+        residuals_v: NDArrayFloatType,
+        residuals_u: NDArrayFloatType,
+        delta_v: float,
+        delta_u: float,
+    ) -> NDArrayFloatType:
+        """Return the per-axis precision-weighted covariance.
+
+        With one inlier the technique reports the CRLB floor from the
+        feature's ``position_cov_px``.  With two or more inliers the
+        per-axis residual scatter dominates and is reported.
+        """
+        if len(inliers) <= 1:
+            cov = inliers[0].position_cov_px
+            if cov is None:
+                return np.eye(2, dtype=np.float64)
+            return np.asarray(cov, dtype=np.float64).copy()
+        total_weight = float(weights.sum())
+        var_v = float(np.sum(weights * (residuals_v - delta_v) ** 2)) / total_weight
+        var_u = float(np.sum(weights * (residuals_u - delta_u) ** 2)) / total_weight
+        floor = 1.0 / max(total_weight, 1e-12)
+        return np.diag([max(var_v, floor), max(var_u, floor)]).astype(np.float64)
+
+    def _fail(
+        self,
+        *,
+        features: list[NavFeature],
+        reason: str,
+        diagnostics: StarRefineDiagnostics,
+    ) -> NavTechniqueResult:
+        """Return a zero-confidence spurious result with the supplied reason."""
+        self.logger.info('Reporting spurious result: %s', reason)
+        return NavTechniqueResult(
+            technique_name=self.name,
+            feature_ids=tuple(f.feature_id for f in features),
+            offset_px=(0.0, 0.0),
+            covariance_px2=1e6 * np.eye(2, dtype=np.float64),
+            confidence=0.0,
+            spurious=True,
+            at_edge=False,
+            diagnostics=diagnostics,
+        )

--- a/src/nav/nav_technique/nav_technique_star_unique_match.py
+++ b/src/nav/nav_technique/nav_technique_star_unique_match.py
@@ -243,6 +243,25 @@ class StarUniqueMatchNav(NavTechnique):
                 peak_b,
             )
             return None
+        # Overlapping search windows can return the SAME detection for
+        # both predictions (one bright peak shared between the
+        # ``[predicted - W, predicted + W]`` slabs of two close
+        # predictions).  Without this guard the 2-star math would fit
+        # both catalog stars to the same observation, fabricate a
+        # zero-residual cross-check, and report high confidence on a
+        # wrong offset.  Two centroids less than 1 pixel apart almost
+        # certainly came from the same matched-filter peak — fall
+        # back to the one-star path so the brightness-margin gate
+        # gets a chance to reject the ambiguous match.
+        det_separation_px = math.hypot(det_a[0] - det_b[0], det_a[1] - det_b[1])
+        if det_separation_px < 1.0:
+            self.logger.debug(
+                'Two-star path: both predictions resolved to the same '
+                'detection (separation %.4f px < 1.0); falling back to '
+                'one-star path',
+                det_separation_px,
+            )
+            return None
         pred_a = chosen[0].geometry.predicted_vu  # type: ignore[union-attr]
         pred_b = chosen[1].geometry.predicted_vu  # type: ignore[union-attr]
         # Assignment 1: det_a -> pred_a, det_b -> pred_b.

--- a/src/nav/nav_technique/nav_technique_star_unique_match.py
+++ b/src/nav/nav_technique/nav_technique_star_unique_match.py
@@ -1,0 +1,463 @@
+"""``StarUniqueMatchNav`` — translation fit when 1 or 2 stars are uniquely matched.
+
+Two paths share one technique:
+
+- **One-star path.**  When the catalog reduction produces one star whose
+  predicted brightness is at least ``brightness_margin_to_next_catalog_star_mag``
+  brighter than the next-brightest predictable star, the brightest
+  detection inside its search window is unambiguously its match.  The
+  offset is the centroid minus the prediction; confidence is capped at
+  the configured one-star limit (default 0.7) because a single match
+  cannot cross-check itself.
+
+- **Two-star path.**  With two predictable stars, the technique tries
+  both detection-to-prediction assignments and picks the one whose
+  joint residual is smaller.  The residual cross-checks the assignment;
+  confidence is capped at the configured two-star limit (default 0.8).
+
+Local-window detection is intentional: the search window is sized to
+the per-instrument SPICE pointing-error envelope, so a brightest peak
+inside the window is the matched detection.  No global star-detection
+pass is needed (and this technique is feasible even on images where
+multi-star detection would fail because the rest of the field is too
+faint or too crowded).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from nav.config import Config
+from nav.feature.feature import NavFeature
+from nav.feature.feature_type import NavFeatureType
+from nav.nav_technique._star_helpers import (
+    brightness_margin_mag,
+    local_centroid,
+    predicted_snr,
+    usable_stars,
+)
+from nav.nav_technique.confidence import evaluate_sigmoid_combination
+from nav.nav_technique.diagnostics import StarUniqueMatchDiagnostics
+from nav.nav_technique.feasibility import NavFeasibilityReport
+from nav.nav_technique.nav_technique import (
+    NavTechnique,
+    log_confidence_breakdown,
+    search_window_for_obs,
+)
+from nav.nav_technique.technique_result import NavTechniqueResult
+from nav.support.types import NDArrayFloatType
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from nav.nav_orchestrator.nav_context import NavContext
+
+__all__ = ['StarUniqueMatchNav']
+
+
+# All numeric tunables for this technique live in
+# ``config_files/config_510_techniques.yaml`` under
+# ``techniques.StarUniqueMatchNav.tuning``.  No Python-level fallback;
+# missing-key access in ``__init__`` is a KeyError so a config typo
+# fails fast at process startup.
+
+
+def _build_covariance(feature: NavFeature, *, residual_px: float) -> NDArrayFloatType:
+    """Return a 2x2 covariance for the star match.
+
+    Uses the per-feature anisotropic CRLB covariance carried on the
+    ``NavFeature.position_cov_px`` (computed from predicted SNR + smear
+    by ``NavModelStars``) as the floor and inflates it by
+    ``residual_px**2`` so a noisy match honestly reports its scatter
+    rather than the noise-free CRLB lower bound.
+
+    The same inflation applies in both 1-star and 2-star modes: the
+    1-star path's ``residual_px`` is the prediction-to-detection
+    distance (no second observation to subtract), and the 2-star path's
+    ``residual_px`` is already a per-axis RMS, so squaring either
+    yields the right per-axis variance addend.
+
+    Parameters:
+        feature: The star feature whose CRLB cov is the floor.
+        residual_px: Final per-axis residual magnitude.
+
+    Returns:
+        2x2 float64 covariance matrix.
+    """
+    floor = feature.position_cov_px
+    base = (
+        np.eye(2, dtype=np.float64) if floor is None else np.asarray(floor, dtype=np.float64).copy()
+    )
+    inflation = residual_px * residual_px
+    return base + inflation * np.eye(2, dtype=np.float64)
+
+
+class _UniqueMatchConfidenceContext:
+    """Adapter binding ``StarUniqueMatchDiagnostics`` plus side flags."""
+
+    def __init__(
+        self,
+        *,
+        at_edge: bool,
+        spurious: bool,
+        diagnostics: StarUniqueMatchDiagnostics,
+    ) -> None:
+        self.at_edge = at_edge
+        self.spurious = spurious
+        self.predicted_snr = diagnostics.predicted_snr
+        self.brightness_margin_mag = diagnostics.brightness_margin_mag
+        self.residual_px = diagnostics.residual_px
+        # Note: ``mode`` is a string, so it is intentionally not surfaced
+        # to the confidence formula (no numeric meaning).  Mode-driven
+        # caps are applied inside ``StarUniqueMatchNav.navigate``.
+
+
+class StarUniqueMatchNav(NavTechnique):
+    """Star unique-match translation fit (1- or 2-star path).
+
+    Class attributes:
+        accepts_feature_types: ``frozenset({STAR})``.
+        requires_prior: ``False`` — runs in pass 1.
+    """
+
+    name = 'StarUniqueMatchNav'
+    accepts_feature_types = frozenset({NavFeatureType.STAR})
+    requires_prior = False
+    confidence_attributes = frozenset(
+        {
+            'at_edge',
+            'spurious',
+            'predicted_snr',
+            'brightness_margin_mag',
+            'residual_px',
+        }
+    )
+
+    def __init__(self, *, config: Config | None = None) -> None:
+        super().__init__(config=config)
+        self.config.read_config()  # ensure cls.tuning is populated
+        self._brightness_margin_floor_mag = float(
+            self.tuning['brightness_margin_to_next_catalog_star_mag']
+        )
+        self._search_window_px = float(self.tuning['search_window_px'])
+        self._centroid_box_half_px = int(self.tuning['centroid_box_half_px'])
+        self._max_residual_px = float(self.tuning['max_residual_px'])
+        self._detection_sigma = float(self.tuning['detection_sigma'])
+        self._one_star_confidence_cap = float(self.tuning['one_star_confidence_cap'])
+        self._two_star_confidence_cap = float(self.tuning['two_star_confidence_cap'])
+        self._at_edge_tolerance_px = float(self.tuning['at_edge_tolerance_px'])
+        if not 0.0 <= self._one_star_confidence_cap <= 1.0:
+            raise ValueError(
+                f'one_star_confidence_cap must lie in [0, 1]; got {self._one_star_confidence_cap!r}'
+            )
+        if not 0.0 <= self._two_star_confidence_cap <= 1.0:
+            raise ValueError(
+                f'two_star_confidence_cap must lie in [0, 1]; got {self._two_star_confidence_cap!r}'
+            )
+
+    def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
+        """Report feasibility based on the predictable-star cohort.
+
+        Reads only feature metadata; never any pixels.  Feasible when at
+        least one usable STAR feature is in the input set; the navigate
+        path then decides whether the 1-star or 2-star branch wins.
+        """
+        usable = usable_stars(features)
+        if not usable:
+            return NavFeasibilityReport(feasible=False, reason='no_usable_star_features')
+        consumed = min(len(usable), 2)
+        return NavFeasibilityReport(feasible=True, reason='ok', consumed_feature_count=consumed)
+
+    def navigate(self, features: list[NavFeature], context: NavContext) -> NavTechniqueResult:
+        """Recover translation from the 1- or 2-star uniquely-bright match.
+
+        Parameters:
+            features: STAR features (the orchestrator pre-filters by type).
+            context: Per-image NavContext.
+
+        Returns:
+            ``NavTechniqueResult`` with offset, 2x2 covariance, calibrated
+            confidence, and a populated :class:`StarUniqueMatchDiagnostics`.
+        """
+        with self.logger.open(f'TECHNIQUE: {self.name}'):
+            usable = usable_stars(features)
+            self.logger.info(
+                'Consuming %d usable STAR feature(s) (out of %d offered)',
+                len(usable),
+                len(features),
+            )
+            if not usable:
+                return self._fail(
+                    features=features,
+                    diagnostics=StarUniqueMatchDiagnostics(
+                        mode='',
+                        predicted_snr=0.0,
+                        brightness_margin_mag=0.0,
+                        residual_px=0.0,
+                    ),
+                    reason='no_usable_star_features',
+                )
+            ranked = sorted(usable, key=predicted_snr, reverse=True)
+            image_ext = np.asarray(context.image_ext, np.float64)
+            noise_sigma = float(max(context.image_noise_sigma, 1e-9))
+            if len(ranked) >= 2:
+                two_star_result = self._try_two_star(
+                    ranked[:2], ranked[2:], image_ext, noise_sigma, context
+                )
+                if two_star_result is not None:
+                    return two_star_result
+            return self._try_one_star(ranked[0], ranked[1:], image_ext, noise_sigma, context)
+
+    def _try_two_star(
+        self,
+        chosen: list[NavFeature],
+        rest: list[NavFeature],
+        image_ext: NDArrayFloatType,
+        noise_sigma: float,
+        context: NavContext,
+    ) -> NavTechniqueResult | None:
+        """Attempt the 2-star path; return ``None`` when both detections fail."""
+        det_a, peak_a = local_centroid(
+            image_ext,
+            chosen[0].geometry.predicted_vu,  # type: ignore[union-attr]
+            search_window_px=self._search_window_px,
+            centroid_box_half_px=self._centroid_box_half_px,
+            image_noise_sigma=noise_sigma,
+            detection_sigma=self._detection_sigma,
+        )
+        det_b, peak_b = local_centroid(
+            image_ext,
+            chosen[1].geometry.predicted_vu,  # type: ignore[union-attr]
+            search_window_px=self._search_window_px,
+            centroid_box_half_px=self._centroid_box_half_px,
+            image_noise_sigma=noise_sigma,
+            detection_sigma=self._detection_sigma,
+        )
+        if det_a is None or det_b is None:
+            self.logger.debug(
+                'Two-star path: at least one of the two predictions had no '
+                'usable detection (peak_a=%.3f DN, peak_b=%.3f DN); falling '
+                'back to one-star path',
+                peak_a,
+                peak_b,
+            )
+            return None
+        pred_a = chosen[0].geometry.predicted_vu  # type: ignore[union-attr]
+        pred_b = chosen[1].geometry.predicted_vu  # type: ignore[union-attr]
+        # Assignment 1: det_a -> pred_a, det_b -> pred_b.
+        offset_1_v = 0.5 * ((det_a[0] - pred_a[0]) + (det_b[0] - pred_b[0]))
+        offset_1_u = 0.5 * ((det_a[1] - pred_a[1]) + (det_b[1] - pred_b[1]))
+        residual_1 = math.hypot(
+            (det_a[0] - pred_a[0]) - offset_1_v,
+            (det_a[1] - pred_a[1]) - offset_1_u,
+        )
+        # Assignment 2: det_a -> pred_b, det_b -> pred_a.
+        offset_2_v = 0.5 * ((det_a[0] - pred_b[0]) + (det_b[0] - pred_a[0]))
+        offset_2_u = 0.5 * ((det_a[1] - pred_b[1]) + (det_b[1] - pred_a[1]))
+        residual_2 = math.hypot(
+            (det_a[0] - pred_b[0]) - offset_2_v,
+            (det_a[1] - pred_b[1]) - offset_2_u,
+        )
+        if residual_1 <= residual_2:
+            offset_v, offset_u, residual_px = offset_1_v, offset_1_u, residual_1
+            assignment = 'a->1,b->2'
+        else:
+            offset_v, offset_u, residual_px = offset_2_v, offset_2_u, residual_2
+            assignment = 'a->2,b->1'
+        if residual_px > self._max_residual_px:
+            self.logger.info(
+                'Two-star path: best-assignment residual %.3f px exceeds '
+                'max_residual_px %.3f; falling back to one-star path',
+                residual_px,
+                self._max_residual_px,
+            )
+            return None
+        # Brightness-margin diagnostic: magnitude difference to the
+        # next-brightest *unmatched* predictable star.  When only two
+        # predictable stars exist (no third star in ``rest``) the
+        # diagnostic reports ``+inf`` — there is no unmatched star to
+        # compare against, which is the strongest possible margin.
+        brightest_snr = predicted_snr(chosen[0])
+        next_snr = predicted_snr(rest[0]) if rest else 0.0
+        margin_mag = brightness_margin_mag(brightest_snr, next_snr)
+        diagnostics = StarUniqueMatchDiagnostics(
+            mode='two_star',
+            predicted_snr=brightest_snr,
+            brightness_margin_mag=margin_mag,
+            residual_px=residual_px,
+        )
+        margin_v, margin_u = search_window_for_obs(context)
+        at_edge = (
+            abs(offset_v) >= margin_v - self._at_edge_tolerance_px
+            or abs(offset_u) >= margin_u - self._at_edge_tolerance_px
+        )
+        confidence = self._evaluate_confidence(
+            diagnostics=diagnostics,
+            at_edge=at_edge,
+            spurious=False,
+            cap=self._two_star_confidence_cap,
+        )
+        self.logger.info(
+            'Two-star path: assignment %s; offset (%.4f, %.4f) px; residual '
+            '%.4f px; brightness margin %.3f mag; confidence %.4f',
+            assignment,
+            offset_v,
+            offset_u,
+            residual_px,
+            margin_mag,
+            confidence,
+        )
+        feature_ids = (chosen[0].feature_id, chosen[1].feature_id)
+        # Average the two stars' covariances as a coarse 2-star floor.
+        cov_a = _build_covariance(chosen[0], residual_px=residual_px)
+        cov_b = _build_covariance(chosen[1], residual_px=residual_px)
+        cov = 0.5 * (cov_a + cov_b)
+        cov = 0.5 * (cov + cov.T)
+        return NavTechniqueResult(
+            technique_name=self.name,
+            feature_ids=feature_ids,
+            offset_px=(offset_v, offset_u),
+            covariance_px2=cov,
+            confidence=confidence,
+            spurious=False,
+            at_edge=at_edge,
+            diagnostics=diagnostics,
+        )
+
+    def _try_one_star(
+        self,
+        brightest: NavFeature,
+        rest: list[NavFeature],
+        image_ext: NDArrayFloatType,
+        noise_sigma: float,
+        context: NavContext,
+    ) -> NavTechniqueResult:
+        """Attempt the 1-star path with the brightness-uniqueness gate."""
+        brightest_snr = predicted_snr(brightest)
+        next_snr = predicted_snr(rest[0]) if rest else 0.0
+        margin_mag = brightness_margin_mag(brightest_snr, next_snr)
+        if margin_mag < self._brightness_margin_floor_mag:
+            diagnostics = StarUniqueMatchDiagnostics(
+                mode='one_star',
+                predicted_snr=brightest_snr,
+                brightness_margin_mag=margin_mag,
+                residual_px=0.0,
+            )
+            return self._fail(
+                features=[brightest, *rest],
+                diagnostics=diagnostics,
+                reason=(
+                    f'brightness_margin {margin_mag:.3f} mag below floor '
+                    f'{self._brightness_margin_floor_mag:.3f} mag'
+                ),
+            )
+        det, peak = local_centroid(
+            image_ext,
+            brightest.geometry.predicted_vu,  # type: ignore[union-attr]
+            search_window_px=self._search_window_px,
+            centroid_box_half_px=self._centroid_box_half_px,
+            image_noise_sigma=noise_sigma,
+            detection_sigma=self._detection_sigma,
+        )
+        if det is None:
+            diagnostics = StarUniqueMatchDiagnostics(
+                mode='one_star',
+                predicted_snr=brightest_snr,
+                brightness_margin_mag=margin_mag,
+                residual_px=0.0,
+            )
+            return self._fail(
+                features=[brightest],
+                diagnostics=diagnostics,
+                reason=f'no_detection_above_threshold (peak {peak:.3f} DN)',
+            )
+        pred_v, pred_u = brightest.geometry.predicted_vu  # type: ignore[union-attr]
+        offset_v = det[0] - pred_v
+        offset_u = det[1] - pred_u
+        residual_px = math.hypot(offset_v, offset_u)
+        # Even though "residual_px" is really the offset magnitude here
+        # (the 1-star path has no second observation to subtract), it is
+        # the only honest measure of how far we travelled to find the
+        # detection inside the search window.  The technique reports it
+        # so the confidence formula can penalise large excursions.
+        diagnostics = StarUniqueMatchDiagnostics(
+            mode='one_star',
+            predicted_snr=brightest_snr,
+            brightness_margin_mag=margin_mag,
+            residual_px=residual_px,
+        )
+        margin_v, margin_u = search_window_for_obs(context)
+        at_edge = (
+            abs(offset_v) >= margin_v - self._at_edge_tolerance_px
+            or abs(offset_u) >= margin_u - self._at_edge_tolerance_px
+        )
+        confidence = self._evaluate_confidence(
+            diagnostics=diagnostics,
+            at_edge=at_edge,
+            spurious=False,
+            cap=self._one_star_confidence_cap,
+        )
+        self.logger.info(
+            'One-star path: matched %s at (%.4f, %.4f); offset (%.4f, %.4f) '
+            'px; brightness margin %.3f mag; confidence %.4f',
+            brightest.feature_id,
+            det[0],
+            det[1],
+            offset_v,
+            offset_u,
+            margin_mag,
+            confidence,
+        )
+        cov = _build_covariance(brightest, residual_px=residual_px)
+        return NavTechniqueResult(
+            technique_name=self.name,
+            feature_ids=(brightest.feature_id,),
+            offset_px=(offset_v, offset_u),
+            covariance_px2=cov,
+            confidence=confidence,
+            spurious=False,
+            at_edge=at_edge,
+            diagnostics=diagnostics,
+        )
+
+    def _evaluate_confidence(
+        self,
+        *,
+        diagnostics: StarUniqueMatchDiagnostics,
+        at_edge: bool,
+        spurious: bool,
+        cap: float,
+    ) -> float:
+        """Run the YAML confidence formula and apply the per-mode cap."""
+        assert self.confidence_spec is not None
+        confidence, breakdown = evaluate_sigmoid_combination(
+            self.confidence_spec,
+            _UniqueMatchConfidenceContext(
+                at_edge=at_edge, spurious=spurious, diagnostics=diagnostics
+            ),
+            technique_name=self.name,
+            return_breakdown=True,
+        )
+        log_confidence_breakdown(self.logger, breakdown)
+        return min(float(confidence), cap)
+
+    def _fail(
+        self,
+        *,
+        features: list[NavFeature],
+        diagnostics: StarUniqueMatchDiagnostics,
+        reason: str,
+    ) -> NavTechniqueResult:
+        """Return a zero-confidence spurious result with the supplied reason."""
+        self.logger.info('Reporting spurious result: %s', reason)
+        return NavTechniqueResult(
+            technique_name=self.name,
+            feature_ids=tuple(f.feature_id for f in features),
+            offset_px=(0.0, 0.0),
+            covariance_px2=1e6 * np.eye(2, dtype=np.float64),
+            confidence=0.0,
+            spurious=True,
+            at_edge=False,
+            diagnostics=diagnostics,
+        )

--- a/tests/integration/image_library/images/one_bright_star_no_body/W1449079117_1_CALIB.yaml
+++ b/tests/integration/image_library/images/one_bright_star_no_body/W1449079117_1_CALIB.yaml
@@ -1,0 +1,31 @@
+schema_version: 1
+image_id: W1449079117_1_CALIB
+mission: CASSINI_ISS            # CASSINI_ISS | VOYAGER_ISS | GOSSI | NHLORRI
+camera: WAC              # NAC | WAC | SSI | NA | WA | LORRI
+filter_combo: 'CL1+RED'          # canonicalized: filters sorted, '+'-joined
+image_url: 'pds3://calibrated/COISS_1xxx/COISS_1009/data/1449071343_1449079877/W1449079117_1_CALIB.IMG'
+
+scene_tags:
+  - one_bright_star_no_body            # First tag is the primary class;
+                                       # must match the directory the
+                                       # sidecar lives in.
+
+ground_truth:
+  offset_dv_px: 3.0579
+  offset_du_px: -0.0188
+  offset_uncertainty_px: 1.0           # 1sigma marginal; tighten
+                                       # for bright stars / sharp limbs.
+  source: operator_verified
+  operator: rfrench
+  verified_date: 2026-04-30
+  ui_version: 'rms-nav 0.1.dev25'
+  notes: |
+    Single star (Vega) in FOV.
+    RED filter.
+
+expected:
+  status: ok                           # ok | failed | conflicted
+  confidence_tier: low                # high | medium | low | failed
+  primary_technique: StarRefineNav  # e.g. BodyLimbNav
+  techniques_must_run: [StarUniqueMatchNav]
+  techniques_must_skip: []

--- a/tests/integration/image_library/images/star_dominated/W1580760393_1_CALIB.yaml
+++ b/tests/integration/image_library/images/star_dominated/W1580760393_1_CALIB.yaml
@@ -1,0 +1,31 @@
+schema_version: 1
+image_id: W1580760393_1_CALIB
+mission: CASSINI_ISS            # CASSINI_ISS | VOYAGER_ISS | GOSSI | NHLORRI
+camera: WAC              # NAC | WAC | SSI | NA | WA | LORRI
+filter_combo: 'CL1+CL2'          # canonicalized: filters sorted, '+'-joined
+image_url: 'pds3://calibrated/COISS_2xxx/COISS_2041/data/1580756433_1580830157/W1580760393_1_CALIB.IMG'
+
+scene_tags:
+  - star_dominated                     # First tag is the primary class;
+                                       # must match the directory the
+                                       # sidecar lives in.
+
+ground_truth:
+  offset_dv_px: -2.6792
+  offset_du_px: -3.6839
+  offset_uncertainty_px: 1.0           # 1sigma marginal; tighten
+                                       # for bright stars / sharp limbs.
+  source: operator_verified
+  operator: rfrench
+  verified_date: 2026-04-30
+  ui_version: 'rms-nav 0.1.dev25'
+  notes: |
+    Dense star field in FOV.
+    CLEAR filter.
+
+expected:
+  status: failed                           # ok | failed | conflicted
+  confidence_tier: failed                # high | medium | low | failed
+  primary_technique: StarFieldFromCatalogNav  # e.g. BodyLimbNav
+  techniques_must_run: [StarFieldFromCatalogNav]
+  techniques_must_skip: []

--- a/tests/nav/feature/test_composition.py
+++ b/tests/nav/feature/test_composition.py
@@ -403,10 +403,12 @@ def _make_star(
 
 
 def test_compose_dialog_overlay_renders_star_marker_rectangle() -> None:
-    """A STAR feature renders a rectangle outline around its predicted (v, u).
+    """A STAR feature renders an exact rectangle-outline pixel set.
 
-    Pin the exact corner pixels so a regression in the marker geometry
-    or in the bbox-to-half-extent conversion fails this test loud.
+    Pin the full perimeter — top + bottom + left + right at half-width
+    5 around (20, 25) — so a regression in the marker geometry, the
+    bbox-to-half-extent conversion, or the choice of outline-vs-filled
+    rasteriser fails this test loud.
     """
     from nav.feature.composition import compose_dialog_overlay
 
@@ -416,14 +418,21 @@ def test_compose_dialog_overlay_renders_star_marker_rectangle() -> None:
         bbox_pad=6,  # bbox spans (14, 19, 27, 32) -> half-width 5
     )
     image, mask = compose_dialog_overlay([star], (40, 40))
-    # Rectangle corners at (v ± 5, u ± 5).
-    for v_corner in (15, 25):
-        for u_corner in (20, 30):
-            assert mask[v_corner, u_corner], f'corner {(v_corner, u_corner)} missing'
-            assert image[v_corner, u_corner] == 1.0
-    # Centre of the rectangle is NOT painted (outline only).
-    assert image[20, 25] == 0.0
-    assert not mask[20, 25]
+    expected_pixels = set()
+    half = 5
+    v_min, v_max = 20 - half, 20 + half
+    u_min, u_max = 25 - half, 25 + half
+    for u in range(u_min, u_max + 1):
+        expected_pixels.add((v_min, u))  # top
+        expected_pixels.add((v_max, u))  # bottom
+    for v in range(v_min, v_max + 1):
+        expected_pixels.add((v, u_min))  # left
+        expected_pixels.add((v, u_max))  # right
+    actual_pixels = set(zip(*np.nonzero(image), strict=True))
+    assert actual_pixels == expected_pixels
+    assert set(zip(*np.nonzero(mask), strict=True)) == expected_pixels
+    assert np.count_nonzero(image) == len(expected_pixels)
+    assert np.count_nonzero(mask) == len(expected_pixels)
 
 
 def test_compose_dialog_overlay_star_marker_off_image_no_op() -> None:
@@ -440,11 +449,13 @@ def test_compose_dialog_overlay_star_marker_off_image_no_op() -> None:
 
 
 def test_compose_dialog_overlay_star_marker_clamps_at_edge() -> None:
-    """A STAR centre near the FOV edge clamps the marker half-width down.
+    """A STAR centre near the FOV edge produces an exact 3x3-perimeter pixel set.
 
     With predicted (1, 1) on a 20x20 FOV, the marker can extend at most
     1 pixel before hitting the edge — the floor (3) does not apply here
-    because the explicit edge clamp is tighter.
+    because the explicit edge clamp is tighter.  The full 8-pixel
+    perimeter (3x3 outline minus the centre) is asserted as an exact
+    set so a regression in the half-width clamp logic fails loud.
     """
     from nav.feature.composition import compose_dialog_overlay
 
@@ -454,9 +465,20 @@ def test_compose_dialog_overlay_star_marker_clamps_at_edge() -> None:
         bbox_pad=6,
     )
     image, mask = compose_dialog_overlay([star], (20, 20))
-    # Half-width clamped to 1 -> rectangle corners at (0, 0), (0, 2),
-    # (2, 0), (2, 2).
-    for v_corner in (0, 2):
-        for u_corner in (0, 2):
-            assert mask[v_corner, u_corner], f'corner {(v_corner, u_corner)} missing'
+    # Half-width clamped to 1 -> 3x3 outline around (1, 1).
+    expected_pixels = {
+        (0, 0),
+        (0, 1),
+        (0, 2),
+        (1, 0),
+        (1, 2),
+        (2, 0),
+        (2, 1),
+        (2, 2),
+    }
+    actual_pixels = set(zip(*np.nonzero(image), strict=True))
+    assert actual_pixels == expected_pixels
+    assert set(zip(*np.nonzero(mask), strict=True)) == expected_pixels
+    assert np.count_nonzero(image) == len(expected_pixels)
+    assert np.count_nonzero(mask) == len(expected_pixels)
     assert image[1, 1] == 0.0  # centre not painted

--- a/tests/nav/feature/test_composition.py
+++ b/tests/nav/feature/test_composition.py
@@ -363,3 +363,100 @@ def test_compose_dialog_overlay_blob_clips_to_extfov_bounds() -> None:
     assert set(zip(*np.nonzero(mask), strict=True)) == expected_pixels
     assert np.count_nonzero(image) == 1
     assert np.count_nonzero(mask) == 1
+
+
+def _make_star(
+    *,
+    feature_id: str,
+    predicted_vu: tuple[float, float],
+    bbox_pad: int = 6,
+) -> NavFeature:
+    """Build a STAR feature with a PSF-sized bbox around the prediction."""
+    from nav.feature.flags import StarFlags
+    from nav.feature.geometry import StarGeometry
+
+    pv, pu = predicted_vu
+    bbox = (
+        int(np.floor(pv - bbox_pad)),
+        int(np.floor(pu - bbox_pad)),
+        int(np.ceil(pv + bbox_pad)) + 1,
+        int(np.ceil(pu + bbox_pad)) + 1,
+    )
+    return NavFeature(
+        feature_id=feature_id,
+        feature_type=NavFeatureType.STAR,
+        source_model='stars',
+        geometry=StarGeometry(
+            predicted_vu=predicted_vu,
+            catalog_vu=predicted_vu,
+            bbox_extfov_vu=bbox,
+        ),
+        subject_range_km=float('inf'),
+        position_cov_px=None,
+        intensity_sigma_rel=0.0,
+        preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
+        reliability=0.95,
+        reliability_reasons=NavReliabilityBreakdown(predicted_snr=1.0),
+        usable_types=frozenset({NavFeatureType.STAR}),
+        flags=StarFlags(predicted_snr=10.0),
+    )
+
+
+def test_compose_dialog_overlay_renders_star_marker_rectangle() -> None:
+    """A STAR feature renders a rectangle outline around its predicted (v, u).
+
+    Pin the exact corner pixels so a regression in the marker geometry
+    or in the bbox-to-half-extent conversion fails this test loud.
+    """
+    from nav.feature.composition import compose_dialog_overlay
+
+    star = _make_star(
+        feature_id='star:UCAC4:1',
+        predicted_vu=(20.0, 25.0),
+        bbox_pad=6,  # bbox spans (14, 19, 27, 32) -> half-width 5
+    )
+    image, mask = compose_dialog_overlay([star], (40, 40))
+    # Rectangle corners at (v ± 5, u ± 5).
+    for v_corner in (15, 25):
+        for u_corner in (20, 30):
+            assert mask[v_corner, u_corner], f'corner {(v_corner, u_corner)} missing'
+            assert image[v_corner, u_corner] == 1.0
+    # Centre of the rectangle is NOT painted (outline only).
+    assert image[20, 25] == 0.0
+    assert not mask[20, 25]
+
+
+def test_compose_dialog_overlay_star_marker_off_image_no_op() -> None:
+    """A STAR whose predicted (v, u) is off-image paints no pixels."""
+    from nav.feature.composition import compose_dialog_overlay
+
+    star = _make_star(
+        feature_id='star:UCAC4:offscreen',
+        predicted_vu=(-50.0, -50.0),
+    )
+    image, mask = compose_dialog_overlay([star], (20, 20))
+    assert np.count_nonzero(image) == 0
+    assert np.count_nonzero(mask) == 0
+
+
+def test_compose_dialog_overlay_star_marker_clamps_at_edge() -> None:
+    """A STAR centre near the FOV edge clamps the marker half-width down.
+
+    With predicted (1, 1) on a 20x20 FOV, the marker can extend at most
+    1 pixel before hitting the edge — the floor (3) does not apply here
+    because the explicit edge clamp is tighter.
+    """
+    from nav.feature.composition import compose_dialog_overlay
+
+    star = _make_star(
+        feature_id='star:UCAC4:edge',
+        predicted_vu=(1.0, 1.0),
+        bbox_pad=6,
+    )
+    image, mask = compose_dialog_overlay([star], (20, 20))
+    # Half-width clamped to 1 -> rectangle corners at (0, 0), (0, 2),
+    # (2, 0), (2, 2).
+    for v_corner in (0, 2):
+        for u_corner in (0, 2):
+            assert mask[v_corner, u_corner], f'corner {(v_corner, u_corner)} missing'
+    assert image[1, 1] == 0.0  # centre not painted

--- a/tests/nav/nav_orchestrator/test_orchestrator.py
+++ b/tests/nav/nav_orchestrator/test_orchestrator.py
@@ -239,10 +239,23 @@ def test_orchestrator_only_models_filter_drops_models(fake_obs: _FakeObs) -> Non
 def test_orchestrator_only_techniques_filter_drops_techniques(
     fake_obs: _FakeObs,
 ) -> None:
-    """only_techniques='!_FakeStarTechnique' yields no_feasible_techniques."""
+    """An exclusion glob that rejects every STAR technique yields ``no_feasible_techniques``.
+
+    The exclude list covers ``_FakeStarTechnique`` plus every shipped
+    STAR-accepting NavTechnique so the only feasible matches against
+    the fake STAR features are filtered out, leaving an empty pass-1
+    result list and the corresponding status reason.
+    """
     obs = fake_obs
     model = _FakeStarModel(obs, feature_count=3)
-    orch = NavOrchestrator([model], only_techniques='!_FakeStarTechnique')
+    orch = NavOrchestrator(
+        [model],
+        only_techniques=[
+            '!_FakeStarTechnique',
+            '!_RaisingTechnique',
+            '!Star*',
+        ],
+    )
     result = orch.navigate(obs)  # type: ignore[arg-type]
     assert result.status == 'failed'
     assert result.status_reason == NavStatusReason.NO_FEASIBLE_TECHNIQUES

--- a/tests/nav/nav_technique/conftest.py
+++ b/tests/nav/nav_technique/conftest.py
@@ -19,8 +19,13 @@ import pytest
 
 from nav.feature.feature import NavFeature, NavReliabilityBreakdown
 from nav.feature.feature_type import NavFeatureType
-from nav.feature.flags import LimbArcFlags, RingEdgeFlags, TerminatorArcFlags
-from nav.feature.geometry import LimbPolyline, RingEdgePolyline, TerminatorPolyline
+from nav.feature.flags import LimbArcFlags, RingEdgeFlags, StarFlags, TerminatorArcFlags
+from nav.feature.geometry import (
+    LimbPolyline,
+    RingEdgePolyline,
+    StarGeometry,
+    TerminatorPolyline,
+)
 from nav.nav_orchestrator.image_classifier_result import NavImageClassifierResult
 from nav.nav_orchestrator.image_derivatives import (
     DEFAULT_IMAGE_GRADIENT_SIGMA_PX,
@@ -58,14 +63,18 @@ NavContextFactory = Callable[..., NavContext]
 NavFeatureFactory = Callable[..., NavFeature]
 """Signature of the ``make_*_feature`` factory fixtures (kwargs-flexible)."""
 
+DrawGaussianStarFactory = Callable[..., None]
+"""Signature of the ``draw_gaussian_star`` factory fixture (kwargs-flexible)."""
+
 
 class FakeObs:
     """Minimal observation stand-in matching the obs.* attribute access used by
     the DT techniques.
 
     The technique implementations only read ``obs.extfov_margin_vu`` (via the
-    private ``_search_window_for_obs`` helper); the rest of the obs surface is
-    irrelevant once a fully-populated ``NavContext`` is supplied directly.
+    shared :func:`nav.nav_technique.nav_technique.search_window_for_obs`
+    helper); the rest of the obs surface is irrelevant once a
+    fully-populated ``NavContext`` is supplied directly.
 
     Parameters:
         extfov_margin_vu: ``(margin_v, margin_u)`` extfov margin tuple
@@ -110,6 +119,25 @@ def _render_horizontal_step_image(shape: tuple[int, int], step_v: float) -> np.n
     return image.astype(np.float64)
 
 
+def _draw_gaussian_star(
+    image: np.ndarray, center_vu: tuple[float, float], peak_dn: float, sigma: float = 1.0
+) -> None:
+    """Add a 2-D Gaussian point source to ``image`` in place."""
+    h, w = image.shape
+    half = max(1, int(np.ceil(3.0 * sigma)))
+    cv, cu = center_vu
+    v_lo = max(0, int(np.floor(cv - half)))
+    v_hi = min(h, int(np.ceil(cv + half)) + 1)
+    u_lo = max(0, int(np.floor(cu - half)))
+    u_hi = min(w, int(np.ceil(cu + half)) + 1)
+    vs = np.arange(v_lo, v_hi, dtype=np.float64)
+    us = np.arange(u_lo, u_hi, dtype=np.float64)
+    vv, uu = np.meshgrid(vs, us, indexing='ij')
+    image[v_lo:v_hi, u_lo:u_hi] += peak_dn * np.exp(
+        -((vv - cv) ** 2 + (uu - cu) ** 2) / (2.0 * sigma * sigma)
+    )
+
+
 @pytest.fixture
 def disc_image() -> DiscImageFactory:
     """Factory fixture producing anti-aliased bright-disc images."""
@@ -120,6 +148,16 @@ def disc_image() -> DiscImageFactory:
 def horizontal_step_image() -> HorizontalStepImageFactory:
     """Factory fixture producing horizontal-step images for flat-edge tests."""
     return _render_horizontal_step_image
+
+
+@pytest.fixture
+def draw_gaussian_star() -> DrawGaussianStarFactory:
+    """Factory fixture for stamping a 2-D Gaussian PSF onto an image in place.
+
+    Signature: ``draw_gaussian_star(image, center_vu, peak_dn, sigma=1.0)``.
+    Mutates ``image`` and returns ``None``.
+    """
+    return _draw_gaussian_star
 
 
 # ---------------------------------------------------------------------------
@@ -387,6 +425,58 @@ def _make_ring_feature(
     )
 
 
+def _make_star_feature(
+    feature_id: str,
+    *,
+    predicted_vu: tuple[float, float],
+    predicted_snr: float,
+    bbox_pad: int = 6,
+    in_body_silhouette: bool = False,
+    in_saturation_or_cosmic_mask: bool = False,
+    vmag: float | None = 5.0,
+) -> NavFeature:
+    """Build a STAR ``NavFeature`` with the supplied prediction + brightness."""
+    pv, pu = predicted_vu
+    bbox = (
+        int(np.floor(pv - bbox_pad)),
+        int(np.floor(pu - bbox_pad)),
+        int(np.ceil(pv + bbox_pad)),
+        int(np.ceil(pu + bbox_pad)),
+    )
+    sigma = 0.5
+    cov = (sigma * sigma) * np.eye(2, dtype=np.float64)
+    return NavFeature(
+        feature_id=feature_id,
+        feature_type=NavFeatureType.STAR,
+        source_model='stars',
+        geometry=StarGeometry(
+            predicted_vu=predicted_vu,
+            catalog_vu=predicted_vu,
+            bbox_extfov_vu=bbox,
+        ),
+        subject_range_km=float('inf'),
+        position_cov_px=cov,
+        intensity_sigma_rel=0.0,
+        preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
+        reliability=0.95,
+        reliability_reasons=NavReliabilityBreakdown(
+            predicted_snr=1.0,
+            in_body_silhouette=in_body_silhouette,
+            in_saturation_or_cosmic=in_saturation_or_cosmic_mask,
+            smear_length_ok=True,
+        ),
+        usable_types=frozenset({NavFeatureType.STAR}),
+        flags=StarFlags(
+            saturated=False,
+            smear_length_px=0.0,
+            in_body_silhouette=in_body_silhouette,
+            in_saturation_or_cosmic_mask=in_saturation_or_cosmic_mask,
+            predicted_snr=predicted_snr,
+            vmag=vmag,
+        ),
+    )
+
+
 @pytest.fixture
 def make_limb_feature() -> NavFeatureFactory:
     """Factory fixture producing ``LIMB_ARC`` ``NavFeature`` instances."""
@@ -403,3 +493,9 @@ def make_terminator_feature() -> NavFeatureFactory:
 def make_ring_feature() -> NavFeatureFactory:
     """Factory fixture producing ``RING_EDGE`` ``NavFeature`` instances."""
     return _make_ring_feature
+
+
+@pytest.fixture
+def make_star_feature() -> NavFeatureFactory:
+    """Factory fixture producing ``STAR`` ``NavFeature`` instances."""
+    return _make_star_feature

--- a/tests/nav/nav_technique/test_nav_technique_body_blob.py
+++ b/tests/nav/nav_technique/test_nav_technique_body_blob.py
@@ -211,7 +211,7 @@ def test_body_blob_marks_at_edge_when_centroid_hits_window(
     disc_image: DiscImageFactory,
     make_nav_context: NavContextFactory,
 ) -> None:
-    """A converged offset within ``AT_EDGE_TOLERANCE_PX`` of the search-window
+    """A converged offset within ``at_edge_tolerance_px`` of the search-window
     edge is flagged ``at_edge=True`` and forced to zero confidence by the
     ``hard_zero_if`` gate.
     """

--- a/tests/nav/nav_technique/test_nav_technique_manual.py
+++ b/tests/nav/nav_technique/test_nav_technique_manual.py
@@ -163,12 +163,61 @@ def test_run_manual_nav_returns_spurious_on_cancel() -> None:
     assert result.confidence == 0.0
 
 
-def test_run_manual_nav_returns_none_when_no_template_features(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """No template-bearing feature → dialog is not opened, ``None`` is returned."""
+def test_run_manual_nav_runs_on_template_less_star_feature() -> None:
+    """A STAR feature without a template still renders as a marker rectangle.
+
+    The dialog opens because ``StarGeometry`` is recognised by both
+    ``compose_dialog_overlay`` and ``NavTechniqueManual.is_feasible`` —
+    the absence of ``template_img`` / ``template_mask`` no longer
+    short-circuits feasibility for star-only scenes.
+    """
     obs = _FakeObsForRunManual()
     obs.with_template = False  # type: ignore[attr-defined]
+    fake_dialog, instances = _make_fake_dialog((True, (1.5, -0.5), 0.7))
+    with patch('nav.ui.manual_nav_dialog.ManualNavDialog', fake_dialog):
+        result = run_manual_nav(obs)  # type: ignore[arg-type]
+    assert result is not None
+    assert result.spurious is False
+    assert result.offset_px == (1.5, -0.5)
+    assert len(instances) == 1
+
+
+class _StubEmptyModel(NavModel):
+    """NavModel that emits zero features.  Drives the no-feasible path."""
+
+    def __init__(self, obs: Any) -> None:
+        super().__init__('stars', obs)
+
+    def create_model(self) -> None:
+        return None
+
+    def to_features(self, context: Any) -> list[NavFeature]:
+        return []
+
+    def to_annotations(self, context: Any) -> Annotations:
+        return Annotations()
+
+
+def test_run_manual_nav_returns_none_when_no_features(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A scene that emits zero features → dialog is not opened, ``None`` is returned."""
+    obs = _FakeObsForRunManual()
+
+    from nav.nav_technique import nav_technique_manual
+
+    def _empty_builder(obs: Any) -> list[NavModel]:
+        return [_StubEmptyModel(obs)]
+
+    monkeypatch.setattr(
+        nav_technique_manual,
+        'build_models_for_obs',
+        _empty_builder,
+        raising=False,
+    )
+    import nav.nav_model as nav_model_pkg
+
+    monkeypatch.setattr(nav_model_pkg, 'build_models_for_obs', _empty_builder, raising=False)
     result = run_manual_nav(obs)  # type: ignore[arg-type]
     assert result is None
     captured = capsys.readouterr()

--- a/tests/nav/nav_technique/test_nav_technique_star_field.py
+++ b/tests/nav/nav_technique/test_nav_technique_star_field.py
@@ -1,0 +1,425 @@
+"""End-to-end and helper-level tests for ``StarFieldFromCatalogNav``."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from tests.nav.nav_technique.conftest import (
+    DrawGaussianStarFactory,
+    NavContextFactory,
+    NavFeatureFactory,
+)
+
+from nav.feature.feature import NavFeature
+from nav.nav_technique.diagnostics import StarFieldDiagnostics
+from nav.nav_technique.nav_technique import NavTechnique
+from nav.nav_technique.nav_technique_star_field import (
+    StarFieldFromCatalogNav,
+    _detect_image_sources,
+    _enumerate_triplets,
+    _greedy_inlier_count,
+    _hash_distance_sq,
+    _seed_from_image_et,
+    _solve_translation,
+    _triplet_hash,
+)
+
+
+def _star_field_image(
+    star_centers: list[tuple[float, float]],
+    *,
+    draw: DrawGaussianStarFactory,
+    shape: tuple[int, int] = (300, 300),
+    peak_dn: float = 200.0,
+    sigma: float = 1.2,
+) -> np.ndarray:
+    """Return an image with planted Gaussian stars at the supplied centers."""
+    image = np.zeros(shape, dtype=np.float64)
+    for cv, cu in star_centers:
+        draw(image, (cv, cu), peak_dn=peak_dn, sigma=sigma)
+    return image
+
+
+def _make_star_field_features(
+    centers: list[tuple[float, float]],
+    *,
+    make_feature: NavFeatureFactory,
+    offset: tuple[float, float],
+    snrs: list[float] | None = None,
+) -> list[NavFeature]:
+    """Build a STAR feature per planted center, predicted at ``center - offset``.
+
+    ``offset`` is the planted ``(dv, du)`` translation: predicted at
+    position ``center - offset`` so that the technique recovers
+    ``offset``.
+    """
+    if snrs is None:
+        snrs = [40.0 - 0.5 * i for i in range(len(centers))]
+    features: list[NavFeature] = []
+    for i, (cv, cu) in enumerate(centers):
+        pred = (cv - offset[0], cu - offset[1])
+        features.append(
+            make_feature(
+                f'star:UCAC4:{i}',
+                predicted_vu=pred,
+                predicted_snr=snrs[i],
+            )
+        )
+    return features
+
+
+# ---------------------------------------------------------------------------
+# Sub-piece 1 — source detection.
+# ---------------------------------------------------------------------------
+
+
+def test_detect_image_sources_finds_planted_stars(
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """The matched-filter detector recovers planted Gaussian peaks."""
+    centers = [(50.0, 60.0), (120.0, 80.0), (200.0, 220.0)]
+    image = _star_field_image(centers, draw=draw_gaussian_star)
+    detected = _detect_image_sources(
+        image,
+        image_noise_sigma=1.0,
+        sigma_px=1.2,
+        detection_sigma=4.0,
+        centroid_box_half_px=3,
+        max_sources=30,
+    )
+    assert len(detected) == 3
+    detected_centers = sorted((s.v, s.u) for s in detected)
+    expected = sorted(centers)
+    for got, want in zip(detected_centers, expected, strict=True):
+        assert got[0] == pytest.approx(want[0], abs=0.5)
+        assert got[1] == pytest.approx(want[1], abs=0.5)
+
+
+def test_detect_image_sources_caps_at_max_sources(
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """``max_sources`` keeps the brightest peaks first."""
+    image = _star_field_image(
+        [(50.0, 50.0), (100.0, 100.0), (150.0, 150.0), (200.0, 200.0)],
+        draw=draw_gaussian_star,
+        peak_dn=200.0,
+    )
+    # Plant a fainter fifth peak — it must rank below the four brighter
+    # ones and get dropped when max_sources=4.
+    draw_gaussian_star(image, (250.0, 250.0), peak_dn=80.0, sigma=1.2)
+    detected = _detect_image_sources(
+        image,
+        image_noise_sigma=1.0,
+        sigma_px=1.2,
+        detection_sigma=4.0,
+        centroid_box_half_px=3,
+        max_sources=4,
+    )
+    assert len(detected) == 4
+    assert all(s.peak_dn >= detected[-1].peak_dn for s in detected)
+
+
+def test_detect_image_sources_returns_empty_when_blank() -> None:
+    """A blank image yields no detections."""
+    image = np.zeros((100, 100), dtype=np.float64)
+    detected = _detect_image_sources(
+        image,
+        image_noise_sigma=1.0,
+        sigma_px=1.2,
+        detection_sigma=4.0,
+        centroid_box_half_px=3,
+        max_sources=30,
+    )
+    assert detected == []
+
+
+# ---------------------------------------------------------------------------
+# Sub-piece 2 — triplet hashing.
+# ---------------------------------------------------------------------------
+
+
+def test_triplet_hash_is_translation_invariant() -> None:
+    """The hash does not change when every vertex is translated by the same offset."""
+    a = (10.0, 20.0)
+    b = (12.0, 35.0)
+    c = (40.0, 22.0)
+    h1 = _triplet_hash(a, b, c)
+    h2 = _triplet_hash(
+        (a[0] + 7.0, a[1] - 3.0),
+        (b[0] + 7.0, b[1] - 3.0),
+        (c[0] + 7.0, c[1] - 3.0),
+    )
+    assert h1 is not None
+    assert h2 is not None
+    for v1, v2 in zip(h1, h2, strict=True):
+        assert v1 == pytest.approx(v2)
+
+
+def test_triplet_hash_is_uniform_scale_invariant() -> None:
+    """Multiplying every vertex by a constant scale leaves the hash unchanged."""
+    a = (10.0, 20.0)
+    b = (12.0, 35.0)
+    c = (40.0, 22.0)
+    s = 3.7
+    h1 = _triplet_hash(a, b, c)
+    h2 = _triplet_hash(
+        (a[0] * s, a[1] * s),
+        (b[0] * s, b[1] * s),
+        (c[0] * s, c[1] * s),
+    )
+    assert h1 is not None
+    assert h2 is not None
+    for v1, v2 in zip(h1, h2, strict=True):
+        assert v1 == pytest.approx(v2)
+
+
+def test_triplet_hash_drops_collinear() -> None:
+    """A triplet with two coincident points is rejected (None)."""
+    h = _triplet_hash((10.0, 10.0), (10.0, 10.0), (20.0, 20.0))
+    assert h is None
+
+
+def test_enumerate_triplets_yields_one_per_unordered_set() -> None:
+    """Each unordered triplet appears exactly once with A=brightest."""
+    points = [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (5.0, 5.0)]
+    # Brightness rank 0 = brightest; rank by index here.
+    brightness_rank = [0, 1, 2, 3]
+    triplets = _enumerate_triplets(points, brightness_rank)
+    # C(4,3) = 4 triplets.
+    assert len(triplets) == 4
+    # The brightest of each unordered set is correctly identified as A.
+    seen_keys: set[tuple[int, int, int]] = set()
+    for t in triplets:
+        # b and c indices are sorted ascending.
+        assert t.idx_b < t.idx_c
+        # A index has the lowest brightness rank.
+        ranks = (
+            brightness_rank[t.idx_a],
+            brightness_rank[t.idx_b],
+            brightness_rank[t.idx_c],
+        )
+        assert ranks[0] == min(ranks)
+        # Unordered triplet seen once.
+        sorted_indices = sorted([t.idx_a, t.idx_b, t.idx_c])
+        key = (sorted_indices[0], sorted_indices[1], sorted_indices[2])
+        assert key not in seen_keys
+        seen_keys.add(key)
+
+
+def test_hash_distance_sq_zero_for_identical_hashes() -> None:
+    """``_hash_distance_sq(h, h, ...)`` is exactly zero."""
+    h = (1.5, 2.5, 0.7)
+    d_sq = _hash_distance_sq(h, h, ratio_weight=1.0, angle_weight=1.0)
+    assert d_sq == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Helper-level translation solve and inlier counting.
+# ---------------------------------------------------------------------------
+
+
+def test_solve_translation_recovers_constant_offset() -> None:
+    """Constant per-correspondence offset is recovered as the weighted mean."""
+    catalog = np.asarray([[10.0, 20.0], [30.0, 50.0], [70.0, 110.0]], dtype=np.float64)
+    planted = (4.0, -2.5)
+    detection = catalog + np.asarray(planted)
+    weights = np.ones(3, dtype=np.float64)
+    dv, du = _solve_translation(detection, catalog, weights)
+    assert dv == pytest.approx(planted[0])
+    assert du == pytest.approx(planted[1])
+
+
+def test_greedy_inlier_count_under_perfect_offset() -> None:
+    """Every detection is an inlier when the offset perfectly aligns the catalog."""
+    catalog = np.asarray([[10.0, 20.0], [30.0, 50.0], [70.0, 110.0]], dtype=np.float64)
+    offset = (4.0, -2.5)
+    detections = catalog + np.asarray(offset)
+    n_inliers, pairs = _greedy_inlier_count(detections, catalog, offset_vu=offset, tolerance_px=0.5)
+    assert n_inliers == 3
+    assert sorted(pairs) == [(0, 0), (1, 1), (2, 2)]
+
+
+def test_greedy_inlier_count_does_not_double_match() -> None:
+    """Each catalog star matches at most one detection."""
+    catalog = np.asarray([[10.0, 20.0]], dtype=np.float64)
+    detections = np.asarray([[10.0, 20.0], [10.5, 19.9]], dtype=np.float64)
+    n_inliers, pairs = _greedy_inlier_count(
+        detections, catalog, offset_vu=(0.0, 0.0), tolerance_px=2.0
+    )
+    assert n_inliers == 1
+    assert pairs == [(0, 0)]
+
+
+# ---------------------------------------------------------------------------
+# Sub-piece 3 / 4 — RANSAC + verification (technique-level).
+# ---------------------------------------------------------------------------
+
+
+def test_star_field_recovers_planted_offset(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """RANSAC + Tukey refit recovers a planted translation on a clean field."""
+    centers = [
+        (60.0, 80.0),
+        (110.0, 130.0),
+        (180.0, 90.0),
+        (220.0, 200.0),
+        (90.0, 240.0),
+        (250.0, 70.0),
+    ]
+    image = _star_field_image(centers, draw=draw_gaussian_star, shape=(320, 320))
+    planted = (3.0, -2.5)
+    features = _make_star_field_features(centers, make_feature=make_star_feature, offset=planted)
+    technique = StarFieldFromCatalogNav()
+    context = make_nav_context(image, extfov_margin_vu=(32, 32))
+    feasibility = technique.is_feasible(features)
+    assert feasibility.feasible is True
+    result = technique.navigate(features, context)
+    assert result.spurious is False
+    assert result.offset_px[0] == pytest.approx(planted[0], abs=0.5)
+    assert result.offset_px[1] == pytest.approx(planted[1], abs=0.5)
+    assert isinstance(result.diagnostics, StarFieldDiagnostics)
+    assert result.diagnostics.n_inliers >= 6
+
+
+def test_star_field_is_deterministic_across_two_invocations(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """Two back-to-back invocations on the same obs return bit-identical fits."""
+    centers = [
+        (60.0, 80.0),
+        (110.0, 130.0),
+        (180.0, 90.0),
+        (220.0, 200.0),
+        (90.0, 240.0),
+        (250.0, 70.0),
+    ]
+    image = _star_field_image(centers, draw=draw_gaussian_star, shape=(320, 320))
+    planted = (1.5, 2.0)
+    features = _make_star_field_features(centers, make_feature=make_star_feature, offset=planted)
+    technique = StarFieldFromCatalogNav()
+    context = make_nav_context(image)
+    result_a = technique.navigate(features, context)
+    result_b = technique.navigate(features, context)
+    assert result_a.offset_px == result_b.offset_px
+    assert np.array_equal(result_a.covariance_px2, result_b.covariance_px2)
+    assert result_a.confidence == result_b.confidence
+    assert result_a.diagnostics == result_b.diagnostics
+
+
+def test_star_field_infeasible_with_fewer_than_three_features(
+    make_star_feature: NavFeatureFactory,
+) -> None:
+    """``is_feasible`` requires >= 3 usable STAR features."""
+    feat_a = make_star_feature('star:UCAC4:A', predicted_vu=(50.0, 50.0), predicted_snr=40.0)
+    feat_b = make_star_feature('star:UCAC4:B', predicted_vu=(80.0, 80.0), predicted_snr=35.0)
+    technique = StarFieldFromCatalogNav()
+    report = technique.is_feasible([feat_a, feat_b])
+    assert report.feasible is False
+    assert 'fewer_than_3_predicted_stars' in report.reason
+
+
+def test_star_field_infeasible_when_all_stars_occluded(
+    make_star_feature: NavFeatureFactory,
+) -> None:
+    """Stars marked in_body_silhouette are filtered out before feasibility."""
+    features = [
+        make_star_feature(
+            f'star:UCAC4:{i}',
+            predicted_vu=(50.0 + 30.0 * i, 60.0 + 25.0 * i),
+            predicted_snr=30.0,
+            in_body_silhouette=True,
+        )
+        for i in range(5)
+    ]
+    technique = StarFieldFromCatalogNav()
+    report = technique.is_feasible(features)
+    assert report.feasible is False
+    assert 'fewer_than_3_predicted_stars' in report.reason
+
+
+def test_star_field_returns_spurious_when_too_few_detections(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """Image with only 2 bright peaks fails the >= 3 detected-sources check."""
+    image = _star_field_image(
+        [(50.0, 50.0), (120.0, 130.0)], draw=draw_gaussian_star, shape=(200, 200)
+    )
+    centers = [(50.0, 50.0), (120.0, 130.0), (160.0, 80.0)]
+    features = _make_star_field_features(centers, make_feature=make_star_feature, offset=(0.0, 0.0))
+    technique = StarFieldFromCatalogNav()
+    context = make_nav_context(image)
+    result = technique.navigate(features, context)
+    assert result.spurious is True
+    assert isinstance(result.diagnostics, StarFieldDiagnostics)
+    assert result.diagnostics.n_detected_sources == 2
+
+
+def test_star_field_marks_at_edge_when_offset_hits_margin(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """An offset that hits the search-window edge is flagged + zero confidence."""
+    centers = [
+        (80.0, 80.0),
+        (110.0, 130.0),
+        (140.0, 90.0),
+        (170.0, 200.0),
+        (200.0, 70.0),
+        (90.0, 240.0),
+        (250.0, 130.0),
+    ]
+    image = _star_field_image(centers, draw=draw_gaussian_star, shape=(320, 320))
+    margin = (8, 8)
+    # Plant the offset on the V-axis margin.
+    planted = (float(margin[0]), 0.0)
+    features = _make_star_field_features(centers, make_feature=make_star_feature, offset=planted)
+    technique = StarFieldFromCatalogNav()
+    context = make_nav_context(image, extfov_margin_vu=margin)
+    result = technique.navigate(features, context)
+    # Translation hit the v-axis margin: at_edge fires and the
+    # confidence formula's hard_zero_if pushes confidence to zero.
+    assert result.at_edge is True
+    assert result.confidence == pytest.approx(0.0)
+
+
+def test_star_field_registered_with_navtechnique_registry() -> None:
+    """``StarFieldFromCatalogNav`` self-registers on import."""
+    assert StarFieldFromCatalogNav in NavTechnique._registry
+
+
+def test_star_field_min_inliers_less_than_three_raises() -> None:
+    """Construction rejects a ``pattern_match_min_inliers`` below 3."""
+    technique_class = StarFieldFromCatalogNav
+    bad_tuning = dict(technique_class.tuning)
+    bad_tuning['pattern_match_min_inliers'] = 2
+    original_tuning = technique_class.tuning
+    try:
+        technique_class.tuning = bad_tuning
+        with pytest.raises(ValueError, match='pattern_match_min_inliers'):
+            technique_class()
+    finally:
+        technique_class.tuning = original_tuning
+
+
+def test_star_field_seed_from_image_et_handles_edge_cases() -> None:
+    """``_seed_from_image_et`` produces a stable 64-bit unsigned integer."""
+    seed_zero = _seed_from_image_et(0.0)
+    assert seed_zero == 0
+    seed_pos = _seed_from_image_et(123.456)
+    assert seed_pos > 0
+    seed_neg = _seed_from_image_et(-1.0)
+    # Negative ETs (pre-J2000 obs, e.g. Voyager) wrap into the unsigned
+    # 64-bit range rather than overflowing the RNG seed.
+    assert seed_neg > 0
+    seed_nan = _seed_from_image_et(math.nan)
+    assert seed_nan == 0

--- a/tests/nav/nav_technique/test_nav_technique_star_refine.py
+++ b/tests/nav/nav_technique/test_nav_technique_star_refine.py
@@ -117,7 +117,7 @@ def test_star_refine_requires_prior(
     # Don't attach a prior.
     result = technique.navigate([feature], context)
     assert result.spurious is True
-    assert 'prior' in str(result.feature_ids) or result.confidence == 0.0
+    assert result.confidence == 0.0
 
 
 def test_star_refine_caps_single_inlier_confidence(

--- a/tests/nav/nav_technique/test_nav_technique_star_refine.py
+++ b/tests/nav/nav_technique/test_nav_technique_star_refine.py
@@ -1,0 +1,216 @@
+"""End-to-end tests for ``StarRefineNav``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from tests.nav.nav_technique.conftest import (
+    DrawGaussianStarFactory,
+    NavContextFactory,
+    NavFeatureFactory,
+)
+
+from nav.nav_orchestrator.nav_context import NavContext
+from nav.nav_technique.diagnostics import StarRefineDiagnostics
+from nav.nav_technique.nav_technique import NavTechnique
+from nav.nav_technique.nav_technique_star_refine import StarRefineNav
+
+
+def _attach_prior(context: NavContext, *, prior_offset_px: tuple[float, float]) -> NavContext:
+    """Return ``context`` with the supplied pass-1 prior attached."""
+    return context.with_prior(
+        offset_px=prior_offset_px,
+        covariance_px2=np.eye(2, dtype=np.float64),
+    )
+
+
+def test_star_refine_recovers_residual_correction(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """A small residual after the prior is recovered as a delta."""
+    shape = (220, 220)
+    image = np.zeros(shape, dtype=np.float64)
+    actual_a = (60.0, 70.0)
+    actual_b = (160.0, 130.0)
+    actual_c = (110.0, 170.0)
+    for c in (actual_a, actual_b, actual_c):
+        draw_gaussian_star(image, c, peak_dn=200.0, sigma=1.2)
+    # Pass-1 prior is 1 px off the true offset along V.
+    true_offset = (3.0, -2.0)
+    prior = (true_offset[0] - 1.0, true_offset[1])
+    pred_a = (actual_a[0] - true_offset[0], actual_a[1] - true_offset[1])
+    pred_b = (actual_b[0] - true_offset[0], actual_b[1] - true_offset[1])
+    pred_c = (actual_c[0] - true_offset[0], actual_c[1] - true_offset[1])
+    features = [
+        make_star_feature('star:UCAC4:A', predicted_vu=pred_a, predicted_snr=30.0),
+        make_star_feature('star:UCAC4:B', predicted_vu=pred_b, predicted_snr=30.0),
+        make_star_feature('star:UCAC4:C', predicted_vu=pred_c, predicted_snr=30.0),
+    ]
+    technique = StarRefineNav()
+    context = make_nav_context(image)
+    context = _attach_prior(context, prior_offset_px=prior)
+    feasibility = technique.is_feasible(features)
+    assert feasibility.feasible is True
+    result = technique.navigate(features, context)
+    assert result.spurious is False
+    # The technique reports the absolute offset (delta + prior); should
+    # converge to the true planted value to sub-pixel.
+    assert result.offset_px[0] == pytest.approx(true_offset[0], abs=0.5)
+    assert result.offset_px[1] == pytest.approx(true_offset[1], abs=0.5)
+    assert isinstance(result.diagnostics, StarRefineDiagnostics)
+    assert result.diagnostics.n_stars_used == 3
+
+
+def test_star_refine_drops_outlier_star(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """A star whose detection sits far from the shifted prediction is dropped."""
+    shape = (220, 220)
+    image = np.zeros(shape, dtype=np.float64)
+    actual_a = (60.0, 70.0)
+    actual_b = (160.0, 130.0)
+    draw_gaussian_star(image, actual_a, peak_dn=200.0, sigma=1.2)
+    draw_gaussian_star(image, actual_b, peak_dn=200.0, sigma=1.2)
+    # A wild prediction that would land far from any peak in the image.
+    actual_c_predicted = (50.0, 200.0)
+    draw_gaussian_star(image, (50.0, 60.0), peak_dn=200.0, sigma=1.2)
+    true_offset = (1.0, 1.0)
+    prior = (true_offset[0], true_offset[1])
+    pred_a = (actual_a[0] - true_offset[0], actual_a[1] - true_offset[1])
+    pred_b = (actual_b[0] - true_offset[0], actual_b[1] - true_offset[1])
+    features = [
+        make_star_feature('star:UCAC4:A', predicted_vu=pred_a, predicted_snr=30.0),
+        make_star_feature('star:UCAC4:B', predicted_vu=pred_b, predicted_snr=30.0),
+        make_star_feature(
+            'star:UCAC4:C',
+            predicted_vu=actual_c_predicted,
+            predicted_snr=30.0,
+        ),
+    ]
+    technique = StarRefineNav()
+    context = make_nav_context(image)
+    context = _attach_prior(context, prior_offset_px=prior)
+    result = technique.navigate(features, context)
+    assert isinstance(result.diagnostics, StarRefineDiagnostics)
+    # A and B contribute; the wild C prediction is dropped because no
+    # bright peak sits inside its refine window.
+    assert result.diagnostics.n_stars_used == 2
+
+
+def test_star_refine_requires_prior(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """``StarRefineNav.requires_prior`` is True; navigate without prior fails."""
+    assert StarRefineNav.requires_prior is True
+    shape = (200, 200)
+    image = np.zeros(shape, dtype=np.float64)
+    draw_gaussian_star(image, (100.0, 100.0), peak_dn=200.0, sigma=1.2)
+    feature = make_star_feature('star:UCAC4:A', predicted_vu=(100.0, 100.0), predicted_snr=30.0)
+    technique = StarRefineNav()
+    context = make_nav_context(image)
+    # Don't attach a prior.
+    result = technique.navigate([feature], context)
+    assert result.spurious is True
+    assert 'prior' in str(result.feature_ids) or result.confidence == 0.0
+
+
+def test_star_refine_caps_single_inlier_confidence(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """A 1-inlier refine on a near-perfect prior is capped at the configured ceiling.
+
+    Pin the contract by reading the cap value from
+    ``StarRefineNav.tuning`` rather than hard-coding 0.5.  A 1-inlier
+    refine carries no independent cross-check, so its confidence must
+    not exceed ``single_inlier_confidence_cap`` even when the
+    underlying sigmoid would give a higher number.
+    """
+    cap = float(StarRefineNav.tuning['single_inlier_confidence_cap'])
+    shape = (220, 220)
+    image = np.zeros(shape, dtype=np.float64)
+    actual = (110.0, 130.0)
+    draw_gaussian_star(image, actual, peak_dn=200.0, sigma=1.2)
+    true_offset = (1.0, 1.0)
+    pred = (actual[0] - true_offset[0], actual[1] - true_offset[1])
+    feature = make_star_feature('star:UCAC4:lone', predicted_vu=pred, predicted_snr=40.0)
+    technique = StarRefineNav()
+    context = make_nav_context(image)
+    context = _attach_prior(context, prior_offset_px=true_offset)
+    result = technique.navigate([feature], context)
+    assert result.spurious is False
+    assert isinstance(result.diagnostics, StarRefineDiagnostics)
+    assert result.diagnostics.n_stars_used == 1
+    # The cap is a hard ceiling on the post-sigmoid confidence.
+    assert result.confidence <= cap + 1e-12
+
+
+def test_star_refine_skips_single_inlier_cap_log_for_multi_inlier(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A multi-inlier refine never logs the single-inlier-cap line.
+
+    The structural cap only applies when ``n_stars_used == 1``; with
+    two or more inliers the per-star residual scatter cross-checks the
+    joint fit and the cap path is skipped.  Asserting on the log
+    output confirms the cap branch did not fire.
+    """
+    shape = (220, 220)
+    image = np.zeros(shape, dtype=np.float64)
+    actual_a = (60.0, 70.0)
+    actual_b = (160.0, 130.0)
+    draw_gaussian_star(image, actual_a, peak_dn=200.0, sigma=1.2)
+    draw_gaussian_star(image, actual_b, peak_dn=200.0, sigma=1.2)
+    true_offset = (1.0, 1.0)
+    pred_a = (actual_a[0] - true_offset[0], actual_a[1] - true_offset[1])
+    pred_b = (actual_b[0] - true_offset[0], actual_b[1] - true_offset[1])
+    features = [
+        make_star_feature('star:UCAC4:A', predicted_vu=pred_a, predicted_snr=40.0),
+        make_star_feature('star:UCAC4:B', predicted_vu=pred_b, predicted_snr=40.0),
+    ]
+    technique = StarRefineNav()
+    context = make_nav_context(image)
+    context = _attach_prior(context, prior_offset_px=true_offset)
+    result = technique.navigate(features, context)
+    assert result.spurious is False
+    assert isinstance(result.diagnostics, StarRefineDiagnostics)
+    assert result.diagnostics.n_stars_used == 2
+    captured = capsys.readouterr()
+    assert 'Single-inlier refine' not in captured.out
+
+
+def test_star_refine_rejects_invalid_single_inlier_cap() -> None:
+    """Construction rejects ``single_inlier_confidence_cap`` outside [0, 1]."""
+    technique_class = StarRefineNav
+    bad_tuning = dict(technique_class.tuning)
+    bad_tuning['single_inlier_confidence_cap'] = 1.5
+    original_tuning = technique_class.tuning
+    try:
+        technique_class.tuning = bad_tuning
+        with pytest.raises(ValueError, match='single_inlier_confidence_cap'):
+            technique_class()
+    finally:
+        technique_class.tuning = original_tuning
+
+
+def test_star_refine_infeasible_on_empty_input() -> None:
+    """``is_feasible([])`` reports infeasibility."""
+    technique = StarRefineNav()
+    report = technique.is_feasible([])
+    assert report.feasible is False
+    assert 'no_usable_star_features' in report.reason
+
+
+def test_star_refine_registered_with_navtechnique_registry() -> None:
+    """``StarRefineNav`` self-registers on import."""
+    assert StarRefineNav in NavTechnique._registry

--- a/tests/nav/nav_technique/test_nav_technique_star_shared.py
+++ b/tests/nav/nav_technique/test_nav_technique_star_shared.py
@@ -1,0 +1,71 @@
+"""Shared behaviour tests across the three star-accepting NavTechniques.
+
+The per-technique test files cover technique-specific paths
+(``StarUniqueMatchNav`` 1- vs 2-star, ``StarRefineNav`` outlier drop,
+``StarFieldFromCatalogNav`` triplet matching).  Tests in this file
+parameterize behaviour that is identical across all three star
+techniques — currently the "blank-image input yields a spurious
+result with confidence zero" contract.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from tests.nav.nav_technique.conftest import NavContextFactory, NavFeatureFactory
+
+from nav.nav_orchestrator.nav_context import NavContext
+from nav.nav_technique.nav_technique import NavTechnique
+from nav.nav_technique.nav_technique_star_field import StarFieldFromCatalogNav
+from nav.nav_technique.nav_technique_star_refine import StarRefineNav
+from nav.nav_technique.nav_technique_star_unique_match import StarUniqueMatchNav
+
+
+def _attach_zero_prior(context: NavContext) -> NavContext:
+    """Return ``context`` with a (0, 0) pass-1 prior attached."""
+    return context.with_prior(
+        offset_px=(0.0, 0.0),
+        covariance_px2=np.eye(2, dtype=np.float64),
+    )
+
+
+@pytest.mark.parametrize(
+    ('technique_cls', 'feature_count', 'requires_prior'),
+    [
+        pytest.param(StarUniqueMatchNav, 1, False, id='StarUniqueMatchNav'),
+        pytest.param(StarRefineNav, 1, True, id='StarRefineNav'),
+        pytest.param(StarFieldFromCatalogNav, 3, False, id='StarFieldFromCatalogNav'),
+    ],
+)
+def test_star_technique_blank_image_returns_spurious(
+    technique_cls: type[NavTechnique],
+    feature_count: int,
+    requires_prior: bool,
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+) -> None:
+    """Each star technique reports spurious + zero confidence on a blank image.
+
+    StarUniqueMatchNav fires the 1-star path against one feature whose
+    search window contains nothing but noise floor; StarRefineNav has a
+    prior attached but no inliers to refine on; StarFieldFromCatalogNav
+    needs ≥ 3 STAR features but cannot match any of them against an
+    empty image.  All three return ``spurious=True`` and confidence
+    ``0.0`` rather than raising.
+    """
+    image = np.zeros((220, 220), dtype=np.float64)
+    features = [
+        make_star_feature(
+            f'star:UCAC4:{i}',
+            predicted_vu=(60.0 + 30.0 * i, 80.0 + 25.0 * i),
+            predicted_snr=30.0,
+        )
+        for i in range(feature_count)
+    ]
+    technique = technique_cls()
+    context = make_nav_context(image)
+    if requires_prior:
+        context = _attach_zero_prior(context)
+    result = technique.navigate(features, context)
+    assert result.spurious is True
+    assert result.confidence == pytest.approx(0.0)

--- a/tests/nav/nav_technique/test_nav_technique_star_unique_match.py
+++ b/tests/nav/nav_technique/test_nav_technique_star_unique_match.py
@@ -1,0 +1,158 @@
+"""End-to-end tests for ``StarUniqueMatchNav``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from tests.nav.nav_technique.conftest import (
+    DrawGaussianStarFactory,
+    NavContextFactory,
+    NavFeatureFactory,
+)
+
+from nav.nav_technique.diagnostics import StarUniqueMatchDiagnostics
+from nav.nav_technique.nav_technique import NavTechnique
+from nav.nav_technique.nav_technique_star_unique_match import StarUniqueMatchNav
+
+
+def test_star_unique_match_one_star_recovers_planted_offset(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """A single uniquely-bright star recovers the planted translation."""
+    shape = (200, 200)
+    image = np.zeros(shape, dtype=np.float64)
+    actual_vu = (100.0, 100.0)
+    draw_gaussian_star(image, actual_vu, peak_dn=200.0, sigma=1.2)
+    planted = (2.0, -3.0)
+    pred_vu = (actual_vu[0] - planted[0], actual_vu[1] - planted[1])
+    feature = make_star_feature('star:UCAC4:1', predicted_vu=pred_vu, predicted_snr=40.0)
+    technique = StarUniqueMatchNav()
+    context = make_nav_context(image)
+    feas = technique.is_feasible([feature])
+    assert feas.feasible is True
+    result = technique.navigate([feature], context)
+    assert result.spurious is False
+    assert result.offset_px[0] == pytest.approx(planted[0], abs=0.5)
+    assert result.offset_px[1] == pytest.approx(planted[1], abs=0.5)
+    assert isinstance(result.diagnostics, StarUniqueMatchDiagnostics)
+    assert result.diagnostics.mode == 'one_star'
+    assert result.confidence <= 0.7 + 1e-12
+
+
+def test_star_unique_match_two_star_recovers_planted_offset(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """The 2-star path picks the smaller-residual assignment."""
+    shape = (200, 200)
+    image = np.zeros(shape, dtype=np.float64)
+    actual_a = (60.0, 60.0)
+    actual_b = (140.0, 140.0)
+    draw_gaussian_star(image, actual_a, peak_dn=200.0, sigma=1.2)
+    draw_gaussian_star(image, actual_b, peak_dn=180.0, sigma=1.2)
+    planted = (1.0, 1.5)
+    pred_a = (actual_a[0] - planted[0], actual_a[1] - planted[1])
+    pred_b = (actual_b[0] - planted[0], actual_b[1] - planted[1])
+    feat_a = make_star_feature('star:UCAC4:A', predicted_vu=pred_a, predicted_snr=60.0)
+    feat_b = make_star_feature('star:UCAC4:B', predicted_vu=pred_b, predicted_snr=40.0)
+    technique = StarUniqueMatchNav()
+    context = make_nav_context(image)
+    result = technique.navigate([feat_a, feat_b], context)
+    assert result.spurious is False
+    assert result.offset_px[0] == pytest.approx(planted[0], abs=0.4)
+    assert result.offset_px[1] == pytest.approx(planted[1], abs=0.4)
+    assert isinstance(result.diagnostics, StarUniqueMatchDiagnostics)
+    assert result.diagnostics.mode == 'two_star'
+    # No third predictable star, so the brightness margin diagnostic is +inf.
+    assert result.diagnostics.brightness_margin_mag == float('inf')
+    assert result.confidence <= 0.8 + 1e-12
+
+
+def test_star_unique_match_one_star_fails_when_brightness_margin_too_small(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """Two near-equal-brightness stars fail the 1-star uniqueness test.
+
+    With two stars whose predicted SNRs are close and the 2-star path
+    fails (e.g. wrong-position prediction such that one detection misses
+    its window entirely), the technique reports a spurious result with
+    a brightness-margin reason rather than picking the wrong star.
+    """
+    shape = (200, 200)
+    image = np.zeros(shape, dtype=np.float64)
+    actual = (100.0, 100.0)
+    draw_gaussian_star(image, actual, peak_dn=200.0, sigma=1.2)
+    planted = (1.0, 1.0)
+    pred_a = (actual[0] - planted[0], actual[1] - planted[1])
+    # Second prediction in a region with no signal so its detection
+    # fails — forcing the one-star fallback.
+    pred_b = (10.0, 10.0)
+    feat_a = make_star_feature('star:UCAC4:A', predicted_vu=pred_a, predicted_snr=20.0)
+    feat_b = make_star_feature(
+        'star:UCAC4:B',
+        predicted_vu=pred_b,
+        predicted_snr=18.0,  # too close to A — no margin
+    )
+    technique = StarUniqueMatchNav()
+    context = make_nav_context(image)
+    result = technique.navigate([feat_a, feat_b], context)
+    # Cannot trigger the 2-star path because pred_b has no detection.
+    # The 1-star fallback rejects because brightness margin to feat_b
+    # is below the 1.5 mag floor.
+    assert result.spurious is True
+    assert result.confidence == pytest.approx(0.0)
+
+
+def test_star_unique_match_infeasible_on_empty_input() -> None:
+    """``is_feasible([])`` reports infeasibility."""
+    technique = StarUniqueMatchNav()
+    report = technique.is_feasible([])
+    assert report.feasible is False
+    assert 'no_usable_star_features' in report.reason
+
+
+def test_star_unique_match_skips_occluded_stars(
+    make_star_feature: NavFeatureFactory,
+) -> None:
+    """STAR features marked in_body_silhouette are filtered out."""
+    feature = make_star_feature(
+        'star:UCAC4:occluded',
+        predicted_vu=(100.0, 100.0),
+        predicted_snr=30.0,
+        in_body_silhouette=True,
+    )
+    technique = StarUniqueMatchNav()
+    report = technique.is_feasible([feature])
+    assert report.feasible is False
+    assert 'no_usable_star_features' in report.reason
+
+
+def test_star_unique_match_registered_with_navtechnique_registry() -> None:
+    """``StarUniqueMatchNav`` self-registers on import."""
+    assert StarUniqueMatchNav in NavTechnique._registry
+
+
+def test_star_unique_match_marks_at_edge_when_offset_hits_margin(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """An offset that hits the search-window edge is flagged + zero confidence."""
+    shape = (220, 220)
+    image = np.zeros(shape, dtype=np.float64)
+    actual_vu = (110.0, 110.0)
+    draw_gaussian_star(image, actual_vu, peak_dn=200.0, sigma=1.2)
+    margin = (8, 8)
+    # Plant the offset exactly on the search-window edge.
+    pred_vu = (actual_vu[0] - float(margin[0]), actual_vu[1])
+    feature = make_star_feature('star:UCAC4:edge', predicted_vu=pred_vu, predicted_snr=40.0)
+    technique = StarUniqueMatchNav()
+    context = make_nav_context(image, extfov_margin_vu=margin)
+    result = technique.navigate([feature], context)
+    assert result.at_edge is True
+    assert result.confidence == pytest.approx(0.0)


### PR DESCRIPTION
## Purpose

Ship Phase 7 (`StarUniqueMatchNav`, `StarRefineNav`) and Phase 8
(`StarFieldFromCatalogNav`) per `AUTONAV_PLAN.md` so every star scene has a
feasibility envelope: 1-2 stars via unique-match, ≥ 3 via field-match,
prior-required refinement in pass 2.  Includes the manual-nav-dialog STAR
rendering fix surfaced during library curation, the `at_edge_tolerance_px` /
`AT_EDGE_TOLERANCE_PX` body-technique cleanup, and two seed sidecars (Vega,
Pleiades).

## Changes

**Phase 7 — Star unique-match + refine (new techniques):**

- `nav_technique_star_unique_match.py` — 1-star path (cap 0.7) and 2-star
  path (cap 0.8) with brightness-margin gate; YAML tunables for search
  window, centroid box, residual cap, per-mode confidence caps.
- `nav_technique_star_refine.py` — pass-2 refinement on a pass-1 prior with
  per-star inverse-variance weighting, outlier drop, single-inlier
  confidence cap (default 0.5) so a 1-inlier refine cannot dominate a
  1-star unique-match on the same observation.

**Phase 8 — Multi-star RANSAC pattern matcher:**

- `nav_technique_star_field.py` — four-stage pipeline (matched-filter
  source detection, similarity-invariant triplet hashing, deterministic
  RANSAC sorted-by-hash-distance + lex-sorted detection-source indices per
  AUTONAV_PLAN §33, Tukey-biweight verification).  Translation-only
  Procrustes; rotation-enabled 3-DoF lights up in Phase 9.
- Sub-piece TDD: 6 helper-level tests cover detection / hashing /
  enumeration / candidate ranking / translation solve / inlier counting.
- Determinism guard asserts byte-equal `(offset_px, covariance_px2,
  confidence, diagnostics)` across two back-to-back invocations.

**Cross-technique cleanup (closes Phase 7+8 critique High findings):**

- New `nav.nav_technique._star_helpers` submodule consolidates
  `star_features`, `usable_stars`, `predicted_snr`, `predicted_vu`,
  `brightness_margin_mag`, `local_centroid` (was duplicated across three
  star modules with cross-module private imports).
- `search_window_for_obs` promoted to `nav.nav_technique.nav_technique`
  (was 8 identical per-module copies, body / ring / star).
- `AT_EDGE_TOLERANCE_PX` constant deleted from `dt_fitting`; every
  technique reads `at_edge_tolerance_px` from
  `config_510_techniques.yaml.tuning` (matching `RingEdgeNav`'s pattern).

**Manual-nav dialog STAR rendering (real bug surfaced during curation):**

- `compose_dialog_overlay` paints a bbox-sized rectangle outline around
  every STAR feature's predicted (v, u).  Previously star-only scenes hit
  `no_renderable_features_for_manual_nav` even though there was a star to
  align — affected every Scenario A / B operator-curation workflow.
- Matching `is_feasible` branch in `NavTechniqueManual`.
- Three new tests in `test_composition.py` (rectangle painting, off-image
  no-op, near-edge half-width clamp) plus a manual-nav test for
  template-less STAR features.

**Diagnostics polish:**

- `StarUniqueMatchDiagnostics.brightness_margin_mag` reports `+inf` when
  no third predictable star is available (was reporting the magnitude
  difference between the two matched stars in the 2-star + no-third-star
  case, which contradicted the field docstring).

**Operator runbook + seed sidecars:**

- `PHASE7_LIBRARY_SEED.md` covers the four scenarios (A bright single
  star, B optional two-star, C star-rich field, D stars + body) plus the
  manual-nav workflow.  Scenario B is documented as optional — the
  2-star path is structurally identical to 1-star and fully exercised by
  the synthetic unit test.
- Seed sidecars: `W1449079117_1_CALIB` (Vega, Scenario A) and
  `W1580760393_1_CALIB` (Pleiades, Scenario C).  The Pleiades sidecar
  records `expected.status: failed` pending the Phase 10F SNR-units fix
  filed during curation.

**Plan + docs updates:**

- `AUTONAV_PLAN.md`: Phase 7 + 8 marked complete with implementation
  notes; Phase 8 Sub-piece 4 wording corrected to match the shipped
  translation-only Procrustes; new Phase 10 scope F documents the
  calibrated-IF SNR-unit-mismatch bug surfaced during W1580760393
  curation.
- `developer_guide_techniques.rst`: new "Star techniques" section
  covering all three new techniques.
- `developer_guide_navigation_models_stars.rst`,
  `introduction_configuration.rst`, `user_guide_navigation.rst`: updated
  technique listings.

## Type of Change

- [x] New feature (non-breaking) — Phase 7 + 8 techniques
- [x] Bug fix (non-breaking) — manual-nav dialog dropped STAR-only scenes
- [x] Refactor (no functional or API changes) — DRY consolidation across 9
      technique modules
- [x] Documentation — runbook + plan + Sphinx
- [x] Tests only (no production code change) — 35 new unit tests

## Testing

- [x] Unit tests pass — 1191 passed, 1 warning (`pytest -n auto
      --dist=loadfile`)
- [x] Integration tests pass (if applicable) — collection clean; not run
      end-to-end on this branch (no `PDS3_HOLDINGS_DIR` env in CI image)
- [x] New or updated tests for changed code — 35 new tests across
      `test_nav_technique_star_unique_match.py` (7), `_star_refine.py` (8),
      `_star_field.py` (21), `_star_shared.py` (3 parameterized),
      `test_composition.py` (3 STAR-marker tests),
      `test_nav_technique_manual.py` (1 template-less STAR test, 1
      no-features test)
- [x] Tested manually — manual-nav dialog opened and `Save as Library
      Entry…` exercised for both seed sidecars (Vega and Pleiades)

## Potential Impacts

**Public API additions:**

- `nav.nav_technique.StarUniqueMatchNav`, `StarRefineNav`,
  `StarFieldFromCatalogNav` (re-exported from
  `nav.nav_technique.__init__`).
- `nav.nav_technique.diagnostics.StarUniqueMatchDiagnostics`,
  `StarRefineDiagnostics`, `StarFieldDiagnostics`.
- `nav.nav_technique.nav_technique.search_window_for_obs` (new public
  helper for technique authors).
- `nav.nav_technique._star_helpers` (private submodule; not exported).

**Removed symbols:**

- `nav.nav_technique.dt_fitting.AT_EDGE_TOLERANCE_PX` — replaced by per-
  technique YAML `at_edge_tolerance_px`.  No callers outside the
  technique package.

**Config schema additions** (`config_510_techniques.yaml`):

- `techniques.StarUniqueMatchNav.*`, `StarRefineNav.*`,
  `StarFieldFromCatalogNav.*` blocks added (placeholders pending Phase
  10 calibration sweep).
- `at_edge_tolerance_px: 1.0` added under each body / ring technique's
  `tuning` block.
- `single_inlier_confidence_cap: 0.5` added under
  `StarRefineNav.tuning`.

**Performance:** none expected for downstream callers; the new techniques
are M^3 in catalog-and-detection counts but bounded at 30 by the
`max_sources` cap (~27 K candidate triplets per side, ~10 ms per
invocation in the unit-test harness).

**Backward compatibility:** none broken.  No public-API removals.

## Checklist

- [x] Code follows project style (`ruff check`, `ruff format`)
- [x] Type annotations present and `mypy --strict` passes (282 source files)
- [x] Docstrings and Sphinx docs updated (`sphinx-build -W -b html docs
      docs/_build` clean)
- [ ] CHANGES.md updated — deferred to Phase 11 per the plan's per-phase
      definition of done
- [x] No temporary or debug code left in
- [x] Breaking changes flagged in Type of Change above (none)

## Notes

**Phase 10 follow-up filed during this branch.**  Curating
`W1580760393_1_CALIB` (Pleiades) for Scenario C surfaced a real bug:
`predicted_snr.integrated_signal_dn` returns DN-equivalent values, but
`image_noise_sigma` is in whatever units the obs delivered (DN for
`_RAW`, I/F for `_CALIB`).  For I/F images the SNR formula collapses to
`√sig` and every star fails the reliability gate.  Filed as Phase 10
scope item F; the worked example and direction (per-instrument-per-
processing-level scale factor or convert `image_noise_sigma` to
DN-equivalent at NavContext build time) are documented in
`AUTONAV_PLAN.md`.  The Pleiades sidecar's `expected.status: failed`
records honest current behavior; flip to `ok` once Phase 10F lands.

**Vega sidecar `primary_technique`.**  The W1449079117 sidecar pins
`primary_technique: StarRefineNav` because that was the orchestrator's
actual output before the `single_inlier_confidence_cap` shipped on this
branch.  After the cap, `StarUniqueMatchNav` should win primary on a
1-star scene.  A follow-up commit (or the Phase 10 calibration pass)
should re-run `nav_offset` on Vega and flip the sidecar back to
`StarUniqueMatchNav` once the new behavior is verified.

**Scenario B (two-star) deferred.**  Documented as optional in
`PHASE7_LIBRARY_SEED.md` — real frames with exactly 2 detectable
catalog stars are rare on Cassini ISS (NAC FOV too narrow, WAC
typically catches a third), and the 2-star path is fully exercised by
the synthetic unit test
`test_star_unique_match_two_star_recovers_planted_offset`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Three new star navigation techniques added: StarUniqueMatchNav, StarRefineNav, StarFieldFromCatalogNav.
  * Star features now render as bounding-box overlays in manual navigation dialogs.
  * New at_edge_tolerance_px tuning applied to body navigation techniques.

* **Documentation**
  * Navigation guides and configuration docs updated with detailed STAR technique specs and operator guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->