### PR TITLE
fix: PDS3 image range scan and label filespecs (#136, #12)

### DIFF
--- a/docs/dev_guide/dev_guide_extending.rst
+++ b/docs/dev_guide/dev_guide_extending.rst
@@ -30,11 +30,55 @@ Example:
 
 The dataset will automatically be available to the CLI once registered.
 
-PDS3 datasets additionally implement the static index-parsing hooks
-(:meth:`~spindoctor.dataset.dataset_pds3.DataSetPDS3._get_label_filespec_from_index`,
-``_get_image_filespec_from_label_filespec``, ``_get_img_name_from_label_filespec``,
-``_extract_img_number``, ``_volset_and_volume``, ``_volume_to_index``,
-``_results_path_stub``) and should review two behaviors:
+PDS3 datasets additionally implement the static index-parsing hooks (private
+methods, so they are shown here rather than in the API reference). A minimal
+skeleton, using the Cassini ISS implementation
+(``src/spindoctor/dataset/dataset_pds3_cassini_iss.py``) as the reference:
+
+.. code-block:: python
+
+   class DataSetPDS3NewInstrument(DataSetPDS3):
+       _ALL_VOLUME_NAMES = tuple(f'NEWI_{n:04d}' for n in range(1, 12))
+       _INDEX_COLUMNS = ('FILE_SPECIFICATION_NAME',)
+       _VOLUMES_DIR_NAME = 'volumes'
+
+       @staticmethod
+       def _get_label_filespec_from_index(row):
+           # Index row -> label filespec (the primary filespec).
+           return row['FILE_SPECIFICATION_NAME'].replace('.IMG', '.LBL')
+
+       @staticmethod
+       def _get_image_filespec_from_label_filespec(label_filespec):
+           # Index-time guess; see the label-pointer note below.
+           return label_filespec.replace('.LBL', '.IMG')
+
+       @staticmethod
+       def _get_img_name_from_label_filespec(filespec):
+           # 'data/<range>/NEW1234567890.LBL' -> 'NEW1234567890';
+           # None = valid but not processed; ValueError = malformed.
+           return filespec.rsplit('/', 1)[-1].split('.', 1)[0]
+
+       @staticmethod
+       def _img_name_valid(img_name):
+           return img_name.upper().startswith('NEW')
+
+       @staticmethod
+       def _extract_img_number(img_name):
+           return int(img_name[3:13])
+
+       @staticmethod
+       def _volset_and_volume(volume):
+           return f'NEWI_xxxx/{volume}'
+
+       @staticmethod
+       def _volume_to_index(volume):
+           return f'NEWI_xxxx/{volume}/{volume}_index.lbl'
+
+       @staticmethod
+       def _results_path_stub(volume, filespec):
+           return str(Path(f'{volume}/{filespec}').with_suffix(''))
+
+Two behaviors deserve attention:
 
 * ``_get_image_filespec_from_label_filespec`` is an index-time *guess* (typically an
   extension swap). The definitive image filename is resolved lazily from the label's
@@ -46,8 +90,9 @@ PDS3 datasets additionally implement the static index-parsing hooks
   index scanner whether every image number in a volume exceeds every image number in
   all earlier volumes, which permits stopping a ``--last-image-num`` scan after the
   first volume that is entirely past the range. Set it to ``False`` when the
-  instrument's image counter resets between volumes (Voyager FDS counts restart per
-  spacecraft/encounter), at the cost of scanning every requested volume.
+  instrument's image counter resets between volumes (Voyager Flight Data Subsystem
+  (FDS) counts restart per spacecraft/encounter), at the cost of scanning every
+  requested volume.
 
 Implementing PDS4 bundle generation methods
 -------------------------------------------

--- a/docs/dev_guide/dev_guide_extending.rst
+++ b/docs/dev_guide/dev_guide_extending.rst
@@ -37,6 +37,11 @@ skeleton, using the Cassini ISS implementation
 
 .. code-block:: python
 
+   from pathlib import Path
+
+   from spindoctor.dataset.dataset_pds3 import DataSetPDS3
+
+
    class DataSetPDS3NewInstrument(DataSetPDS3):
        _ALL_VOLUME_NAMES = tuple(f'NEWI_{n:04d}' for n in range(1, 12))
        _INDEX_COLUMNS = ('FILE_SPECIFICATION_NAME',)

--- a/docs/dev_guide/dev_guide_extending.rst
+++ b/docs/dev_guide/dev_guide_extending.rst
@@ -30,6 +30,25 @@ Example:
 
 The dataset will automatically be available to the CLI once registered.
 
+PDS3 datasets additionally implement the static index-parsing hooks
+(:meth:`~spindoctor.dataset.dataset_pds3.DataSetPDS3._get_label_filespec_from_index`,
+``_get_image_filespec_from_label_filespec``, ``_get_img_name_from_label_filespec``,
+``_extract_img_number``, ``_volset_and_volume``, ``_volume_to_index``,
+``_results_path_stub``) and should review two behaviors:
+
+* ``_get_image_filespec_from_label_filespec`` is an index-time *guess* (typically an
+  extension swap). The definitive image filename is resolved lazily from the label's
+  ``^IMAGE`` pointer when the image is first retrieved, via the
+  :attr:`~spindoctor.dataset.dataset.ImageFile.image_url_resolver` installed on every
+  yielded :class:`~spindoctor.dataset.dataset.ImageFile`; the guess only needs to be
+  right often enough to serve as a display name and manifest entry.
+* ``_IMG_NUM_MONOTONIC_ACROSS_VOLUMES`` (class attribute, default ``True``) tells the
+  index scanner whether every image number in a volume exceeds every image number in
+  all earlier volumes, which permits stopping a ``--last-image-num`` scan after the
+  first volume that is entirely past the range. Set it to ``False`` when the
+  instrument's image counter resets between volumes (Voyager FDS counts restart per
+  spacecraft/encounter), at the cost of scanning every requested volume.
+
 Implementing PDS4 bundle generation methods
 -------------------------------------------
 

