### PR TITLE
feat: ensemble consensus-subset outlier rejection (#124)

### DIFF
--- a/docs/dev_guide/dev_guide_orchestrator_ensemble.rst
+++ b/docs/dev_guide/dev_guide_orchestrator_ensemble.rst
@@ -37,11 +37,10 @@ Every result with
 preserves an at-edge result when it is the only signal the orchestrator has — better a
 hint at a search-window edge than no answer at all.
 
-Step 3 — single-link Mahalanobis grouping
------------------------------------------
+Step 3 — pairwise agreement
+---------------------------
 
-Surviving results are clustered by single-linkage Mahalanobis-distance agreement. Two
-results :math:`(\mu_{a}, \Sigma_{a})` and :math:`(\mu_{b}, \Sigma_{b})` are linked when
+Two results :math:`(\mu_{a}, \Sigma_{a})` and :math:`(\mu_{b}, \Sigma_{b})` agree when
 
 .. math::
 
@@ -49,17 +48,34 @@ results :math:`(\mu_{a}, \Sigma_{a})` and :math:`(\mu_{b}, \Sigma_{b})` are link
                         (\mu_{a} - \mu_{b})}
 
 is at most ``agreement_sigma``, where the pseudoinverse uses
-:func:`scipy.linalg.pinvh` so rank-deficient covariances are handled. A result whose
+:func:`scipy.linalg.pinvh` so rank-deficient covariances are handled, *or* when their
+Euclidean translation distance is at most ``agreement_pixel_floor`` (default 5 px). The
+pixel floor exists because per-technique covariances are CRLB-tight — well below the
+actual position uncertainty driven by model error — so results agreeing visually to a
+few pixels can register as hundreds of sigmas apart. A result whose
 :math:`(\mu_{a} - \mu_{b})` projects into the null space of the summed covariance is
-treated as infinite distance — estimates cannot agree along an unobservable axis.
+treated as infinite Mahalanobis distance — estimates cannot agree along an
+unobservable axis.
 
-Step 4 — pick the highest summed-confidence group
--------------------------------------------------
+Step 4 — consensus-subset selection and outlier rejection
+---------------------------------------------------------
 
-For each connected component, sum the per-technique confidences and pick the group with
-the highest sum. When the runner-up's summed confidence is within ``agreement_gap`` of
-the winner's, the ensemble flags the conflict and returns a ``status='conflicted'``
-:class:`~spindoctor.nav_orchestrator.nav_result.NavResult` instead of fusing.
+Every surviving result sponsors a candidate subset: the results that agree with it
+pairwise under Step 3. The subset with the highest summed confidence wins and is the
+set the ensemble fuses; results outside it are *excluded from the consensus* and
+reported on
+:attr:`~spindoctor.nav_orchestrator.nav_result.NavResult.excluded_from_consensus`.
+
+Exclusion forces the conflicted branch only when the excluded results constitute a
+genuine alternative answer: the strongest consensus formable among the excluded
+results alone either has at least two members (an alternative with quorum) or the
+winning subset is itself a singleton (no quorum anywhere). In that case, when the
+summed-confidence gap between winner and runner-up falls below ``agreement_gap``, the
+ensemble returns a ``status='conflicted'``
+:class:`~spindoctor.nav_orchestrator.nav_result.NavResult` instead of fusing. A lone
+dissenter against a multi-technique consensus is outlier-rejected: the consensus is
+fused normally (with the Step 6 disagreement penalty) and the dissenter appears only
+in ``excluded_from_consensus`` and ``per_technique``.
 
 Step 5 — precision-weighted merge
 ---------------------------------
@@ -75,7 +91,7 @@ unbounded marginal sigma.
 Step 6 — disagreement and conflict penalties
 --------------------------------------------
 
-When more than one Mahalanobis-distance group survived, the fused confidence is multiplied
+When any result was excluded from the consensus, the fused confidence is multiplied
 by ``disagreement_penalty`` (default 0.7). When the conflict branch fired in Step 4 the
 ``status='conflicted'`` :class:`~spindoctor.nav_orchestrator.nav_result.NavResult` is returned with a further
 ``conflicted_confidence_multiplier`` (default 0.3) applied to the runner-up's summed
@@ -174,14 +190,17 @@ Examples
 penalty fires (only one group existed) so the fused confidence is the summed per-technique
 confidence (capped by the project-wide ceiling).
 
-**Single-link grouping with three techniques.**  Three techniques converge:
+**Consensus selection with three techniques.**  Three techniques converge:
 :math:`(7.0, -18.0)` ± 0.3, :math:`(8.0, -17.5)` ± 0.5, :math:`(11.6, 12.6)` ± 0.4. The
