### PR TITLE
Rank-1 flat-ring support: pipeline, sidecar schema, manual nav (#203, #204)

### DIFF
--- a/docs/dev_guide/dev_guide_techniques_ring_edge.rst
+++ b/docs/dev_guide/dev_guide_techniques_ring_edge.rst
@@ -15,9 +15,13 @@ Tukey-reweighted Levenberg-Marquardt refinement that
 
 When every consumed ring edge is flagged straight-line the combined Jacobian is rank-
 deficient — all parallel ring edges share a single ring-plane normal so the along-edge axis
-is unobservable. The returned covariance is honestly rank-1 in that case; the orchestrator's
-ensemble combine fuses it with any orthogonal-axis result (a star, body limb, body blob)
-before declaring a final answer.
+is unobservable. The technique projects the returned covariance to be *exactly* rank-1
+(see below); the orchestrator's ensemble combine fuses it with any orthogonal-axis result
+(a star, body limb, body blob) before declaring a final answer, and when no orthogonal
+information exists the fused result carries
+:attr:`~spindoctor.support.status_reason.NavStatusReason.RANK_1_ONLY` with the offset
+reported as the minimum-norm representative along the edge and the unobservable axis
+surfaced through ``sigma_along_unobservable_px``.
 
 Feasibility passes when at least one offered ``RING_EDGE`` has a non-empty polyline. A single
 non-empty edge is sufficient — even an all-flat scene produces a useful rank-1 constraint.
@@ -37,12 +41,19 @@ Rank-deficient covariance
 
 Ring edges differ from limbs in that each ring edge is only locally observable along its
 *radial* direction (orthogonal to the edge tangent). Motion along the tangent of a single
-ring edge produces no DT cost change. When a single ring edge dominates the consumed set,
-the joint Jacobian's null space is the along-edge tangent and the M-estimator information
-matrix is rank-1. The Moore-Penrose pseudoinverse used by
-:func:`~spindoctor.nav_technique.dt_fitting.information_matrix_to_covariance` handles this
-gracefully — the returned 2x2 covariance has an effectively-infinite eigenvalue along the
-tangent direction.
+ring edge produces no DT cost change *in the interior*; the finite polyline's end vertices
+do respond to tangential motion (they track wherever the detected edge enters and leaves
+the frame), so the raw LM covariance of an all-straight scene often comes back numerically
+tight along the tangent — a false constraint. The technique therefore enforces the rank-1
+contract explicitly: when every consumed edge is straight (or the raw covariance already
+fails the relative-eigenvalue rank test), the translation covariance is rebuilt as the
+exactly singular ``sigma_n^2 n n^T``, where ``n`` is the dominant eigenvector of the
+per-vertex normals' outer-product sum (polarity-sign-independent) and ``sigma_n^2`` the raw
+covariance's marginal variance along it. Exact singularity is the representation the
+ensemble is built around: ``pinvh`` keeps the normal-axis measurement when forming the
+information matrix, the combine's rank-deficiency test fires, and the unobservable axis is
+reported through the ``sigma_along_unobservable_px`` sentinel rather than an inflated
+per-axis sigma.
 
 Multi-edge inputs at different orbital radii share the same ring-plane normal but sample
 different points around the projected ring; the joint information matrix becomes full-rank
@@ -74,8 +85,9 @@ Sources of uncertainty
 ----------------------
 
 The reported covariance is the Moore-Penrose pseudoinverse of the M-estimator information
-matrix at convergence; the rank-1 case carries an unbounded eigenvalue along the tangent
-direction. When the converged offset sits within the at-edge tolerance of any axis bound,
+matrix at convergence; the rank-1 case is projected to an exactly singular covariance whose
+only non-null axis is the aggregate edge normal (see above). When the converged offset sits
+within the at-edge tolerance of any axis bound,
 or when the rotation parameter is at the configured fraction of its cap, the result is
 flagged :attr:`~spindoctor.nav_technique.technique_result.NavTechniqueResult.at_edge`.
 
@@ -95,6 +107,14 @@ All numeric tunables for this technique live in ``techniques.RingEdgeNav.tuning`
   threshold; the threshold is the larger of the floor and the per-feature sigma multiple.
 - ``spurious_min_inliers`` — int, default ``6`` (count). Below this Tukey-inlier count the
   M-estimator covariance is uninformative; the result is flagged spurious.
+- ``spurious_min_inlier_fraction`` — float, default ``0.5`` (dimensionless). A Tukey inlier
+  fraction (inliers over aggregated model vertices) below this marks the result spurious.
+  This is the wrong-ringlet mis-convergence detector: a fit locked onto the wrong ring
+  anchors a minority of the model vertices, while a correct fit whose faintest edge is
+  simply undetectable in the image still anchors a large majority. Residual statistics
+  cannot make that distinction — an undetected edge and a misaligned edge both sit a
+  ringlet spacing from the nearest image edge — which is why the gate is a support
+  fraction rather than a residual threshold.
 - ``rotation_at_edge_fraction`` — float, default ``0.95`` (dimensionless). When
   :attr:`~spindoctor.nav_orchestrator.nav_context.NavContext.fit_camera_rotation` is true, the
   converged rotation magnitude trips
@@ -105,7 +125,7 @@ All numeric tunables for this technique live in ``techniques.RingEdgeNav.tuning`
 Per-instrument overrides
 ------------------------
 
-The five keys above are global; per-instrument YAML files in
+The keys above are global; per-instrument YAML files in
 ``src/spindoctor/config_files/config_4N0_inst_*.yaml`` do not override any of them.
 
 Confidence formula

--- a/src/spindoctor/config_files/config_510_techniques.yaml
+++ b/src/spindoctor/config_files/config_510_techniques.yaml
@@ -407,16 +407,19 @@ techniques:
       # Below this Tukey-inlier count the M-estimator covariance is no
       # longer informative.
       spurious_min_inliers: 6
-      # ``per_edge_dt_rms_summed / edge_count`` (the raw, un-Tukey-weighted
-      # average per-edge RMS) exceeding this many radial-sigmas marks
-      # the result spurious.  ``result.rms_px`` after Tukey reweighting
-      # collapses to ~0 when the LM converges to a local minimum where
-      # one edge fits cleanly and the others are wholly mis-aligned;
-      # the per-edge sum surfaces those bad edges so the ensemble does
-      # not have to absorb a confidence-zero result with a far-from-
-      # truth offset (Cassini Tethys N1572471790 was the calibration
-      # case — the LM locked onto one of three rings).
-      spurious_per_edge_rms_factor: 5.0
+      # A Tukey inlier fraction (inliers over aggregated model vertices)
+      # below this marks the result spurious.  ``result.rms_px`` after
+      # Tukey reweighting collapses to ~0 when the LM converges to a
+      # local minimum where one edge fits cleanly and the others are
+      # wholly mis-aligned (Cassini Tethys N1572471790 was the
+      # calibration case — the LM locked onto one of three rings,
+      # anchoring on ~1/3 of the vertices).  No residual statistic
+      # separates that from a correct fit whose faintest edge is simply
+      # undetectable in the image (routine on flat Keeler-gap ansa
+      # frames, #203), but the explained fraction does: a wrong-ring
+      # lock anchors a minority of the model, a correct fit with one
+      # missing edge anchors >0.8.
+      spurious_min_inlier_fraction: 0.5
       # See ``BodyLimbNav.spurious_max_lm_displacement_px``.
       spurious_max_lm_displacement_px: 4.0
       # See ``BodyLimbNav.lm_trust_region_px``.

--- a/src/spindoctor/nav_technique/diagnostics.py
+++ b/src/spindoctor/nav_technique/diagnostics.py
@@ -164,6 +164,12 @@ class RingEdgeDiagnostics:
             so it -- not the raw sum -- is the scale the confidence formula
             uses; the sum grows with the number of fused edges and a fixed
             divisor cannot normalise it.
+        per_edge_dt_median_max: Largest per-edge median absolute DT residual
+            (px).  The mis-convergence gate statistic: a wholly misaligned
+            edge (the wrong-ringlet failure mode) drives its own median to
+            the ringlet spacing, while a minority of vertices snapping to a
+            neighbouring parallel edge (routine on flat multi-edge scenes)
+            leaves every median near the fit residual.
         edge_count: Number of RING_EDGE features fused.
         is_rank_1: True if every ring-edge feature was straight-line and the
             combined covariance is rank-1.
@@ -172,12 +178,14 @@ class RingEdgeDiagnostics:
     total_edge_length_px: float = 0.0
     per_edge_dt_rms_summed: float = 0.0
     per_edge_dt_rms_mean: float = 0.0
+    per_edge_dt_median_max: float = 0.0
     edge_count: int = 0
     is_rank_1: bool = False
     CURATOR_FIELDS: ClassVar[dict[str, str | None]] = {
         'total_edge_length_px': 'total_edge_length_px',
         'per_edge_dt_rms_summed': 'per_edge_dt_rms_summed',
         'per_edge_dt_rms_mean': 'per_edge_dt_rms_mean',
+        'per_edge_dt_median_max': 'per_edge_dt_median_max',
         'edge_count': 'edge_count',
         'is_rank_1': 'is_rank_1',
     }

--- a/src/spindoctor/nav_technique/nav_technique_manual.py
+++ b/src/spindoctor/nav_technique/nav_technique_manual.py
@@ -28,6 +28,7 @@ from spindoctor.feature.feature_type import NavFeatureType
 from spindoctor.nav_technique.diagnostics import ManualNavDiagnostics
 from spindoctor.nav_technique.feasibility import NavFeasibilityReport
 from spindoctor.nav_technique.nav_technique import NavTechnique
+from spindoctor.nav_technique.nav_technique_ring_edge import aggregate_edge_normal_angle_deg
 from spindoctor.nav_technique.technique_result import NavTechniqueResult
 
 if TYPE_CHECKING:  # pragma: no cover - typing-only import
@@ -164,6 +165,7 @@ class NavTechniqueManual(NavTechnique):
                 model_mask_ext=model_mask,
                 annotations=self._annotations,
                 config=self.config,
+                constraint_normal_seed_deg=aggregate_edge_normal_angle_deg(features),
                 parent=None,
             )
             accepted, chosen_offset, _last_corr = dialog.run_modal()

--- a/src/spindoctor/nav_technique/nav_technique_ring_edge.py
+++ b/src/spindoctor/nav_technique/nav_technique_ring_edge.py
@@ -41,7 +41,7 @@ from spindoctor.support.types import NDArrayFloatType
 if TYPE_CHECKING:  # pragma: no cover - typing-only import
     from spindoctor.nav_orchestrator.nav_context import NavContext
 
-__all__ = ['RingEdgeNav']
+__all__ = ['RingEdgeNav', 'aggregate_edge_normal_angle_deg']
 
 # All numeric tunables for this technique live in
 # ``config_files/config_510_techniques.yaml`` under