--- a/docs/user_guide/user_guide_navigation.rst
+++ b/docs/user_guide/user_guide_navigation.rst
@@ -151,7 +151,10 @@ For PDS3 datasets (``coiss``, ``coiss_pds3``, ``coiss_cruise``, ``coiss_cruise_p
 
 * ``img_name`` (positional, repeatable): specific image name(s) to process.
 * ``--first-image-num N``: minimum image number (inclusive).
-* ``--last-image-num N``: maximum image number (inclusive).
+* ``--last-image-num N``: maximum image number (inclusive). Voyager FDS counts
+  restart per spacecraft/encounter, so for Voyager a number range can match
+  frames from more than one encounter; combine it with the volume options to
+  bound the selection.
 * ``--volumes NAME[,NAME...]`` (repeatable): one or more complete PDS3 volume names; you may pass comma-separated values or specify the option multiple times.
 * ``--first-volume NAME``: starting PDS3 volume; only that volume and chronologically later ones are processed.
 * ``--last-volume NAME``: ending PDS3 volume; only that volume and chronologically earlier ones are processed.

--- a/docs/user_guide/user_guide_navigation.rst
+++ b/docs/user_guide/user_guide_navigation.rst
@@ -151,10 +151,10 @@ For PDS3 datasets (``coiss``, ``coiss_pds3``, ``coiss_cruise``, ``coiss_cruise_p
 
 * ``img_name`` (positional, repeatable): specific image name(s) to process.
 * ``--first-image-num N``: minimum image number (inclusive).
-* ``--last-image-num N``: maximum image number (inclusive). Voyager FDS counts
-  restart per spacecraft/encounter, so for Voyager a number range can match
-  frames from more than one encounter; combine it with the volume options to
-  bound the selection.
+* ``--last-image-num N``: maximum image number (inclusive). Voyager Flight
+  Data Subsystem (FDS) counts restart per spacecraft/encounter, so for Voyager
+  a number range can match frames from more than one encounter; combine it
+  with the volume options to bound the selection.
 * ``--volumes NAME[,NAME...]`` (repeatable): one or more complete PDS3 volume names; you may pass comma-separated values or specify the option multiple times.
 * ``--first-volume NAME``: starting PDS3 volume; only that volume and chronologically later ones are processed.
 * ``--last-volume NAME``: ending PDS3 volume; only that volume and chronologically earlier ones are processed.

--- a/plans/FULL_PROGRAM_AFTER_MANUAL_WORK_2026-07-11.md
+++ b/plans/FULL_PROGRAM_AFTER_MANUAL_WORK_2026-07-11.md
@@ -1,0 +1,209 @@
+# Complete program after the manual work — 2026-07-11
+
+This is the full task inventory that remains after your five manual steps (merge
+#208/#213/#214, vote `batch_retriage2`, sidecar reconciliation, ring_only_flat
+curation, the two small leftovers). It supersedes the abbreviated "Part 5" of the
+previous handoff, which listed only immediate follow-ons.
+
+Sources: `plans/VALIDATION_AND_CALIBRATION_PLAN.md` (workstreams WS-0..WS-18 and
+Milestones A–D), `plans/ROADMAP.md` (Phases 0–3 + hardening track),
+`critiques/PROJECT_STATE_REVIEW_2026-07-08.md` (open dispositions), the 121 open
+GitHub issues, and this week's session findings. Effort classes: **S** ≤ 1 day,
+**M** = days, **L** = 1–2 weeks, **XL** = multi-week — assuming I do the work and
+you review.
+
+Bottom line up front: the remaining program is **six tracks**. Track A is the
+science half (the calibration core you asked about). Tracks B–F are engineering,
+capability, and debt work — much of it schedulable in parallel, none of it a
+substitute for Track A.
+
+---
+
+## Track A — The validation & calibration program (the science half)
+
+This is Milestones B and C of the validation plan. Status of every workstream:
+
+| WS | What it is | Status | Effort left |
+|---|---|---|---|
+| WS-0a | Identifiability map + agreement-estimator math, proven on a truth-known sim | **Not started** | M |
+| WS-0b | Bias-independence verdict for the estimator (needs the WS-2 sim) | **Not started** | M |
+| WS-1 | Multi-object cross-technique agreement on real frames — the primary real-image accuracy instrument | **Not started** | XL |
+| WS-1b | Reprojection consistency across overlapping frames (secondary corroboration; shares code with WS-18) | **Not started** | L |
+| WS-2 | De-circularize the simulator AND prove it realistic against real images | **Not started** | XL |
+| WS-3 | Real-image cohort: ≥120 sidecars, ≥20 per instrument | **In progress** (62; Cassini+Voyager only) | L (ongoing) |
+| WS-4 | Real-image tests in CI | **Open** — CI still runs `-m "not integration"`; the library tier never runs automatically | M |
+| WS-5 | Confidence calibration | **Sim-anchored interim done** (this week); full version re-anchors on WS-1's real error measurements | M (re-run once anchors exist) |
+| WS-9 | Justify/derive/measure the remaining magic constants | **Partial** (many measured by the sim campaigns; remainder inventoried in #176) | M |
+| WS-10 | Fix the limb ~0.09 px DT systematic (`#150`, related `#128`) | **Open** — still measurable in this week's refreshed report | M–L |
+| WS-13 | Make the calibrated (I/F) sim path realistic and tested (noise model; currently noise-free) | **Open** | M |
+| WS-17 | Geometric distortion model validation (Voyager/Galileo prerequisite for WS-1 off-Cassini) | **Not started** | M–L |
+
+Already done and out of the list: WS-11 (degenerate-rotation reporting), WS-14
+(provenance), WS-6's honesty half (docs no longer overclaim; the formal capability
+matrix rides with Track D decisions).
+
+**Execution order** (from the plan's dependency section, unchanged by this week):
+
+1. **WS-3 continues** — your batch votes → my Stage-D sidecars → repeat with new
+   cohort scans. Target: fill `faint_stars` and `ring_only_flat`, get every class
+   to ≥2, add first Galileo SSI and New Horizons LORRI frames. WS-3 gates
+   everything else.
+2. **WS-2 and WS-0a start in parallel** immediately after your merges — neither
+   waits on anything but WS-3's existing images.
+   - WS-2 is the big one: separate the sim's rendering from the nav models'
+     rendering (today they share functions in `src/spindoctor/sim/render.py` —
+     the circularity), then prove realism statistically against real frames
+     (noise spectra, PSF wings, limb profiles, ring-edge shapes, photometric
+     levels). Issue #153 holds the deferred calibration-validation scene work
+     that belongs here; #194/#195 (crater seed/illumination) rise in priority if
+     they surface during realism comparison. **This has real architectural
+     choices — the one Track-A item where I'll bring you a design to approve.**
+   - WS-0a is analysis code: given N techniques' offsets+covariances on one
+     frame, when is per-technique σ recoverable, and is the estimator unbiased.
+3. **WS-17** — validate the Voyager/Galileo distortion models on star frames
+   (Cassini's distortion is benign; this gates only the off-Cassini half of WS-1).
+4. **WS-1** — the flagship: run the pipeline over a large multi-feature cohort
+   (hundreds–thousands of frames, no hand-verified truth needed for the pairwise
+   layer), measure cross-technique agreement at scale, extract per-technique σ in
+   the WS-0-qualified bins, plus absolute attitude on the scarce star tie-points.
+   Includes the star-technique real anchoring (the ~19 star-class queue failures
+   are symptoms this study diagnoses). WS-1b rides alongside.
+5. **WS-4** — wire the library + accuracy-regression tests into a scheduled CI
+   tier (not per-PR; the plan is explicit about that).
+6. **WS-5 full** — re-run this week's fit tooling against the WS-1/WS-2 anchors;
+   re-derive tier boundaries; drop the sim-anchored caveats from the docs.
+7. **WS-9, WS-10, WS-13** — close out with real anchors in hand.
+
+**Your role in Track A** (much smaller than mine, but load-bearing): approve the
+WS-2 de-circularization design; bless the realism verdict; approve WS-1 frame
+selection; spot-verify outlier frames; re-bless tiers after WS-5-full. Plus the
+ongoing batch voting that feeds WS-3.
+
+---
+
+## Track B — Navigation-correctness engineering (ROADMAP 1A + session findings)
+
+These fix known wrongness or fragility in the navigator itself. Several directly
+improve WS-1's data quality, so they should land before or during it.
+
+| Item | Why | Effort |
+|---|---|---|
+| #123 — Mahalanobis grouping breaks on CRLB-tight covariances | Possibly largely fixed by this week's #210 sigma floors — needs verification and closure either way. Ensemble agreement quality feeds WS-1 directly. | S–M |
+| #124 — No cross-technique outlier rejection (one disagreement forces `conflicted`) | Ensemble robustness; visible in the queue's `conflicted` frames. | M |
+| #86 — Fix ring models (Saturn) | Essential per roadmap; ring-heavy frames are a large cohort fraction. | M–L |
+| #125 — BodyTerminatorNav mis-convergence has no per-technique signal | Same class of defect as #209/#211: a technique that can't self-flag. | M |
+| #179 / #191 — DT coarse-prior search robustness + minimum-support guard | Known false-lock vectors for limb/ring techniques. | M |
+| #128 — Robust limb navigation redesign (all body types/illuminations) | The strategic fix behind #150/#125/#187. | XL (design first) |
+| #150 — Limb floor is model-vs-image edge offset (the WS-10 systematic) | Accuracy floor for the limb technique. | M |
+| #145 — Star-ring occlusion mis-classifies stars near ringlet edges | Star-technique data quality for WS-1. | S–M |
+| #130 — Calibrate per-instrument star limiting magnitudes on real fields | Part of the star-gate real anchoring. | M |
+| #146, #136, #12 — config-override selection bug, WAC ingest drop, label filespecs | Ingest/config correctness. | S each |
+| #25 — Blurring for high-resolution bodies | Roadmap "important" for close flybys. | M |
+| #202 — sd_offset exhausts >61 GB on N1646315051 (Helene) | Must be fixed before any large WS-1 campaign (it would kill batch runs). | M |
+| Session: multi_body N17023890xx triage (3 frames, all techniques spurious) | Likely occlusion/model-conflict bug; one debugging session. | S–M |
+| Session: Voyager scattered_light C00598xx quintet fails wholesale | Voyager photometric path or prescan criteria. | M |
+| Session: sub-5 px body policy — expected-failure sidecars vs a relaxed-disc pathway | Your rescue proved the disc can lock 4–5 px bodies with loosened gates; decide and implement or curate as expected failures. **Needs your decision.** | S–M |
+| #212 — closes after your CPU RMA (remove systemd unit + setup.sh taskset) | Hardware tracker. | S |
+
+---
+
+## Track C — Statistics, QA, and the accuracy checkpoint (ROADMAP 1C)
+
+| Item | Why | Effort |
+|---|---|---|
+| #35 — Navigation statistics system (metadata → SQLite → report) | The roadmap's accuracy checkpoint: success/failure rates, technique usage, offset stats, per-frame disagreement, and "does confidence predict accuracy" — the standing QA check on calibration. Runs over any day/instrument. | L |
+| `library_crosscheck.py` re-run after your sidecar reconciliation | Confirms tier agreement post-reconciliation; repeat after every calibration change. | S (recurring) |
+| Coverage-matrix test (every class ≥2 sidecars, every technique exercised) wired into the deliberate tier | Turns Phase-10's deferred invariant on once Track-A/WS-3 fills the classes. | S |
+
+---
+
+## Track D — Capability gaps (Milestone D; decision gates first)
+
+Each starts with a **scope-or-implement decision that is yours**:
+
+| Item | The decision | If implemented | Effort |
+|---|---|---|---|
+| WS-7 / #60 — Titan navigation | Titan is a registered no-op placeholder. Implement atmospheric-limb navigation, or scope it out in the capability matrix? | New technique + model against haze-limb physics | XL |
+| WS-8 / #53 family — PDS4 beyond Cassini | Generalize bundle generation or ship Cassini-only? Children: #71–#79, #66, #67, #69, #47, #54, #55, #57, #63, #70, #73, #74, #75, #76 | Label templates, LID builders, collection machinery per mission | XL |
+| WS-12 / #93 — the four instrument user-guide appendices | Write them (needs per-instrument measured behavior from Track A/Phase 2) | — | M |
+| WS-15 — performance & safe parallelism (#126 rotation pyramid ~10 min, #134 oops precision global mutation, #103 thread-unsafe caches) | Needed before cloud-scale campaigns; #134 also bites WS-1 batch runs | — | M–L |
+| WS-18 — end-product geometric accuracy (backplanes, mosaics, PDS4 values) | The last validation layer; needs WS-1b + WS-2 + WS-8 | — | L |
+| #188 / #50 — CK kernels with updated pointing as a delivered product | Roadmap 1H; a major deliverable decision | — | L |
+
+---
+
+## Track E — Test-coverage and documentation debt (from the active critique)
+
+The critique's still-open addendum item 6 plus section-4 leftovers:
+
+| Item | Why | Effort |
+|---|---|---|
+| Unit tests for `src/spindoctor/cli/backplanes/` — currently **zero** | A whole delivered stage with no tests. | M |
+| Unit tests for `src/spindoctor/cli/pds4/` — currently **zero** | Same. | M |
+| Tests for the real star-conflict logic (`nav_model/stars/conflicts.py`) | Untested and mocked-out where it would run; #145 lives here too. | S–M |
+| #174 — real-image regression baselines beyond the single frame | 1 baseline vs 62 sidecars; the library test asserts behavior but only one frame pins exact numbers. | M |
+| #177 — unit tests for `summary_png` | Filed, open. | S |
+| api_reference: the 8 missing `mosaic_viewer` modules | Critique section 4 item 7. | S |
+| #129 — zero Sphinx nitpicky warnings, gated in CI | Doc hygiene target. | M |
+| #178 — missing dev-guide pages: filters, uncertainty, troubleshooting | The uncertainty page becomes important once WS-5-full makes sigmas load-bearing. | M |
+| #122 — verify terminator albedo/sharpness doc rationale | Small doc-accuracy item. | S |
+
+---
+
+## Track F — Phase 2 instruments, Phase 3 features, and the hardening tail
+
+**Phase 2 (after the Cassini spine is proven through Track A):**
+- 2A Voyager: #19 (VGISS star navigation broken — overlaps the WS-17/WS-1 star work)
+- 2B Galileo: #18 (GOSSI star nav), #17 (REDO handling)
+- 2C LORRI: #2 (PSF calibration), #138 (`_eng` product policy)
+- 2D Ring models: #82 Jupiter, #81 Uranus, #83 Neptune
+- 2E Cross-instrument calibration: extend #173/#130/#93 per instrument as library
+  frames land (this is WS-5-full run per-instrument)
+- 2F Shared: #126 (rotation pyramid cost — bites Galileo/Voyager), #181
+  (degradation classifier taxonomy)
+
+**Phase 3 (after multi-instrument):** #27 BOTSIM, #22 star streaks, #107
+backplane-reader repo, #34 Cassini PDS4 archive source, #84 sim ring edges/gaps,
+#194–#198 sim polish (higher priority if WS-2 surfaces them), #184 CartographicNav
++ bootstrap (the crater-mapping design — explicitly far off), #183 polarity-aware
+ring matching, #187 chaotic-rotator pose handling, #186 manual-nav dialog
+redesign, #185 gated-feature PNG styling, #182 stop-after-features flag, #158/#157
+sim rendering polish, #155 display-scaling consolidation.
+
+**Hardening/cleanup (parallel, any time, mostly S each):** #65 exception class,
+#104 broad-except control flow, #192 ensemble bare assert, #193 rotation-combine
+weighting doc, #103 thread-unsafe caches, #98 registry consolidation, #97
+oversized modules, #96 dead code, #135 from_file dedup, #143 viewer cursor bug,
+#144 QApplication lifetime, #109/#110/#100 shared helpers, #101/#102 CLI cleanup,
+#99 orphan module, #92 dependency groups, #105 Any→TypedDict boundaries, #140
+geometry union access, #139 malformed global-index LID, #137 dead validation
+helper, #141/#142 cloud-task dedup/cardinality, #118 config validation system,
+#147 confidence-context dedup, #119 PNG creation location, #108 CLI
+logging/cloud audit, #39 AttrDict, #77 backplane args, #55/#57 backplane content
+decisions.
+
+---
+
+## Suggested global order (what I'd actually do)
+
+1. **Immediately after your merges:** rebases; batch-vote sidecars (WS-3);
+   #202 memory fix + #123 verification (they block campaign-scale runs);
+   WS-2 design proposal to you; WS-0a estimator in parallel.
+2. **While WS-2 builds:** Track B correctness items (#86, #124, #125, #179/#191,
+   #145), #35 statistics system (it pays for itself immediately), Track E test
+   debt (backplanes/pds4/star-conflict tests), WS-4 CI tier.
+3. **Then:** WS-17 → WS-1 (+1b) → WS-5-full → WS-9/10/13. This is the calibration
+   finish line: confidence and sigma defensible against reality.
+4. **Then:** Track D decisions (Titan, PDS4 scope, CK kernels) and Phase 2
+   instruments, with 2E re-running the now-proven calibration per instrument.
+5. **Continuous:** hardening tail as filler; library growth every time you have
+   review bandwidth.
+
+**Effort honesty:** Track A alone is multi-week at agent pace (WS-2 and WS-1 are
+the two XL items and they serialize through WS-0/WS-17 in between). Tracks B+C+E
+are roughly 2–3 weeks of interleavable M/S items. Track D depends entirely on
+your scope decisions. Phase 2 is another multi-week block per the same pattern as
+Cassini but smaller. Nothing on this list besides your five manual steps and the
+five decision gates marked "**yours**" requires your hands on a keyboard — the
+rest needs your eyes (PR review, PNG verification, design sign-off) at the points
+noted.

--- a/plans/FULL_PROGRAM_AFTER_MANUAL_WORK_2026-07-11.md
+++ b/plans/FULL_PROGRAM_AFTER_MANUAL_WORK_2026-07-11.md
@@ -96,8 +96,13 @@ matrix rides with Track D decisions).
      (noise spectra, PSF wings, limb profiles, ring-edge shapes, photometric
      levels). Issue #153 holds the deferred calibration-validation scene work
      that belongs here; #194/#195 (crater seed/illumination) rise in priority if
-     they surface during realism comparison. **This has real architectural
-     choices — the one Track-A item where I'll bring you a design to approve.**
+     they surface during realism comparison. An explicit WS-2 deliverable is
+     sim `TERMINATOR_ARC` emission plus a terminator calibration pass (#223):
+     `BodyTerminatorNav` is the one technique with no sim anchoring, and the
+     terminator's photometric nature means emitting it before the shading/
+     texture realism verdict would calibrate against the least-validated part
+     of the renderer. **This has real architectural choices — the one Track-A
+     item where I'll bring you a design to approve.**
    - WS-0a is analysis code: given N techniques' offsets+covariances on one
      frame, when is per-technique σ recoverable, and is the estimator unbiased.
 3. **WS-17** — validate the Voyager/Galileo distortion models on star frames

--- a/plans/FULL_PROGRAM_AFTER_MANUAL_WORK_2026-07-11.md
+++ b/plans/FULL_PROGRAM_AFTER_MANUAL_WORK_2026-07-11.md
@@ -41,9 +41,11 @@ each merge): **#208 → #213 → #214 → #215 → #216 → #217 → #218 → #2
 Track B remainder (deferred with reasons): #128 (design first), #150 (WS-10
 science; validate against real images before touching), #130 (needs a real
 star-field campaign), #179 (needs a calibration pass), #25
-(investigation), #210 (NCC covariance scale — the big open covariance item), the sub-5 px policy
-and #212 (**yours**), and the two session triage items (multi_body,
-Voyager scattered_light) — not started.
+(investigation), #210 (rescoped to the NCC covariance-model review; the coverage symptom is
+fixed by the floors), the sub-5 px policy (**yours**), #212 (rescoped to the
+software xdist nondeterminism — the faulty cores are permanently disabled, no
+RMA), and the two session triage items (multi_body, Voyager scattered_light)
+— not started.
 
 Sources: `plans/VALIDATION_AND_CALIBRATION_PLAN.md` (workstreams WS-0..WS-18 and
 Milestones A–D), `plans/ROADMAP.md` (Phases 0–3 + hardening track),
