### PR TITLE
Expose ensemble and reliability-gate settings in YAML config

### DIFF
--- a/src/spindoctor/config/config.py
+++ b/src/spindoctor/config/config.py
@@ -141,6 +141,7 @@ class Config:
         self._config_bootstrap: dict[str, Any] = AttrDict({})
         self._config_backplanes: dict[str, Any] = AttrDict({})
         self._config_pds4: dict[str, Any] = AttrDict({})
+        self._config_orchestrator: dict[str, Any] = AttrDict({})
 
     @property
     def is_loaded(self) -> bool:
@@ -178,6 +179,7 @@ class Config:
         self._config_bootstrap = AttrDict(self._config_dict.get('bootstrap', {}))
         self._config_backplanes = AttrDict(self._config_dict.get('backplanes', {}))
         self._config_pds4 = AttrDict(self._config_dict.get('pds4', {}))
+        self._config_orchestrator = AttrDict(self._config_dict.get('orchestrator', {}))
 
     def _load_yaml(self, config_path: str | Path) -> dict[str, Any]:
         """Loads a YAML file and returns a dictionary mapping.
@@ -510,6 +512,13 @@ class Config:
 
         self.read_config()
         return self._config_bootstrap
+
+    @property
+    def orchestrator(self) -> Any:
+        """Returns the orchestrator (ensemble + reliability gate) settings."""
+
+        self.read_config()
+        return self._config_orchestrator
 
     @property
     def backplanes(self) -> Any:

--- a/src/spindoctor/config_files/config_540_orchestrator.yaml
+++ b/src/spindoctor/config_files/config_540_orchestrator.yaml
@@ -1,0 +1,46 @@
+# Orchestrator-level acceptance parameters: the ensemble combine and the
+# per-feature-type reliability gate.
+#
+# Every value here mirrors the code default (DEFAULT_* constants in
+# spindoctor.nav_orchestrator.ensemble and
+# spindoctor.feature.reliability); the section exists so calibration
+# sweeps and user config files can override them without code changes.
+# All values are placeholders subject to Phase-10 empirical calibration.
+orchestrator:
+  ensemble:
+    # Mahalanobis-distance threshold for grouping per-technique results.
+    agreement_sigma: 2.0
+    # Euclidean translation-distance fallback grouping threshold (px).
+    agreement_pixel_floor: 5.0
+    # Minimum summed-confidence gap between best and runner-up groups
+    # before declaring a conflict.
+    agreement_gap: 0.5
+    # Multiplier on combined confidence when more than one group existed.
+    disagreement_penalty: 0.7
+    # Additional multiplier when the conflicted branch fires.
+    conflicted_confidence_multiplier: 0.3
+    # Final-result threshold below which the ensemble returns failed.
+    min_confidence: 0.2
+    # rcond for scipy.linalg.pinvh.
+    pinvh_rcond: 1.0e-9
+    # Maximum |rotation| (deg) a 3-DoF result may take before rejection.
+    max_allowed_rotation_deg: 5.0
+    # Confidence/sigma requirements per confidence tier; max_sigma_px
+    # null means no sigma requirement for that tier.
+    tier_thresholds:
+      high: {min_confidence: 0.8, max_sigma_px: 0.5}
+      medium: {min_confidence: 0.5, max_sigma_px: 2.0}
+      low: {min_confidence: 0.2, max_sigma_px: null}
+  # Minimum reliability per feature type; features below their type's
+  # threshold are gated out before any technique runs.  Feature types
+  # not listed fall through with a 0.0 threshold (no gate).
+  reliability_gate:
+    STAR: 0.20
+    LIMB_ARC: 0.30
+    TERMINATOR_ARC: 0.30
+    BODY_DISC: 0.30
+    BODY_BLOB: 0.20
+    RING_EDGE: 0.30
+    RING_ANNULUS: 0.30
+    CARTOGRAPHIC_MODEL: 0.30
+    TITAN_LIMB: 0.30

--- a/src/spindoctor/feature/reliability.py
+++ b/src/spindoctor/feature/reliability.py
@@ -13,7 +13,7 @@ when no override is supplied by the loader.
 import math
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Final
+from typing import Any, Final
 
 from spindoctor.feature.feature import NavFeature
 from spindoctor.feature.feature_type import NavFeatureType
@@ -73,6 +73,38 @@ class FeatureReliabilityGate:
     thresholds: dict[NavFeatureType, float] = field(
         default_factory=lambda: dict(DEFAULT_RELIABILITY_THRESHOLDS)
     )
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, Any] | None) -> 'FeatureReliabilityGate':
+        """Build a gate from a YAML-derived ``{type name: threshold}`` mapping.
+
+        Parameters:
+            mapping: The ``orchestrator.reliability_gate`` config section.
+                ``None`` or empty returns the code defaults.  Keys are
+                ``NavFeatureType`` member names; each value overrides the
+                default threshold for that type only, so a partial mapping
+                leaves the other types at their defaults.
+
+        Returns:
+            A ``FeatureReliabilityGate`` with the merged thresholds.
+
+        Raises:
+            ValueError: If a key is not a ``NavFeatureType`` member name.
+        """
+        if not mapping:
+            return cls()
+        thresholds = dict(DEFAULT_RELIABILITY_THRESHOLDS)
+        for name, value in mapping.items():
+            try:
+                ftype = NavFeatureType[str(name)]
+            except KeyError:
+                valid = ', '.join(t.name for t in NavFeatureType)
+                raise ValueError(
+                    f'Unknown feature type {name!r} in reliability_gate config; '
+                    f'valid names: {valid}'
+                ) from None
+            thresholds[ftype] = float(value)
+        return cls(thresholds=thresholds)
 
     def __post_init__(self) -> None:
         """Validate the thresholds mapping and every threshold value."""

--- a/src/spindoctor/feature/reliability.py
+++ b/src/spindoctor/feature/reliability.py
@@ -103,7 +103,12 @@ class FeatureReliabilityGate:
                     f'Unknown feature type {name!r} in reliability_gate config; '
                     f'valid names: {valid}'
                 ) from None
-            thresholds[ftype] = float(value)
+            try:
+                thresholds[ftype] = float(value)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f'orchestrator.reliability_gate.{name} must be a number; got {value!r}'
+                ) from exc
         return cls(thresholds=thresholds)
 
     def __post_init__(self) -> None:

--- a/src/spindoctor/nav_orchestrator/ensemble.py
+++ b/src/spindoctor/nav_orchestrator/ensemble.py
@@ -146,7 +146,14 @@ class EnsembleConfig:
         unknown = set(data) - scalar_fields
         if unknown:
             raise ValueError(f'Unknown orchestrator.ensemble config keys: {sorted(unknown)}')
-        kwargs: dict[str, Any] = {key: float(value) for key, value in data.items()}
+        kwargs: dict[str, Any] = {}
+        for key, value in data.items():
+            try:
+                kwargs[key] = float(value)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f'orchestrator.ensemble.{key} must be a number; got {value!r}'
+                ) from exc
         if tiers_raw is not None:
             if not isinstance(tiers_raw, Mapping):
                 raise ValueError('orchestrator.ensemble.tier_thresholds must be a mapping')
@@ -161,7 +168,13 @@ class EnsembleConfig:
                 for key, value in spec.items():
                     if key not in ('min_confidence', 'max_sigma_px'):
                         raise ValueError(f'Unknown tier_thresholds[{tier!r}] key {key!r}')
-                    tiers[tier][key] = None if value is None else float(value)
+                    try:
+                        tiers[tier][key] = None if value is None else float(value)
+                    except (TypeError, ValueError) as exc:
+                        raise ValueError(
+                            f'orchestrator.ensemble.tier_thresholds[{tier!r}].{key} '
+                            f'must be a number or null; got {value!r}'
+                        ) from exc
             kwargs['tier_thresholds'] = tiers
         return cls(**kwargs)
 

--- a/src/spindoctor/nav_orchestrator/ensemble.py
+++ b/src/spindoctor/nav_orchestrator/ensemble.py
@@ -18,7 +18,8 @@ correctness here is what makes the rest of the pipeline trustworthy.
 
 import copy
 import math
-from dataclasses import dataclass, field
+from collections.abc import Mapping
+from dataclasses import dataclass, field, fields
 from typing import Any, cast
 
 import numpy as np
@@ -117,6 +118,52 @@ class EnsembleConfig:
     tier_thresholds: dict[str, dict[str, float | None]] = field(
         default_factory=lambda: copy.deepcopy(DEFAULT_TIER_THRESHOLDS)
     )
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, Any] | None) -> 'EnsembleConfig':
+        """Build an ``EnsembleConfig`` from a YAML-derived mapping.
+
+        Parameters:
+            mapping: The ``orchestrator.ensemble`` config section.  ``None``
+                or empty returns the code defaults.  Scalar keys override
+                their field; a ``tier_thresholds`` block is merged tier-by-
+                tier over the defaults, so a partial override (for example
+                only ``low.min_confidence``) leaves the other tiers intact.
+
+        Returns:
+            An ``EnsembleConfig`` with mapping values overriding the code
+            defaults field-by-field.
+
+        Raises:
+            ValueError: If the mapping contains an unknown key, an unknown
+                tier name, or an unknown tier-threshold key.
+        """
+        if not mapping:
+            return cls()
+        data = dict(mapping)
+        tiers_raw = data.pop('tier_thresholds', None)
+        scalar_fields = {f.name for f in fields(cls)} - {'tier_thresholds'}
+        unknown = set(data) - scalar_fields
+        if unknown:
+            raise ValueError(f'Unknown orchestrator.ensemble config keys: {sorted(unknown)}')
+        kwargs: dict[str, Any] = {key: float(value) for key, value in data.items()}
+        if tiers_raw is not None:
+            if not isinstance(tiers_raw, Mapping):
+                raise ValueError('orchestrator.ensemble.tier_thresholds must be a mapping')
+            tiers = copy.deepcopy(DEFAULT_TIER_THRESHOLDS)
+            for tier, spec in tiers_raw.items():
+                if tier not in tiers:
+                    raise ValueError(
+                        f'Unknown tier {tier!r} in tier_thresholds; valid tiers: {sorted(tiers)}'
+                    )
+                if not isinstance(spec, Mapping):
+                    raise ValueError(f'tier_thresholds[{tier!r}] must be a mapping')
+                for key, value in spec.items():
+                    if key not in ('min_confidence', 'max_sigma_px'):
+                        raise ValueError(f'Unknown tier_thresholds[{tier!r}] key {key!r}')
+                    tiers[tier][key] = None if value is None else float(value)
+            kwargs['tier_thresholds'] = tiers
+        return cls(**kwargs)
 
 
 def _mahalanobis_distance(

--- a/src/spindoctor/nav_orchestrator/orchestrator.py
+++ b/src/spindoctor/nav_orchestrator/orchestrator.py
@@ -252,7 +252,9 @@ class NavOrchestrator(NavBase):
         only_techniques: Glob-pattern string or list selecting which
             techniques run.  Default ``'*'`` runs every registered
             technique.
-        ensemble_config: Optional ``EnsembleConfig`` override.
+        ensemble_config: Optional ``EnsembleConfig`` override; when omitted
+            the ensemble parameters come from the ``orchestrator.ensemble``
+            config section (config_540_orchestrator.yaml defaults).
         image_quality_thresholds: Optional thresholds for the image-quality
             classifier.
         spindoctor_version: Version string written into provenance.
@@ -275,13 +277,16 @@ class NavOrchestrator(NavBase):
             models=_ModelRegistry(models=models).filter_by_glob(only_models)
         )
         self._only_techniques = only_techniques
-        self._ensemble_config = ensemble_config or EnsembleConfig()
+        orch_cfg = self.config.orchestrator
+        self._ensemble_config = ensemble_config or EnsembleConfig.from_mapping(
+            orch_cfg.get('ensemble')
+        )
         # ``image_quality_thresholds`` overrides the per-instrument config
         # block when supplied; otherwise the orchestrator builds the
         # thresholds from ``obs.inst_config`` per image.
         self._explicit_thresholds = image_quality_thresholds
         self._image_derivatives_config = image_derivatives_config or ImageDerivativesConfig()
-        self._gate = FeatureReliabilityGate()
+        self._gate = FeatureReliabilityGate.from_mapping(orch_cfg.get('reliability_gate'))
         self._spindoctor_version = spindoctor_version
 
     def prepare(

--- a/tests/spindoctor/nav_orchestrator/test_acceptance_config.py
+++ b/tests/spindoctor/nav_orchestrator/test_acceptance_config.py
@@ -100,3 +100,22 @@ def test_bundled_yaml_gate_section_matches_code_defaults() -> None:
     section = config.orchestrator.get('reliability_gate')
     gate = FeatureReliabilityGate.from_mapping(section)
     assert gate.thresholds == DEFAULT_RELIABILITY_THRESHOLDS
+
+
+def test_ensemble_from_mapping_non_numeric_scalar_names_key() -> None:
+    with pytest.raises(
+        ValueError, match=r'orchestrator\.ensemble\.min_confidence must be a number'
+    ):
+        EnsembleConfig.from_mapping({'min_confidence': 'high'})
+
+
+def test_ensemble_from_mapping_non_numeric_tier_value_names_key() -> None:
+    with pytest.raises(
+        ValueError, match=r"tier_thresholds\['low'\]\.min_confidence must be a number"
+    ):
+        EnsembleConfig.from_mapping({'tier_thresholds': {'low': {'min_confidence': 'tiny'}}})
+
+
+def test_gate_from_mapping_non_numeric_value_names_key() -> None:
+    with pytest.raises(ValueError, match=r'orchestrator\.reliability_gate\.STAR must be a number'):
+        FeatureReliabilityGate.from_mapping({'STAR': 'strict'})

--- a/tests/spindoctor/nav_orchestrator/test_acceptance_config.py
+++ b/tests/spindoctor/nav_orchestrator/test_acceptance_config.py
@@ -1,0 +1,102 @@
+"""Tests for the YAML plumbing of ensemble and reliability-gate settings.
+
+Covers ``EnsembleConfig.from_mapping``, ``FeatureReliabilityGate.
+from_mapping``, and the invariant that the bundled
+``config_540_orchestrator.yaml`` section reproduces the code defaults
+exactly.
+"""
+
+import pytest
+
+from spindoctor.config.config import Config
+from spindoctor.feature.feature_type import NavFeatureType
+from spindoctor.feature.reliability import (
+    DEFAULT_RELIABILITY_THRESHOLDS,
+    FeatureReliabilityGate,
+)
+from spindoctor.nav_orchestrator.ensemble import EnsembleConfig
+
+
+def test_ensemble_from_mapping_none_returns_defaults() -> None:
+    assert EnsembleConfig.from_mapping(None) == EnsembleConfig()
+
+
+def test_ensemble_from_mapping_empty_returns_defaults() -> None:
+    assert EnsembleConfig.from_mapping({}) == EnsembleConfig()
+
+
+def test_ensemble_from_mapping_scalar_override() -> None:
+    cfg = EnsembleConfig.from_mapping({'min_confidence': 0.05})
+    assert cfg.min_confidence == 0.05
+
+
+def test_ensemble_from_mapping_scalar_override_keeps_other_defaults() -> None:
+    cfg = EnsembleConfig.from_mapping({'min_confidence': 0.05})
+    assert cfg.agreement_sigma == EnsembleConfig().agreement_sigma
+
+
+def test_ensemble_from_mapping_partial_tier_override() -> None:
+    cfg = EnsembleConfig.from_mapping({'tier_thresholds': {'low': {'min_confidence': 0.01}}})
+    assert cfg.tier_thresholds['low']['min_confidence'] == 0.01
+
+
+def test_ensemble_from_mapping_partial_tier_keeps_other_tiers() -> None:
+    cfg = EnsembleConfig.from_mapping({'tier_thresholds': {'low': {'min_confidence': 0.01}}})
+    assert cfg.tier_thresholds['high'] == EnsembleConfig().tier_thresholds['high']
+
+
+def test_ensemble_from_mapping_tier_none_sigma_allowed() -> None:
+    cfg = EnsembleConfig.from_mapping({'tier_thresholds': {'medium': {'max_sigma_px': None}}})
+    assert cfg.tier_thresholds['medium']['max_sigma_px'] is None
+
+
+def test_ensemble_from_mapping_unknown_key_raises() -> None:
+    with pytest.raises(ValueError, match=r'Unknown orchestrator\.ensemble config keys'):
+        EnsembleConfig.from_mapping({'not_a_field': 1.0})
+
+
+def test_ensemble_from_mapping_unknown_tier_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown tier 'extreme'"):
+        EnsembleConfig.from_mapping({'tier_thresholds': {'extreme': {}}})
+
+
+def test_ensemble_from_mapping_unknown_tier_key_raises() -> None:
+    with pytest.raises(ValueError, match="key 'max_wobble'"):
+        EnsembleConfig.from_mapping({'tier_thresholds': {'low': {'max_wobble': 1.0}}})
+
+
+def test_gate_from_mapping_none_returns_defaults() -> None:
+    gate = FeatureReliabilityGate.from_mapping(None)
+    assert gate.thresholds == DEFAULT_RELIABILITY_THRESHOLDS
+
+
+def test_gate_from_mapping_partial_override() -> None:
+    gate = FeatureReliabilityGate.from_mapping({'BODY_DISC': 0.05})
+    assert gate.thresholds[NavFeatureType.BODY_DISC] == 0.05
+
+
+def test_gate_from_mapping_partial_override_keeps_other_types() -> None:
+    gate = FeatureReliabilityGate.from_mapping({'BODY_DISC': 0.05})
+    assert (
+        gate.thresholds[NavFeatureType.STAR] == DEFAULT_RELIABILITY_THRESHOLDS[NavFeatureType.STAR]
+    )
+
+
+def test_gate_from_mapping_unknown_type_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown feature type 'BODY_HALO'"):
+        FeatureReliabilityGate.from_mapping({'BODY_HALO': 0.5})
+
+
+def test_bundled_yaml_ensemble_section_matches_code_defaults() -> None:
+    config = Config()
+    config.read_config()
+    section = config.orchestrator.get('ensemble')
+    assert EnsembleConfig.from_mapping(section) == EnsembleConfig()
+
+
+def test_bundled_yaml_gate_section_matches_code_defaults() -> None:
+    config = Config()
+    config.read_config()
+    section = config.orchestrator.get('reliability_gate')
+    gate = FeatureReliabilityGate.from_mapping(section)
+    assert gate.thresholds == DEFAULT_RELIABILITY_THRESHOLDS


### PR DESCRIPTION
## Summary

Fixes #206: the final acceptance machinery (ensemble combine + feature reliability gate) carried hardcoded dataclass defaults that `--config-file` overrides could not reach — the `EnsembleConfig` docstring even referenced a `config_540_orchestrator.yaml` that did not exist. This PR creates that file and plumbs it through:

- **`config_540_orchestrator.yaml`** — new `orchestrator:` section with `ensemble` (agreement/disagreement knobs, `min_confidence`, `pinvh_rcond`, `max_allowed_rotation_deg`, `tier_thresholds`) and `reliability_gate` (per-`NavFeatureType` thresholds). Values mirror the code defaults exactly.
- **`EnsembleConfig.from_mapping`** — builds from the section; partial overrides merge field-by-field (tier thresholds merge tier-by-tier); unknown keys/tiers raise `ValueError`.
- **`FeatureReliabilityGate.from_mapping`** — same pattern; keys are `NavFeatureType` member names.
- **`NavOrchestrator`** — reads the section when no explicit `ensemble_config` is passed; the gate is likewise config-built.
- **`Config.orchestrator`** — new section property.

Default behavior is unchanged — asserted by tests that reload the bundled YAML and compare against `EnsembleConfig()` / `DEFAULT_RELIABILITY_THRESHOLDS`.

## Motivation

Cohort-curation batch-2 review surfaced navigable frames blocked only by these hardcoded values (e.g. N1462002948: two star techniques agreeing to 0.008 px, rejected at the hardcoded 0.2 floor; N1560096003: usable Phoebe limb with the disc feature gated at hardcoded 0.300). Phase-10 calibration sweeps need to tune these without code changes, same as the technique confidence specs in `config_510_techniques.yaml`.

## Testing

- 16 new tests in `tests/spindoctor/nav_orchestrator/test_acceptance_config.py`
- `pytest tests/spindoctor/nav_orchestrator tests/spindoctor/feature tests/spindoctor/config`: 260 passed
- ruff check/format, mypy strict: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KW6fkURsA2zgrWFKjbR5JY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new orchestrator configuration section, including ensemble settings and feature reliability thresholds.
  * Introduced bundled defaults for the orchestrator so behavior can be tuned from configuration without code changes.

* **Bug Fixes**
  * Improved configuration loading to validate unknown settings and reject invalid override structures.
  * Ensured partial overrides keep existing defaults intact when only some values are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->