@@ -425,6 +425,39 @@ def _is_rank_1(covariance: NDArrayFloatType) -> bool:
     if largest == 0.0:
         return True
     return smallest / largest < _RANK1_NULL_RELATIVE_THRESHOLD
+
+
+def aggregate_edge_normal_angle_deg(features: list[NavFeature]) -> float | None:
+    """Return the dominant edge-normal orientation of an all-straight scene.
+
+    The angle is in degrees in the ``(v, u)`` frame, measured from ``+v``
+    toward ``+u`` (the unit normal is ``(cos, sin)``) — the same convention
+    as the sidecar schema's ``ground_truth.constraint.normal_angle_deg``.
+    The orientation is the dominant eigenvector of the per-vertex normals'
+    outer-product sum, so it is independent of each edge's polarity sign.
+
+    Parameters:
+        features: Any feature list; only ``RING_EDGE`` polylines are read.
+
+    Returns:
+        The orientation in degrees, normalised to ``(-90, 90]``, or ``None``
+        unless at least one ring-edge polyline is present and every one is
+        straight — the constraint direction is only meaningful for a rank-1
+        scene.
+    """
+    _vertices, normals, _sigmas, ids, every_straight = _aggregate_ring_edges(features)
+    if not ids or not every_straight:
+        return None
+    outer_sum = normals.T @ normals
+    _eigvals, eigvecs = np.linalg.eigh(outer_sum)
+    n_hat = eigvecs[:, -1]
+    angle = math.degrees(math.atan2(float(n_hat[1]), float(n_hat[0])))
+    # An orientation, not a direction: fold to (-90, 90].
+    if angle <= -90.0:
+        angle += 180.0
+    elif angle > 90.0:
+        angle -= 180.0
+    return float(angle)
 
 
 def _rank1_projected_covariance(

--- a/src/spindoctor/nav_technique/nav_technique_ring_edge.py
+++ b/src/spindoctor/nav_technique/nav_technique_ring_edge.py
@@ -122,6 +122,7 @@ class RingEdgeNav(NavTechnique):
             'total_edge_length_px',
             'per_edge_dt_rms_summed',
             'per_edge_dt_rms_mean',
+            'per_edge_dt_median_max',
             'edge_count',
             'is_rank_1',
         }
@@ -134,7 +135,7 @@ class RingEdgeNav(NavTechnique):
         self._spurious_dt_rms_factor = float(self.tuning['spurious_dt_rms_factor'])
         self._spurious_dt_floor_px = float(self.tuning['spurious_dt_floor_px'])
         self._spurious_min_inliers = int(self.tuning['spurious_min_inliers'])
-        self._spurious_per_edge_rms_factor = float(self.tuning['spurious_per_edge_rms_factor'])
+        self._spurious_min_inlier_fraction = float(self.tuning['spurious_min_inlier_fraction'])
         self._spurious_max_lm_displacement_px = float(
             self.tuning['spurious_max_lm_displacement_px']
         )
@@ -270,24 +271,28 @@ class RingEdgeNav(NavTechnique):
             covariance = result.covariance
             total_edge_length_px = float(vertices.shape[0])
             per_edge_rms_summed = _per_edge_rms_summed(features, result.residuals_px)
+            per_edge_median_max = _per_edge_median_max(features, result.residuals_px)
             edge_count = len(feature_ids)
             # ``result.rms_px`` is the *Tukey-weighted* residual RMS; when
             # the LM converges to a local minimum where one edge fits
             # cleanly and the rest are wholly mis-aligned, Tukey rejects
             # the bad-edge vertices and ``rms_px`` collapses to near
-            # zero — a textbook mis-convergence that the existing
-            # ``rms_px > floor`` threshold cannot detect.  The raw
-            # ``per_edge_dt_rms_summed`` does not have outlier
-            # rejection, so it surfaces the bad edges; flag spurious
-            # when the per-edge average exceeds the same DT residual
-            # threshold the Tukey-weighted check uses.  The check
-            # protects the downstream ensemble combine from a
-            # confidence-zero result whose offset is far from the
-            # true fit (Cassini Tethys N1572471790 is the calibration
-            # case; the LM converged on the wrong ring of three).
-            per_edge_rms_threshold = max(
-                self._spurious_dt_floor_px,
-                self._spurious_per_edge_rms_factor * sigma_min_px,
+            # zero — a textbook mis-convergence the ``rms_px > floor``
+            # threshold cannot detect (Cassini Tethys N1572471790 is the
+            # calibration case; the LM converged on the wrong ring of
+            # three, anchoring the fit on a third of the model vertices).
+            # No residual statistic separates that from a correct fit
+            # whose faintest edge simply is not detectable in the image —
+            # in both, one edge's residuals sit at the ringlet spacing
+            # (Keeler-gap ansa frames run 9-30 px; issue #203).  What does
+            # separate them is how much of the model the fit explains:
+            # the Tukey inlier fraction is ~1/3 for the wrong-ring lock
+            # and >0.8 for a correct flat fit with one undetected edge,
+            # so the gate is a minimum inlier fraction over the aggregated
+            # vertices.
+            total_vertices = int(vertices.shape[0])
+            inlier_fraction = (
+                float(result.inlier_count) / float(total_vertices) if total_vertices else 0.0
             )
             lm_displacement_px = float(
                 math.hypot(dv_final - float(coarse_dv), du_final - float(coarse_du))
@@ -300,10 +305,7 @@ class RingEdgeNav(NavTechnique):
                     self._spurious_dt_rms_factor * sigma_min_px,
                 )
                 or result.inlier_count < self._spurious_min_inliers
-                or (
-                    edge_count > 0
-                    and per_edge_rms_summed / float(edge_count) > per_edge_rms_threshold
-                )
+                or inlier_fraction < self._spurious_min_inlier_fraction
                 or lm_displacement_px > self._spurious_max_lm_displacement_px
             )
             rotation_rad: float | None
@@ -328,11 +330,27 @@ class RingEdgeNav(NavTechnique):
                 sigma_rotation_rad = None
             covariance = np.asarray(covariance, np.float64)
             is_rank_1 = _is_rank_1(covariance) or every_straight
+            if is_rank_1:
+                # Enforce the rank-1 contract on the reported covariance.
+                # On an all-straight scene the along-edge (tangent) offset
+                # component is physically unobservable, but the LM
+                # covariance often comes back numerically tight along the
+                # tangent anyway: the model polyline's *ends* anchor the
+                # along-edge coordinate against wherever the detected edge
+                # happens to enter and leave the frame — a false
+                # constraint.  Rebuild the translation covariance as the
+                # LM's marginal variance along the aggregate edge normal
+                # plus an effectively infinite tangent variance, so the
+                # ensemble's rank-deficiency test fires and the result
+                # surfaces as ``rank_1_only`` instead of a confidently
+                # full-rank fix (issue #203).
+                covariance = _rank1_projected_covariance(covariance, polarity_normals)
             per_edge_rms_mean = per_edge_rms_summed / float(max(edge_count, 1))
             diagnostics = RingEdgeDiagnostics(
                 total_edge_length_px=total_edge_length_px,
                 per_edge_dt_rms_summed=per_edge_rms_summed,
                 per_edge_dt_rms_mean=per_edge_rms_mean,
+                per_edge_dt_median_max=per_edge_median_max,
                 edge_count=edge_count,
                 is_rank_1=bool(is_rank_1),
             )