@@ -152,7 +154,7 @@ improve WS-1's data quality, so they should land before or during it.
 | Session: multi_body N17023890xx triage (3 frames, all techniques spurious) | Likely occlusion/model-conflict bug; one debugging session. | Open |
 | Session: Voyager scattered_light C00598xx quintet fails wholesale | Voyager photometric path or prescan criteria. | Open |
 | Session: sub-5 px body policy — expected-failure sidecars vs a relaxed-disc pathway | Decide and implement or curate as expected failures. **Needs your decision.** | Open — yours |
-| #212 — closes after your CPU RMA (remove systemd unit + setup.sh taskset) | Hardware tracker. | Open — yours |
+| #212 — xdist worker-history nondeterminism | The faulty CPU cores are permanently disabled (no RMA; the systemd offline unit and `setup.sh` taskset line are permanent). Rescoped to the software flake only; nothing gates on hardware. | Open |
 
 ---
 

--- a/plans/FULL_PROGRAM_AFTER_MANUAL_WORK_2026-07-11.md
+++ b/plans/FULL_PROGRAM_AFTER_MANUAL_WORK_2026-07-11.md
@@ -1,9 +1,49 @@
 # Complete program after the manual work — 2026-07-11
 
-This is the full task inventory that remains after your five manual steps (merge
-#208/#213/#214, vote `batch_retriage2`, sidecar reconciliation, ring_only_flat
+This is the full task inventory that remains after your manual steps (merge the
+PR stack, vote `batch_retriage2`, sidecar reconciliation, ring_only_flat
 curation, the two small leftovers). It supersedes the abbreviated "Part 5" of the
 previous handoff, which listed only immediate follow-ons.
+
+## Status update — 2026-07-11 (Track B/C execution pass)
+
+The executable parts of Track B and all of Track C item 1 are **done**, delivered
+as stacked PRs. Merge order (squash each; I rebase the rest of the stack after
+each merge): **#208 → #213 → #214 → #215 → #216 → #217 → #218 → #219 → #220**.
+
+- **#215** — #136 (`--last-image-num` WAC drop) + #12 (image filespec from the
+  label `^IMAGE` pointer). Voyager number ranges now correctly match across
+  encounters (FDS counts are not monotonic across volumes).
+- **#216** — #146 (per-run config governs model *selection*) + #145 (per-pixel
+  star-ring occlusion, `ring_occlusion_min_opaque_fraction`).
+- **#217** — #124 (ensemble consensus-subset outlier rejection; new
+  `excluded_from_consensus` metadata field). #123 closed as already fixed
+  (pixel floor + tests verified; Option A remains #210).
+- **#218** — #125 (terminator basin second-opinion spurious gate;
+  `find_secondary_dt_minimum` reusable for #179's blast radius).
+- **#219** — #202 (Helene OOM: BodyBlobNav matched-filter kernel unbounded in
+  predicted body diameter; clamped to the frame half-diagonal; A/B-verified
+  root cause — the triage `--skip-names` workaround can retire).
+- **#220** — #35 (statistics system: `sd_stats_ingest` / `sd_stats_report`;
+  smoke-tested on the 270 real triage metadata files).
+- **Closed without PRs:** #86 (already fixed by the four-pass ring filter's
+  Pass-4 fade-conflict logic; W1728613298 verified) and #123.
+- **Validation:** full unit suite, sim integration suites (zero baseline
+  changes), sphinx, and the 62-sidecar `library_crosscheck` — every per-image
+  delta vs the v7 baseline is byte-identical on the #214 parent (zero
+  Track-B-caused deltas; the #209 poster frame N1465178827 now passes).
+- **New issues from the crosscheck diff** (pre-existing, parent-era): **#221**
+  (rank-1 flat-ring RingEdge outvotes an absolute blob constraint — high tier
+  with 7–10 px along-edge error) and **#222** (pass-2 StarRefine corroborates
+  its own pass-1 prior — expected-failed frame reports success/high). Both sit
+  squarely in WS-1's blast radius and belong near the top of Track B.
+
+Track B remainder (deferred with reasons): #128 (design first), #150 (WS-10
+science; validate against real images before touching), #130 (needs a real
+star-field campaign), #179 (needs a calibration pass), #25 (investigation),
+#210 (NCC covariance scale — the big open covariance item), the sub-5 px policy
+and #212 (**yours**), and the two session triage items (multi_body,
+Voyager scattered_light) — not started.
 
 Sources: `plans/VALIDATION_AND_CALIBRATION_PLAN.md` (workstreams WS-0..WS-18 and
 Milestones A–D), `plans/ROADMAP.md` (Phases 0–3 + hardening track),
