### PR TITLE
fix: config-honoring model selection + per-pixel ring occlusion (#146, #145)

### DIFF
--- a/docs/dev_guide/dev_guide_navigation_models.rst
+++ b/docs/dev_guide/dev_guide_navigation_models.rst
@@ -17,7 +17,11 @@ predicted-scene generators. Each subclass implements three methods:
 Concrete subclasses self-register via ``__init_subclass__``; abstract
 bases set ``_abstract = True`` to opt out. The class method
 :meth:`~spindoctor.nav_model.nav_model.NavModel.instances_for_obs` is the per-class hook that
-:func:`~spindoctor.nav_model.nav_model.build_models_for_obs` iterates.
+:func:`~spindoctor.nav_model.nav_model.build_models_for_obs` iterates. Both take a
+keyword-only ``config`` parameter used for *selection* (which ring systems have
+catalogs, which satellites are considered) as well as for constructing the
+instances, so a per-run configuration override changes which models exist the
+same way it changes how they behave; ``None`` uses ``DEFAULT_CONFIG``.
 
 Registered concrete models, grouped by feature family:
 

--- a/docs/dev_guide/dev_guide_navigation_models_star.rst
+++ b/docs/dev_guide/dev_guide_navigation_models_star.rst
@@ -219,6 +219,11 @@ The model's runtime knobs live in ``stars`` in
   ``too_bright_dn`` (reserved tuning slot).
 - ``ring_occlusion_enabled`` — bool, default ``true``. Whether to flag stars whose
   predicted positions lie inside a planet's ring system.
+- ``ring_occlusion_min_opaque_fraction`` — float, default ``0.25``. Fraction of the
+  star's conflict-window pixels that must fall inside an opaque annulus before the
+  star is flagged ring-occluded. Membership is tested per pixel, so a star whose
+  window straddles a ringlet edge or a gap boundary is judged by how much of the
+  window is actually over opaque material.
 - ``ring_occlusion_radii_km`` — dict[str, list[list[float]]]. Per-planet ring annular
   bounds (km) used by the occlusion check. Saturn entry covers C, B, and A rings; Uranus
   covers the main ring system; Neptune covers Galle through Adams rings.

--- a/src/spindoctor/config_files/config_030_stars.yaml
+++ b/src/spindoctor/config_files/config_030_stars.yaml
@@ -43,6 +43,12 @@ stars:
   too_bright_dn: 1000
   too_bright_factor: 1  # TODO
   ring_occlusion_enabled: true
+  # Fraction of the star's conflict-window pixels that must fall inside an
+  # opaque annulus before the star is marked ring-occluded. Membership is
+  # tested per pixel, so a star sitting on a ringlet edge or straddling a gap
+  # is judged by how much of its window is actually over opaque material
+  # rather than by the window's median radius.
+  ring_occlusion_min_opaque_fraction: 0.25
   ring_occlusion_radii_km:
     SATURN:
       - [74490.0, 91980.0]    # C ring

--- a/src/spindoctor/nav_model/nav_model.py
+++ b/src/spindoctor/nav_model/nav_model.py
@@ -90,7 +90,7 @@ class NavModel(NavBase, ABC):
         return self._metadata
 
     @classmethod
-    def instances_for_obs(cls, obs: ObsSnapshot) -> list[NavModel]:
+    def instances_for_obs(cls, obs: ObsSnapshot, *, config: Config | None = None) -> list[NavModel]:
         """Return concrete NavModel instances applicable to ``obs``.
 
         Default returns ``[]``.  Subclasses that auto-instantiate from an
@@ -104,11 +104,13 @@ class NavModel(NavBase, ABC):
 
         Parameters:
             obs: Observation snapshot to inspect.
+            config: Configuration used both to decide which instances apply
+                and to construct them.  None uses ``DEFAULT_CONFIG``.
 
         Returns:
             Zero or more NavModel instances.
         """
-        del obs
+        del obs, config
         return []
 
     @abstractmethod
@@ -154,7 +156,7 @@ class NavModel(NavBase, ABC):
         """
 
 
-def build_models_for_obs(obs: ObsSnapshot) -> list[NavModel]:
+def build_models_for_obs(obs: ObsSnapshot, *, config: Config | None = None) -> list[NavModel]:
     """Construct every NavModel applicable to ``obs``.
 
     Iterates ``NavModel._registry`` and lets each registered concrete
@@ -165,11 +167,15 @@ def build_models_for_obs(obs: ObsSnapshot) -> list[NavModel]:
 
     Parameters:
         obs: Observation snapshot.
+        config: Configuration used both to decide which instances apply and
+            to construct them, so a per-run override changes model selection
+            the same way it changes model behavior.  None uses
+            ``DEFAULT_CONFIG``.
 
     Returns:
         Flat list of NavModel instances ready for the orchestrator.
     """
     out: list[NavModel] = []
     for cls in NavModel._registry:
-        out.extend(cls.instances_for_obs(obs))
+        out.extend(cls.instances_for_obs(obs, config=config))
     return out

--- a/src/spindoctor/nav_model/nav_model_body.py
+++ b/src/spindoctor/nav_model/nav_model_body.py
@@ -238,7 +238,7 @@ class NavModelBody(NavModelBodyBase):
         self._phase_angle_factor: float = 0.0
 
     @classmethod
-    def instances_for_obs(cls, obs: Observation) -> list[NavModel]:
+    def instances_for_obs(cls, obs: Observation, *, config: Config | None = None) -> list[NavModel]:
         """Return one NavModelBody per body whose bbox lies inside extfov.
 
         Calls ``obs.inventory`` once with the planet + satellites list
@@ -247,6 +247,9 @@ class NavModelBody(NavModelBodyBase):
 
         Parameters:
             obs: Observation snapshot.
+            config: Configuration whose satellite catalog decides which bodies
+                are considered; also passed to the constructed instances.  None
+                uses ``DEFAULT_CONFIG``.
 
         Returns:
             One ``NavModelBody`` per body present in the extfov.
@@ -254,7 +257,8 @@ class NavModelBody(NavModelBodyBase):
         # Simulated obs use the sim-params-driven NavModelBodySimulated instead.
         if getattr(obs, 'is_simulated', False):
             return []
-        config = DEFAULT_CONFIG
+        if config is None:
+            config = DEFAULT_CONFIG
         planet = getattr(obs, 'closest_planet', None)
         if planet is None:
             return []
@@ -276,7 +280,7 @@ class NavModelBody(NavModelBodyBase):
                 continue
             if not in_extfov(entry):
                 continue
-            out.append(cls(f'body:{body_name}', obs, body_name, inventory=entry))
+            out.append(cls(f'body:{body_name}', obs, body_name, inventory=entry, config=config))
         return out
 
     def create_model(self) -> None:

--- a/src/spindoctor/nav_model/nav_model_body_simulated.py
+++ b/src/spindoctor/nav_model/nav_model_body_simulated.py
@@ -233,7 +233,7 @@ class NavModelBodySimulated(NavModelBodyBase):
         self._bbox_extfov_vu: tuple[int, int, int, int] = (0, 0, 0, 0)
 
     @classmethod
-    def instances_for_obs(cls, obs: Observation) -> list[NavModel]:
+    def instances_for_obs(cls, obs: Observation, *, config: Config | None = None) -> list[NavModel]:
         """Build one simulated body model per body of a simulated obs.
 
         Reads the per-body parameters the sim obs stashes on its snapshot
@@ -252,6 +252,8 @@ class NavModelBodySimulated(NavModelBodyBase):
 
         Parameters:
             obs: Observation snapshot.
+            config: Configuration passed to the constructed instances.  None
+                uses ``DEFAULT_CONFIG``.
 
         Returns:
             One ``NavModelBodySimulated`` per body in the sim scene.
@@ -266,7 +268,15 @@ class NavModelBodySimulated(NavModelBodyBase):
             if not isinstance(body_params, dict):
                 continue
             body_name = str(body_params.get('name', 'SIM-BODY'))
-            out.append(cls(f'body_sim:{body_name}', obs, body_name, _nav_params(body_params)))
+            out.append(
+                cls(
+                    f'body_sim:{body_name}',
+                    obs,
+                    body_name,
+                    _nav_params(body_params),
+                    config=config,
+                )
+            )
         return out
 
     def create_model(self) -> None:

--- a/src/spindoctor/nav_model/nav_model_rings.py
+++ b/src/spindoctor/nav_model/nav_model_rings.py
@@ -228,6 +228,10 @@ class NavModelRings(NavModelRingsBase):
             config: Configuration whose ring catalog decides which planets have
                 navigable rings; also passed to the constructed instances.  None
                 uses ``DEFAULT_CONFIG``.
+
+        Returns:
+            ``[NavModelRings]`` for the closest planet when its ring catalog is
+            configured and the obs exposes the extfov surface, else ``[]``.
         """
         # Simulated obs use the sim-params-driven NavModelRingsSimulated instead.
         if getattr(obs, 'is_simulated', False):

--- a/src/spindoctor/nav_model/nav_model_rings.py
+++ b/src/spindoctor/nav_model/nav_model_rings.py
@@ -218,8 +218,17 @@ class NavModelRings(NavModelRingsBase):
         self._subject_range_km: float = float('inf')
 
     @classmethod
-    def instances_for_obs(cls, obs: oops.Observation) -> list[NavModel]:
-        """Return one NavModelRings per planet whose ring catalog touches the FOV."""
+    def instances_for_obs(
+        cls, obs: oops.Observation, *, config: Config | None = None
+    ) -> list[NavModel]:
+        """Return one NavModelRings per planet whose ring catalog touches the FOV.
+
+        Parameters:
+            obs: Observation snapshot.
+            config: Configuration whose ring catalog decides which planets have
+                navigable rings; also passed to the constructed instances.  None
+                uses ``DEFAULT_CONFIG``.
+        """
         # Simulated obs use the sim-params-driven NavModelRingsSimulated instead.
         if getattr(obs, 'is_simulated', False):
             return []
@@ -230,11 +239,11 @@ class NavModelRings(NavModelRingsBase):
         # stand-ins that don't expose those are not applicable.
         if not hasattr(obs, 'extdata_shape_vu') or not hasattr(obs, 'ext_bp'):
             return []
-        rings_config = DEFAULT_CONFIG.rings
+        rings_config = (config if config is not None else DEFAULT_CONFIG).rings
         ring_features_dict = getattr(rings_config, 'ring_features', None)
         if not ring_features_dict or planet not in ring_features_dict:
             return []
-        return [cls(f'rings:{planet}', obs)]
+        return [cls(f'rings:{planet}', obs, config=config)]
 
     def create_model(self) -> None:
         """Run the four-pass filter, render surviving features, populate metadata."""

--- a/src/spindoctor/nav_model/nav_model_rings_simulated.py
+++ b/src/spindoctor/nav_model/nav_model_rings_simulated.py
@@ -127,7 +127,9 @@ class NavModelRingsSimulated(NavModelRingsBase):
         self._bbox_extfov_vu: tuple[int, int, int, int] = (0, 0, 0, 0)
 
     @classmethod
-    def instances_for_obs(cls, obs: oops.Observation) -> list[NavModel]:
+    def instances_for_obs(
+        cls, obs: oops.Observation, *, config: Config | None = None
+    ) -> list[NavModel]:
         """Build one simulated ring model per ring of a simulated obs.
 
         Reads ``obs.sim_params['rings']``; returns an empty list for a real obs
@@ -135,6 +137,8 @@ class NavModelRingsSimulated(NavModelRingsBase):
 
         Parameters:
             obs: Observation snapshot.
+            config: Configuration passed to the constructed instances.  None
+                uses ``DEFAULT_CONFIG``.
 
         Returns:
             One ``NavModelRingsSimulated`` per ring in the sim scene.
@@ -149,7 +153,7 @@ class NavModelRingsSimulated(NavModelRingsBase):
             if not isinstance(ring_params, dict):
                 continue
             ring_name = str(ring_params.get('name', 'SIM-RING'))
-            out.append(cls(f'rings_sim:{ring_name}', obs, ring_name, ring_params))
+            out.append(cls(f'rings_sim:{ring_name}', obs, ring_name, ring_params, config=config))
         return out
 
     def create_model(self) -> None:

--- a/src/spindoctor/nav_model/stars/conflicts.py
+++ b/src/spindoctor/nav_model/stars/conflicts.py
@@ -127,6 +127,32 @@ def _conflict_body_list(obs: ObsSnapshot, config: Config) -> list[str]:
     return body_list
 
 
+def _ring_opaque_fraction(
+    radii_km: np.ndarray,
+    valid_mask: np.ndarray,
+    annuli: list[tuple[float, float]],
+) -> float:
+    """Fraction of the valid window pixels that lie inside an opaque annulus.
+
+    Parameters:
+        radii_km: Ring-radius backplane values over the conflict window, in km.
+        valid_mask: True where the backplane value is valid (ring plane
+            intercepted); same shape as ``radii_km``.
+        annuli: List of opaque ``(inner_km, outer_km)`` annuli.
+
+    Returns:
+        Opaque-pixel count divided by valid-pixel count, or 0.0 when no
+        window pixel is valid.
+    """
+    n_valid = int(np.count_nonzero(valid_mask))
+    if n_valid == 0:
+        return 0.0
+    opaque = np.zeros(radii_km.shape, dtype=bool)
+    for inner_km, outer_km in annuli:
+        opaque |= (radii_km >= inner_km) & (radii_km <= outer_km)
+    return float(np.count_nonzero(opaque & valid_mask)) / n_valid
+
+
 def _check_one_star(
     *,
     obs: ObsSnapshot,
@@ -135,8 +161,16 @@ def _check_one_star(
     ring_annuli: dict[str, list[tuple[float, float]]],
     rings_can_conflict: bool,
     body_conflict_margin: float,
+    ring_min_opaque_fraction: float,
 ) -> bool:
     """Return True if ``star`` conflicts with a body or ring; sets the flag.
+
+    Ring membership is tested per pixel over the conflict window: the star is
+    ring-occluded when at least ``ring_min_opaque_fraction`` of the valid
+    window pixels fall inside an opaque annulus.  A single collapsed statistic
+    (the window's median radius) would mis-classify stars whose window
+    straddles a ringlet edge or a gap boundary -- exactly where occlusion
+    matters most.
 
     Parameters:
         obs: Observation snapshot.
@@ -146,6 +180,8 @@ def _check_one_star(
         rings_can_conflict: Toggle the ring check.
         body_conflict_margin: Pixel slop around the star when building
             the conflict-check meshgrid.
+        ring_min_opaque_fraction: Minimum opaque fraction of valid window
+            pixels for a ring conflict.
 
     Returns:
         True if a conflict was found (and ``star.conflicts`` set);
@@ -170,11 +206,12 @@ def _check_one_star(
             ring_target = f'{obs.closest_planet.lower()}:ring'
             bp_radii = backplane.ring_radius(ring_target)
             if not bp_radii.is_all_masked():
-                radius_km = float(bp_radii.median().vals)
-                for inner_km, outer_km in annuli:
-                    if inner_km <= radius_km <= outer_km:
-                        star.conflicts = f'RING: {obs.closest_planet}'
-                        return True
+                radii_km = np.asarray(bp_radii.vals, dtype=np.float64)
+                valid_mask = ~np.broadcast_to(np.asarray(bp_radii.mask, dtype=bool), radii_km.shape)
+                fraction = _ring_opaque_fraction(radii_km, valid_mask, annuli)
+                if fraction >= ring_min_opaque_fraction:
+                    star.conflicts = f'RING: {obs.closest_planet}'
+                    return True
     return False
 
 
@@ -195,8 +232,10 @@ def mark_body_and_ring_conflicts(
 
     2. **Ring annulus occlusion.**  When ``stars.ring_occlusion_enabled``
        is True and the closest-planet has annuli configured, the same
-       meshgrid is queried for ``ring_radius`` and the median radius is
-       compared against each annulus.  A hit marks the star with
+       meshgrid is queried for ``ring_radius`` and each valid pixel's
+       radius is tested against the annuli.  When at least
+       ``stars.ring_occlusion_min_opaque_fraction`` of the valid window
+       pixels are opaque, the star is marked with
        ``conflicts = 'RING: <planet>'``.
 
     Stars already marked with a non-empty ``conflicts`` (e.g. ``'STAR'``
@@ -212,6 +251,7 @@ def mark_body_and_ring_conflicts(
     ring_annuli = parse_ring_occlusion_annuli(_cast_dict(stars_config.ring_occlusion_radii_km))
     rings_can_conflict = bool(stars_config.ring_occlusion_enabled)
     margin = float(stars_config.body_conflict_margin)
+    min_opaque_fraction = float(stars_config.ring_occlusion_min_opaque_fraction)
     for star in stars:
         if star.conflicts:
             continue
@@ -222,6 +262,7 @@ def mark_body_and_ring_conflicts(
             ring_annuli=ring_annuli,
             rings_can_conflict=rings_can_conflict,
             body_conflict_margin=margin,
+            ring_min_opaque_fraction=min_opaque_fraction,
         )
 
 

--- a/src/spindoctor/nav_model/stars/nav_model_stars.py
+++ b/src/spindoctor/nav_model/stars/nav_model_stars.py
@@ -107,7 +107,7 @@ class NavModelStars(NavModel):
         self._smear_vu: tuple[float, float] = (0.0, 0.0)
 
     @classmethod
-    def instances_for_obs(cls, obs: Observation) -> list[NavModel]:
+    def instances_for_obs(cls, obs: Observation, *, config: Config | None = None) -> list[NavModel]:
         """Return one star NavModel per real observation.
 
         Simulated obs have no real star-catalog pointing, so no star model is
@@ -115,13 +115,15 @@ class NavModelStars(NavModel):
 
         Parameters:
             obs: Observation snapshot.
+            config: Configuration passed to the constructed instance.  None
+                uses ``DEFAULT_CONFIG``.
 
         Returns:
             ``[NavModelStars('stars', obs)]`` for a real obs, else ``[]``.
         """
         if getattr(obs, 'is_simulated', False):
             return []
-        return [cls('stars', obs)]
+        return [cls('stars', obs, config=config)]
 
     @property
     def stars(self) -> list[MutableStar]:

--- a/src/spindoctor/nav_model/stars/nav_model_stars_simulated.py
+++ b/src/spindoctor/nav_model/stars/nav_model_stars_simulated.py
@@ -28,6 +28,7 @@ from spindoctor.nav_model.stars.nav_model_stars import (
 from spindoctor.support.time import now_dt
 
 if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from spindoctor.config import Config
     from spindoctor.support.types import MutableStar
 
 __all__ = ['NavModelStarsSimulated']
@@ -48,7 +49,7 @@ class NavModelStarsSimulated(NavModelStars):
     """
 
     @classmethod
-    def instances_for_obs(cls, obs: Observation) -> list[NavModel]:
+    def instances_for_obs(cls, obs: Observation, *, config: Config | None = None) -> list[NavModel]:
         """Return one star model for a simulated obs that rendered stars.
 
         Returns an empty list for a real obs (the catalog-driven
@@ -57,6 +58,8 @@ class NavModelStarsSimulated(NavModelStars):
 
         Parameters:
             obs: Observation snapshot.
+            config: Configuration passed to the constructed instance.  None
+                uses ``DEFAULT_CONFIG``.
 
         Returns:
             ``[NavModelStarsSimulated('stars', obs)]`` for a simulated obs
@@ -66,7 +69,7 @@ class NavModelStarsSimulated(NavModelStars):
             return []
         if not getattr(obs, 'sim_star_list', None):
             return []
-        return [cls('stars', obs)]
+        return [cls('stars', obs, config=config)]
 
     def create_model(self) -> None:
         """Populate the star list from the rendered scene.

--- a/tests/spindoctor/nav_model/stars/test_conflicts.py
+++ b/tests/spindoctor/nav_model/stars/test_conflicts.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+import numpy as np
 import pytest
 
-from spindoctor.nav_model.stars.conflicts import _conflict_body_list, parse_ring_occlusion_annuli
+import spindoctor.nav_model.stars.conflicts as conflicts_module
+from spindoctor.nav_model.stars.conflicts import (
+    _conflict_body_list,
+    _ring_opaque_fraction,
+    parse_ring_occlusion_annuli,
+)
 
 
 def test_parse_ring_occlusion_annuli_normalises_keys() -> None:
@@ -106,3 +112,141 @@ def test_conflict_body_list_returns_empty_when_no_closest_planet() -> None:
     """When ``obs.closest_planet`` is ``None`` the body list is empty."""
     out = _conflict_body_list(cast(Any, _FakeObsNoPlanet()), cast(Any, _FakeEmptyConfig()))
     assert out == []
+
+
+# --- Per-pixel ring occlusion (issue #145) ---
+
+
+def test_ring_opaque_fraction_counts_per_pixel_membership() -> None:
+    """Half the window inside the annulus gives fraction 0.5."""
+    radii = np.array([[100.0, 100.0], [200.0, 200.0]])
+    valid = np.ones_like(radii, dtype=bool)
+    fraction = _ring_opaque_fraction(radii, valid, [(150.0, 250.0)])
+    assert fraction == pytest.approx(0.5)
+
+
+def test_ring_opaque_fraction_ignores_invalid_pixels() -> None:
+    """Masked pixels are excluded from both numerator and denominator."""
+    radii = np.array([[100.0, 200.0], [200.0, 200.0]])
+    valid = np.array([[True, True], [False, False]])
+    fraction = _ring_opaque_fraction(radii, valid, [(150.0, 250.0)])
+    assert fraction == pytest.approx(0.5)
+
+
+def test_ring_opaque_fraction_zero_when_all_invalid() -> None:
+    """An all-masked window yields fraction 0.0 (no occlusion verdict)."""
+    radii = np.array([[100.0, 200.0]])
+    valid = np.zeros_like(radii, dtype=bool)
+    assert _ring_opaque_fraction(radii, valid, [(150.0, 250.0)]) == 0.0
+
+
+def test_ring_opaque_fraction_unions_annuli() -> None:
+    """A pixel inside any configured annulus counts as opaque."""
+    radii = np.array([[100.0, 300.0, 500.0]])
+    valid = np.ones_like(radii, dtype=bool)
+    fraction = _ring_opaque_fraction(radii, valid, [(90.0, 110.0), (290.0, 310.0)])
+    assert fraction == pytest.approx(2.0 / 3.0)
+
+
+class _FakeScalar:
+    """Stand-in for the oops ring-radius backplane scalar."""
+
+    def __init__(self, vals: np.ndarray, mask: np.ndarray | bool = False) -> None:
+        self.vals = vals
+        self.mask = mask
+
+    def is_all_masked(self) -> bool:
+        """True when every window pixel is masked."""
+        return bool(np.all(self.mask))
+
+
+class _FakeBackplane:
+    """Stand-in Backplane serving canned body and ring answers."""
+
+    ring_radii: np.ndarray = np.zeros((1, 1))
+
+    def __init__(self, obs: Any, meshgrid: Any) -> None:
+        del obs, meshgrid
+
+    def where_intercepted(self, body_name: str) -> np.ndarray:
+        """No body intercepts anywhere in the window."""
+        del body_name
+        return np.zeros((2, 2), dtype=bool)
+
+    def ring_radius(self, ring_target: str) -> _FakeScalar:
+        """Serve the canned ring-radius window."""
+        del ring_target
+        return _FakeScalar(self.ring_radii)
+
+
+class _FakeMeshgrid:
+    """Stand-in for ``oops.Meshgrid`` construction."""
+
+    @staticmethod
+    def for_fov(fov: Any, *, origin: Any, limit: Any) -> None:
+        """Accept the call; the fake backplane ignores the meshgrid."""
+        del fov, origin, limit
+        return None
+
+
+class _FakeStar:
+    """Minimal star record for the conflict check."""
+
+    def __init__(self) -> None:
+        self.u = 10.0
+        self.v = 10.0
+        self.conflicts = ''
+
+
+def _run_check_one_star(
+    monkeypatch: pytest.MonkeyPatch,
+    ring_radii: np.ndarray,
+    *,
+    min_opaque_fraction: float,
+) -> _FakeStar:
+    """Run ``_check_one_star`` against a canned ring-radius window."""
+    monkeypatch.setattr(conflicts_module, 'Meshgrid', _FakeMeshgrid)
+    monkeypatch.setattr(conflicts_module, 'Backplane', _FakeBackplane)
+    monkeypatch.setattr(_FakeBackplane, 'ring_radii', ring_radii)
+    star = _FakeStar()
+    obs = _FakeObsWithSaturn()
+    obs_any = cast(Any, obs)
+    obs_any.fov = object()
+    conflicts_module._check_one_star(
+        obs=obs_any,
+        star=cast(Any, star),
+        body_list=['SATURN'],
+        ring_annuli={'SATURN': [(74490.0, 91980.0)]},
+        rings_can_conflict=True,
+        body_conflict_margin=2.0,
+        ring_min_opaque_fraction=min_opaque_fraction,
+    )
+    return star
+
+
+def test_check_one_star_flags_star_straddling_annulus_edge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A window straddling the annulus edge is judged per pixel, not by median.
+
+    Two thirds of the window sit just outside the C-ring inner edge, so the
+    median radius lands in free space and a collapsed-median test would clear
+    the star -- but a third of its window is over opaque ring material.
+    """
+    ring_radii = np.array([[74000.0, 74000.0, 74000.0], [74500.0, 74500.0, 74000.0]])
+    star = _run_check_one_star(monkeypatch, ring_radii, min_opaque_fraction=0.25)
+    assert star.conflicts == 'RING: SATURN'
+
+
+def test_check_one_star_clears_star_when_median_falls_in_thin_annulus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A visible star is kept when only a sliver of the window is opaque.
+
+    The median radius of this window falls inside the annulus, so the
+    collapsed-median test would reject the star even though only one of six
+    pixels is actually over ring material.
+    """
+    ring_radii = np.array([[60000.0, 70000.0, 74500.0], [95000.0, 100000.0, 105000.0]])
+    star = _run_check_one_star(monkeypatch, ring_radii, min_opaque_fraction=0.25)
+    assert star.conflicts == ''

--- a/tests/spindoctor/nav_model/test_model_selection_config.py
+++ b/tests/spindoctor/nav_model/test_model_selection_config.py
@@ -54,10 +54,10 @@ class _FakeSaturnObs:
     closest_planet = 'saturn'
 
     def inventory(self, body_list: list[str], return_type: str = 'full') -> dict[str, Any]:
-        """Report Saturn present in the FOV; no satellites visible."""
+        """Report every requested body as present in the FOV."""
         del return_type
         entry = {'center_uv': np.array([5.0, 5.0]), 'u_pixel_size': 4.0, 'v_pixel_size': 4.0}
-        return {name: entry for name in body_list if name.lower() == 'saturn'}
+        return dict.fromkeys(body_list, entry)
 
     def inventory_body_in_extfov(self, entry: dict[str, Any]) -> bool:
         """Every reported body is inside the extended FOV."""
@@ -65,10 +65,31 @@ class _FakeSaturnObs:
         return True
 
 
+def _config_with_titan_only_satellites(tmp_path: Path) -> Config:
+    override = tmp_path / 'satellites_override.yaml'
+    # List values replace wholesale on merge, so this shrinks Saturn's
+    # satellite catalog to a single body.
+    override.write_text('satellites:\n  SATURN:\n    - TITAN\n')
+    config = Config()
+    config.update_config(override)
+    return config
+
+
+def test_body_selection_uses_config_satellite_catalog(tmp_path: Path) -> None:
+    # The satellite catalog in the supplied config decides which bodies are
+    # even considered: an override shrinking Saturn's satellites to Titan
+    # must shrink the instantiated model set accordingly.
+    config = _config_with_titan_only_satellites(tmp_path)
+    instances = NavModelBody.instances_for_obs(cast(Any, _FakeSaturnObs()), config=config)
+    assert sorted(m.name for m in instances) == ['body:TITAN', 'body:saturn']
+    default_instances = NavModelBody.instances_for_obs(cast(Any, _FakeSaturnObs()))
+    assert len(default_instances) > len(instances)
+
+
 def test_body_selection_threads_config_to_instances(tmp_path: Path) -> None:
     # The selection stage and the constructed instances must share the same
     # per-run config object.
     config = _config_with_jupiter_rings(tmp_path)
     instances = NavModelBody.instances_for_obs(cast(Any, _FakeSaturnObs()), config=config)
-    assert len(instances) == 1
-    assert instances[0]._config is config
+    assert len(instances) > 0
+    assert all(m._config is config for m in instances)

--- a/tests/spindoctor/nav_model/test_model_selection_config.py
+++ b/tests/spindoctor/nav_model/test_model_selection_config.py
@@ -1,0 +1,74 @@
+"""Tests that model selection honors a per-run config override (issue #146)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+
+from spindoctor.config import Config
+from spindoctor.nav_model.nav_model_body import NavModelBody
+from spindoctor.nav_model.nav_model_rings import NavModelRings
+
+
+class _FakeJupiterObs:
+    """Observation stand-in exposing what ring-model selection inspects."""
+
+    is_simulated = False
+    closest_planet = 'jupiter'
+    extdata_shape_vu = (10, 10)
+    ext_bp = object()
+
+
+def _config_with_jupiter_rings(tmp_path: Path) -> Config:
+    override = tmp_path / 'override.yaml'
+    override.write_text(
+        'rings:\n  ring_features:\n    jupiter:\n      main:\n        fiducial_features: []\n'
+    )
+    config = Config()
+    config.update_config(override)
+    return config
+
+
+def test_rings_selection_defaults_to_no_jupiter_model() -> None:
+    # The bundled defaults carry no Jupiter ring catalog, so no model applies.
+    instances = NavModelRings.instances_for_obs(cast(Any, _FakeJupiterObs()))
+    assert instances == []
+
+
+def test_rings_selection_honors_config_override(tmp_path: Path) -> None:
+    # A per-run override that adds a Jupiter ring catalog must change which
+    # models are instantiated, not just how the instances behave.
+    config = _config_with_jupiter_rings(tmp_path)
+    instances = NavModelRings.instances_for_obs(cast(Any, _FakeJupiterObs()), config=config)
+    assert len(instances) == 1
+    assert instances[0].name == 'rings:jupiter'
+    assert instances[0]._config is config
+
+
+class _FakeSaturnObs:
+    """Observation stand-in with an inventory for body-model selection."""
+
+    is_simulated = False
+    closest_planet = 'saturn'
+
+    def inventory(self, body_list: list[str], return_type: str = 'full') -> dict[str, Any]:
+        """Report Saturn present in the FOV; no satellites visible."""
+        del return_type
+        entry = {'center_uv': np.array([5.0, 5.0]), 'u_pixel_size': 4.0, 'v_pixel_size': 4.0}
+        return {name: entry for name in body_list if name.lower() == 'saturn'}
+
+    def inventory_body_in_extfov(self, entry: dict[str, Any]) -> bool:
+        """Every reported body is inside the extended FOV."""
+        del entry
+        return True
+
+
+def test_body_selection_threads_config_to_instances(tmp_path: Path) -> None:
+    # The selection stage and the constructed instances must share the same
+    # per-run config object.
+    config = _config_with_jupiter_rings(tmp_path)
+    instances = NavModelBody.instances_for_obs(cast(Any, _FakeSaturnObs()), config=config)
+    assert len(instances) == 1
+    assert instances[0]._config is config


### PR DESCRIPTION
Stacked on #215 (`trackb-dataset-selection`). Review only the last commit; rebase after each squash-merge below it.

## #146 — model selection ignored per-run config overrides

`NavModelRings.instances_for_obs` and `NavModelBody.instances_for_obs` hardcoded `DEFAULT_CONFIG` for deciding *which* models to build, even though the constructed instances accept a per-instance config. A per-run override that (say) adds a ring catalog appeared to have no effect at the selection stage.

`instances_for_obs` (base + all six overrides) and `build_models_for_obs` now take a keyword-only `config` parameter used both for selection and for constructing the instances, defaulting to `DEFAULT_CONFIG` when omitted — all existing callers are unchanged in behavior.

## #145 — star-ring occlusion judged by median window radius

`_check_one_star` collapsed the ring-radius backplane over the star's conflict window to a single median radius. Near ringlet edges and gap boundaries — exactly where occlusion matters — that mis-classifies in both directions: a star with 1/3 of its window over the C ring was cleared (median in free space), and a star over a wide radius spread was rejected whenever the median happened to land inside a thin annulus.

Ring membership is now tested per pixel: the star is occluded when at least `stars.ring_occlusion_min_opaque_fraction` (new config knob, default 0.25) of the valid window pixels fall inside an opaque annulus. Masked pixels are excluded from numerator and denominator; an all-masked window never occludes (same as before).

## Testing

- `tests/spindoctor/nav_model/test_model_selection_config.py`: Jupiter ring-catalog override changes the instantiated model set; body selection threads the same config object into instances.
- `tests/spindoctor/nav_model/stars/test_conflicts.py`: `_ring_opaque_fraction` unit tests plus two `_check_one_star` regressions (edge-straddling star flagged; thin-annulus-median star cleared) against a fake Backplane.
- Full unit suite green (1850 passed). ruff/mypy clean.
- Dev guide updated (`ring_occlusion_min_opaque_fraction` documented).

Behavior note: the default 0.25 threshold makes the occlusion gate slightly more permissive than "median inside annulus" for stars sitting mostly in gaps and stricter for stars partially over ring material. Star-count deltas on ring-heavy frames are possible but were not observed in the unit corpus; the real-image library regression runs on the stack head before merge.

Fixes #146. Fixes #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KW6fkURsA2zgrWFKjbR5JY

## Updates since the initial description

- **Docs pass**: `dev_guide_navigation_models.rst` documents the `config` parameter on `instances_for_obs` / `build_models_for_obs` (selection and construction; `None` = `DEFAULT_CONFIG`).
- **Library crosscheck** (62 sidecars, run on the stack head): zero deltas caused by this stack — see the PR comment for numbers and the two pre-existing findings it produced (#221, #222).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-run configuration overrides for selecting and constructing navigation models.
  * Added configurable ring-occlusion detection based on the percentage of conflict-window pixels covered by opaque rings.
  * Added the `ring_occlusion_min_opaque_fraction` setting, defaulting to 0.25.

* **Documentation**
  * Updated navigation model and star-occlusion guidance to explain configuration overrides and per-pixel ring coverage behavior.

* **Bug Fixes**
  * Improved handling of stars near ring boundaries, gaps, and narrow annuli.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Operator checklist

- **Pre-merge: nothing.** Merge after #215 merges, the rebase lands, and CI is green.
- **Post-merge: nothing.** #146 and #145 auto-close via the description — verify they did.
