### PR TITLE
fix: restore calibrated-image ring navigation

### DIFF
--- a/src/nav/config_files/config_510_techniques.yaml
+++ b/src/nav/config_files/config_510_techniques.yaml
@@ -298,8 +298,15 @@ techniques:
         alpha: 1.0
         divisor: 200.0
         cap_at: 1.0
-      - feature: per_edge_dt_rms_summed
-        alpha: -2.0
+      # Penalise the MEAN per-edge DT residual (px), not the raw sum.  The sum
+      # scales with the number of fused edges, so with a fixed divisor a frame
+      # with more rings was penalised purely for having more rings, driving
+      # confidence to zero on real multi-edge scenes.  The mean is
+      # edge-count independent: alpha -1.0 with the default unit divisor costs
+      # ~1 logit per pixel of mean per-edge residual.  PROVISIONAL magnitude --
+      # the px scale awaits the integration-library calibration sweep.
+      - feature: per_edge_dt_rms_mean
+        alpha: -1.0
     hard_zero_if:
       at_edge: true
     tuning:
@@ -335,12 +342,16 @@ techniques:
       # See ``BodyLimbNav.lm_tikhonov_alpha``.
       lm_tikhonov_alpha: 0.0
       # Final continuous gradient-ridge sub-pixel refinement; see
-      # ``BodyLimbNav.gradient_ridge_refine``.  Held OFF: the ring edges are
-      # symmetric, so the gradient peak already coincides with the geometric
-      # edge and the DT-LM fit is at its floor (~0.016 px sweep median,
-      # already below the 0.02 px target); the continuous refine does not
-      # improve it.  1 enables, 0 disables.
-      gradient_ridge_refine: 0
+      # ``BodyLimbNav.gradient_ridge_refine``.  1 enables, 0 disables.
+      # ON: the binary edge mask quantises detected edges to the integer
+      # pixel grid, so on dense real ring scenes a large fraction of model
+      # vertices land exactly on edge pixels (DT == 0, zero gradient) and the
+      # DT-LM step stalls at the integer coarse-NCC seed.  The continuous
+      # gradient-ridge pass refines against the un-thresholded gradient
+      # magnitude, recovering the sub-pixel offset the quantised DT discards.
+      # (On clean sim scenes the DT-LM already reaches its ~0.016 px floor, so
+      # the refine is a no-op there.)
+      gradient_ridge_refine: 1
       # Rotation-axis ``at_edge`` fraction; see
       # ``BodyDiscCorrelateNav.rotation_at_edge_fraction``.
       rotation_at_edge_fraction: 0.95

--- a/src/nav/nav_technique/diagnostics.py
+++ b/src/nav/nav_technique/diagnostics.py
@@ -159,6 +159,11 @@ class RingEdgeDiagnostics:
         total_edge_length_px: Cumulative pixel length of all surviving
             ring-edge polylines.
         per_edge_dt_rms_summed: Sum of per-edge final DT RMS values.
+        per_edge_dt_rms_mean: Mean per-edge final DT RMS value
+            (``per_edge_dt_rms_summed / edge_count``).  Edge-count independent,
+            so it -- not the raw sum -- is the scale the confidence formula
+            uses; the sum grows with the number of fused edges and a fixed
+            divisor cannot normalise it.
         edge_count: Number of RING_EDGE features fused.
         is_rank_1: True if every ring-edge feature was straight-line and the
             combined covariance is rank-1.
@@ -166,11 +171,13 @@ class RingEdgeDiagnostics:
 
     total_edge_length_px: float = 0.0
     per_edge_dt_rms_summed: float = 0.0
+    per_edge_dt_rms_mean: float = 0.0
     edge_count: int = 0
     is_rank_1: bool = False
     CURATOR_FIELDS: ClassVar[dict[str, str | None]] = {
         'total_edge_length_px': 'total_edge_length_px',
         'per_edge_dt_rms_summed': 'per_edge_dt_rms_summed',
+        'per_edge_dt_rms_mean': 'per_edge_dt_rms_mean',
         'edge_count': 'edge_count',
         'is_rank_1': 'is_rank_1',
     }

--- a/src/nav/nav_technique/nav_technique_ring_edge.py
+++ b/src/nav/nav_technique/nav_technique_ring_edge.py
@@ -121,6 +121,7 @@ class RingEdgeNav(NavTechnique):
             'at_edge',
             'total_edge_length_px',
             'per_edge_dt_rms_summed',
+            'per_edge_dt_rms_mean',
             'edge_count',
             'is_rank_1',
         }
@@ -327,9 +328,11 @@ class RingEdgeNav(NavTechnique):
                 sigma_rotation_rad = None
             covariance = np.asarray(covariance, np.float64)
             is_rank_1 = _is_rank_1(covariance) or every_straight