@@ -86,34 +126,36 @@ ongoing batch voting that feeds WS-3.
 These fix known wrongness or fragility in the navigator itself. Several directly
 improve WS-1's data quality, so they should land before or during it.
 
-| Item | Why | Effort |
+| Item | Why | Status |
 |---|---|---|
-| #123 — Mahalanobis grouping breaks on CRLB-tight covariances | Possibly largely fixed by this week's #210 sigma floors — needs verification and closure either way. Ensemble agreement quality feeds WS-1 directly. | S–M |
-| #124 — No cross-technique outlier rejection (one disagreement forces `conflicted`) | Ensemble robustness; visible in the queue's `conflicted` frames. | M |
-| #86 — Fix ring models (Saturn) | Essential per roadmap; ring-heavy frames are a large cohort fraction. | M–L |
-| #125 — BodyTerminatorNav mis-convergence has no per-technique signal | Same class of defect as #209/#211: a technique that can't self-flag. | M |
-| #179 / #191 — DT coarse-prior search robustness + minimum-support guard | Known false-lock vectors for limb/ring techniques. | M |
-| #128 — Robust limb navigation redesign (all body types/illuminations) | The strategic fix behind #150/#125/#187. | XL (design first) |
-| #150 — Limb floor is model-vs-image edge offset (the WS-10 systematic) | Accuracy floor for the limb technique. | M |
-| #145 — Star-ring occlusion mis-classifies stars near ringlet edges | Star-technique data quality for WS-1. | S–M |
-| #130 — Calibrate per-instrument star limiting magnitudes on real fields | Part of the star-gate real anchoring. | M |
-| #146, #136, #12 — config-override selection bug, WAC ingest drop, label filespecs | Ingest/config correctness. | S each |
-| #25 — Blurring for high-resolution bodies | Roadmap "important" for close flybys. | M |
-| #202 — sd_offset exhausts >61 GB on N1646315051 (Helene) | Must be fixed before any large WS-1 campaign (it would kill batch runs). | M |
-| Session: multi_body N17023890xx triage (3 frames, all techniques spurious) | Likely occlusion/model-conflict bug; one debugging session. | S–M |
-| Session: Voyager scattered_light C00598xx quintet fails wholesale | Voyager photometric path or prescan criteria. | M |
-| Session: sub-5 px body policy — expected-failure sidecars vs a relaxed-disc pathway | Your rescue proved the disc can lock 4–5 px bodies with loosened gates; decide and implement or curate as expected failures. **Needs your decision.** | S–M |
-| #212 — closes after your CPU RMA (remove systemd unit + setup.sh taskset) | Hardware tracker. | S |
+| #123 — Mahalanobis grouping breaks on CRLB-tight covariances | Ensemble agreement quality feeds WS-1 directly. | **Closed** — pixel floor + tests verified; Option A remains #210 |
+| #124 — No cross-technique outlier rejection (one disagreement forces `conflicted`) | Ensemble robustness; visible in the queue's `conflicted` frames. | **Done** — PR #217 |
+| #86 — Fix ring models (Saturn) | Ring-heavy frames are a large cohort fraction. | **Closed** — already fixed by the four-pass filter's Pass 4; verified on W1728613298 |
+| #125 — BodyTerminatorNav mis-convergence has no per-technique signal | Same class of defect as #209/#211: a technique that can't self-flag. | **Done** — PR #218 (basin second-opinion) |
+| #179 — DT coarse-prior search robustness (#191's guard already landed) | Known false-lock vector for limb/ring techniques. | Open — needs a calibration pass; #218 closes its confident-wrong endpoint for the terminator |
+| #128 — Robust limb navigation redesign (all body types/illuminations) | The strategic fix behind #150/#125/#187. | Open — XL, design first |
+| #150 — Limb floor is model-vs-image edge offset (the WS-10 systematic) | Accuracy floor for the limb technique. | Open — WS-10; validate against real images before touching |
+| #145 — Star-ring occlusion mis-classifies stars near ringlet edges | Star-technique data quality for WS-1. | **Done** — PR #216 (per-pixel membership) |
+| #130 — Calibrate per-instrument star limiting magnitudes on real fields | Part of the star-gate real anchoring. | Open — needs a real star-field campaign |
+| #146, #136, #12 — config-override selection bug, WAC ingest drop, label filespecs | Ingest/config correctness. | **Done** — PRs #215 / #216 |
+| #221 — rank-1 RingEdge outvotes an absolute blob constraint at high tier | Found by the 2026-07-11 crosscheck diff; pre-existing. Flat-ring accuracy + tier honesty. | Open — new; fix is rank-aware agreement or a tier guard |
+| #222 — pass-2 refine corroborates its own pass-1 prior | Found by the same diff; inflates consensus confidence on wrong priors. | Open — new |
+| #25 — Blurring for high-resolution bodies | Roadmap "important" for close flybys. | Open — investigation |
+| #202 — sd_offset exhausts >61 GB on N1646315051 (Helene) | Blocks any large WS-1 campaign. | **Done** — PR #219 (kernel clamp; root cause A/B-verified) |
+| Session: multi_body N17023890xx triage (3 frames, all techniques spurious) | Likely occlusion/model-conflict bug; one debugging session. | Open |
+| Session: Voyager scattered_light C00598xx quintet fails wholesale | Voyager photometric path or prescan criteria. | Open |
+| Session: sub-5 px body policy — expected-failure sidecars vs a relaxed-disc pathway | Decide and implement or curate as expected failures. **Needs your decision.** | Open — yours |
+| #212 — closes after your CPU RMA (remove systemd unit + setup.sh taskset) | Hardware tracker. | Open — yours |
 
 ---
 
 ## Track C — Statistics, QA, and the accuracy checkpoint (ROADMAP 1C)
 
-| Item | Why | Effort |
+| Item | Why | Status |
 |---|---|---|
-| #35 — Navigation statistics system (metadata → SQLite → report) | The roadmap's accuracy checkpoint: success/failure rates, technique usage, offset stats, per-frame disagreement, and "does confidence predict accuracy" — the standing QA check on calibration. Runs over any day/instrument. | L |
-| `library_crosscheck.py` re-run after your sidecar reconciliation | Confirms tier agreement post-reconciliation; repeat after every calibration change. | S (recurring) |
-| Coverage-matrix test (every class ≥2 sidecars, every technique exercised) wired into the deliberate tier | Turns Phase-10's deferred invariant on once Track-A/WS-3 fills the classes. | S |
+| #35 — Navigation statistics system (metadata → SQLite → report) | The roadmap's accuracy checkpoint: success/failure rates, technique usage, offset stats, per-frame disagreement, and "does confidence predict accuracy" — the standing QA check on calibration. Runs over any day/instrument. | **Done** — PR #220 (`sd_stats_ingest` / `sd_stats_report`) |
+| `library_crosscheck.py` re-run after your sidecar reconciliation | Confirms tier agreement post-reconciliation; repeat after every calibration change. | Recurring — last run 2026-07-11 on the stack head (result in PR #216 comment) |
+| Coverage-matrix test (every class ≥2 sidecars, every technique exercised) wired into the deliberate tier | Turns Phase-10's deferred invariant on once Track-A/WS-3 fills the classes. | Open — S |
 
 ---
 
@@ -187,11 +229,12 @@ decisions.
 ## Suggested global order (what I'd actually do)
 
 1. **Immediately after your merges:** rebases; batch-vote sidecars (WS-3);
-   #202 memory fix + #123 verification (they block campaign-scale runs);
-   WS-2 design proposal to you; WS-0a estimator in parallel.
-2. **While WS-2 builds:** Track B correctness items (#86, #124, #125, #179/#191,
-   #145), #35 statistics system (it pays for itself immediately), Track E test
-   debt (backplanes/pds4/star-conflict tests), WS-4 CI tier.
+   WS-2 design proposal to you; WS-0a estimator in parallel. (#202 and #123 —
+   previously in this slot — are done/closed.)
+2. **While WS-2 builds:** the remaining Track B items (#221, #222, #179, the
+   two session triage items), Track E test debt (backplanes/pds4 tests;
+   star-conflict tests partially covered by PR #216), WS-4 CI tier. (#86,
+   #124, #125, #145, #35 — previously in this slot — are done/closed.)
 3. **Then:** WS-17 → WS-1 (+1b) → WS-5-full → WS-9/10/13. This is the calibration
    finish line: confidence and sigma defensible against reality.
 4. **Then:** Track D decisions (Titan, PDS4 scope, CK kernels) and Phase 2
@@ -200,8 +243,9 @@ decisions.
    review bandwidth.
 
 **Effort honesty:** Track A alone is multi-week at agent pace (WS-2 and WS-1 are
-the two XL items and they serialize through WS-0/WS-17 in between). Tracks B+C+E
-are roughly 2–3 weeks of interleavable M/S items. Track D depends entirely on
+the two XL items and they serialize through WS-0/WS-17 in between). Track B+C's
+executable half landed 2026-07-11 (PRs #215–#220); the remainder plus Track E
+is roughly 1–2 weeks of interleavable M/S items. Track D depends entirely on
 your scope decisions. Phase 2 is another multi-week block per the same pattern as
 Cassini but smaller. Nothing on this list besides your five manual steps and the
 five decision gates marked "**yours**" requires your hands on a keyboard — the

--- a/plans/FULL_PROGRAM_AFTER_MANUAL_WORK_2026-07-11.md
+++ b/plans/FULL_PROGRAM_AFTER_MANUAL_WORK_2026-07-11.md
@@ -86,8 +86,10 @@ matrix rides with Track D decisions).
 
 1. **WS-3 continues** — your batch votes → my Stage-D sidecars → repeat with new
    cohort scans. Target: fill `faint_stars` and `ring_only_flat`, get every class
-   to ≥2, add first Galileo SSI and New Horizons LORRI frames. WS-3 gates
-   everything else.
+   to ≥2, add first Galileo SSI and New Horizons LORRI frames. WS-3 gates the
+   *breadth* of everything downstream — the missing classes and the off-Cassini
+   instruments cap what WS-1/WS-2 can eventually claim — but its existing 62
+   images are enough to start on, which is why step 2 begins in parallel.
 2. **WS-2 and WS-0a start in parallel** immediately after your merges — neither
    waits on anything but WS-3's existing images.
    - WS-2 is the big one: separate the sim's rendering from the nav models'

--- a/plans/FULL_PROGRAM_AFTER_MANUAL_WORK_2026-07-11.md
+++ b/plans/FULL_PROGRAM_AFTER_MANUAL_WORK_2026-07-11.md
@@ -40,8 +40,8 @@ each merge): **#208 → #213 → #214 → #215 → #216 → #217 → #218 → #2
 
 Track B remainder (deferred with reasons): #128 (design first), #150 (WS-10
 science; validate against real images before touching), #130 (needs a real