@@ -366,10 +384,12 @@ class RingEdgeNav(NavTechnique):
                 self.logger.info('Diagnostic flags: spurious=%s, at_edge=%s', spurious, at_edge)
             self.logger.debug(
                 'LM iterations = %d, sigma_min = %.3f px, '
-                'per_edge_rms_summed = %.3f, total_edge_length = %.1f px',
+                'per_edge_rms_summed = %.3f, per_edge_median_max = %.3f, '
+                'total_edge_length = %.1f px',
                 result.iterations,
                 sigma_min_px,
                 per_edge_rms_summed,
+                per_edge_median_max,
                 total_edge_length_px,
             )
             return NavTechniqueResult(
@@ -407,6 +427,52 @@ def _is_rank_1(covariance: NDArrayFloatType) -> bool:
     return smallest / largest < _RANK1_NULL_RELATIVE_THRESHOLD
 
 
+def _rank1_projected_covariance(
+    covariance: NDArrayFloatType, polarity_normals: NDArrayFloatType
+) -> NDArrayFloatType:
+    """Project a rank-1 fit's covariance onto its observable (edge-normal) axis.
+
+    The translation block becomes the exactly singular ``sigma_n^2 n n^T``,
+    where ``n`` is the aggregate edge-normal orientation and ``sigma_n^2``
+    the input covariance's marginal variance along it.  Exact singularity is
+    the representation the ensemble is built around: ``pinvh`` drops the
+    exact null space when forming the information matrix (keeping the
+    normal-axis measurement), the combine's rank-deficiency test fires, the
+    fused offset becomes the minimum-norm representative along the edge
+    (sliding along a straight edge is a symmetry of the scene), and the
+    unobservable axis is reported through the
+    ``sigma_along_unobservable_px = inf`` sentinel rather than an inflated
+    per-axis sigma that would poison the tier check.
+
+    The normal orientation is the dominant eigenvector of the per-vertex
+    normals' outer-product sum, which is polarity-sign-independent — the
+    aggregated edges' normals point in opposite senses (a gap's inner and
+    outer edges), so a plain mean could cancel.
+
+    For a 3x3 (rotation-fitting) covariance the rotation variance is kept
+    and the translation-rotation cross-covariances are zeroed: a
+    cross-covariance into an unobservable translation direction carries no
+    usable information.
+
+    Parameters:
+        covariance: The LM's ``(2, 2)`` or ``(3, 3)`` covariance.
+        polarity_normals: ``(N, 2)`` per-vertex edge normals (either sign).
+
+    Returns:
+        A new covariance of the input shape whose translation block is
+        exactly rank-1.
+    """
+    outer_sum = polarity_normals.T @ polarity_normals
+    _eigvals, eigvecs = np.linalg.eigh(outer_sum)
+    n_hat = eigvecs[:, -1]
+    sigma_n_sq = float(n_hat @ covariance[:2, :2] @ n_hat)
+    projected = np.zeros_like(covariance)
+    projected[:2, :2] = sigma_n_sq * np.outer(n_hat, n_hat)
+    if covariance.shape == (3, 3):
+        projected[2, 2] = covariance[2, 2]
+    return projected
+
+
 def _per_edge_rms_summed(features: list[NavFeature], residuals: NDArrayFloatType) -> float:
     """Sum the per-edge weighted RMS DT residual across all consumed edges."""
     total = 0.0
@@ -426,6 +492,45 @@ def _per_edge_rms_summed(features: list[NavFeature], residuals: NDArrayFloatType
     return total
 
 
+def _per_edge_median_max(features: list[NavFeature], residuals: NDArrayFloatType) -> float:
+    """Return the largest per-edge median absolute DT residual across edges.
+
+    A mis-convergence *diagnostic* (surfaced through
+    :class:`RingEdgeDiagnostics`, not a spurious gate): a wholly misaligned
+    or undetected edge puts most of its vertices roughly a ringlet spacing
+    from the nearest image edge, driving its median to that spacing, while
+    a well-matched edge's median sits at the fit residual.  Taking the max
+    over edges keeps one bad edge visible among any number of clean ones.
+    Residuals alone cannot separate "misaligned" from "undetectable in the
+    image", which is why the spurious decision uses the inlier fraction
+    instead.
+
+    Parameters:
+        features: The consumed features, in the order their vertices were
+            concatenated for the LM fit.
+        residuals: Per-vertex signed DT residuals from the fit, in the same
+            concatenation order.
+
+    Returns:
+        ``max_e median(|residuals_e|)`` over the consumed edges, or ``0.0``
+        when no edge has vertices.
+    """
+    worst = 0.0
+    cursor = 0
+    for feat in features:
+        if not isinstance(feat.geometry, RingEdgePolyline):
+            continue
+        n = feat.geometry.vertices_vu.shape[0]
+        if n == 0:
+            continue
+        slice_residuals = residuals[cursor : cursor + n]
+        cursor += n
+        if slice_residuals.size == 0:
+            continue
+        worst = max(worst, float(np.median(np.abs(slice_residuals))))
+    return worst
+
+
 class _RingEdgeConfidenceContext:
     """Adapter exposing ring-edge confidence terms in a single attribute set."""
 
@@ -434,5 +539,6 @@ class _RingEdgeConfidenceContext:
         self.total_edge_length_px = diagnostics.total_edge_length_px
         self.per_edge_dt_rms_summed = diagnostics.per_edge_dt_rms_summed
         self.per_edge_dt_rms_mean = diagnostics.per_edge_dt_rms_mean
+        self.per_edge_dt_median_max = diagnostics.per_edge_dt_median_max
         self.edge_count = diagnostics.edge_count
         self.is_rank_1 = diagnostics.is_rank_1

--- a/src/spindoctor/nav_technique/nav_technique_ring_edge.py
+++ b/src/spindoctor/nav_technique/nav_technique_ring_edge.py
@@ -13,7 +13,7 @@ body blob) before declaring a final answer.
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 
@@ -262,11 +262,28 @@ class RingEdgeNav(NavTechnique):
             # See BodyLimbNav: ``>=`` covers both at-edge and over-edge cases
             # so an LM that walked past the coarse-NCC search window does
             # not silently report an offset outside the extfov margin.
-            at_edge = (
-                abs(dv_final) >= margin_v - self._at_edge_tolerance_px
-                or abs(du_final) >= margin_u - self._at_edge_tolerance_px
-                or rotation_at_edge
-            )
+            if every_straight:
+                # Rank-1 scene: the along-edge (tangent) offset component is
+                # unobservable and nothing constrains it, so the LM may
+                # slide to the search-window boundary along it (Tikhonov is
+                # off by default).  Gating per axis would hard-zero a
+                # perfectly valid normal-component fix; gate on the
+                # observable component instead — at-edge along the normal
+                # means the *measurement* is pinned at the window limit.
+                n_hat = _aggregate_normal_orientation(polarity_normals)
+                offset_along_normal = abs(dv_final * n_hat[0] + du_final * n_hat[1])
+                # Maximum reach of the search box along the normal.
+                bound_along_normal = abs(n_hat[0]) * margin_v + abs(n_hat[1]) * margin_u
+                at_edge = (
+                    offset_along_normal >= bound_along_normal - self._at_edge_tolerance_px
+                    or rotation_at_edge
+                )
+            else:
+                at_edge = (
+                    abs(dv_final) >= margin_v - self._at_edge_tolerance_px
+                    or abs(du_final) >= margin_u - self._at_edge_tolerance_px
+                    or rotation_at_edge
+                )
             sigma_min_px = float(sigmas.min()) if sigmas.size else 1.0
             covariance = result.covariance
             total_edge_length_px = float(vertices.shape[0])
@@ -294,9 +311,19 @@ class RingEdgeNav(NavTechnique):
             inlier_fraction = (
                 float(result.inlier_count) / float(total_vertices) if total_vertices else 0.0
             )
-            lm_displacement_px = float(
-                math.hypot(dv_final - float(coarse_dv), du_final - float(coarse_du))
-            )
+            if every_straight:
+                # As with at_edge above: the tangent component of the
+                # LM-vs-coarse displacement is unconstrained slide along the
+                # unobservable axis, not evidence of a runaway fit.
+                n_hat = _aggregate_normal_orientation(polarity_normals)
+                lm_displacement_px = abs(
+                    (dv_final - float(coarse_dv)) * n_hat[0]
+                    + (du_final - float(coarse_du)) * n_hat[1]
+                )
+            else:
+                lm_displacement_px = float(
+                    math.hypot(dv_final - float(coarse_dv), du_final - float(coarse_du))
+                )
             spurious = (
                 result.degenerate
                 or result.rms_px
@@ -427,6 +454,24 @@ def _is_rank_1(covariance: NDArrayFloatType) -> bool:
     return smallest / largest < _RANK1_NULL_RELATIVE_THRESHOLD
 
 
+def _aggregate_normal_orientation(polarity_normals: NDArrayFloatType) -> NDArrayFloatType:
+    """Return the dominant unit-normal orientation of the aggregated edges.
+
+    The dominant eigenvector of the per-vertex normals' outer-product sum;
+    polarity-sign-independent (a gap's inner and outer edges carry opposite
+    normal senses, so a plain mean could cancel).
+
+    Parameters:
+        polarity_normals: ``(N, 2)`` per-vertex edge normals (either sign).
+
+    Returns:
+        Unit 2-vector in ``(v, u)`` order.
+    """
+    outer_sum = polarity_normals.T @ polarity_normals
+    _eigvals, eigvecs = np.linalg.eigh(outer_sum)
+    return cast(NDArrayFloatType, eigvecs[:, -1])
+
+
 def aggregate_edge_normal_angle_deg(features: list[NavFeature]) -> float | None:
     """Return the dominant edge-normal orientation of an all-straight scene.
 
@@ -448,9 +493,7 @@ def aggregate_edge_normal_angle_deg(features: list[NavFeature]) -> float | None:
     _vertices, normals, _sigmas, ids, every_straight = _aggregate_ring_edges(features)
     if not ids or not every_straight:
         return None
-    outer_sum = normals.T @ normals
-    _eigvals, eigvecs = np.linalg.eigh(outer_sum)
-    n_hat = eigvecs[:, -1]
+    n_hat = _aggregate_normal_orientation(normals)
     angle = math.degrees(math.atan2(float(n_hat[1]), float(n_hat[0])))
     # An orientation, not a direction: fold to (-90, 90].
     if angle <= -90.0:
@@ -495,9 +538,7 @@ def _rank1_projected_covariance(
         A new covariance of the input shape whose translation block is
         exactly rank-1.
     """
-    outer_sum = polarity_normals.T @ polarity_normals
-    _eigvals, eigvecs = np.linalg.eigh(outer_sum)
-    n_hat = eigvecs[:, -1]
+    n_hat = _aggregate_normal_orientation(polarity_normals)
     sigma_n_sq = float(n_hat @ covariance[:2, :2] @ n_hat)
     projected = np.zeros_like(covariance)
     projected[:2, :2] = sigma_n_sq * np.outer(n_hat, n_hat)

--- a/src/spindoctor/ui/library_entry.py
+++ b/src/spindoctor/ui/library_entry.py
@@ -16,6 +16,7 @@ file before committing it.
 
 from __future__ import annotations
 
+import math
 import os
 from dataclasses import dataclass
 from datetime import date
@@ -194,6 +195,7 @@ def build_sidecar_yaml(
     ui_version: str,
     operator: str | None = None,
     today: date | None = None,
+    constraint_normal_angle_deg: float | None = None,
 ) -> str:
     """Render the sidecar as a YAML string with placeholders for the rest.
 
@@ -202,6 +204,12 @@ def build_sidecar_yaml(
     to edit before committing.  Fields the dialog can infer
     (``offset_*_px``, ``mission``, ``camera``, ``filter_combo``,
     ``exposure_time_sec``, ``image_id``) are filled in directly.
+
+    When ``constraint_normal_angle_deg`` is set (the operator navigated
+    with the constrained-drag mode on a rank-1 scene), the ground truth
+    carries a ``constraint`` block — ``offset_along_normal_px`` computed
+    from the saved 2-D offset so the two stay consistent by construction —
+    and ``expected`` pins ``status_reason: rank_1_only``.
     """
     op_name = operator or os.environ.get('USER') or 'unknown'
     on_date = (today or date.today()).isoformat()
@@ -216,6 +224,23 @@ def build_sidecar_yaml(
         )
     else:
         datetime_block = f"image_datetime_utc: '{draft.image_datetime_utc}'\n"
+    constraint_block = ''
+    status_reason_block = ''
+    if constraint_normal_angle_deg is not None:
+        angle_rad = math.radians(constraint_normal_angle_deg)
+        along_normal = offset_dv_px * math.cos(angle_rad) + offset_du_px * math.sin(angle_rad)
+        constraint_block = (
+            '  # Rank-1 scene: only the offset component along this normal is\n'
+            '  # observable; (offset_dv_px, offset_du_px) is a representative\n'
+            '  # point on the constraint line.\n'
+            '  constraint:\n'
+            '    type: rank_1\n'
+            f'    normal_angle_deg: {constraint_normal_angle_deg:.4f}\n'
+            f'    offset_along_normal_px: {along_normal:.4f}\n'
+            '    # 1sigma along the normal; tighten for sharp edges.\n'
+            '    uncertainty_px: 1.0\n'
+        )
+        status_reason_block = '  status_reason: rank_1_only\n'
     return (
         'schema_version: 1\n'
         '# COISS | VGISS | GOSSI | NHLORRI\n'
@@ -238,8 +263,7 @@ def build_sidecar_yaml(
         f'  offset_dv_px: {offset_dv_px:.4f}\n'
         f'  offset_du_px: {offset_du_px:.4f}\n'
         '  # 1sigma marginal; tighten for bright stars / sharp limbs.\n'
-        '  offset_uncertainty_px: 1.0\n'
-        '  source: operator_verified\n'
+        '  offset_uncertainty_px: 1.0\n' + constraint_block + '  source: operator_verified\n'
         f'  operator: {op_name}\n'
         f'  verified_date: {on_date}\n'
         f"  ui_version: 'spindoctor {ui_version}'\n"
@@ -250,8 +274,7 @@ def build_sidecar_yaml(
         '  # success | failed | conflicted\n'
         '  status: success\n'
         '  # high | medium | low | failed\n'
-        '  confidence_tier: high\n'
-        '  # e.g. BodyLimbNav\n'
+        '  confidence_tier: high\n' + status_reason_block + '  # e.g. BodyLimbNav\n'
         '  primary_technique: TODO_REPLACE_TECHNIQUE\n'
         '  techniques_must_run: []\n'
         '  techniques_must_skip: []\n'

--- a/src/spindoctor/ui/manual_nav_dialog.py
+++ b/src/spindoctor/ui/manual_nav_dialog.py
@@ -288,6 +288,7 @@ class ManualNavDialog(QDialog):
         model_mask_ext: NDArrayBoolType,
         config: Config | None,
         annotations: Annotations | None = None,
+        constraint_normal_seed_deg: float | None = None,
         parent: QWidget | None = None,
     ) -> None:
         """Initialize the manual-navigation dialog.
@@ -306,6 +307,13 @@ class ManualNavDialog(QDialog):
                 alongside a saved sidecar.  ``None`` (or empty) is
                 permitted; the saved PNG then carries the source-image
                 grayscale alone.
+            constraint_normal_seed_deg: Optional seed for the
+                constrained-drag normal angle (degrees in the ``(v, u)``
+                frame, ``+v`` toward ``+u``).  Supplied by the caller when
+                the scene's observable axis is known — e.g. the aggregate
+                edge normal of an all-straight flat-ring scene — so the
+                operator can toggle the constraint on without measuring
+                the angle by eye.  ``None`` leaves the angle at 0.
             parent: Optional Qt parent widget.
         """
         super().__init__(parent)
@@ -361,6 +369,10 @@ class ManualNavDialog(QDialog):
         # Offsets (dv, du)
         self._dv = 0.0
         self._du = 0.0
+
+        # Constrained-drag state (rank-1 scenes): when enabled, drags move
+        # the offset only along the normal at ``_constraint_angle_deg``.
+        self._constraint_seed_deg = constraint_normal_seed_deg
 
         # Zoom/pan state
         self._zoom = 1.0
@@ -596,6 +608,31 @@ class ManualNavDialog(QDialog):
         self._spin_du.valueChanged.connect(self._on_spin_du)
         offset_form.addRow('dV (rows):', self._spin_dv)
         offset_form.addRow('dU (cols):', self._spin_du)
+        # Constrained drag (rank-1 scenes): restrict right-drag motion to the
+        # normal direction so the operator cannot move the model along an
+        # axis the scene does not constrain (a straight ring edge's tangent).
+        self._chk_constrain = QCheckBox('Constrain drag to normal')
+        self._chk_constrain.setChecked(False)
+        self._chk_constrain.setToolTip(
+            'Restrict right-drag to the normal direction below. Use for '
+            'rank-1 scenes (straight ring edges) where only the edge-normal '
+            'offset component is observable; the saved sidecar then carries '
+            'a ground_truth.constraint block.'
+        )
+        self._spin_constraint_angle = QDoubleSpinBox()
+        self._spin_constraint_angle.setDecimals(2)
+        self._spin_constraint_angle.setRange(-180.0, 180.0)
+        self._spin_constraint_angle.setSingleStep(1.0)
+        self._spin_constraint_angle.setValue(
+            self._constraint_seed_deg if self._constraint_seed_deg is not None else 0.0
+        )
+        self._spin_constraint_angle.setToolTip(
+            'Normal direction in the (v, u) frame, measured from +v toward '
+            '+u; the unit normal is (cos, sin). Seeded from the aggregate '
+            'ring-edge normal when the scene is all-straight.'
+        )
+        offset_form.addRow(self._chk_constrain)
+        offset_form.addRow('Normal angle (deg):', self._spin_constraint_angle)
         offset_group.setLayout(offset_form)
         right.addWidget(offset_group)
 
@@ -869,6 +906,9 @@ class ManualNavDialog(QDialog):
         if not path_str:
             return
         image_url = compute_image_url(self._obs, self._config)
+        constraint_angle: float | None = None
+        if self._chk_constrain.isChecked():
+            constraint_angle = float(self._spin_constraint_angle.value())
         try:
             yaml_text = build_sidecar_yaml(
                 draft=draft,
@@ -876,6 +916,7 @@ class ManualNavDialog(QDialog):
                 offset_dv_px=self._dv,
                 offset_du_px=self._du,
                 ui_version=_spindoctor_version,
+                constraint_normal_angle_deg=constraint_angle,
             )
             FCPath(path_str).write_text(yaml_text)
         except OSError as exc:
@@ -930,8 +971,19 @@ class ManualNavDialog(QDialog):
             delta = current_pos - self._drag_start_pos
             if self._drag_start_offset is not None:
                 # Convert label-pixel delta to image pixels via zoom
-                du = self._drag_start_offset[1] + (delta.x() / max(self._zoom, 1e-6))
-                dv = self._drag_start_offset[0] + (delta.y() / max(self._zoom, 1e-6))
+                ddv = delta.y() / max(self._zoom, 1e-6)
+                ddu = delta.x() / max(self._zoom, 1e-6)
+                if self._chk_constrain.isChecked():
+                    # Project the drag onto the constraint normal so the
+                    # offset moves only along the observable axis.
+                    angle = math.radians(self._spin_constraint_angle.value())
+                    n_v = math.cos(angle)
+                    n_u = math.sin(angle)
+                    along = ddv * n_v + ddu * n_u
+                    ddv = along * n_v
+                    ddu = along * n_u
+                dv = self._drag_start_offset[0] + ddv
+                du = self._drag_start_offset[1] + ddu
                 # Clamp within extfov bounds (minus 1 to keep slices valid after rounding)
                 dv = float(
                     np.clip(

--- a/tests/integration/sidecar.py
+++ b/tests/integration/sidecar.py
@@ -24,6 +24,8 @@ from typing import Any
 
 from ruamel.yaml import YAML
 
+from spindoctor.support.status_reason import NavStatusReason
+
 # ---------------------------------------------------------------------------
 # Library-wide enumerations
 # ---------------------------------------------------------------------------
@@ -87,8 +89,16 @@ ALLOWED_STATUSES: frozenset[str] = frozenset({'success', 'failed', 'conflicted'}
 # expected.confidence_tier value alongside the four tier names.
 ALLOWED_TIERS: frozenset[str] = frozenset({'high', 'medium', 'low', 'failed', 'conflicted'})
 ALLOWED_GT_SOURCES: frozenset[str] = frozenset({'operator_verified'})
+ALLOWED_CONSTRAINT_TYPES: frozenset[str] = frozenset({'rank_1'})
+ALLOWED_STATUS_REASONS: frozenset[str] = frozenset({reason.value for reason in NavStatusReason})
 
 CURRENT_SCHEMA_VERSION: int = 1
+
+# Maximum disagreement (px) tolerated between the 2-D representative offset
+# projected onto the constraint normal and the declared
+# ``offset_along_normal_px``.  Both come from the same manual-nav save, so any
+# larger gap means one of them was hand-edited inconsistently.
+_CONSTRAINT_PROJECTION_TOLERANCE_PX: float = 0.01
 
 
 # ---------------------------------------------------------------------------
@@ -97,8 +107,34 @@ CURRENT_SCHEMA_VERSION: int = 1
 
 
 @dataclass(frozen=True)
+class GroundTruthConstraint:
+    """Single-axis (rank-1) observability constraint on a ground-truth offset.
+
+    For a straight (flat) ring edge only the offset component along the edge
+    normal is observable; the along-edge component is physically
+    unconstrained.  ``normal_angle_deg`` is the edge-normal direction in the
+    ``(v, u)`` frame, measured from ``+v`` toward ``+u`` — the unit normal is
+    ``(cos(angle), sin(angle))`` and a 2-D offset's observable component is
+    ``dv * cos(angle) + du * sin(angle)``.
+    """
+
+    type: str
+    normal_angle_deg: float
+    offset_along_normal_px: float
+    uncertainty_px: float
+
+
+@dataclass(frozen=True)
 class GroundTruth:
-    """Operator-verified offset for one image."""
+    """Operator-verified offset for one image.
+
+    When ``constraint`` is present the 2-D ``offset_dv_px`` /
+    ``offset_du_px`` pair is a *representative point* on the constraint line
+    (whatever the operator saved from the manual-nav drag); only the
+    component along the constraint normal is operator-verified, and the
+    regression comparison projects onto that normal instead of comparing per
+    axis.
+    """
 
     offset_dv_px: float
     offset_du_px: float
@@ -108,17 +144,25 @@ class GroundTruth:
     verified_date: date
     ui_version: str
     notes: str | None = None
+    constraint: GroundTruthConstraint | None = None
 
 
 @dataclass(frozen=True)
 class Expected:
-    """Expected-outcome targets the regression test compares against."""
+    """Expected-outcome targets the regression test compares against.
+
+    ``status_reason`` is optional: when present the regression test also
+    asserts the orchestrator's discrete ``NavStatusReason`` (e.g.
+    ``rank_1_only`` for a flat-ring frame whose only observable axis is the
+    edge normal); when absent only the status / tier are checked.
+    """
 
     status: str
     confidence_tier: str
     primary_technique: str
     techniques_must_run: tuple[str, ...] = ()
     techniques_must_skip: tuple[str, ...] = ()
+    status_reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -299,6 +343,19 @@ def _validate_ground_truth(raw: dict[str, Any], *, path: Path) -> GroundTruth:
     notes = raw.get('notes')
     if notes is not None and not isinstance(notes, str):
         raise SidecarValidationError(f'{path}: ground_truth.notes must be a string when present')
+    constraint = _validate_constraint(raw.get('constraint'), path=path)
+    if constraint is not None:
+        projected = offset_dv_px * math.cos(
+            math.radians(constraint.normal_angle_deg)
+        ) + offset_du_px * math.sin(math.radians(constraint.normal_angle_deg))
+        if abs(projected - constraint.offset_along_normal_px) > _CONSTRAINT_PROJECTION_TOLERANCE_PX:
+            raise SidecarValidationError(
+                f'{path}: ground_truth (offset_dv_px, offset_du_px) projected onto the '
+                f'constraint normal is {projected:.4f} px but '
+                f'constraint.offset_along_normal_px is '
+                f'{constraint.offset_along_normal_px:.4f} px; the representative point '
+                f'must lie on the constraint line'
+            )
     return GroundTruth(
         offset_dv_px=offset_dv_px,
         offset_du_px=offset_du_px,
@@ -308,6 +365,30 @@ def _validate_ground_truth(raw: dict[str, Any], *, path: Path) -> GroundTruth:
         verified_date=verified_date,
         ui_version=ui_version,
         notes=notes,
+        constraint=constraint,
+    )
+
+
+def _validate_constraint(raw: Any, *, path: Path) -> GroundTruthConstraint | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise SidecarValidationError(
+            f'{path}: ground_truth.constraint must be a mapping when present'
+        )
+    constraint_type = _require_enum(raw, 'type', ALLOWED_CONSTRAINT_TYPES, path=path)
+    normal_angle_deg = _require_float(raw, 'normal_angle_deg', path=path)
+    offset_along_normal_px = _require_float(raw, 'offset_along_normal_px', path=path)
+    uncertainty_px = _require_float(raw, 'uncertainty_px', path=path)
+    if uncertainty_px <= 0.0:
+        raise SidecarValidationError(
+            f'{path}: ground_truth.constraint.uncertainty_px must be > 0, got {uncertainty_px}'
+        )
+    return GroundTruthConstraint(
+        type=constraint_type,
+        normal_angle_deg=normal_angle_deg,
+        offset_along_normal_px=offset_along_normal_px,
+        uncertainty_px=uncertainty_px,
     )
 
 
@@ -342,12 +423,21 @@ def _validate_expected(raw: dict[str, Any], *, path: Path) -> Expected:
         raise SidecarValidationError(
             f'{path}: techniques_must_run and techniques_must_skip overlap: {sorted(overlap)}'
         )
+    status_reason = raw.get('status_reason')
+    if status_reason is not None and (
+        not isinstance(status_reason, str) or status_reason not in ALLOWED_STATUS_REASONS
+    ):
+        raise SidecarValidationError(
+            f'{path}: expected.status_reason must be one of '
+            f'{sorted(ALLOWED_STATUS_REASONS)} when present, got {status_reason!r}'
+        )
     return Expected(
         status=status,
         confidence_tier=confidence_tier,
         primary_technique=primary_technique,
         techniques_must_run=techniques_must_run,
         techniques_must_skip=techniques_must_skip,
+        status_reason=status_reason,
     )
 
 

--- a/tests/integration/sim_baselines/planted_rank1_ring_flat.json
+++ b/tests/integration/sim_baselines/planted_rank1_ring_flat.json
@@ -1,0 +1,7 @@
+{
+  "confidence": 0.9,
+  "offset_du_px": -1.01,
+  "offset_dv_px": 0.0,
+  "scene_name": "planted_rank1_ring_flat",
+  "status": "success"
+}

--- a/tests/integration/sim_scenes/algorithmic_invariants/planted_rank1_ring_flat.yaml
+++ b/tests/integration/sim_scenes/algorithmic_invariants/planted_rank1_ring_flat.yaml
@@ -1,0 +1,32 @@
+schema_version: 1
+scene_name: planted_rank1_ring_flat
+instrument: coiss_nac
+size_v: 220
+size_u: 220
+random_seed: 7
+exposure_sec: 1.0
+# A flat (rank-1) ringlet: the ring centre sits ~50000 px off-frame to the
+# left, so the two edges crossing the FOV are straight to well under the
+# 1 px FLAT_CURVATURE_THRESHOLD_PX (sagitta ~0.2 px over the frame) and the
+# simulated ring model emits both RING_EDGE polylines with
+# is_straight_line=True.  Both edge normals are ~+u, so only the planted
+# offset's u component is observable; RingEdgeNav returns an exactly rank-1
+# covariance and the ensemble surfaces status_reason=rank_1_only with the
+# minimum-norm offset (the v component projected away).  This is the
+# end-to-end sim anchor for the ring_only_flat scene class (#203/#204).
+bodies: []
+rings:
+  - name: SATURN
+    feature_type: RINGLET
+    center_v: 110.0
+    center_u: -49890.0
+    inner_data:
+      - {mode: 1, a: 49960.0, rms: 1.0, ae: 0.0, long_peri: 0.0, rate_peri: 0.0}
+    outer_data:
+      - {mode: 1, a: 50040.0, rms: 1.0, ae: 0.0, long_peri: 0.0, rate_peri: 0.0}
+noise:
+  poisson: true
+  read_noise_dn: 4.0
+offset_v: 2.75
+offset_u: -1.6
+offset_rotation_deg: 0.0

--- a/tests/integration/test_autonomous_nav.py
+++ b/tests/integration/test_autonomous_nav.py
@@ -21,6 +21,7 @@ skipped automatically when ``PDS3_HOLDINGS_DIR`` is not set.
 
 from __future__ import annotations
 
+import math
 import os
 from pathlib import Path
 from typing import Any
@@ -113,26 +114,50 @@ def test_one_library_image(sidecar: Sidecar, tmp_path: Path) -> None:
         f'{sidecar.expected.status!r})'
     )
 
-    # (b) confidence_rank (no slack, exact match)
+    # (b) confidence_rank (no slack, exact match), plus the optional
+    # status_reason pin (e.g. ``rank_1_only`` for a flat-ring frame).
     actual_rank = nav_meta.get('confidence_rank')
     assert actual_rank == sidecar.expected.confidence_tier, (
         f'{sidecar.image_id}: expected confidence_tier='
         f'{sidecar.expected.confidence_tier}, got {actual_rank}'
     )
+    if sidecar.expected.status_reason is not None:
+        actual_reason = nav_meta.get('status_reason')
+        assert actual_reason == sidecar.expected.status_reason, (
+            f'{sidecar.image_id}: expected status_reason='
+            f'{sidecar.expected.status_reason}, got {actual_reason}'
+        )
 
-    # (c) offset_px within slack on each axis (only for ``ok`` outcomes)
+    # (c) offset within slack (only for ``ok`` outcomes).  A rank-1
+    # constrained ground truth compares only the component along the
+    # constraint normal — the along-edge component is physically
+    # unobservable, so per-axis comparison would score noise.
     if sidecar.expected.status == 'success':
         offset = metadata.get('offset')
         assert offset is not None, f'{sidecar.image_id}: status=ok but metadata carries no offset'
-        slack = sidecar.ground_truth.offset_uncertainty_px + 0.5
-        dv_err = abs(float(offset[0]) - sidecar.ground_truth.offset_dv_px)
-        du_err = abs(float(offset[1]) - sidecar.ground_truth.offset_du_px)
-        assert dv_err <= slack, (
-            f'{sidecar.image_id}: dv error {dv_err:.3f} px exceeds tolerance {slack:.3f} px'
-        )
-        assert du_err <= slack, (
-            f'{sidecar.image_id}: du error {du_err:.3f} px exceeds tolerance {slack:.3f} px'
-        )
+        constraint = sidecar.ground_truth.constraint
+        if constraint is not None:
+            angle = math.radians(constraint.normal_angle_deg)
+            actual_along_normal = float(offset[0]) * math.cos(angle) + float(offset[1]) * math.sin(
+                angle
+            )
+            slack = constraint.uncertainty_px + 0.5
+            normal_err = abs(actual_along_normal - constraint.offset_along_normal_px)
+            assert normal_err <= slack, (
+                f'{sidecar.image_id}: edge-normal offset error {normal_err:.3f} px '
+                f'exceeds tolerance {slack:.3f} px (constraint normal at '
+                f'{constraint.normal_angle_deg:.2f} deg)'
+            )
+        else:
+            slack = sidecar.ground_truth.offset_uncertainty_px + 0.5
+            dv_err = abs(float(offset[0]) - sidecar.ground_truth.offset_dv_px)
+            du_err = abs(float(offset[1]) - sidecar.ground_truth.offset_du_px)
+            assert dv_err <= slack, (
+                f'{sidecar.image_id}: dv error {dv_err:.3f} px exceeds tolerance {slack:.3f} px'
+            )
+            assert du_err <= slack, (
+                f'{sidecar.image_id}: du error {du_err:.3f} px exceeds tolerance {slack:.3f} px'
+            )
 
     per_technique = nav_meta.get('per_technique', [])
     technique_names = [entry.get('technique_name') for entry in per_technique]

--- a/tests/integration/test_image_library.py
+++ b/tests/integration/test_image_library.py
@@ -224,3 +224,101 @@ def test_load_sidecar_rejects_unknown_schema_version(tmp_path: Path) -> None:
     p.write_text(bad)
     with pytest.raises(SidecarValidationError, match=r'schema_version'):
         load_sidecar(p)
+
+
+# 12.5 * cos(60 deg) + (-3.25) * sin(60 deg) = 3.435
+_RANK1_CONSTRAINT_BLOCK = """\
+  constraint:
+    type: rank_1
+    normal_angle_deg: 60.0
+    offset_along_normal_px: 3.435
+    uncertainty_px: 0.4
+"""
+
+
+def _with_constraint(text: str, block: str = _RANK1_CONSTRAINT_BLOCK) -> str:
+    """Insert a ``ground_truth.constraint`` block into the reference YAML."""
+    return text.replace(
+        "  notes: 'Hand-picked for the schema test.'\n",
+        "  notes: 'Hand-picked for the schema test.'\n" + block,
+    )
+
+
+def test_load_sidecar_accepts_rank_1_constraint(tmp_path: Path) -> None:
+    """A consistent ``ground_truth.constraint`` block round-trips."""
+    p = tmp_path / 'TEST_IMG_0001.yaml'
+    p.write_text(_with_constraint(_VALID_SIDECAR_TEXT))
+    sidecar = load_sidecar(p)
+    constraint = sidecar.ground_truth.constraint
+    assert constraint is not None
+    assert constraint.type == 'rank_1'
+    assert constraint.normal_angle_deg == 60.0
+    assert constraint.offset_along_normal_px == 3.435
+    assert constraint.uncertainty_px == 0.4
+
+
+def test_load_sidecar_constraint_absent_is_none(tmp_path: Path) -> None:
+    """A sidecar without a constraint block parses with ``constraint=None``."""
+    p = tmp_path / 'TEST_IMG_0001.yaml'
+    p.write_text(_VALID_SIDECAR_TEXT)
+    assert load_sidecar(p).ground_truth.constraint is None
+
+
+def test_load_sidecar_rejects_constraint_off_line_representative(tmp_path: Path) -> None:
+    """The 2-D offset must project onto the declared normal component."""
+    bad = _with_constraint(
+        _VALID_SIDECAR_TEXT,
+        _RANK1_CONSTRAINT_BLOCK.replace(
+            'offset_along_normal_px: 3.435', 'offset_along_normal_px: 5.0'
+        ),
+    )
+    p = tmp_path / 'BAD.yaml'
+    p.write_text(bad)
+    with pytest.raises(SidecarValidationError, match=r'constraint line'):
+        load_sidecar(p)
+
+
+def test_load_sidecar_rejects_unknown_constraint_type(tmp_path: Path) -> None:
+    """``constraint.type`` must be a declared constraint type."""
+    bad = _with_constraint(
+        _VALID_SIDECAR_TEXT, _RANK1_CONSTRAINT_BLOCK.replace('type: rank_1', 'type: rank_2')
+    )
+    p = tmp_path / 'BAD.yaml'
+    p.write_text(bad)
+    with pytest.raises(SidecarValidationError, match=r'type'):
+        load_sidecar(p)
+
+
+def test_load_sidecar_rejects_nonpositive_constraint_uncertainty(tmp_path: Path) -> None:
+    """``constraint.uncertainty_px`` must be strictly positive."""
+    bad = _with_constraint(
+        _VALID_SIDECAR_TEXT,
+        _RANK1_CONSTRAINT_BLOCK.replace('uncertainty_px: 0.4', 'uncertainty_px: 0.0'),
+    )
+    p = tmp_path / 'BAD.yaml'
+    p.write_text(bad)
+    with pytest.raises(SidecarValidationError, match=r'uncertainty_px'):
+        load_sidecar(p)
+
+
+def test_load_sidecar_accepts_status_reason(tmp_path: Path) -> None:
+    """An ``expected.status_reason`` from the NavStatusReason enum validates."""
+    good = _VALID_SIDECAR_TEXT.replace(
+        'primary_technique: BodyLimbNav',
+        'primary_technique: BodyLimbNav\n  status_reason: rank_1_only',
+    )
+    p = tmp_path / 'TEST_IMG_0001.yaml'
+    p.write_text(good)
+    assert load_sidecar(p).expected.status_reason == 'rank_1_only'
+
+
+def test_load_sidecar_rejects_unknown_status_reason(tmp_path: Path) -> None:
+    """``expected.status_reason`` outside the NavStatusReason enum fails."""
+    bad = _VALID_SIDECAR_TEXT.replace(
+        'primary_technique: BodyLimbNav',
+        'primary_technique: BodyLimbNav\n  status_reason: half_rank',
+    )
+    p = tmp_path / 'BAD.yaml'
+    p.write_text(bad)
+    with pytest.raises(SidecarValidationError, match=r'status_reason'):
+        load_sidecar(p)

--- a/tests/integration/test_sim_algorithmic_invariants.py
+++ b/tests/integration/test_sim_algorithmic_invariants.py
@@ -109,6 +109,13 @@ _UNIQUE_MATCH_PATHS = [p for p in _INVARIANT_PATHS if p.stem.startswith(_UNIQUE_
 _UNIQUE_MATCH_IDS = [p.stem for p in _UNIQUE_MATCH_PATHS]
 _REFINE_PATHS = [p for p in _INVARIANT_PATHS if p.stem.startswith(_REFINE_STEM_PREFIX)]
 _REFINE_IDS = [p.stem for p in _REFINE_PATHS]
+# Rank-1 scenes are all-straight flat-ring frames: only the offset component
+# along the edge normal is observable, so full 2-D recovery is undefined and
+# the assertions are rank-1-specific (status_reason, exact covariance rank
+# deficiency, and recovery of the normal component only).
+_RANK1_STEM_PREFIX = 'planted_rank1'
+_RANK1_PATHS = [p for p in _INVARIANT_PATHS if p.stem.startswith(_RANK1_STEM_PREFIX)]
+_RANK1_IDS = [p.stem for p in _RANK1_PATHS]
 # Disc scenes assert full-ensemble offset recovery.  Blob, star, rotation, ring,
 # and the technique-pinned star scenes recover on a pinned technique instead (the
 # fused offset is weak, absent, or per-technique), so they are held out; limb
@@ -118,6 +125,7 @@ _DISC_EXCLUDE = (
     _STAR_STEM_PREFIX,
     _ROTATION_STEM_PREFIX,
     _RING_STEM_PREFIX,
+    _RANK1_STEM_PREFIX,
     _UNIQUE_MATCH_STEM_PREFIX,
     _REFINE_STEM_PREFIX,
 )
@@ -184,6 +192,59 @@ def test_there_are_unique_match_scenes() -> None:
 def test_there_are_refine_scenes() -> None:
     """At least one star-field scene exists for the StarRefineNav coverage."""
     assert _REFINE_PATHS
+
+
+def test_there_are_rank1_scenes() -> None:
+    """At least one flat-ring scene exists for the rank-1 coverage."""
+    assert _RANK1_PATHS
+
+
+@pytest.mark.parametrize('path', _RANK1_PATHS, ids=_RANK1_IDS)
+def test_rank1_scene_reports_rank_1_only(path: Path) -> None:
+    """A flat-ring scene fuses to success with the rank_1_only status reason.
+
+    The unobservable axis is surfaced through both the discrete reason and
+    the ``sigma_along_unobservable_px`` sentinel; the fused covariance is
+    exactly rank-deficient (the technique projects it onto the edge normal).
+    """
+    import numpy as np
+
+    from spindoctor.support.status_reason import NavStatusReason
+
+    result = _navigate(load_sim_scene(path))
+    assert result.status == 'success'
+    assert result.status_reason == NavStatusReason.RANK_1_ONLY
+    assert result.sigma_along_unobservable_px == math.inf
+    cov = np.asarray(result.covariance_px2, dtype=np.float64)
+    eigvals = np.linalg.eigvalsh(cov[:2, :2])
+    assert float(eigvals.min()) == pytest.approx(0.0, abs=1.0e-9)
+    assert float(eigvals.max()) > 0.0
+
+
+@pytest.mark.parametrize('path', _RANK1_PATHS, ids=_RANK1_IDS)
+def test_rank1_scene_recovers_normal_component(path: Path) -> None:
+    """A flat-ring scene recovers the planted offset's edge-normal component.
+
+    The along-edge component is physically unobservable (the fused offset
+    is the minimum-norm representative), so the invariant projects the
+    recovery error onto the observable axis — the fused covariance's only
+    non-null eigenvector — and bounds that component alone.
+    """
+    import numpy as np
+
+    scene = load_sim_scene(path)
+    result = _navigate(scene)
+    assert result.offset_px is not None
+    cov = np.asarray(result.covariance_px2, dtype=np.float64)
+    _eigvals, eigvecs = np.linalg.eigh(cov[:2, :2])
+    n_hat = eigvecs[:, -1]
+    error_vu = np.array(
+        [
+            result.offset_px[0] - scene['offset_v'],
+            result.offset_px[1] - scene['offset_u'],
+        ]
+    )
+    assert abs(float(error_vu @ n_hat)) < _OFFSET_TOLERANCE_PX
 
 
 @pytest.mark.parametrize('path', _NAVIGATES_SUCCESS_PATHS, ids=_NAVIGATES_SUCCESS_IDS)

--- a/tests/spindoctor/nav_orchestrator/test_orchestrator.py
+++ b/tests/spindoctor/nav_orchestrator/test_orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import Any
 
 import numpy as np
@@ -111,9 +112,19 @@ class _FakeStarModel(NavModel):
 
 
 class _FakeStarTechnique(NavTechnique):
-    """Stand-in technique that always reports a fixed offset."""
+    """Stand-in technique that always reports a fixed offset.
+
+    ``_abstract = True`` keeps this (and every fake below) out of the
+    process-wide ``NavTechnique._registry`` at import; the autouse
+    ``_register_fakes`` fixture registers them for the duration of each
+    test in this module.  A permanently registered fake would otherwise
+    run inside every later full-ensemble navigation in the same worker
+    (e.g. the sim invariant tests) and fuse its hardcoded offset into
+    real results.
+    """
 
     name = '_FakeStarTechnique'
+    _abstract = True
     accepts_feature_types = frozenset({NavFeatureType.STAR})
 
     def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
@@ -140,6 +151,31 @@ class _FakeStarTechnique(NavTechnique):
 def fake_obs() -> _FakeObs:
     """Provide a clean fake observation."""
     return _FakeObs()
+
+
+@pytest.fixture(autouse=True)
+def _register_fakes() -> Iterator[None]:
+    """Register this module's fake techniques for the duration of one test.
+
+    The fakes carry ``_abstract = True`` so they never enter the global
+    ``NavTechnique._registry`` at import; this fixture makes them
+    name-resolvable (``only_techniques=['_FakeStarTechnique']``) inside
+    this module's tests only, and guarantees no other test in the same
+    process ever sees them.
+    """
+    fakes: list[type[NavTechnique]] = [
+        _FakeStarTechnique,
+        _RaisingTechnique,
+        _PassTwoTechnique,
+        _FakeBodyPrimary,
+        _FakeBodyFallback,
+    ]
+    NavTechnique._registry.extend(fakes)
+    try:
+        yield
+    finally:
+        for fake in fakes:
+            NavTechnique._registry.remove(fake)
 
 
 def test_orchestrator_runs_pipeline_end_to_end(fake_obs: _FakeObs) -> None:
@@ -373,6 +409,7 @@ class _RaisingTechnique(NavTechnique):
     """NavTechnique whose ``navigate`` always raises a RuntimeError."""
 
     name = '_RaisingTechnique'
+    _abstract = True  # scoped to this module via _register_fakes
     accepts_feature_types = frozenset({NavFeatureType.STAR})
 
     def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
@@ -388,6 +425,7 @@ class _PassTwoTechnique(NavTechnique):
     """Pass-2 (requires_prior=True) technique that captures the prior offset."""
 
     name = '_PassTwoTechnique'
+    _abstract = True  # scoped to this module via _register_fakes
     accepts_feature_types = frozenset({NavFeatureType.STAR})
     requires_prior = True
     captured_prior: tuple[float, float] | None = None
@@ -732,6 +770,7 @@ class _FakeBodyPrimary(NavTechnique):
     """Primary technique consuming BODY_DISC; tracks how many times it ran."""
 
     name = '_FakeBodyPrimary'
+    _abstract = True  # scoped to this module via _register_fakes
     accepts_feature_types = frozenset({NavFeatureType.BODY_DISC})
     tier = 'primary'
     run_count: int = 0
@@ -764,6 +803,7 @@ class _FakeBodyFallback(NavTechnique):
     """Fallback technique consuming BODY_BLOB; tracks how many times it ran."""
 
     name = '_FakeBodyFallback'
+    _abstract = True  # scoped to this module via _register_fakes
     accepts_feature_types = frozenset({NavFeatureType.BODY_BLOB})
     tier = 'fallback'
     run_count: int = 0

--- a/tests/spindoctor/nav_technique/test_nav_technique.py
+++ b/tests/spindoctor/nav_technique/test_nav_technique.py
@@ -26,9 +26,16 @@ from spindoctor.nav_technique.technique_result import NavTechniqueResult
 
 
 class _ConcreteTechniqueForTest(NavTechnique):
-    """Concrete subclass for registry testing."""
+    """Concrete subclass for direct-invocation testing.
+
+    ``_abstract = True`` keeps it out of the process-wide registry so it
+    cannot leak into full-ensemble navigations run later in the same
+    worker; the registration behaviour itself is exercised by
+    ``test_navtechnique_registry_records_subclass`` with a scoped probe.
+    """
 
     name = '_ConcreteTechniqueForTest'
+    _abstract = True
     accepts_feature_types = frozenset({NavFeatureType.STAR})
 
     def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
@@ -49,7 +56,36 @@ class _ConcreteTechniqueForTest(NavTechnique):
 
 def test_navtechnique_registry_records_subclass() -> None:
     """Concrete subclasses self-register via __init_subclass__."""
-    assert _ConcreteTechniqueForTest in NavTechnique._registry
+
+    class _RegistrationProbe(_ConcreteTechniqueForTest):
+        name = '_RegistrationProbe'
+        _abstract = False
+
+    try:
+        assert _RegistrationProbe in NavTechnique._registry
+    finally:
+        NavTechnique._registry.remove(_RegistrationProbe)
+
+
+def test_navtechnique_abstract_subclass_stays_out_of_registry() -> None:
+    """``_abstract = True`` opts a subclass out of the registry entirely."""
+    assert _ConcreteTechniqueForTest not in NavTechnique._registry
+
+
+def test_registry_contains_only_shipped_techniques() -> None:
+    """No test-defined technique leaks into the process-wide registry.
+
+    A leaked fake runs inside every later full-ensemble navigation in
+    the same process and fuses its hardcoded offset into real results —
+    a worker-colocation heisenbug under pytest-xdist.  Test fakes must
+    set ``_abstract = True`` and register through a scoped fixture.
+    """
+    for cls in NavTechnique._registry:
+        assert cls.__module__.startswith('spindoctor.'), (
+            f'{cls.__module__}.{cls.__qualname__} is registered in '
+            f'NavTechnique._registry but is not a shipped technique; test fakes '
+            f'must set _abstract = True and use a scoped registration fixture'
+        )
 
 
 def test_navtechnique_can_invoke_navigate() -> None:

--- a/tests/spindoctor/nav_technique/test_nav_technique_ring_edge.py
+++ b/tests/spindoctor/nav_technique/test_nav_technique_ring_edge.py
@@ -292,6 +292,69 @@ def test_ring_edge_nav_flat_parallel_edges_with_minority_snaps_not_spurious(
     assert result.diagnostics.is_rank_1 is True
 
 
+def test_ring_edge_nav_rank1_tangent_slide_not_gated(
+    monkeypatch: pytest.MonkeyPatch,
+    horizontal_step_image: HorizontalStepImageFactory,
+    flat_polyline: FlatPolylineFactory,
+    make_ring_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    """Tangent slide on a rank-1 scene trips neither at_edge nor displacement.
+
+    Nothing constrains the along-edge axis of an all-straight fit, so the
+    LM may drift to the search-window boundary along the tangent (Cassini
+    N1863267979: dv slid to the margin while the observable normal
+    component was mid-window).  Both the at-edge check and the
+    LM-displacement spurious gate must therefore be evaluated on the
+    edge-normal component only.
+    """
+    from spindoctor.nav_technique import dt_fitting, nav_technique_ring_edge
+
+    shape = (200, 200)
+    image = horizontal_step_image(shape, 100.0)
+    vertices, outward = flat_polyline(101.5, 20.0, 180.0, 60)
+    feature = make_ring_feature(
+        'flat', vertices=vertices, outward_normals=outward, is_straight_line=True
+    )
+    technique = RingEdgeNav()
+    context = make_nav_context(image)  # extfov margins (32, 32)
+
+    # Horizontal edge: normal is +v, tangent is +u.  The forged fit slid
+    # 31.5 px along the tangent — at the (32 - 1) px per-axis at-edge
+    # boundary and far past the 4 px displacement gate — while the
+    # observable normal component stays a benign -1.5 px.
+    residuals = np.full(vertices.shape[0], 0.5, dtype=np.float64)
+    forged_result = dt_fitting.LMRefineResult(
+        offset_vu=(-1.5, 31.5),
+        rotation_rad=0.0,
+        covariance=np.array([[0.04, 0.0], [0.0, 1.0e9]], dtype=np.float64),
+        residuals_px=residuals,
+        weights=np.ones(residuals.size, dtype=np.float64),
+        rms_px=0.5,
+        raw_rms_px=0.5,
+        iterations=10,
+        converged=True,
+        inlier_count=int(residuals.size),
+        degenerate=False,
+    )
+    monkeypatch.setattr(
+        nav_technique_ring_edge,
+        'lm_subpixel_refine',
+        lambda **_kwargs: forged_result,
+    )
+    monkeypatch.setattr(
+        nav_technique_ring_edge,
+        'coarse_ncc_search',
+        lambda *_args, **_kwargs: (-2, 0),
+    )
+
+    result = technique.navigate([feature], context)
+    assert result.at_edge is False
+    assert result.spurious is False
+    assert isinstance(result.diagnostics, RingEdgeDiagnostics)
+    assert result.diagnostics.is_rank_1 is True
+
+
 def test_aggregate_edge_normal_angle_all_straight_horizontal(
     flat_polyline: FlatPolylineFactory,
     make_ring_feature: NavFeatureFactory,

--- a/tests/spindoctor/nav_technique/test_nav_technique_ring_edge.py
+++ b/tests/spindoctor/nav_technique/test_nav_technique_ring_edge.py
@@ -18,6 +18,7 @@ from spindoctor.nav_technique.diagnostics import RingEdgeDiagnostics
 from spindoctor.nav_technique.nav_technique_ring_edge import (
     _RANK1_NULL_RELATIVE_THRESHOLD,
     RingEdgeNav,
+    aggregate_edge_normal_angle_deg,
 )
 
 
@@ -289,6 +290,58 @@ def test_ring_edge_nav_flat_parallel_edges_with_minority_snaps_not_spurious(
     assert result.diagnostics.per_edge_dt_rms_mean > 3.0
     assert result.spurious is False
     assert result.diagnostics.is_rank_1 is True
+
+
+def test_aggregate_edge_normal_angle_all_straight_horizontal(
+    flat_polyline: FlatPolylineFactory,
+    make_ring_feature: NavFeatureFactory,
+) -> None:
+    """Horizontal straight edges have a +v-aligned normal: angle 0 deg."""
+    vertices, outward = flat_polyline(100.5, 20.0, 180.0, 60)
+    feature = make_ring_feature(
+        'flat', vertices=vertices, outward_normals=outward, is_straight_line=True
+    )
+    angle = aggregate_edge_normal_angle_deg([feature])
+    assert angle is not None
+    assert angle == pytest.approx(0.0, abs=1.0e-6)
+
+
+def test_aggregate_edge_normal_angle_polarity_sign_independent(
+    flat_polyline: FlatPolylineFactory,
+    make_ring_feature: NavFeatureFactory,
+) -> None:
+    """Two parallel edges with opposite normal senses do not cancel."""
+    vertices_a, outward_a = flat_polyline(80.5, 20.0, 180.0, 60)
+    vertices_b, outward_b = flat_polyline(120.5, 20.0, 180.0, 60)
+    feat_a = make_ring_feature(
+        'inner', vertices=vertices_a, outward_normals=outward_a, is_straight_line=True
+    )
+    feat_b = make_ring_feature(
+        'outer', vertices=vertices_b, outward_normals=-outward_b, is_straight_line=True
+    )
+    angle = aggregate_edge_normal_angle_deg([feat_a, feat_b])
+    assert angle is not None
+    assert angle == pytest.approx(0.0, abs=1.0e-6)
+
+
+def test_aggregate_edge_normal_angle_none_when_any_edge_curved(
+    circle_polyline: CirclePolylineFactory,
+    flat_polyline: FlatPolylineFactory,
+    make_ring_feature: NavFeatureFactory,
+) -> None:
+    """A mixed straight + curved scene is full-rank: no constraint seed."""
+    curved_v, curved_n = circle_polyline((100.0, 100.0), 30.0, 60)
+    flat_v, flat_n = flat_polyline(150.5, 20.0, 180.0, 60)
+    curved = make_ring_feature(
+        'curved', vertices=curved_v, outward_normals=curved_n, is_straight_line=False
+    )
+    flat = make_ring_feature('flat', vertices=flat_v, outward_normals=flat_n, is_straight_line=True)
+    assert aggregate_edge_normal_angle_deg([curved, flat]) is None
+
+
+def test_aggregate_edge_normal_angle_none_without_ring_edges() -> None:
+    """No ring-edge features means no seed."""
+    assert aggregate_edge_normal_angle_deg([]) is None
 
 
 def test_ring_edge_nav_registered_with_navtechnique_registry() -> None:

--- a/tests/spindoctor/nav_technique/test_nav_technique_ring_edge.py
+++ b/tests/spindoctor/nav_technique/test_nav_technique_ring_edge.py
@@ -204,10 +204,91 @@ def test_ring_edge_nav_marks_spurious_when_per_edge_rms_collapses_to_one(
     result = technique.navigate([feat_a, feat_b, feat_c], context)
     assert isinstance(result.diagnostics, RingEdgeDiagnostics)
     assert result.diagnostics.edge_count == 3
-    # Average per-edge RMS = (0 + 50 + 50) / 3 ≈ 33.3, far above any
-    # plausible spurious threshold derived from sub-pixel sigmas.
+    # The forged fit anchors only edge A — one third of the model
+    # vertices — so the inlier fraction sits far below the 0.5 gate.
+    # The per-edge diagnostics record the misalignment signature.
+    assert result.diagnostics.per_edge_dt_median_max == pytest.approx(50.0)
     assert result.diagnostics.per_edge_dt_rms_summed > 50.0
     assert result.spurious is True
+
+
+def test_ring_edge_nav_flat_parallel_edges_with_minority_snaps_not_spurious(
+    monkeypatch: pytest.MonkeyPatch,
+    horizontal_step_image: HorizontalStepImageFactory,
+    flat_polyline: FlatPolylineFactory,
+    make_ring_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    """A correct flat multi-edge fit with an outlier minority passes the gate.
+
+    Models the ``ring_only_flat`` production regression (#203, Cassini
+    N1863267799): parallel straight Keeler-gap edges fit cleanly while a
+    minority of vertices (an edge too faint to detect, vertices snapping
+    to a neighbouring parallel edge 9-30 px away) are Tukey outliers.
+    Those outliers inflate every raw per-edge residual statistic past any
+    sigma-derived threshold even though the joint fit is correct — which is
+    exactly what used to gate every flat ansa frame as spurious.  The fit
+    still anchors 85% of the model vertices, so the inlier-fraction gate
+    passes and the result survives with ``is_rank_1=True`` for the ensemble
+    to surface as ``rank_1_only``.
+    """
+    from spindoctor.nav_technique import dt_fitting, nav_technique_ring_edge
+
+    shape = (200, 200)
+    image = horizontal_step_image(shape, 100.0)
+    features = []
+    for name, row in (('inner', 80.5), ('middle', 100.5), ('outer', 120.5)):
+        vertices, outward = flat_polyline(row, 20.0, 180.0, 60)
+        features.append(
+            make_ring_feature(
+                name, vertices=vertices, outward_normals=outward, is_straight_line=True
+            )
+        )
+    technique = RingEdgeNav()
+    context = make_nav_context(image)
+
+    # Per-edge residuals: 85% of vertices at the ~1 px fit residual, 15%
+    # snapped to a parallel neighbour 20 px away.  Raw per-edge RMS is
+    # sqrt(0.85*1 + 0.15*400) ~ 7.8 px — any sigma-derived residual gate
+    # would fire — but the inlier fraction is 0.85, well above the gate.
+    n_per_edge = 60
+    per_edge = np.full(n_per_edge, 1.0, dtype=np.float64)
+    per_edge[: int(0.15 * n_per_edge)] = 20.0
+    residuals = np.concatenate([per_edge] * 3)
+    weights = np.ones(residuals.size, dtype=np.float64)
+    forged_result = dt_fitting.LMRefineResult(
+        offset_vu=(-1.5, 0.0),
+        rotation_rad=0.0,
+        covariance=np.array([[0.04, 0.0], [0.0, 1.0e9]], dtype=np.float64),
+        residuals_px=residuals,
+        weights=weights,
+        rms_px=1.0,
+        raw_rms_px=float(np.sqrt(np.mean(residuals**2))),
+        iterations=10,
+        converged=True,
+        inlier_count=int(residuals.size * 0.85),
+        degenerate=False,
+    )
+    monkeypatch.setattr(
+        nav_technique_ring_edge,
+        'lm_subpixel_refine',
+        lambda **_kwargs: forged_result,
+    )
+    # Pin the coarse seed next to the forged LM offset so the unrelated
+    # LM-displacement gate stays quiet; this test is about the per-edge gate.
+    monkeypatch.setattr(
+        nav_technique_ring_edge,
+        'coarse_ncc_search',
+        lambda *_args, **_kwargs: (-2, 0),
+    )
+
+    result = technique.navigate(features, context)
+    assert isinstance(result.diagnostics, RingEdgeDiagnostics)
+    assert result.diagnostics.edge_count == 3
+    assert result.diagnostics.per_edge_dt_median_max == pytest.approx(1.0)
+    assert result.diagnostics.per_edge_dt_rms_mean > 3.0
+    assert result.spurious is False
+    assert result.diagnostics.is_rank_1 is True
 
 
 def test_ring_edge_nav_registered_with_navtechnique_registry() -> None:

--- a/tests/spindoctor/ui/test_library_entry.py
+++ b/tests/spindoctor/ui/test_library_entry.py
@@ -7,6 +7,7 @@ isolation so the (heavier) dialog tests stay focused on UI wiring.
 
 from __future__ import annotations
 
+import math
 from datetime import date
 from pathlib import Path
 from typing import Any
@@ -261,3 +262,70 @@ def test_build_sidecar_yaml_unedited_fails_validation(tmp_path: Path) -> None:
         SidecarValidationError, match=r'TODO_REPLACE_PRIMARY_CLASS|primary scene_tag'
     ):
         load_sidecar(p)
+
+
+def test_build_sidecar_yaml_constraint_round_trips_through_validator(tmp_path: Path) -> None:
+    """A constrained (rank-1) save emits a constraint block that validates.
+
+    ``offset_along_normal_px`` is computed from the same 2-D offset the
+    YAML carries, so the validator's on-the-line consistency check passes
+    by construction, and the ``expected`` block pins ``rank_1_only``.
+    """
+    draft = LibraryEntryDraft(
+        image_id='N1863267799_1_CALIB',
+        mission='COISS',
+        camera='NAC',
+        filter_combo='CL1+CL2',
+        exposure_time_sec=0.68,
+        image_datetime_utc='2016-12-18T01:23:45.678Z',
+    )
+    yaml_text = build_sidecar_yaml(
+        draft=draft,
+        image_url='pds3://volumes/COISS_2xxx/COISS_2116/.../N1863267799_1_CALIB.IMG',
+        offset_dv_px=47.2772,
+        offset_du_px=-73.4648,
+        ui_version='0.1.dev0',
+        operator='rfrench',
+        today=date(2026, 7, 10),
+        constraint_normal_angle_deg=45.0,
+    )
+    edited = (
+        yaml_text.replace('TODO_REPLACE_PRIMARY_CLASS', 'ring_only_flat')
+        .replace('TODO_REPLACE_TECHNIQUE', 'RingEdgeNav')
+        .replace(
+            'TODO: describe the scene and any caveats.',
+            'Straight Keeler-gap edges; normal component only.',
+        )
+    )
+    p = tmp_path / 'N1863267799_1_CALIB.yaml'
+    p.write_text(edited)
+    sidecar = load_sidecar(p)
+    constraint = sidecar.ground_truth.constraint
+    assert constraint is not None
+    assert constraint.type == 'rank_1'
+    assert constraint.normal_angle_deg == pytest.approx(45.0)
+    expected_along = 47.2772 * math.cos(math.radians(45.0)) - 73.4648 * math.sin(math.radians(45.0))
+    assert constraint.offset_along_normal_px == pytest.approx(expected_along, abs=1e-3)
+    assert sidecar.expected.status_reason == 'rank_1_only'
+
+
+def test_build_sidecar_yaml_without_constraint_has_no_block() -> None:
+    """An unconstrained save emits neither constraint nor status_reason."""
+    draft = LibraryEntryDraft(
+        image_id='X',
+        mission='COISS',
+        camera='NAC',
+        filter_combo='CL+CL',
+        exposure_time_sec=None,
+        image_datetime_utc=None,
+    )
+    yaml_text = build_sidecar_yaml(
+        draft=draft,
+        image_url='pds3://x/X.IMG',
+        offset_dv_px=0.0,
+        offset_du_px=0.0,
+        ui_version='0.0.0',
+        today=date(2026, 7, 10),
+    )
+    assert 'constraint:' not in yaml_text
+    assert 'status_reason' not in yaml_text


### PR DESCRIPTION
Fixes #203 and implements the pipeline + curation halves of #204. Based on `ws5-sim-confidence-calibration` (uses the calibrated gates); retarget to `main` after #208 merges.

## #203 — flat edges now surface as `rank_1_only` instead of `all_techniques_spurious`

Three defects stacked up to kill every `ring_only_flat` frame:

1. **Per-edge raw-RMS spurious gate** fired on any flat multi-edge scene: an edge too faint to detect sits a ringlet spacing (9–30 px) from the nearest image edge, inflating raw per-edge RMS past any sigma-derived threshold even when the joint fit is correct. No residual statistic separates that from the wrong-ringlet mis-convergence the gate exists for (Tethys N1572471790) — but the *explained fraction* does: the gate is now a minimum Tukey inlier fraction (`spurious_min_inlier_fraction: 0.5`; wrong-ring lock anchors ~1/3, correct fit with an undetected edge anchors >0.8). `per_edge_dt_median_max` joins the diagnostics.
2. **Falsely full-rank covariance**: the polyline end vertices anchor the along-edge axis against wherever the detected edge enters/leaves the frame, so the LM covariance came back numerically tight on the unobservable axis and even un-gated results fused as confident 2-D fixes. The technique now projects the covariance to exactly rank-1 (`sigma_n^2 n n^T`, `n` from the polarity-sign-independent normals outer product) — the representation the ensemble's `pinvh`/rank-test/`sigma_along_unobservable_px` machinery is built around.
3. **Per-axis at_edge / LM-displacement gates**: nothing constrains the tangent, so the LM slides along it to the search-window boundary and the gates hard-zeroed valid fixes. Both now project onto the edge normal for all-straight scenes.

**Validation**: 13 of 15 `ring_only_flat` batch-001 candidates navigate to `success`/`rank_1_only` at tier high (was 0/20 in triage); the two failures are honest (18% model support; pointing pinned at the window limit along the normal). New sim scene `planted_rank1_ring_flat` anchors the path end to end as an algorithmic invariant.

## #204 — rank-1 ground truth (schema + manual nav)

- Sidecar schema: additive optional `ground_truth.constraint` block (`type: rank_1`, `normal_angle_deg`, `offset_along_normal_px`, `uncertainty_px`); the 2-D offset pair becomes a representative point validated to lie on the constraint line; the library regression compares the projection along the normal instead of per axis. Optional `expected.status_reason` pins `rank_1_only`.
- Manual nav: 'Constrain drag to normal' toggle + angle control (auto-seeded from the aggregate ring-edge normal on all-straight scenes); constrained saves emit the constraint block with `offset_along_normal_px` consistent by construction.

## Drive-by: test-fake NavTechnique registry leak (worker-colocation heisenbug)

Test-defined `NavTechnique` subclasses self-register at import and stayed in the production registry for the process lifetime — `_FakeBodyPrimary`/`_FakeStarTechnique` ran inside every later full-ensemble navigation in the same pytest worker and fused hardcoded offsets into real results, deterministically failing 9 sim invariant tests whenever `test_orchestrator.py` shared a worker. Pre-existing on the base branch (worktree-verified); fixed with `_abstract = True` + a scoped autouse registration fixture + a registry tripwire test. This was a second, independent source of "xdist flakiness" alongside the hardware issue in #212.

## Checks

Full default suite 1813 passed (xdist, twice); sim + library integration suites green; `mypy` strict, `ruff`, `sphinx -W` clean. One real-image baseline refresh (N1597846115, stale from the calibration batch) was committed to the base branch.

## For the operator

- The `at_edge`/displacement projection means a rank-1 frame whose *normal* component is pinned at the window limit still fails honestly (N1863267115) — widening the search window for the 1467xxxxxx group would need a config override, not code.
- `library_crosscheck.py` (util/calibration) still compares per-axis; it skips constraint sidecars gracefully today (none exist yet) but should learn the projection when the first `ring_only_flat` sidecars land.
- The confidence-formula numbers in `dev_guide_techniques_ring_edge.rst` predate the WS-5 calibration (stale alphas); untouched here — that resync belongs with #208's doc debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KW6fkURsA2zgrWFKjbR5JY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rank-1 navigation results, including observable-axis covariance and unobservable-axis reporting.
  * Manual offset dragging can now be constrained to a detected normal direction.
  * Saved library entries can include rank-1 ground-truth constraints and status details.
  * Added diagnostic reporting for maximum per-edge distance-transform residuals.

* **Bug Fixes**
  * Improved detection of incorrect ring matches using inlier fractions.
  * Reduced false spurious results for valid flat-edge and tangent-slide scenarios.

* **Documentation**
  * Expanded guidance on rank-deficient covariance behavior and added the new inlier-fraction tuning option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Operator checklist

- **Pre-merge: nothing.** Merge after #208 merges, the rebase of this branch lands, and CI is green.
- **Post-merge: close #204 manually** with a one-line comment (this PR delivers its scope — the sidecar `ground_truth.constraint` block and the manual-nav constrained-drag save — but only #203 auto-closes via the description).
- No frames to run or output to review; the "For the operator" notes above are informational only.