+            per_edge_rms_mean = per_edge_rms_summed / float(max(edge_count, 1))
             diagnostics = RingEdgeDiagnostics(
                 total_edge_length_px=total_edge_length_px,
                 per_edge_dt_rms_summed=per_edge_rms_summed,
+                per_edge_dt_rms_mean=per_edge_rms_mean,
                 edge_count=edge_count,
                 is_rank_1=bool(is_rank_1),
             )
@@ -430,5 +433,6 @@ class _RingEdgeConfidenceContext:
         self.at_edge = at_edge
         self.total_edge_length_px = diagnostics.total_edge_length_px
         self.per_edge_dt_rms_summed = diagnostics.per_edge_dt_rms_summed
+        self.per_edge_dt_rms_mean = diagnostics.per_edge_dt_rms_mean
         self.edge_count = diagnostics.edge_count
         self.is_rank_1 = diagnostics.is_rank_1

--- a/src/nav/support/noise_estimate.py
+++ b/src/nav/support/noise_estimate.py
@@ -2,12 +2,19 @@
 
 The autonomous-navigation orchestrator computes ``image_noise_sigma`` once per
 image and stores it on ``NavContext`` so every extractor and technique uses
-the same value.  This module owns the implementation: a single MAD-based
-robust standard-deviation over the sensor pixels.
+the same value.  This module owns the implementation.
 
-The estimate is global — it does not require knowledge of where any feature
+The estimate is global -- it does not require knowledge of where any feature
 lives in the image, and is therefore not biased by a wrong SPICE pointing
-prediction.
+prediction.  It is computed from a 3x3 second-difference (Laplacian) response
+so that smooth scene structure (ring brightness ramps, limb shading, a bright
+extended disc) cancels and only pixel-to-pixel noise survives; the MAD over
+that response further rejects the minority of pixels sitting on sharp edges or
+cosmic rays.  A plain MAD of the raw intensities is *not* used: when the scene
+is dominated by structure (for example rings filling the frame) it measures the
+bright-to-dark spread rather than the noise and overestimates sigma by orders
+of magnitude, which in turn pushes the edge-detection threshold above every
+real gradient and empties the distance transform.
 """
 
 import numpy as np
@@ -19,22 +26,32 @@ __all__ = [
     'estimate_image_noise_sigma',
 ]
 
+# The 3x3 second-difference (Laplacian) kernel [[1, -2, 1], [-2, 4, -2],
+# [1, -2, 1]] has coefficients whose sum of squares is 36, so for white noise
+# of standard deviation ``s`` the response variance is ``36 * s**2``; dividing
+# the robust response standard deviation by 6 recovers ``s``.  The double
+# difference cancels any locally linear brightness ramp, so smooth scene
+# content does not inflate the estimate.
+_LAPLACIAN_NORM = 6.0
+
 
 def estimate_image_noise_sigma(
     image: NDArrayFloatType, sensor_mask: NDArrayBoolType | None = None
 ) -> float:
     """Return a robust noise sigma over the sensor pixels.
 
-    Uses the MAD-based estimator ``1.4826 * median(abs(x - median(x)))``
-    which is insensitive to bright body / star content because the median
-    is dominated by background pixels (the majority of the image).  The
-    estimate is therefore stable across scene type.
+    The estimate is the MAD-based standard deviation of a 3x3 second-difference
+    (Laplacian) response, divided by 6.  The second difference cancels smooth
+    brightness structure so the value reflects pixel-to-pixel noise rather than
+    scene content, and the MAD rejects the minority of pixels on sharp edges or
+    cosmic rays.
 
     Parameters:
         image: 2-D float input array.
         sensor_mask: Optional boolean mask with ``True`` for sensor pixels and
             ``False`` for extfov padding.  If ``None``, every pixel of
-            ``image`` is treated as sensor data.
+            ``image`` is treated as sensor data.  Only response pixels whose
+            full 3x3 neighbourhood lies inside the mask contribute.
 
     Returns:
         Robust noise sigma in the same DN units as ``image``.