-star-field campaign), #179 (needs a calibration pass), #25 (investigation),
-#210 (NCC covariance scale — the big open covariance item), the sub-5 px policy
+star-field campaign), #179 (needs a calibration pass), #25
+(investigation), #210 (NCC covariance scale — the big open covariance item), the sub-5 px policy
 and #212 (**yours**), and the two session triage items (multi_body,
 Voyager scattered_light) — not started.
 
@@ -205,22 +205,22 @@ The critique's still-open addendum item 6 plus section-4 leftovers:
   (degradation classifier taxonomy)
 
 **Phase 3 (after multi-instrument):** #27 BOTSIM, #22 star streaks, #107
-backplane-reader repo, #34 Cassini PDS4 archive source, #84 sim ring edges/gaps,
-#194–#198 sim polish (higher priority if WS-2 surfaces them), #184 CartographicNav
+backplane-reader repo, #34 Cassini PDS4 archive source, #84 sim ring
+edges/gaps, #194–#198 sim polish (higher priority if WS-2 surfaces them), #184 CartographicNav
 + bootstrap (the crater-mapping design — explicitly far off), #183 polarity-aware
 ring matching, #187 chaotic-rotator pose handling, #186 manual-nav dialog
 redesign, #185 gated-feature PNG styling, #182 stop-after-features flag, #158/#157
 sim rendering polish, #155 display-scaling consolidation.
 
-**Hardening/cleanup (parallel, any time, mostly S each):** #65 exception class,
-#104 broad-except control flow, #192 ensemble bare assert, #193 rotation-combine
+**Hardening/cleanup (parallel, any time, mostly S each):** #65 exception
+class, #104 broad-except control flow, #192 ensemble bare assert, #193 rotation-combine
 weighting doc, #103 thread-unsafe caches, #98 registry consolidation, #97
-oversized modules, #96 dead code, #135 from_file dedup, #143 viewer cursor bug,
-#144 QApplication lifetime, #109/#110/#100 shared helpers, #101/#102 CLI cleanup,
-#99 orphan module, #92 dependency groups, #105 Any→TypedDict boundaries, #140
+oversized modules, #96 dead code, #135 from_file dedup, #143 viewer cursor
+bug, #144 QApplication lifetime, #109/#110/#100 shared helpers, #101/#102 CLI
+cleanup, #99 orphan module, #92 dependency groups, #105 Any→TypedDict boundaries, #140
 geometry union access, #139 malformed global-index LID, #137 dead validation
-helper, #141/#142 cloud-task dedup/cardinality, #118 config validation system,
-#147 confidence-context dedup, #119 PNG creation location, #108 CLI
+helper, #141/#142 cloud-task dedup/cardinality, #118 config validation
+system, #147 confidence-context dedup, #119 PNG creation location, #108 CLI
 logging/cloud audit, #39 AttrDict, #77 backplane args, #55/#57 backplane content
 decisions.
 