-first two are within ``agreement_sigma`` of each other; the third is several sigma off in
-both axes. Single-link grouping puts the first two in one cluster and the third in its
-own. The first cluster's summed confidence is 0.49; the third's is 0.74. When the gap
-:math:`0.74 - 0.49 = 0.25` falls below ``agreement_gap=0.5`` the ensemble flags the
-conflict and returns ``status='conflicted'`` rather than picking the higher-confidence
-isolated wrong answer (this is the documented ``multi_body`` test scene's behaviour).
+first two agree pairwise; the third is several sigma off in both axes. The candidate
+subsets are the agreeing pair (summed confidence 0.49) and the singleton (0.74); the
+singleton wins on summed confidence, and the excluded pair is an alternative *with
+quorum*. The gap :math:`0.74 - 0.49 = 0.25` falls below ``agreement_gap=0.5``, so the
+ensemble flags the conflict and returns ``status='conflicted'`` rather than picking the
+higher-confidence isolated wrong answer (this is the documented ``multi_body`` test
+scene's behaviour). Had a *third* technique joined the pair, the pair-plus-one subset
+would have outweighed the singleton and the ensemble would have fused it, excluding the
+dissenter as an outlier instead of conflicting.
 
 **Rank-deficient ring-edge fit.**  A flat-ring-only scene produces a
 :class:`~spindoctor.nav_technique.nav_technique_ring_edge.RingEdgeNav` result whose covariance is

--- a/docs/dev_guide/dev_guide_orchestrator_nav_result.rst
+++ b/docs/dev_guide/dev_guide_orchestrator_nav_result.rst
@@ -101,6 +101,11 @@ Public fields (autodocumented at :doc:`/api_reference/api_nav_orchestrator`):
 - :attr:`~spindoctor.nav_orchestrator.nav_result.NavResult.per_technique` — list of every
   technique's :class:`~spindoctor.nav_technique.technique_result.NavTechniqueResult` (kept or
   dropped by the ensemble).
+- :attr:`~spindoctor.nav_orchestrator.nav_result.NavResult.excluded_from_consensus` —
+  technique names of viable results the ensemble left out of the reported combine
+  (outliers rejected against a multi-technique consensus, or the runner-up alternative
+  on a conflicted result); empty when every viable result contributed. Also emitted in
+  the metadata JSON.
 - :attr:`~spindoctor.nav_orchestrator.nav_result.NavResult.feature_inventory` — list of
   per-feature :class:`~spindoctor.nav_orchestrator.feature_summary.NavFeatureSummary` entries.
 - :attr:`~spindoctor.nav_orchestrator.nav_result.NavResult.image_classifier` — the

--- a/docs/user_guide/user_guide_navigation.rst
+++ b/docs/user_guide/user_guide_navigation.rst
@@ -471,7 +471,12 @@ These JSON files contain the navigation results, including:
 * Confidence scores
 * Metadata about the navigation process
 * Status information (success, error, etc.)
-* Technique-specific metadata
+* Technique-specific metadata (one ``per_technique`` entry per technique run,
+  with each technique's offset, covariance, confidence, spurious / at-edge
+  flags, and diagnostics)
+* ``excluded_from_consensus`` — technique names the ensemble left out of the
+  reported combine (outliers rejected against a multi-technique consensus, or
+  the runner-up alternative on a conflicted result)
 * Timestamps
 
 .. note::

--- a/src/spindoctor/nav_orchestrator/curator.py
+++ b/src/spindoctor/nav_orchestrator/curator.py
@@ -232,6 +232,7 @@ def build_metadata_dict(result: NavResult) -> dict[str, Any]:
         'confidence_rank': result.confidence_rank,
         'covariance_px2': _round_matrix(result.covariance_px2),
         'techniques_used': sorted({r.technique_name for r in result.per_technique}),
+        'excluded_from_consensus': sorted(result.excluded_from_consensus),
         'feature_count_by_type': feature_count_by_type,
         'per_technique': [_curate_technique_result(r) for r in result.per_technique],
         'feature_inventory': [_curate_feature_summary(s) for s in result.feature_inventory],

--- a/src/spindoctor/nav_orchestrator/ensemble.py
+++ b/src/spindoctor/nav_orchestrator/ensemble.py
@@ -5,12 +5,17 @@ estimates become one offset.  Every step is honest:
 
 1. Drop ``spurious=True`` results.
 2. Drop ``at_edge=True`` results unless dropping them would empty the set.
-3. Group remaining results by Mahalanobis-distance agreement (single-link).
-4. Pick the highest summed-confidence group.
-5. Combine offsets within that group via precision-weighted (Kalman-style)
-   merging.
+3. Select the consensus subset: every result sponsors the set of results
+   that agree with it pairwise (Mahalanobis distance or pixel floor); the
+   subset with the highest summed confidence wins.
+4. Exclude results outside the consensus from the combine.  A lone
+   dissenter against a multi-technique consensus is outlier-rejected;
+   only a genuine alternative (a runner-up consensus with at least two
+   members, or no quorum anywhere) can force the conflicted branch.
+5. Combine offsets within the winning subset via precision-weighted
+   (Kalman-style) merging.
 6. Apply optional disagreement / conflict penalties.
-7. Emit a NavResult.
+7. Emit a NavResult carrying the excluded technique names.
 
 The ensemble is tested in isolation against synthetic per-technique results;
 correctness here is what makes the rest of the pipeline trustworthy.
@@ -24,7 +29,6 @@ from typing import Any, cast
 
 import numpy as np
 from scipy.linalg import pinvh
-from scipy.sparse.csgraph import connected_components
 
 from spindoctor.annotation import Annotations
 from spindoctor.config import IMAGE_LOGGER
@@ -40,7 +44,7 @@ from spindoctor.nav_technique.nav_technique import technique_tier
 from spindoctor.nav_technique.technique_result import NavTechniqueResult
 from spindoctor.support.exceptions import NavContractError
 from spindoctor.support.status_reason import NavStatusReason
-from spindoctor.support.types import NDArrayFloatType
+from spindoctor.support.types import NDArrayBoolType, NDArrayFloatType
 
 __all__ = [
     'EnsembleConfig',
@@ -299,26 +303,45 @@ def _drop_superseded_fallbacks(
     return kept
 
 
-def _agreement_groups(
+@dataclass(frozen=True)
+class _ConsensusSelection:
+    """Output of :func:`_consensus_selection`.
+
+    Parameters:
+        best: The winning consensus subset (never empty).
+        excluded: Viable results outside the winning subset, in input order.
+        runner_up_confidence: Highest summed confidence of any consensus
+            subset formed within ``excluded`` alone; ``0.0`` when nothing
+            was excluded.
+        runner_up_has_quorum: True when that runner-up subset has at least
+            two members -- a genuine alternative consensus rather than a
+            lone dissenter.
+    """
+
+    best: list[NavTechniqueResult]
+    excluded: list[NavTechniqueResult]
+    runner_up_confidence: float
+    runner_up_has_quorum: bool
+
+
+def _agreement_adjacency(
     results: list[NavTechniqueResult],
     *,
     agreement_sigma: float,
     agreement_pixel_floor: float,
     rcond: float,
-    max_allowed_rotation_deg: float,
-) -> list[list[NavTechniqueResult]]:
-    """Single-link clustering by Mahalanobis distance with a pixel-floor fallback.
+) -> NDArrayBoolType:
+    """Pairwise agreement matrix: Mahalanobis threshold with a pixel-floor fallback.
 
-    Two results are placed in the same group iff *either* their pairwise
-    Mahalanobis distance is below ``agreement_sigma`` *or* their
-    Euclidean translation distance (in pixels, ignoring the rotation
-    component for 3-DoF results) is at most ``agreement_pixel_floor``.
-    Transitive closure builds final groups via connected components.
+    Two results agree iff *either* their pairwise Mahalanobis distance is
+    at most ``agreement_sigma`` *or* their Euclidean translation distance
+    (in pixels, ignoring the rotation component for 3-DoF results) is at
+    most ``agreement_pixel_floor``.
 
     The Mahalanobis distance differences the rotation component of two
     3-DoF results linearly; that is correct here because every input
-    rotation is bounded to the small-angle window enforced below, so the
-    pairwise angle difference never approaches the ``+-pi`` wrap.
+    rotation is bounded to the small-angle window enforced by the caller,
+    so the pairwise angle difference never approaches the ``+-pi`` wrap.
 
     The pixel floor compensates for per-technique covariances that
     report only a CRLB-style precision (FFT subpixel localization or
@@ -327,52 +350,20 @@ def _agreement_groups(
     motivation.
 
     Parameters:
-        results: Non-empty list of per-technique results.
-        agreement_sigma: Maximum pairwise Mahalanobis distance for grouping.
+        results: List of two or more per-technique results.
+        agreement_sigma: Maximum pairwise Mahalanobis distance for agreement.
         agreement_pixel_floor: Maximum pairwise Euclidean translation
-            distance (in pixels) for grouping; ``0.0`` disables.
+            distance (in pixels) for agreement; ``0.0`` disables.
         rcond: rcond passed to ``pinvh``.
-        max_allowed_rotation_deg: Small-angle bound; each 3-DoF input's
-            ``rotation_rad`` magnitude must stay strictly below this many
-            degrees for the linear rotation differencing to be valid.
 
     Returns:
-        List of groups (each group a list of NavTechniqueResult).
+        Symmetric boolean ``(n, n)`` matrix with a True diagonal.
 
     Raises:
-        NavContractError: if a 3-DoF input's rotation magnitude is at or
-            above the small-angle bound (an upstream programming error).
+        ValueError: if 2-DoF and 3-DoF results are mixed.
     """
     n = len(results)
-    if n == 0:
-        return []
-    max_rotation_rad = math.radians(max_allowed_rotation_deg)
-    for res in results:
-        cov = np.asarray(res.covariance_px2, np.float64)
-        # Small-angle assumption: a 3-DoF rotation outside +-max_rotation_deg
-        # is an upstream error (every technique clamps its rotation fit to
-        # this bound), and would break the linear rotation differencing.
-        # Raised as NavContractError (not a bare assert) so the check
-        # survives python -O and is never swallowed as an ordinary
-        # technique failure.
-        if (
-            cov.shape == (3, 3)
-            and res.rotation_rad is not None
-            and abs(res.rotation_rad) >= max_rotation_rad
-        ):
-            raise NavContractError(
-                f'{res.technique_name}: rotation '
-                f'{math.degrees(res.rotation_rad):.3f} deg violates small-angle '
-                f'bound +-{max_allowed_rotation_deg:.3f} deg'
-            )
-    if n == 1:
-        return [list(results)]
-    # Build a sparse adjacency matrix marking pairs within threshold.
-    rows: list[int] = []
-    cols: list[int] = []
-    for i in range(n):
-        rows.append(i)
-        cols.append(i)
+    adj = np.eye(n, dtype=bool)
     for i in range(n):
         mu_i = _result_param_vector(results[i])
         cov_i = np.asarray(results[i].covariance_px2, np.float64)
@@ -394,16 +385,133 @@ def _agreement_groups(
             pixel_dist = float(math.hypot(translation_delta[0], translation_delta[1]))
             pixel_match = agreement_pixel_floor > 0.0 and pixel_dist <= agreement_pixel_floor
             if mahal_match or pixel_match:
-                rows.extend([i, j])
-                cols.extend([j, i])
-    # Build dense adjacency.  N is small (typically < 10), so this is fine.
-    adj = np.zeros((n, n), dtype=bool)
-    adj[rows, cols] = True
-    n_components, labels = connected_components(csgraph=adj, directed=False, return_labels=True)
-    groups: list[list[NavTechniqueResult]] = [[] for _ in range(n_components)]
-    for idx, label in enumerate(labels):
-        groups[int(label)].append(results[idx])
-    return groups
+                adj[i, j] = True
+                adj[j, i] = True
+    return adj
+
+
+def _best_neighborhood(
+    results: list[NavTechniqueResult],
+    adj: NDArrayBoolType,
+    candidate_indices: list[int],
+) -> list[int]:
+    """The candidate neighborhood with the highest summed confidence.
+
+    Each candidate ``i`` sponsors the subset of ``candidate_indices`` that
+    agree with it pairwise (including itself).  Subsets are scored by
+    summed confidence; ties break toward the larger subset, then toward
+    the earlier candidate, so the selection is deterministic.
+
+    Parameters:
+        results: The full per-technique result list (for confidences).
+        adj: Pairwise agreement matrix over ``results``.
+        candidate_indices: Indices eligible for this selection round.
+
+    Returns:
+        The winning subset as a list of indices into ``results``.
+    """
+    best: list[int] = []
+    best_key = (float('-inf'), 0)
+    for i in candidate_indices:
+        subset = [j for j in candidate_indices if adj[i, j]]
+        key = (sum(results[j].confidence for j in subset), len(subset))
+        if key > best_key:
+            best = subset
+            best_key = key
+    return best
+
+
+def _consensus_selection(
+    results: list[NavTechniqueResult],
+    *,
+    agreement_sigma: float,
+    agreement_pixel_floor: float,
+    rcond: float,
+    max_allowed_rotation_deg: float,
+) -> _ConsensusSelection:
+    """Select the consensus subset the ensemble combines, and its outliers.
+
+    Every result sponsors a candidate subset -- the results that agree
+    with it pairwise (Mahalanobis distance within ``agreement_sigma`` or
+    translation distance within ``agreement_pixel_floor``).  The subset
+    with the highest summed confidence wins; results outside it are
+    excluded from the combine rather than forcing a conflict, and the
+    strongest consensus formable among the excluded results alone is
+    reported as the runner-up so the caller can distinguish a lone
+    mis-converged dissenter from a genuine alternative answer.
+
+    Unlike single-link transitive-closure grouping, a result that agrees
+    with only one member of the winning subset does not drag the whole
+    subset toward it: membership requires pairwise agreement with the
+    sponsoring result.
+
+    Parameters:
+        results: Non-empty list of per-technique results.
+        agreement_sigma: Maximum pairwise Mahalanobis distance for agreement.
+        agreement_pixel_floor: Maximum pairwise Euclidean translation
+            distance (in pixels) for agreement; ``0.0`` disables.
+        rcond: rcond passed to ``pinvh``.
+        max_allowed_rotation_deg: Small-angle bound; each 3-DoF input's
+            ``rotation_rad`` magnitude must stay strictly below this many
+            degrees for the linear rotation differencing to be valid.
+
+    Returns:
+        The selection: winning subset, excluded results, and runner-up
+        summary.
+
+    Raises:
+        NavContractError: if a 3-DoF input's rotation magnitude is at or
+            above the small-angle bound (an upstream programming error).
+        ValueError: if 2-DoF and 3-DoF results are mixed.
+    """
+    n = len(results)
+    max_rotation_rad = math.radians(max_allowed_rotation_deg)
+    for res in results:
+        cov = np.asarray(res.covariance_px2, np.float64)
+        # Small-angle assumption: a 3-DoF rotation outside +-max_rotation_deg
+        # is an upstream error (every technique clamps its rotation fit to
+        # this bound), and would break the linear rotation differencing.
+        # Raised as NavContractError (not a bare assert) so the check
+        # survives python -O and is never swallowed as an ordinary
+        # technique failure.
+        if (
+            cov.shape == (3, 3)
+            and res.rotation_rad is not None
+            and abs(res.rotation_rad) >= max_rotation_rad
+        ):
+            raise NavContractError(
+                f'{res.technique_name}: rotation '
+                f'{math.degrees(res.rotation_rad):.3f} deg violates small-angle '
+                f'bound +-{max_allowed_rotation_deg:.3f} deg'
+            )
+    if n == 1:
+        return _ConsensusSelection(
+            best=list(results),
+            excluded=[],
+            runner_up_confidence=0.0,
+            runner_up_has_quorum=False,
+        )
+    adj = _agreement_adjacency(
+        results,
+        agreement_sigma=agreement_sigma,
+        agreement_pixel_floor=agreement_pixel_floor,
+        rcond=rcond,
+    )
+    best_indices = _best_neighborhood(results, adj, list(range(n)))
+    best_set = set(best_indices)
+    excluded_indices = [i for i in range(n) if i not in best_set]
+    runner_up_confidence = 0.0
+    runner_up_has_quorum = False
+    if excluded_indices:
+        runner_indices = _best_neighborhood(results, adj, excluded_indices)
+        runner_up_confidence = sum(results[j].confidence for j in runner_indices)
+        runner_up_has_quorum = len(runner_indices) >= 2
+    return _ConsensusSelection(
+        best=[results[i] for i in sorted(best_set)],
+        excluded=[results[i] for i in excluded_indices],
+        runner_up_confidence=runner_up_confidence,
+        runner_up_has_quorum=runner_up_has_quorum,
+    )
 
 
 @dataclass(frozen=True)
@@ -730,21 +838,18 @@ def ensemble(
     interior = [r for r in viable if not r.at_edge]
     if interior:
         viable = interior
-    groups = _agreement_groups(
+    selection = _consensus_selection(
         viable,
         agreement_sigma=cfg.agreement_sigma,
         agreement_pixel_floor=cfg.agreement_pixel_floor,
         rcond=cfg.pinvh_rcond,
         max_allowed_rotation_deg=cfg.max_allowed_rotation_deg,
     )
-    ranked = sorted(
-        groups,
-        key=lambda g: sum(r.confidence for r in g),
-        reverse=True,
-    )
-    best_group = ranked[0]
+    best_group = selection.best
+    excluded = selection.excluded
+    excluded_names = [r.technique_name for r in excluded]
     best_summed_conf = sum(r.confidence for r in best_group)
-    apply_disagreement_penalty = len(groups) > 1
+    apply_disagreement_penalty = bool(excluded)
     try:
         combined = _combine_precision_weighted(
             best_group,
@@ -774,21 +879,28 @@ def ensemble(
             model_metadata=md,
             annotations=ann,
         )
-    # Conflict check: best-vs-runner-up summed-confidence gap.
-    if len(ranked) > 1:
-        runner_up_summed_conf = sum(r.confidence for r in ranked[1])
-        gap = best_summed_conf - runner_up_summed_conf
-        if gap < cfg.agreement_gap:
+    # Conflict check.  Excluded results force the conflicted branch only when
+    # they constitute a genuine alternative: a runner-up consensus with at
+    # least two members, or a lone-vs-lone standoff (the winning subset has no
+    # quorum either).  A single dissenter against a multi-technique consensus
+    # is outlier-rejected instead -- reported via excluded_from_consensus and
+    # the disagreement penalty, not as a conflict.
+    if excluded:
+        genuine_alternative = selection.runner_up_has_quorum or len(best_group) == 1
+        gap = best_summed_conf - selection.runner_up_confidence
+        if genuine_alternative and gap < cfg.agreement_gap:
             conflicted_confidence = combined_confidence * cfg.conflicted_confidence_multiplier
             IMAGE_LOGGER.info(
                 'Conflicted: best-vs-runner-up summed-confidence gap %.3f is '
                 'below the agreement_gap threshold %.3f '
-                '(best %.3f, runner-up %.3f); conflicted confidence = %.3f '
+                '(best %.3f, runner-up %.3f, runner-up quorum: %s); '
+                'conflicted confidence = %.3f '
                 '(combined %.3f x conflicted_multiplier %.3f)',
                 gap,
                 cfg.agreement_gap,
                 best_summed_conf,
-                runner_up_summed_conf,
+                selection.runner_up_confidence,
+                selection.runner_up_has_quorum,
                 conflicted_confidence,
                 combined_confidence,
                 cfg.conflicted_confidence_multiplier,
@@ -801,9 +913,21 @@ def ensemble(
                 feature_inventory=feature_inventory,
                 image_classifier=image_classifier,
                 provenance=provenance,
+                excluded_from_consensus=excluded_names,
                 model_metadata=md,
                 annotations=ann,
             )
+        IMAGE_LOGGER.info(
+            'Excluded %d result(s) from consensus as outlier(s): %s '
+            '(consensus %d member(s) summing %.3f; excluded runner-up %.3f, '
+            'quorum: %s)',
+            len(excluded),
+            ', '.join(excluded_names),
+            len(best_group),
+            best_summed_conf,
+            selection.runner_up_confidence,
+            selection.runner_up_has_quorum,
+        )
     if combined_confidence < cfg.min_confidence:
         IMAGE_LOGGER.info(
             'Combined confidence %.3f is below the min_confidence threshold %.3f',
@@ -877,6 +1001,7 @@ def ensemble(
         image_classifier=image_classifier,
         provenance=provenance,
         sigma_along_unobservable_px=sigma_along_unobservable_px,
+        excluded_from_consensus=excluded_names,
         model_metadata=md,
         annotations=ann,
         rotation_rad=combined.rotation_rad,

--- a/src/spindoctor/nav_orchestrator/nav_result.py
+++ b/src/spindoctor/nav_orchestrator/nav_result.py
@@ -50,6 +50,11 @@ class NavResult:
             ``None`` on failure.
         per_technique: List of every technique's result (whether kept or
             dropped by the ensemble).
+        excluded_from_consensus: Technique names of viable results the
+            ensemble left out of the reported combine -- outliers rejected
+            against a multi-technique consensus, or (on a conflicted
+            result) the runner-up alternative.  Empty when every viable
+            result contributed.
         feature_inventory: Per-feature summary entries — what was
             extracted, what survived the gate, and why.
         image_classifier: The image-quality classifier's verdict.
@@ -76,6 +81,7 @@ class NavResult:
     feature_inventory: list[NavFeatureSummary]
     image_classifier: NavImageClassifierResult
     provenance: Provenance
+    excluded_from_consensus: list[str] = field(default_factory=list)
     model_metadata: dict[str, dict[str, Any]] = field(default_factory=dict)
     annotations: Annotations = field(default_factory=Annotations)
     rotation_rad: float | None = None
@@ -163,6 +169,7 @@ class NavResult:
         image_classifier: NavImageClassifierResult,
         provenance: Provenance,
         sigma_along_unobservable_px: float | None = None,
+        excluded_from_consensus: list[str] | None = None,
         model_metadata: dict[str, dict[str, Any]] | None = None,
         annotations: Annotations | None = None,
         rotation_rad: float | None = None,
@@ -189,6 +196,7 @@ class NavResult:
             feature_inventory=feature_inventory,
             image_classifier=image_classifier,
             provenance=provenance,
+            excluded_from_consensus=excluded_from_consensus or [],
             model_metadata=model_metadata or {},
             annotations=annotations if annotations is not None else Annotations(),
             rotation_rad=rotation_rad,
@@ -206,6 +214,7 @@ class NavResult:
         feature_inventory: list[NavFeatureSummary],
         image_classifier: NavImageClassifierResult,
         provenance: Provenance,
+        excluded_from_consensus: list[str] | None = None,
         model_metadata: dict[str, dict[str, Any]] | None = None,
         annotations: Annotations | None = None,
     ) -> 'NavResult':
@@ -230,6 +239,7 @@ class NavResult:
             feature_inventory=feature_inventory,
             image_classifier=image_classifier,
             provenance=provenance,
+            excluded_from_consensus=excluded_from_consensus or [],
             model_metadata=model_metadata or {},
             annotations=annotations if annotations is not None else Annotations(),
         )

--- a/tests/spindoctor/nav_orchestrator/test_curator.py
+++ b/tests/spindoctor/nav_orchestrator/test_curator.py
@@ -89,6 +89,7 @@ def test_metadata_dict_contains_top_level_keys() -> None:
         'confidence_rank',
         'covariance_px2',
         'techniques_used',
+        'excluded_from_consensus',
         'feature_count_by_type',
         'per_technique',
         'feature_inventory',

--- a/tests/spindoctor/nav_orchestrator/test_ensemble.py
+++ b/tests/spindoctor/nav_orchestrator/test_ensemble.py
@@ -851,3 +851,112 @@ def test_combine_confidence_weight_ignores_rotation_precision() -> None:
     # agreement_factor = 1 + 0.5*log2(2) = 1.5 -> combined = 0.75.  Far above
     # the ~0.2 the rotation-tight result would have forced under the old trace.
     assert combined == pytest.approx(0.75, abs=1e-9)
+
+
+# --- Consensus outlier rejection (issue #124) ---
+
+
+def _three_agreeing_plus_outlier() -> list[NavTechniqueResult]:
+    """Three techniques agreeing at ~(10, 5) plus one mis-converged outlier."""
+    cov = np.eye(2, dtype=np.float64) * 0.25
+    return [
+        _make_result(technique_name='BodyLimbNav', offset=(10.0, 5.0), cov=cov, confidence=0.8),
+        _make_result(
+            technique_name='BodyDiscCorrelateNav', offset=(10.1, 5.1), cov=cov, confidence=0.8
+        ),
+        _make_result(technique_name='RingEdgeNav', offset=(10.0, 5.0), cov=cov, confidence=0.7),
+        _make_result(
+            technique_name='BodyTerminatorNav', offset=(-3.0, 12.0), cov=cov, confidence=0.8
+        ),
+    ]
+
+
+def test_ensemble_rejects_lone_outlier_against_consensus() -> None:
+    """Three agreeing results plus one far-off dissenter yield consensus, not conflict."""
+    result = ensemble(
+        _three_agreeing_plus_outlier(),
+        feature_inventory=[],
+        image_classifier=_classifier(),
+        provenance=_provenance(),
+    )
+    assert result.status == 'success'
+    assert result.excluded_from_consensus == ['BodyTerminatorNav']
+    assert result.offset_px is not None
+    # The combined offset comes from the agreeing trio, unperturbed by the outlier.
+    assert abs(result.offset_px[0] - 10.0) < 0.2
+    assert abs(result.offset_px[1] - 5.0) < 0.2
+    # All four techniques remain visible in per_technique for diagnostics.
+    assert len(result.per_technique) == 4
+
+
+def test_ensemble_outlier_rejection_applies_disagreement_penalty() -> None:
+    """Excluding an outlier still applies the disagreement penalty."""
+    with_outlier = ensemble(
+        _three_agreeing_plus_outlier(),
+        feature_inventory=[],
+        image_classifier=_classifier(),
+        provenance=_provenance(),
+    )
+    unanimous = ensemble(
+        _three_agreeing_plus_outlier()[:3],
+        feature_inventory=[],
+        image_classifier=_classifier(),
+        provenance=_provenance(),
+    )
+    assert unanimous.excluded_from_consensus == []
+    assert with_outlier.confidence < unanimous.confidence
+
+
+def test_ensemble_two_pairs_disagreeing_across_pairs_conflict() -> None:
+    """Two internally-agreeing pairs with comparable confidence conflict (no quorum winner)."""
+    cov = np.eye(2, dtype=np.float64) * 0.25
+    results = [
+        _make_result(technique_name='TechniqueA', offset=(0.0, 0.0), cov=cov, confidence=0.6),
+        _make_result(technique_name='TechniqueB', offset=(0.5, 0.0), cov=cov, confidence=0.6),
+        _make_result(technique_name='TechniqueC', offset=(30.0, 30.0), cov=cov, confidence=0.55),
+        _make_result(technique_name='TechniqueD', offset=(30.5, 30.0), cov=cov, confidence=0.55),
+    ]
+    result = ensemble(
+        results,
+        feature_inventory=[],
+        image_classifier=_classifier(),
+        provenance=_provenance(),
+    )
+    assert result.status == 'conflicted'
+    assert result.excluded_from_consensus == ['TechniqueC', 'TechniqueD']
+
+
+def test_ensemble_dominant_pair_beats_weak_pair_without_conflict() -> None:
+    """A runner-up pair far below the winning pair's summed confidence does not conflict."""
+    cov = np.eye(2, dtype=np.float64) * 0.25
+    results = [
+        _make_result(technique_name='TechniqueA', offset=(0.0, 0.0), cov=cov, confidence=0.9),
+        _make_result(technique_name='TechniqueB', offset=(0.5, 0.0), cov=cov, confidence=0.9),
+        _make_result(technique_name='TechniqueC', offset=(30.0, 30.0), cov=cov, confidence=0.3),
+        _make_result(technique_name='TechniqueD', offset=(30.5, 30.0), cov=cov, confidence=0.3),
+    ]
+    result = ensemble(
+        results,
+        feature_inventory=[],
+        image_classifier=_classifier(),
+        provenance=_provenance(),
+    )
+    assert result.status == 'success'
+    assert result.excluded_from_consensus == ['TechniqueC', 'TechniqueD']
+
+
+def test_ensemble_unanimous_consensus_reports_no_exclusions() -> None:
+    """A fully-agreeing input set reports an empty excluded_from_consensus."""
+    cov = np.eye(2, dtype=np.float64) * 0.25
+    results = [
+        _make_result(technique_name='TechniqueA', offset=(1.0, 2.0), cov=cov, confidence=0.8),
+        _make_result(technique_name='TechniqueB', offset=(1.05, 2.05), cov=cov, confidence=0.8),
+    ]
+    result = ensemble(
+        results,
+        feature_inventory=[],
+        image_classifier=_classifier(),
+        provenance=_provenance(),
+    )
+    assert result.status == 'success'
+    assert result.excluded_from_consensus == []


### PR DESCRIPTION
Stacked on #216. Review only the last commit; rebase after each squash-merge below it.

## Problem (#124)

The ensemble's grouping was purely symmetric: single-link transitive-closure groups, best group by summed confidence, and `conflicted` whenever the runner-up came within `agreement_gap`. One mis-converged technique against three agreeing ones could force `conflicted` — the exact case the ensemble should be most confident about — and the design had no concept of a majority vote.

## Change

`_agreement_groups` is replaced by `_consensus_selection`:

- **Pairwise agreement** is unchanged (Mahalanobis ≤ `agreement_sigma` OR translation ≤ `agreement_pixel_floor`; same rotation small-angle contract, same mixed-DoF rejection).
- **Selection**: every viable result sponsors the subset of results agreeing with it pairwise; the highest-summed-confidence subset wins (ties break to the larger subset, then earlier result — deterministic). Unlike single-link closure, a result agreeing with only one member can't drag the whole chain together.
- **Outlier rejection**: results outside the winning subset are excluded from the fuse and reported on the new `NavResult.excluded_from_consensus` (list of technique names, also emitted in the metadata JSON — useful for the upcoming #35 statistics system). The disagreement penalty (×0.7) still applies whenever anything was excluded.
- **Conflict criterion**: the conflicted branch fires only when the excluded results form a *genuine alternative* — the strongest consensus among the excluded alone has ≥2 members (alternative with quorum), or the winning subset is itself a singleton (no quorum anywhere) — and the summed-confidence gap is below `agreement_gap`. This is a strict narrowing of the old conflict trigger; every previously-conflicting configuration that had quorum-vs-quorum or singleton-vs-singleton still conflicts.

## Verification of #123 (related, already fixed)

While in here I verified #123's status: the Option-B pixel floor (`agreement_pixel_floor`, default 5 px) has been in `_agreement_adjacency` since the Phase 0-10 rewrite, with regression tests covering the CRLB-tight production failure mode (`test_ensemble_pixel_floor_*`). The pairwise math is preserved verbatim by this PR. Option A (making the NCC covariances themselves realistic) remains tracked by #210. I'll close #123 with a comment.

## Testing

- 6 new ensemble tests: lone-outlier rejection (offset unperturbed, excluded name reported), penalty-still-applied, two-pairs conflict, dominant-pair-vs-weak-pair success, unanimous-no-exclusions, plus the metadata key.
- All 38 ensemble tests and the full unit suite (1855) green — every pre-existing conflict/pixel-floor/null-space behavior preserved.
- Sim integration suites (baselines, navigation, regression, algorithmic invariants — 106 tests) green with **zero baseline changes**.
- Dev guide steps 3/4/6 and the worked examples updated (the old text also predated the pixel floor; it documents it now).

Fixes #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KW6fkURsA2zgrWFKjbR5JY

## Updates since the initial description

- **Docs pass**: the user guide's metadata-files section now lists the `per_technique` contents and the `excluded_from_consensus` field.
- The 62-sidecar library crosscheck on the stack head shows zero deltas caused by this stack; it also motivated two new pre-existing-behavior issues in this PR's blast radius worth reading alongside it: #221 (rank-1 RingEdge outvoting an absolute blob constraint) and #222 (pass-2 refine corroborating its own prior).

## Operator checklist

- **Pre-merge: nothing.** Merge after #216 merges, the rebase lands, and CI is green.
- **Post-merge: nothing.** #124 auto-closes via the description — verify it did. (#123 was already closed with a comment.)