@@ -45,15 +62,58 @@ def estimate_image_noise_sigma(
     """
     if image.ndim != 2:
         raise TypeError(f'estimate_image_noise_sigma requires a 2-D image; got ndim={image.ndim}')
-    if sensor_mask is None:
-        sensor = image
-    else:
+    if sensor_mask is not None:
         if sensor_mask.shape != image.shape:
             raise ValueError(
                 f'sensor_mask shape {sensor_mask.shape} differs from image shape {image.shape}'
             )
-        sensor_pixels = image[sensor_mask]
-        if sensor_pixels.size == 0:
+        if not bool(sensor_mask.any()):
             raise ValueError('sensor_mask selects no pixels')
-        sensor = sensor_pixels
-    return mad_std(np.asarray(sensor, np.float64).ravel())
+
+    img = np.asarray(image, np.float64)
+
+    # Images smaller than the 3x3 kernel cannot form a second difference; fall
+    # back to a masked global MAD so a value is still returned.
+    if img.shape[0] < 3 or img.shape[1] < 3:
+        sensor = img if sensor_mask is None else img[sensor_mask]
+        return float(mad_std(sensor.ravel()))
+
+    # Laplacian response over every interior pixel (corners +1, edges -2,
+    # centre +4), aligned to image pixels [1:-1, 1:-1].
+    response = (
+        img[:-2, :-2]
+        + img[:-2, 2:]
+        + img[2:, :-2]
+        + img[2:, 2:]
+        - 2.0 * (img[:-2, 1:-1] + img[1:-1, :-2] + img[1:-1, 2:] + img[2:, 1:-1])
+        + 4.0 * img[1:-1, 1:-1]
+    )
+
+    if sensor_mask is None:
+        samples = response.ravel()
+        fallback = img.ravel()
+    else:
+        m = sensor_mask
+        interior_valid = (
+            m[:-2, :-2]
+            & m[:-2, 1:-1]
+            & m[:-2, 2:]
+            & m[1:-1, :-2]
+            & m[1:-1, 1:-1]
+            & m[1:-1, 2:]
+            & m[2:, :-2]
+            & m[2:, 1:-1]
+            & m[2:, 2:]
+        )
+        samples = response[interior_valid]
+        fallback = img[sensor_mask].ravel()
+
+    # A second difference touching a NaN missing-data marker is NaN, so drop
+    # non-finite responses.  If none survive (no fully-finite 3x3 neighbourhood,
+    # e.g. an image that is almost entirely markers), fall back to a global MAD
+    # over the finite sensor pixels rather than failing.
+    finite = samples[np.isfinite(samples)]
+    if finite.size == 0:
+        return float(mad_std(fallback))
+
+    return float(mad_std(finite) / _LAPLACIAN_NORM)

--- a/tests/integration/sim_baselines/planted_offset_blob_crescent.json
+++ b/tests/integration/sim_baselines/planted_offset_blob_crescent.json
@@ -1,7 +1,7 @@
 {
   "confidence": 0.4,
   "offset_du_px": -0.59,
-  "offset_dv_px": 1.24,
+  "offset_dv_px": 1.25,
   "scene_name": "planted_offset_blob_crescent",
   "status": "success"
 }

--- a/tests/integration/sim_baselines/planted_offset_ring.json
+++ b/tests/integration/sim_baselines/planted_offset_ring.json
@@ -1,7 +1,7 @@
 {
-  "confidence": 0.0,
-  "offset_du_px": null,
-  "offset_dv_px": null,
+  "confidence": 0.4,
+  "offset_du_px": -0.63,
+  "offset_dv_px": 1.41,
   "scene_name": "planted_offset_ring",
-  "status": "failed"
+  "status": "success"
 }


### PR DESCRIPTION
## Problem

Calibrated (I/F) Cassini ring frames (e.g. `W1580218037`) reported `status=failed` even with clearly visible, curved rings filling the frame.

Root cause: the per-image noise sigma was a **global MAD of pixel intensities**. On a ring-filled frame that measures scene *structure*, not noise — overestimating sigma by ~75x (0.069 vs the true ~0.0009). The gradient edge-detection threshold (`4*sigma`) then sat *above every real edge gradient*, so the distance-transform edge map was empty and no DT technique could lock on. Increasing `extfov` did nothing because the offset was never outside the search window — there were simply no edges to match.

## Fix

- **`noise_estimate`**: estimate sigma from a 3x3 second-difference (Laplacian) response, which cancels smooth brightness structure and reflects pixel-to-pixel noise. Robust to NaN missing-data markers.
- **`RingEdgeNav` confidence**: penalize the *mean* per-edge DT RMS instead of the raw sum. The sum scaled with edge count, forcing confidence to zero on real multi-edge frames even with a clean fit.
- **`RingEdgeNav` sub-pixel**: enable `gradient_ridge_refine`. The binary edge mask quantizes the DT fit to the integer pixel grid on dense real frames (the offset pinned to exact integers with RMS 0); the continuous gradient-ridge pass recovers the sub-pixel offset.
- Re-blessed two sim baselines: `planted_offset_ring` (failed -> success, sub-pixel) and `planted_offset_blob_crescent` (dv 1.24 -> 1.25).

## Result

`W1580218037` now navigates: offset **(1.0424, -5.0109)** px (sub-pixel), confidence 0.24, `status=success`.

## Test plan

- Full unit suite: passing (incl. the NaN-marker classifier edge case).
- Sim integration suite — baselines, scenes, algorithmic invariants, regression, sweeps: passing.
- ruff / ruff format / mypy clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ring Edge Navigation technique now enables gradient refinement and uses mean-based per-edge residual calculations for improved confidence estimation.

* **Improvements**
  * Noise estimation algorithm enhanced with robust Laplacian-based computation for more reliable noise detection across varied image conditions.

* **Tests**
  * Integration test baselines updated to reflect navigation and noise estimation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->