--- a/src/spindoctor/cli/sd_offset.py
+++ b/src/spindoctor/cli/sd_offset.py
@@ -283,7 +283,9 @@ def _run_manual_pass(
         sys.exit(1)
 
     image_file = image_files.image_files[0]
-    image_url = image_file.image_file_url
+    # resolve_image_url may correct the URL from the label contents, so it must
+    # run before the URL is read
+    image_url = image_file.resolve_image_url()
     image_path = image_file.image_file_path.absolute()
     image_name = image_path.name
     extra_params = image_file.extra_params

--- a/src/spindoctor/dataset/dataset.py
+++ b/src/spindoctor/dataset/dataset.py
@@ -1,6 +1,6 @@
 import argparse
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
@@ -22,6 +22,12 @@ class ImageFile:
         index_file_row: Optional metadata from index files.
         extra_params: Optional extra parameters that will be passed to the observation
             class's from_file method when the file is read.
+        image_url_resolver: Optional callable ``(image_file_url, label_file_path) ->
+            FCPath | None`` that determines the definitive image URL from the label
+            contents.  When set, it is invoked (at most once) before the image file
+            is first retrieved; a non-None return value replaces ``image_file_url``.
+            ``image_file_url`` is then a provisional guess until
+            :meth:`resolve_image_url` has run.
     """
 
     image_file_url: FCPath
@@ -29,6 +35,7 @@ class ImageFile:
     results_path_stub: str
     index_file_row: dict[str, Any] = field(default_factory=dict)
     extra_params: dict[str, Any] = field(default_factory=dict)
+    image_url_resolver: Callable[[FCPath, Path], FCPath | None] | None = None
     _image_file_path: Path | None = None
     _label_file_path: Path | None = None
 
@@ -50,11 +57,30 @@ class ImageFile:
         dispatch one ``ImageFile`` per worker thread.
         """
         if self._image_file_path is None:
-            self._image_file_path = cast(Path, self.image_file_url.get_local_path())
+            self._image_file_path = cast(Path, self.resolve_image_url().get_local_path())
         return self._image_file_path
 
+    def resolve_image_url(self) -> FCPath:
+        """The definitive image URL, consulting the label when a resolver is set.
+
+        When ``image_url_resolver`` is set, the label file is retrieved and the
+        resolver maps the label contents to the correct image URL, which replaces
+        ``image_file_url``.  The resolver runs at most once; subsequent calls
+        return the memoized URL.
+
+        Returns:
+            The image file URL, corrected from the label contents when a resolver
+            is set and reports a different filename.
+        """
+        if self.image_url_resolver is not None:
+            resolver, self.image_url_resolver = self.image_url_resolver, None
+            resolved = resolver(self.image_file_url, self.label_file_path)
+            if resolved is not None:
+                self.image_file_url = resolved
+        return self.image_file_url
+
     def retrieve_image_file(self) -> Path:
-        return cast(Path, self.image_file_url.retrieve())
+        return cast(Path, self.resolve_image_url().retrieve())
 
     @property
     def label_file_path(self) -> Path:

--- a/src/spindoctor/dataset/dataset.py
+++ b/src/spindoctor/dataset/dataset.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 
 from filecache import FCPath
 
-from spindoctor.config import Config
+from spindoctor.config import MAIN_LOGGER, Config
 from spindoctor.support.nav_base import NavBase
 
 
@@ -68,13 +68,27 @@ class ImageFile:
         ``image_file_url``.  The resolver runs at most once; subsequent calls
         return the memoized URL.
 
+        A resolver failure (typically an unretrievable label) falls back to the
+        current ``image_file_url`` guess with a logged warning: resolution runs
+        before the pipeline's per-image error boundary is open, and the guess is
+        usable whenever the image file itself is retrievable.
+
         Returns:
             The image file URL, corrected from the label contents when a resolver
             is set and reports a different filename.
         """
         if self.image_url_resolver is not None:
             resolver, self.image_url_resolver = self.image_url_resolver, None
-            resolved = resolver(self.image_file_url, self.label_file_path)
+            try:
+                resolved = resolver(self.image_file_url, self.label_file_path)
+            except OSError as exc:
+                MAIN_LOGGER.warning(
+                    'Image URL resolution from label %s failed (%s); keeping %s',
+                    self.label_file_url.as_posix(),
+                    exc,
+                    self.image_file_url.as_posix(),
+                )
+                resolved = None
             if resolved is not None:
                 self.image_file_url = resolved
         return self.image_file_url

--- a/src/spindoctor/dataset/dataset_pds3.py
+++ b/src/spindoctor/dataset/dataset_pds3.py
@@ -2,6 +2,7 @@ import argparse
 import csv
 import os
 import random
+import re
 from abc import abstractmethod
 from collections.abc import Iterator
 from functools import lru_cache
@@ -16,6 +17,16 @@ from spindoctor.support.misc import flatten_list
 
 from .dataset import DataSet, ImageFile, ImageFiles
 
+# A PDS3 ^IMAGE pointer naming the data file that holds the image object, e.g.
+#   ^IMAGE = ("N1454725799_1.IMG",4)
+#   ^IMAGE                          = ("C3250013_GEOMED.IMG", 2)
+#   ^IMAGE = "LOR_0003103486_0X630_SCI.FIT"
+# Matches only the top-level IMAGE pointer, not IMAGE_HEADER / EXTENSION_*_IMAGE.
+_LABEL_IMAGE_POINTER_RE = re.compile(
+    r'^\s*\^IMAGE\s*=\s*\(?\s*"?(?P<name>[^"\',()\s]+)"?',
+    re.MULTILINE,
+)
+
 
 class DataSetPDS3(DataSet):
     """Parent class for PDS3 datasets.
@@ -27,6 +38,12 @@ class DataSetPDS3(DataSet):
     _ALL_VOLUME_NAMES: tuple[str, ...] = ()
     _INDEX_COLUMNS: tuple[str, ...] = ()
     _VOLUMES_DIR_NAME: str = ''
+    # True when every image number in a volume is greater than every image number in
+    # all earlier volumes, letting a sequential scan stop once a whole volume is past
+    # the end of the requested number range. False for datasets whose image counter
+    # resets between volumes (Voyager FDS counts restart per spacecraft/encounter and
+    # VG2 Neptune rolls over below VG1 Jupiter), where every volume must be scanned.
+    _IMG_NUM_MONOTONIC_ACROSS_VOLUMES: bool = True
 
     def __init__(
         self,
@@ -466,6 +483,68 @@ class DataSetPDS3(DataSet):
         #     else:
         #         yield last_image_path
 
+    @staticmethod
+    def _image_filename_from_label(label_path: Path) -> str | None:
+        """Extracts the image data filename from a PDS3 label's ^IMAGE pointer.
+
+        Parameters:
+            label_path: Local path to the retrieved PDS3 label file.
+
+        Returns:
+            The filename named by the label's ``^IMAGE`` pointer, or None when the
+            label has no such pointer or the pointer does not name a file (an
+            attached-label record offset like ``^IMAGE = 3``).
+        """
+        try:
+            label_text = label_path.read_text(encoding='utf-8', errors='replace')
+        except OSError:
+            return None
+        match = _LABEL_IMAGE_POINTER_RE.search(label_text)
+        if match is None:
+            return None
+        name = match.group('name')
+        # An attached-label pointer gives a record offset, not a filename
+        if '.' not in name:
+            return None
+        return name
+
+    def _image_url_from_label(self, image_url: FCPath, label_path: Path) -> FCPath | None:
+        """Resolves the definitive image URL from the label's ^IMAGE pointer.
+
+        Used as the :class:`ImageFile` ``image_url_resolver``: the index-time image
+        filespec is an extension-swap guess derived from the label filespec, and
+        this callback corrects it against what the label actually points to.
+
+        The comparison is case-insensitive because archive labels do not reliably
+        record the on-disk filename case (NH LORRI labels name the ``.fit`` file in
+        uppercase while the holdings store it in lowercase).  When the pointer
+        names a genuinely different file, the label filename's case convention is
+        applied to the pointer name for mono-case names.
+
+        Parameters:
+            image_url: The provisional image URL derived by extension swap.
+            label_path: Local path to the retrieved PDS3 label file.
+
+        Returns:
+            The corrected image URL, or None when the guess already matches the
+            label pointer (or the label has no usable pointer).
+        """
+        name = self._image_filename_from_label(label_path)
+        if name is None or name.lower() == image_url.name.lower():
+            return None
+        label_name = label_path.name
+        if name.isupper() and label_name.islower():
+            name = name.lower()
+        elif name.islower() and label_name.isupper():
+            name = name.upper()
+        self._logger.debug(
+            'Image filespec %s corrected to %s from label %s',
+            image_url.name,
+            name,
+            label_name,
+        )
+        return image_url.parent / name
+
     @lru_cache(maxsize=3)  # noqa: B019 # small cache; dataset instances are long-lived
     def _read_pds_table(self, fn: str, columns: tuple[str, ...] | None = None) -> PdsTable:
         """Reads a PDS table file with caching.
@@ -735,9 +814,12 @@ class DataSetPDS3(DataSet):
             Returns:
                 A tuple ``(imagefile, past_end)``. ``imagefile`` is the constructed
                 ``ImageFile`` if the row passes every filter, or None if it is filtered
-                out. ``past_end`` is True if ``img_num`` exceeds ``img_end_num``; because
-                index rows are in monotonically increasing image-number order, a True
-                value lets sequential scanning stop early.
+                out. ``past_end`` is True if ``img_num`` exceeds ``img_end_num``. Image
+                numbers are monotonic only within one camera's rows -- an index can
+                interleave camera streams (COISS sorts all N* rows before all W* rows,
+                resetting the numeric sequence partway through the volume) -- so a True
+                value means only that *this row's* camera stream has passed the end of
+                the range, not that the scan as a whole can stop.
             """
             label_filespec = self._get_label_filespec_from_index(row)
             img_filespec = self._get_image_filespec_from_label_filespec(label_filespec)
@@ -755,6 +837,20 @@ class DataSetPDS3(DataSet):
             if img_name is None:
                 return None, False  # Not a name we should process
 
+            # Get the image number and test that it's in range. This runs before the
+            # explicit-list filters so a row rejected by those lists still reports
+            # past_end, letting the caller stop scanning volumes past the range.
+            try:
+                img_num = self._extract_img_number(img_name)
+            except ValueError as err:
+                raise ValueError(
+                    f'IMGNUM: Index file "{index_tab_url}" contains bad path "{label_filespec}"'
+                ) from err
+            if img_end_num is not None and img_num > img_end_num:
+                return None, True
+            if img_start_num is not None and img_num < img_start_num:
+                return None, False
+
             # Check that the image filespec is in the requested list
             if img_name_filter_list and img_name not in img_name_filter_list:
                 return None, False
@@ -766,20 +862,6 @@ class DataSetPDS3(DataSet):
                         break
                 else:
                     return None, False
-
-            # Get the image number and test that it's in range
-            # There's no point in checking the range dir for image number
-            # since we have to go through the entire index either way
-            try:
-                img_num = self._extract_img_number(img_name)
-            except ValueError as err:
-                raise ValueError(
-                    f'IMGNUM: Index file "{index_tab_url}" contains bad path "{label_filespec}"'
-                ) from err
-            if img_end_num is not None and img_num > img_end_num:
-                return None, True
-            if img_start_num is not None and img_num < img_start_num:
-                return None, False
 
             # Check that the image meets any additional selection criteria specific
             # to this dataset
@@ -795,6 +877,7 @@ class DataSetPDS3(DataSet):
                 label_file_url=label_url,
                 index_file_row=row,
                 results_path_stub=self._results_path_stub(search_vol, label_filespec),
+                image_url_resolver=self._image_url_from_label,
             )
             return imagefile, False
 
@@ -823,22 +906,28 @@ class DataSetPDS3(DataSet):
             return
 
         # Sequential scanning over the requested volumes in order. Image numbers are
-        # monotonically increasing both within and across volumes, so once we pass the
-        # end of the requested range there is nothing left to find anywhere and we stop
-        # the whole scan.
+        # monotonic within one camera's rows, but an index can interleave camera
+        # streams (COISS sorts all N* rows before all W* rows, resetting the numeric
+        # sequence partway through the volume), so a single past-the-end row must not
+        # stop the scan. When image numbers are monotonic across volumes, the scan
+        # stops after the first volume in which every row is past the end of the
+        # requested range; otherwise every requested volume is scanned.
         num_yields = 0
         for search_vol in valid_volumes:
             rows, index_tab_url = _read_index_rows(search_vol)
+            all_rows_past_end = bool(rows)
             for row in rows:
                 imagefile, past_end = _row_to_imagefile(row, search_vol, index_tab_url)
-                if past_end:
-                    return
+                if not past_end:
+                    all_rows_past_end = False
                 if imagefile is None:
                     continue
                 yield imagefile
                 num_yields += 1
                 if limit_yields is not None and num_yields >= limit_yields:
                     return
+            if all_rows_past_end and self._IMG_NUM_MONOTONIC_ACROSS_VOLUMES:
+                return
 
     def _check_additional_image_selection_criteria(
         self,

--- a/src/spindoctor/dataset/dataset_pds3_voyager_iss.py
+++ b/src/spindoctor/dataset/dataset_pds3_voyager_iss.py
@@ -41,6 +41,11 @@ class DataSetPDS3VoyagerISS(DataSetPDS3):
     )
     _INDEX_COLUMNS = ('FILE_SPECIFICATION_NAME',)
     _VOLUMES_DIR_NAME = 'volumes'
+    # FDS counts restart per spacecraft/encounter (the volume order interleaves VG1
+    # and VG2, and VG2's Neptune counts roll over below VG1's Jupiter counts), so an
+    # image-number range can match frames in any volume and no volume-level early
+    # exit is possible.
+    _IMG_NUM_MONOTONIC_ACROSS_VOLUMES = False
 
     # Methods inherited from DataSetPDS3
 

--- a/src/spindoctor/navigate_image_files.py
+++ b/src/spindoctor/navigate_image_files.py
@@ -105,7 +105,9 @@ def navigate_image_files(
         }
 
     image_file = image_files.image_files[0]
-    image_url = image_file.image_file_url
+    # resolve_image_url may correct the URL from the label contents, so it must
+    # run before the URL is read
+    image_url = image_file.resolve_image_url()
     image_path = image_file.image_file_path.absolute()
     image_name = image_path.name
     extra_params = image_file.extra_params

--- a/tests/spindoctor/dataset/test_dataset_pds3.py
+++ b/tests/spindoctor/dataset/test_dataset_pds3.py
@@ -15,15 +15,21 @@ def ds() -> DataSetPDS3CassiniISS:
 
 
 class _FakeIndexTable:
+    """Stand-in for a PdsTable serving canned index rows."""
+
     def __init__(self, rows: list[dict[str, Any]]) -> None:
         self._rows = rows
 
     def dicts_by_row(self) -> list[dict[str, Any]]:
+        """Return the canned rows in index order."""
         return self._rows
 
 
 class _FakeIndexCache:
+    """Stand-in for the index FileCache: echoes URLs back as local paths."""
+
     def retrieve(self, urls: list[str]) -> list[Path]:
+        """Return the label/table URL pair as paths without any I/O."""
         return [Path(urls[0]), Path(urls[1])]
 
 
@@ -54,6 +60,7 @@ def _coiss_filespecs(camera: str, numbers: list[int]) -> list[str]:
 
 
 def _yielded_names(groups: list[Any]) -> list[str]:
+    """Base image names (no suffix) of the yielded single-image groups."""
     return [g.image_files[0].image_file_name.split('_')[0] for g in groups]
 
 
@@ -153,6 +160,7 @@ def test_yielded_imagefile_carries_label_resolver(
 
 
 def _write_label(tmp_path: Path, name: str, text: str) -> Path:
+    """Write a synthetic PDS3 label file and return its path."""
     label_path = tmp_path / name
     label_path.write_text(text)
     return label_path
@@ -234,6 +242,7 @@ def _make_imagefile(
     label_path: Path,
     resolver: Callable[[FCPath, Path], FCPath | None],
 ) -> ImageFile:
+    """Build an ImageFile with the given provisional URL and resolver."""
     return ImageFile(
         image_file_url=image_url,
         label_file_url=FCPath(label_path),
@@ -278,3 +287,26 @@ def test_image_file_path_uses_resolved_url(tmp_path: Path) -> None:
     )
 
     assert imagefile.image_file_path == real_image
+
+
+def test_resolve_image_url_falls_back_when_resolver_raises(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # An unretrievable label must not abort the image before the pipeline's
+    # per-image error boundary: the provisional guess is kept and a warning
+    # is logged, and the resolver never runs again.
+    label_path = _write_label(tmp_path, 'IMG.LBL', 'END\r\n')
+    guess = FCPath(tmp_path / 'GUESS.IMG')
+    calls: list[FCPath] = []
+
+    def resolver(image_url: FCPath, _label_path: Path) -> FCPath:
+        calls.append(image_url)
+        raise FileNotFoundError('label missing from holdings')
+
+    imagefile = _make_imagefile(guess, label_path, resolver)
+
+    assert imagefile.resolve_image_url() == guess
+    assert imagefile.resolve_image_url() == guess
+    assert len(calls) == 1
+    captured = capsys.readouterr()
+    assert 'Image URL resolution from label' in captured.out + captured.err

--- a/tests/spindoctor/dataset/test_dataset_pds3.py
+++ b/tests/spindoctor/dataset/test_dataset_pds3.py
@@ -1,0 +1,280 @@
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+from filecache import FCPath
+
+from spindoctor.dataset.dataset import ImageFile
+from spindoctor.dataset.dataset_pds3_cassini_iss import DataSetPDS3CassiniISS
+
+
+@pytest.fixture
+def ds() -> DataSetPDS3CassiniISS:
+    return DataSetPDS3CassiniISS('/fake/holdings')
+
+
+class _FakeIndexTable:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def dicts_by_row(self) -> list[dict[str, Any]]:
+        return self._rows
+
+
+class _FakeIndexCache:
+    def retrieve(self, urls: list[str]) -> list[Path]:
+        return [Path(urls[0]), Path(urls[1])]
+
+
+def _install_fake_index(
+    ds: DataSetPDS3CassiniISS,
+    monkeypatch: pytest.MonkeyPatch,
+    volume_filespecs: dict[str, list[str]],
+) -> list[str]:
+    """Serve synthetic index rows per volume; returns the log of volumes read."""
+    volumes_read: list[str] = []
+
+    def fake_read_pds_table(fn: Path, columns: tuple[str, ...] | None = None) -> _FakeIndexTable:
+        for vol, specs in volume_filespecs.items():
+            if vol in str(fn):
+                volumes_read.append(vol)
+                return _FakeIndexTable([{'FILE_SPECIFICATION_NAME': s} for s in specs])
+        raise AssertionError(f'Unexpected index read: {fn}')
+
+    monkeypatch.setattr(ds, '_index_filecache', _FakeIndexCache())
+    monkeypatch.setattr(ds, '_read_pds_table', fake_read_pds_table)
+    return volumes_read
+
+
+def _coiss_filespecs(camera: str, numbers: list[int]) -> list[str]:
+    """Index filespecs for one camera, in the index's per-camera sorted order."""
+    range_dir = f'{numbers[0]:010d}_{numbers[-1]:010d}'
+    return [f'data/{range_dir}/{camera}{num:010d}_1.IMG' for num in numbers]
+
+
+def _yielded_names(groups: list[Any]) -> list[str]:
+    return [g.image_files[0].image_file_name.split('_')[0] for g in groups]
+
+
+def test_last_image_num_keeps_wac_frames(
+    ds: DataSetPDS3CassiniISS, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # COISS indexes sort all N* rows before all W* rows, so the image-number
+    # sequence resets partway through the volume. In-range WAC frames after the
+    # reset must still be yielded (issue #136).
+    numbers = [1000000100, 1000000101, 1000000102, 1000000103, 1000000104]
+    _install_fake_index(
+        ds,
+        monkeypatch,
+        {'COISS_2001': _coiss_filespecs('N', numbers) + _coiss_filespecs('W', numbers)},
+    )
+
+    groups = list(ds.yield_image_files_index(volumes=['COISS_2001'], img_end_num=1000000102))
+
+    assert _yielded_names(groups) == [
+        'N1000000100',
+        'N1000000101',
+        'N1000000102',
+        'W1000000100',
+        'W1000000101',
+        'W1000000102',
+    ]
+
+
+def test_scan_stops_after_first_volume_fully_past_range(
+    ds: DataSetPDS3CassiniISS, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Volumes are chronological, so the scan stops after the first volume whose
+    # rows are all past img_end_num -- without reading any later volume's index.
+    in_range = [1000000100, 1000000101]
+    past_range = [1000000200, 1000000201]
+    far_past_range = [1000000300, 1000000301]
+    volumes_read = _install_fake_index(
+        ds,
+        monkeypatch,
+        {
+            'COISS_2001': _coiss_filespecs('N', in_range) + _coiss_filespecs('W', in_range),
+            'COISS_2002': _coiss_filespecs('N', past_range),
+            'COISS_2003': _coiss_filespecs('N', far_past_range),
+        },
+    )
+
+    groups = list(
+        ds.yield_image_files_index(
+            volumes=['COISS_2001', 'COISS_2002', 'COISS_2003'], img_end_num=1000000101
+        )
+    )
+
+    assert len(groups) == 4
+    assert volumes_read == ['COISS_2001', 'COISS_2002']
+
+
+def test_img_name_list_range_clamp_still_stops_scan(
+    ds: DataSetPDS3CassiniISS, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # An explicit image-name list clamps the number range; rows rejected by the
+    # name list must still report past-the-range so the volume scan terminates.
+    numbers = [1000000100, 1000000101, 1000000102]
+    later = [1000000200, 1000000201]
+    volumes_read = _install_fake_index(
+        ds,
+        monkeypatch,
+        {
+            'COISS_2001': _coiss_filespecs('N', numbers) + _coiss_filespecs('W', numbers),
+            'COISS_2002': _coiss_filespecs('N', later),
+        },
+    )
+
+    groups = list(
+        ds.yield_image_files_index(
+            volumes=['COISS_2001', 'COISS_2002'], img_name_list=['N1000000101']
+        )
+    )
+
+    assert _yielded_names(groups) == ['N1000000101']
+    assert volumes_read == ['COISS_2001', 'COISS_2002']
+
+
+def test_yielded_imagefile_carries_label_resolver(
+    ds: DataSetPDS3CassiniISS, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_fake_index(
+        ds, monkeypatch, {'COISS_2001': _coiss_filespecs('N', [1000000100, 1000000100])[:1]}
+    )
+
+    groups = list(ds.yield_image_files_index(volumes=['COISS_2001']))
+
+    assert len(groups) == 1
+    assert groups[0].image_files[0].image_url_resolver is not None
+
+
+# --- ^IMAGE pointer parsing (issue #12) ---
+
+
+def _write_label(tmp_path: Path, name: str, text: str) -> Path:
+    label_path = tmp_path / name
+    label_path.write_text(text)
+    return label_path
+
+
+@pytest.mark.parametrize(
+    ('pointer_line', 'expected'),
+    [
+        ('^IMAGE = ("N1454725799_1.IMG",4)', 'N1454725799_1.IMG'),
+        ('^IMAGE                          = ("C3250013_GEOMED.IMG", 2)', 'C3250013_GEOMED.IMG'),
+        ('^IMAGE = "LOR_0003103486_0X630_SCI.FIT"', 'LOR_0003103486_0X630_SCI.FIT'),
+        ('^IMAGE = N1454725799_1.IMG', 'N1454725799_1.IMG'),
+    ],
+)
+def test_image_filename_from_label_pointer_forms(
+    tmp_path: Path, pointer_line: str, expected: str
+) -> None:
+    label_path = _write_label(
+        tmp_path,
+        'test.LBL',
+        f'PDS_VERSION_ID = PDS3\r\n^IMAGE_HEADER = ("OTHER.IMG",1)\r\n{pointer_line}\r\nEND\r\n',
+    )
+    assert DataSetPDS3CassiniISS._image_filename_from_label(label_path) == expected
+
+
+def test_image_filename_from_label_attached_offset_is_none(tmp_path: Path) -> None:
+    label_text = 'PDS_VERSION_ID = PDS3\r\n^IMAGE = 3\r\nEND\r\n'
+    label_path = _write_label(tmp_path, 'test.LBL', label_text)
+    assert DataSetPDS3CassiniISS._image_filename_from_label(label_path) is None
+
+
+def test_image_filename_from_label_missing_pointer_is_none(tmp_path: Path) -> None:
+    label_path = _write_label(tmp_path, 'test.LBL', 'PDS_VERSION_ID = PDS3\r\nEND\r\n')
+    assert DataSetPDS3CassiniISS._image_filename_from_label(label_path) is None
+
+
+def test_image_url_from_label_case_insensitive_match_keeps_guess(
+    ds: DataSetPDS3CassiniISS, tmp_path: Path
+) -> None:
+    # NH LORRI labels name the .fit file in uppercase while the holdings store it
+    # in lowercase; a case-only difference must not rewrite the URL.
+    label_path = _write_label(
+        tmp_path,
+        'lor_0003103486_0x630_sci.lbl',
+        '^IMAGE = ("LOR_0003103486_0X630_SCI.FIT", 14)\r\nEND\r\n',
+    )
+    guess = FCPath('/holdings/data/lor_0003103486_0x630_sci.fit')
+    assert ds._image_url_from_label(guess, label_path) is None
+
+
+def test_image_url_from_label_corrects_differing_name(
+    ds: DataSetPDS3CassiniISS, tmp_path: Path
+) -> None:
+    label_path = _write_label(
+        tmp_path,
+        'n1454725799_1.lbl',
+        '^IMAGE = ("N1454725799_1_FULL.IMG", 4)\r\nEND\r\n',
+    )
+    guess = FCPath('/holdings/data/n1454725799_1.img')
+    resolved = ds._image_url_from_label(guess, label_path)
+    assert resolved is not None
+    # The pointer name adopts the label filename's (lowercase) case convention.
+    assert resolved.as_posix() == '/holdings/data/n1454725799_1_full.img'
+
+
+def test_image_url_from_label_no_pointer_keeps_guess(
+    ds: DataSetPDS3CassiniISS, tmp_path: Path
+) -> None:
+    label_path = _write_label(tmp_path, 'test.LBL', 'PDS_VERSION_ID = PDS3\r\nEND\r\n')
+    guess = FCPath('/holdings/data/TEST.IMG')
+    assert ds._image_url_from_label(guess, label_path) is None
+
+
+# --- ImageFile.resolve_image_url ---
+
+
+def _make_imagefile(
+    image_url: FCPath,
+    label_path: Path,
+    resolver: Callable[[FCPath, Path], FCPath | None],
+) -> ImageFile:
+    return ImageFile(
+        image_file_url=image_url,
+        label_file_url=FCPath(label_path),
+        results_path_stub='stub',
+        image_url_resolver=resolver,
+    )
+
+
+def test_resolve_image_url_replaces_url_and_runs_once(tmp_path: Path) -> None:
+    label_path = _write_label(tmp_path, 'IMG.LBL', 'END\r\n')
+    corrected = FCPath(tmp_path / 'CORRECTED.IMG')
+    calls: list[FCPath] = []
+
+    def resolver(image_url: FCPath, _label_path: Path) -> FCPath:
+        calls.append(image_url)
+        return corrected
+
+    imagefile = _make_imagefile(FCPath(tmp_path / 'GUESS.IMG'), label_path, resolver)
+
+    assert imagefile.resolve_image_url() == corrected
+    assert imagefile.image_file_url == corrected
+    assert imagefile.resolve_image_url() == corrected
+    assert len(calls) == 1
+
+
+def test_resolve_image_url_none_keeps_guess(tmp_path: Path) -> None:
+    label_path = _write_label(tmp_path, 'IMG.LBL', 'END\r\n')
+    guess = FCPath(tmp_path / 'GUESS.IMG')
+
+    imagefile = _make_imagefile(guess, label_path, lambda _url, _path: None)
+
+    assert imagefile.resolve_image_url() == guess
+
+
+def test_image_file_path_uses_resolved_url(tmp_path: Path) -> None:
+    label_path = _write_label(tmp_path, 'IMG.LBL', 'END\r\n')
+    real_image = tmp_path / 'REAL.IMG'
+    real_image.write_bytes(b'image')
+
+    imagefile = _make_imagefile(
+        FCPath(tmp_path / 'WRONG.IMG'), label_path, lambda _url, _path: FCPath(real_image)
+    )
+
+    assert imagefile.image_file_path == real_image

--- a/tests/spindoctor/dataset/test_dataset_pds3_voyager_iss.py
+++ b/tests/spindoctor/dataset/test_dataset_pds3_voyager_iss.py
@@ -67,20 +67,23 @@ def test_voyager_iss_yield_img_start_num(
 def test_voyager_iss_yield_img_end_num(
     ds_voyager_iss: dsvgiss.DataSetPDS3VoyagerISS,
 ) -> None:
+    # FDS counts are not monotonic across volumes: VG2's Neptune counts (VGISS_8xxx)
+    # roll over below VG1's Jupiter counts, so this range matches 117 VG1 Jupiter
+    # frames plus 9835 VG2 Neptune frames. Every volume is scanned; a number range
+    # alone does not bound the scan for Voyager.
     ret = list(ds_voyager_iss.yield_image_files_index(img_end_num=1469550))
-    assert len(ret) == 117
-    assert (
-        ret[-2]
-        .image_files[0]
-        .label_file_url.as_posix()
-        .endswith('volumes/VGISS_5xxx/VGISS_5101/DATA/C14695XX/C1469548_GEOMED.LBL')
+    assert len(ret) == 9952
+    specs = [g.image_files[0].label_file_url.as_posix() for g in ret]
+    vg1_jupiter = [s for s in specs if '/VGISS_5xxx/' in s]
+    assert len(vg1_jupiter) == 117
+    assert vg1_jupiter[-2].endswith(
+        'volumes/VGISS_5xxx/VGISS_5101/DATA/C14695XX/C1469548_GEOMED.LBL'
     )
-    assert (
-        ret[-1]
-        .image_files[0]
-        .label_file_url.as_posix()
-        .endswith('volumes/VGISS_5xxx/VGISS_5101/DATA/C14695XX/C1469550_GEOMED.LBL')
+    assert vg1_jupiter[-1].endswith(
+        'volumes/VGISS_5xxx/VGISS_5101/DATA/C14695XX/C1469550_GEOMED.LBL'
     )
+    vg2_neptune = [s for s in specs if '/VGISS_8xxx/' in s]
+    assert len(vg2_neptune) == 9835
 
 
 def test_voyager_iss_yield_volumes(


### PR DESCRIPTION
Stacked on #214 (`fix-209-blob-gate`). Review only the last two commits; rebase onto `main` after #214 squash-merges.

## #136 — `--last-image-num` silently drops WAC frames

`_yield_image_files_index` treated the index as globally monotonic in image number and aborted the whole scan at the first past-the-end row. COISS indexes sort all `N*` rows before all `W*` rows, so the numeric sequence resets partway through each volume and every in-range WAC frame after the reset was dropped — a silent under-selection.

Fix: a past-the-end row now only marks its own camera stream. The range check moved ahead of the explicit-list filters so rejected rows still report past-the-end, and the scan stops after the first volume whose rows are **all** past the range (costing at most one extra index read vs the old early exit).

The stop is gated on a new `_IMG_NUM_MONOTONIC_ACROSS_VOLUMES` class attribute because Voyager FDS counts reset per spacecraft/encounter (VG2 Neptune rolls over **below** VG1 Jupiter), so for VGISS every requested volume must be scanned. The Voyager integration test's expectation changes from 117 to 9952: the old count was an artifact of the early-exit bug (it silently omitted 9835 VG2 Neptune frames whose numbers are genuinely ≤ the requested maximum). The user guide now tells Voyager users to combine number ranges with volume options.

## #12 — image filespec from the label, not extension swap

`ImageFile` gains an optional `image_url_resolver` that runs once before first image retrieval. PDS3 datasets install a resolver that parses the label's `^IMAGE` pointer and corrects the extension-swap guess when they disagree. Notes:

- Comparison is case-insensitive: NH LORRI labels name the `.fit` file in uppercase while the holdings store lowercase, so trusting the label's case verbatim would 404. Case convention is taken from the label's own filename.
- Attached-label pointers (`^IMAGE = 3`) and missing pointers fall back to the extension-swap guess.
- Resolution is lazy (at retrieval, when the label is local) so index scans stay network-free. Cloud-task manifests still serialize the index-time guess — same behavior as before; noted as the remaining gap on #12 if it matters in practice.

## Also in this PR

`plans/FULL_PROGRAM_AFTER_MANUAL_WORK_2026-07-11.md` — the post-manual-work program report, moved into the repo as requested.

## Testing

- New unit tests: `tests/spindoctor/dataset/test_dataset_pds3.py` (16 tests: WAC-retention regression, volume-level early stop, name-list clamp interaction, pointer parsing forms, case handling, resolver semantics).
- Full unit suite green (1856 passed). Voyager composition verified against the live index: 117 VGISS_5xxx + 9835 VGISS_8xxx.
- `ruff check`/`format`, `mypy` strict: clean on touched files.

Fixes #136. Fixes #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KW6fkURsA2zgrWFKjbR5JY

## Updates since the initial description

- **Review follow-ups (CodeRabbit)**: `ImageFile.resolve_image_url()` now catches `OSError` from the resolver (unretrievable label), logs a warning, and keeps the provisional guess — resolution runs before the pipeline's per-image error boundary, and the guess is usable whenever the image itself is retrievable; regression test added. Test helpers gained docstrings; the extension guide gained a minimal PDS3 hook skeleton and expands FDS on first use; wrapped plan lines no longer start with bare issue references. One suggestion declined with rationale (Sphinx roles on private hooks would be unresolvable references; see the inline reply).
- **Docs pass**: `plans/FULL_PROGRAM_AFTER_MANUAL_WORK_2026-07-11.md` updated with the Track B/C execution status (PR stack #215-#220, closures, crosscheck result, new issues #221/#222); `dev_guide_extending.rst` documents the PDS3 index-parsing hooks, the label-pointer image-URL resolution, and `_IMG_NUM_MONOTONIC_ACROSS_VOLUMES`.
- **Validation on the stack head**: 62-sidecar library crosscheck — every per-image delta vs the operator v7 baseline is byte-identical on the parent stack (zero deltas caused by this stack); details in the PR #216 comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Adds lazy, label-driven image URL resolution for PDS3 datasets (via `^IMAGE` pointers) and uses the resolved URL for navigation and retrieval.
- **Bug Fixes**
  - Improves `--last-image-num` range scanning when image numbering resets/interleaves across Voyager encounters/cameras, ensuring correct early-stop behavior.
  - Strengthens `^IMAGE` pointer parsing (including casing/edge cases) and safely falls back if resolution fails.
- **Documentation**
  - Updates user guidance for Voyager numbering restarts and advises pairing `--last-image-num` with volume options.
  - Expands developer instructions for implementing PDS3 dataset hooks.
- **Tests**
  - Adds/updates coverage for scan/yield semantics and image URL resolution lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Operator checklist

- **Pre-merge: nothing.** Merge after #214 merges, the rebase lands, and CI is green.
- **Post-merge: nothing.** #136 and #12 auto-close via the description — verify they did.
