### PR TITLE
feat: terminator basin second-opinion gate (#125)

### DIFF
--- a/docs/dev_guide/dev_guide_techniques_body_terminator.rst
+++ b/docs/dev_guide/dev_guide_techniques_body_terminator.rst
@@ -118,6 +118,19 @@ displacement from the coarse seed; when any of these fails, the result is flagge
 :attr:`~spindoctor.nav_technique.technique_result.NavTechniqueResult.spurious` and similarly forced
 to zero.
 
+A fit that passes every residual metric can still be a mis-convergence onto a rival
+alignment -- a crater shadow, an albedo boundary, or a second body's edge -- because a
+local DT minimum fits the polyline as cleanly as the true one. The *basin second-opinion*
+(:func:`~spindoctor.nav_technique.dt_fitting.find_secondary_dt_minimum`) closes this hole:
+after LM convergence the mean per-vertex DT cost is sampled at every integer shift in the
+coarse search window, and when the best shift farther than ``basin_exclude_radius_px``
+from the converged offset scores below ``basin_cost_ratio_threshold`` times the converged
+cost, the DT surface is not unimodal and the result is flagged spurious. The rival's
+distance and cost ratio are recorded on the diagnostics
+(``secondary_basin_distance_px`` / ``secondary_basin_cost_ratio``). This matters most for
+the lone-primary case: the ensemble's fallback-tier drop protects against a mis-converged
+terminator only when a limb or disc result exists on the same body to supersede it.
+
 Configuration
 =============
 
@@ -138,6 +151,14 @@ All numeric tunables for this technique live in ``techniques.BodyTerminatorNav.t
   distance from any search-window axis bound falls within this tolerance is flagged
   :attr:`~spindoctor.nav_technique.technique_result.NavTechniqueResult.at_edge`. Matches the
   bilinear-DT half-cell width.
+- ``basin_cost_ratio_threshold`` — float, default ``1.2`` (dimensionless). A competing
+  DT basin whose mean per-vertex cost falls below this multiple of the converged cost
+  marks the fit spurious; ``0`` disables the basin second-opinion.
+- ``basin_exclude_radius_px`` — float, default ``5.0`` px. Shifts within this distance of
+  the converged offset belong to the converged basin and are never counted as rivals.
+- ``basin_cost_epsilon_px`` — float, default ``0.25`` px. Floor on the converged cost in
+  the ratio's denominator, so a near-perfect fit is not vetoed by numerical noise; a rival
+  must genuinely match a near-zero converged cost to fire the gate.
 - ``rotation_at_edge_fraction`` — float, default ``0.95`` (dimensionless). When
   :attr:`~spindoctor.nav_orchestrator.nav_context.NavContext.fit_camera_rotation` is true, the
   converged rotation magnitude trips
@@ -148,7 +169,7 @@ All numeric tunables for this technique live in ``techniques.BodyTerminatorNav.t
 Per-instrument overrides
 ------------------------
 
-The six keys above are global; the per-instrument YAML files in
+The keys above are global; the per-instrument YAML files in
 ``src/spindoctor/config_files/config_4N0_inst_*.yaml`` do not override any of them. The
 search-window margin used by the at-edge test comes from the per-instrument
 :class:`~spindoctor.nav_orchestrator.instrument_config.InstrumentSettings` rather than from this

--- a/docs/dev_guide/dev_guide_techniques_body_terminator.rst
+++ b/docs/dev_guide/dev_guide_techniques_body_terminator.rst
@@ -127,7 +127,9 @@ coarse search window, and when the best shift farther than ``basin_exclude_radiu
 from the converged offset scores below ``basin_cost_ratio_threshold`` times the converged
 cost, the DT surface is not unimodal and the result is flagged spurious. The rival's
 distance and cost ratio are recorded on the diagnostics
-(``secondary_basin_distance_px`` / ``secondary_basin_cost_ratio``). This matters most for
+(:attr:`~spindoctor.nav_technique.diagnostics.BodyTerminatorDiagnostics.secondary_basin_distance_px` /
+:attr:`~spindoctor.nav_technique.diagnostics.BodyTerminatorDiagnostics.secondary_basin_cost_ratio`).
+This matters most for
 the lone-primary case: the ensemble's fallback-tier drop protects against a mis-converged
 terminator only when a limb or disc result exists on the same body to supersede it.
 

--- a/docs/dev_guide/dev_guide_techniques_dt_fitting.rst
+++ b/docs/dev_guide/dev_guide_techniques_dt_fitting.rst
@@ -328,7 +328,8 @@ Public surface (autodocumented at :doc:`/api_reference/api_nav_technique`):
 - :func:`~spindoctor.nav_technique.dt_fitting.find_secondary_dt_minimum` — the basin
   second-opinion: scans the search window for a competing DT-cost minimum away from the
   converged offset, so a consuming technique can flag a non-unimodal fit as spurious
-  (``BodyTerminatorNav`` uses it; see :doc:`dev_guide_techniques_body_terminator`).
+  (:class:`~spindoctor.nav_technique.nav_technique_body_terminator.BodyTerminatorNav`
+  uses it; see :doc:`dev_guide_techniques_body_terminator`).
 - :class:`~spindoctor.nav_technique.dt_fitting.LMRefineResult` — frozen result dataclass exposed by
   :func:`~spindoctor.nav_technique.dt_fitting.lm_subpixel_refine`.
 - :class:`~spindoctor.nav_technique.dt_fitting.SecondaryBasin` — frozen result dataclass exposed

--- a/docs/dev_guide/dev_guide_techniques_dt_fitting.rst
+++ b/docs/dev_guide/dev_guide_techniques_dt_fitting.rst
@@ -325,8 +325,14 @@ Public surface (autodocumented at :doc:`/api_reference/api_nav_technique`):
   rotation) LM refinement with Tukey reweighting.
 - :func:`~spindoctor.nav_technique.dt_fitting.information_matrix_to_covariance` — Hessian to
   covariance via the symmetric pseudoinverse.
+- :func:`~spindoctor.nav_technique.dt_fitting.find_secondary_dt_minimum` — the basin
+  second-opinion: scans the search window for a competing DT-cost minimum away from the
+  converged offset, so a consuming technique can flag a non-unimodal fit as spurious
+  (``BodyTerminatorNav`` uses it; see :doc:`dev_guide_techniques_body_terminator`).
 - :class:`~spindoctor.nav_technique.dt_fitting.LMRefineResult` — frozen result dataclass exposed by
   :func:`~spindoctor.nav_technique.dt_fitting.lm_subpixel_refine`.
+- :class:`~spindoctor.nav_technique.dt_fitting.SecondaryBasin` — frozen result dataclass exposed
+  by :func:`~spindoctor.nav_technique.dt_fitting.find_secondary_dt_minimum`.
 
 Consuming techniques follow the same eight-step pattern (the body-limb fit is the canonical
 example documented at :doc:`dev_guide_techniques_body_limb`):

--- a/src/spindoctor/config_files/config_510_techniques.yaml
+++ b/src/spindoctor/config_files/config_510_techniques.yaml
@@ -365,6 +365,21 @@ techniques:
       # bound.  The two scalars are not linked; refitting the limb floor
       # must revisit this one.
       model_error_floor_px: 0.92
+      # Basin second-opinion (#125): after LM convergence, scan the
+      # coarse search window for a competing DT-cost basin farther than
+      # basin_exclude_radius_px from the converged offset.  When the
+      # best competing mean per-vertex DT cost is below
+      # basin_cost_ratio_threshold times the converged cost (with
+      # basin_cost_epsilon_px guarding near-zero converged costs), the
+      # DT surface is not unimodal -- a crater shadow, albedo boundary,
+      # or second body offers a rival alignment the fit has no basis to
+      # rule out -- and the result is marked spurious.  This closes the
+      # lone-primary hole: the fallback-tier drop protects terminator
+      # results only when a limb or disc result exists to supersede
+      # them.  Set the ratio to 0 to disable the check.
+      basin_cost_ratio_threshold: 1.2
+      basin_exclude_radius_px: 5.0
+      basin_cost_epsilon_px: 0.25
 
   RingEdgeNav:
     # Sim campaign: n=596 usable, base rate 0.96, AUC 0.67 -> 0.69,

--- a/src/spindoctor/nav_technique/diagnostics.py
+++ b/src/spindoctor/nav_technique/diagnostics.py
@@ -98,12 +98,13 @@ class BodyTerminatorDiagnostics:
     second-opinion pair:
 
         secondary_basin_distance_px: Distance from the converged offset to
-            the best competing DT-cost basin in the search window; ``0.0``
-            when the scan did not run or found no eligible shift.
+            the best competing DT-cost basin in the search window; ``None``
+            when the scan did not run or found no eligible shift (``0.0``
+            is a legitimate measured value, so it is not the sentinel).
         secondary_basin_cost_ratio: Competing basin's mean per-vertex DT
             cost divided by the converged cost (epsilon-guarded); values
             below the technique's ``basin_cost_ratio_threshold`` mark the
-            fit spurious.  ``0.0`` when not measured.
+            fit spurious.  ``None`` when not measured.
     """
 
     visible_terminator_arc_fraction: float = 0.0
@@ -111,8 +112,8 @@ class BodyTerminatorDiagnostics:
     dt_fit_rms_px: float = 0.0
     lm_iterations: int = 0
     tukey_inlier_count: int = 0
-    secondary_basin_distance_px: float = 0.0
-    secondary_basin_cost_ratio: float = 0.0
+    secondary_basin_distance_px: float | None = None
+    secondary_basin_cost_ratio: float | None = None
     CURATOR_FIELDS: ClassVar[dict[str, str | None]] = {
         'visible_terminator_arc_fraction': 'visible_terminator_arc_fraction',
         'visible_arc_px': 'visible_arc_px',

--- a/src/spindoctor/nav_technique/diagnostics.py
+++ b/src/spindoctor/nav_technique/diagnostics.py
@@ -94,7 +94,16 @@ class BodyTerminatorDiagnostics:
     """Diagnostics emitted by ``BodyTerminatorNav``.
 
     Parameters: same shape as ``BodyLimbDiagnostics`` with
-    ``visible_terminator_arc_fraction`` substituted.
+    ``visible_terminator_arc_fraction`` substituted, plus the basin
+    second-opinion pair:
+
+        secondary_basin_distance_px: Distance from the converged offset to
+            the best competing DT-cost basin in the search window; ``0.0``
+            when the scan did not run or found no eligible shift.
+        secondary_basin_cost_ratio: Competing basin's mean per-vertex DT
+            cost divided by the converged cost (epsilon-guarded); values
+            below the technique's ``basin_cost_ratio_threshold`` mark the
+            fit spurious.  ``0.0`` when not measured.
     """
 
     visible_terminator_arc_fraction: float = 0.0
@@ -102,12 +111,16 @@ class BodyTerminatorDiagnostics:
     dt_fit_rms_px: float = 0.0
     lm_iterations: int = 0
     tukey_inlier_count: int = 0
+    secondary_basin_distance_px: float = 0.0
+    secondary_basin_cost_ratio: float = 0.0
     CURATOR_FIELDS: ClassVar[dict[str, str | None]] = {
         'visible_terminator_arc_fraction': 'visible_terminator_arc_fraction',
         'visible_arc_px': 'visible_arc_px',
         'dt_fit_rms_px': 'dt_fit_rms_px',
         'lm_iterations': 'lm_iterations',
         'tukey_inlier_count': 'tukey_inlier_count',
+        'secondary_basin_distance_px': 'secondary_basin_distance_px',
+        'secondary_basin_cost_ratio': 'secondary_basin_cost_ratio',
     }
 
 

--- a/src/spindoctor/nav_technique/dt_fitting.py
+++ b/src/spindoctor/nav_technique/dt_fitting.py
@@ -396,7 +396,10 @@ def find_secondary_dt_minimum(
     Parameters:
         image_edge_dt: 2-D edge distance transform the LM fit ran against.
         vertices_vu: ``(N, 2)`` polyline vertex positions in ``(v, u)``,
-            unshifted (the same array handed to the LM refine).
+            unshifted. A caller that fitted rotation must pass the vertices
+            already rotated by the converged angle (the geometry the LM
+            evaluated), or the converged cost is inflated relative to the
+            actual fit.
         converged_offset_vu: The LM fit's converged ``(dv, du)``.
         search_window_vu: ``(margin_v, margin_u)`` non-negative integers
             bounding the scan, normally the technique's coarse search

--- a/src/spindoctor/nav_technique/dt_fitting.py
+++ b/src/spindoctor/nav_technique/dt_fitting.py
@@ -44,8 +44,10 @@ __all__ = [
     'DEFAULT_TUKEY_C',
     'LMRefineResult',
     'RidgeRefineResult',
+    'SecondaryBasin',
     'build_polyline_mask',
     'coarse_ncc_search',
+    'find_secondary_dt_minimum',
     'gradient_ridge_refine',
     'information_matrix_to_covariance',
     'lm_subpixel_refine',
@@ -318,6 +320,129 @@ def coarse_ncc_search(
                 best_dv = dv
                 best_du = du
     return best_dv, best_du
+
+
+@dataclass(frozen=True)
+class SecondaryBasin:
+    """A competing DT-cost minimum found away from the converged offset.
+
+    Parameters:
+        offset_vu: Integer ``(dv, du)`` shift of the competing minimum.
+        distance_px: Euclidean distance from the converged offset.
+        cost_px: Mean per-vertex DT value at the competing shift.
+        converged_cost_px: Mean per-vertex DT value at the converged offset,
+            measured with the same sampler so the two costs are comparable.
+    """
+
+    offset_vu: tuple[int, int]
+    distance_px: float
+    cost_px: float
+    converged_cost_px: float
+
+
+def _mean_dt_cost(
+    image_edge_dt: NDArrayFloatType,
+    vertices_vu: NDArrayFloatType,
+    offset_vu: tuple[float, float],
+    *,
+    min_support: float,
+) -> float | None:
+    """Mean DT value over the in-bounds vertices at ``offset_vu``.
+
+    Parameters:
+        image_edge_dt: 2-D edge distance transform.
+        vertices_vu: ``(N, 2)`` polyline vertex positions in ``(v, u)``.
+        offset_vu: ``(dv, du)`` shift applied to every vertex.
+        min_support: Minimum number of in-bounds vertices for the cost to
+            be trustworthy.
+
+    Returns:
+        The mean DT value, or None when fewer than ``min_support`` vertices
+        remain in bounds.
+    """
+    height, width = image_edge_dt.shape
+    shifted = vertices_vu + np.asarray(offset_vu, np.float64)
+    in_bounds = (
+        (shifted[:, 0] >= 0.0)
+        & (shifted[:, 0] <= height - 1.0)
+        & (shifted[:, 1] >= 0.0)
+        & (shifted[:, 1] <= width - 1.0)
+    )
+    if float(np.count_nonzero(in_bounds)) < min_support:
+        return None
+    values = sample_dt_bilinear(image_edge_dt, shifted[in_bounds])
+    return float(values.mean())
+
+
+def find_secondary_dt_minimum(
+    image_edge_dt: NDArrayFloatType,
+    vertices_vu: NDArrayFloatType,
+    *,
+    converged_offset_vu: tuple[float, float],
+    search_window_vu: tuple[int, int],
+    exclude_radius_px: float,
+    min_support_fraction: float = DEFAULT_COARSE_MIN_SUPPORT_FRACTION,
+) -> SecondaryBasin | None:
+    """Search the offset window for a competing DT-cost basin.
+
+    Samples the mean per-vertex DT cost of the polyline at every integer
+    shift in the search window and returns the best-scoring shift farther
+    than ``exclude_radius_px`` from the converged offset.  A converged LM
+    fit whose cost is rivaled by a distant shift is not unimodal: the DT
+    surface offers a second plausible alignment (a crater shadow, an albedo
+    boundary, a second body's edge), and the fit deserves no confidence in
+    having picked the right one.
+
+    Parameters:
+        image_edge_dt: 2-D edge distance transform the LM fit ran against.
+        vertices_vu: ``(N, 2)`` polyline vertex positions in ``(v, u)``,
+            unshifted (the same array handed to the LM refine).
+        converged_offset_vu: The LM fit's converged ``(dv, du)``.
+        search_window_vu: ``(margin_v, margin_u)`` non-negative integers
+            bounding the scan, normally the technique's coarse search
+            window.
+        exclude_radius_px: Shifts within this Euclidean distance of the
+            converged offset belong to the converged basin and are not
+            candidates.
+        min_support_fraction: Minimum fraction of vertices that must stay
+            in bounds for a shift to be scored.
+
+    Returns:
+        The best competing basin, or None when the polyline is empty, the
+        converged cost is unmeasurable, or no eligible shift exists.
+    """
+    n_vertices = int(vertices_vu.shape[0])
+    if n_vertices == 0:
+        return None
+    min_support = min_support_fraction * float(n_vertices)
+    converged_cost = _mean_dt_cost(
+        image_edge_dt, vertices_vu, converged_offset_vu, min_support=min_support
+    )
+    if converged_cost is None:
+        return None
+    margin_v, margin_u = int(search_window_vu[0]), int(search_window_vu[1])
+    conv_dv, conv_du = float(converged_offset_vu[0]), float(converged_offset_vu[1])
+    best: SecondaryBasin | None = None
+    for dv in range(-margin_v, margin_v + 1):
+        for du in range(-margin_u, margin_u + 1):
+            distance = math.hypot(dv - conv_dv, du - conv_du)
+            if distance <= exclude_radius_px:
+                continue
+            cost = _mean_dt_cost(
+                image_edge_dt, vertices_vu, (float(dv), float(du)), min_support=min_support
+            )
+            if cost is None:
+                continue
+            # Ties break toward the nearest rival so the reported distance is
+            # deterministic on cost plateaus (a DT constant along one axis).
+            if best is None or (cost, distance) < (best.cost_px, best.distance_px):
+                best = SecondaryBasin(
+                    offset_vu=(dv, du),
+                    distance_px=distance,
+                    cost_px=cost,
+                    converged_cost_px=converged_cost,
+                )
+    return best
 
 
 def build_polyline_mask(

--- a/src/spindoctor/nav_technique/nav_technique_body_terminator.py
+++ b/src/spindoctor/nav_technique/nav_technique_body_terminator.py
@@ -28,6 +28,7 @@ from spindoctor.feature.geometry import TerminatorPolyline
 from spindoctor.nav_technique.confidence import evaluate_sigmoid_combination
 from spindoctor.nav_technique.diagnostics import BodyTerminatorDiagnostics
 from spindoctor.nav_technique.dt_fitting import (
+    _rotate_vertices,
     build_polyline_mask,
     coarse_ncc_search,
     find_secondary_dt_minimum,
@@ -376,12 +377,21 @@ class BodyTerminatorNav(NavTechnique):
             # the search window for a competing basin; when its cost rivals
             # the converged cost the fit is not unimodal and the result is
             # spurious.  Skipped when already spurious or disabled.
-            secondary_basin_distance_px = 0.0
-            secondary_basin_cost_ratio = 0.0
+            secondary_basin_distance_px: float | None = None
+            secondary_basin_cost_ratio: float | None = None
             if not spurious and self._basin_cost_ratio_threshold > 0.0:
+                # The LM evaluates the DT at the *rotated* vertex positions
+                # when it fits rotation; the basin scan must score the same
+                # geometry, or the converged cost is inflated and a good
+                # rotated fit reads as non-unimodal.
+                basin_vertices = vertices
+                if fit_rotation and result.rotation_rad != 0.0:
+                    basin_vertices = _rotate_vertices(
+                        vertices, pivot_vu, float(result.rotation_rad)
+                    )
                 basin = find_secondary_dt_minimum(
                     edge_dt,
-                    vertices,
+                    basin_vertices,
                     converged_offset_vu=(dv_final, du_final),
                     search_window_vu=(margin_v, margin_u),
                     exclude_radius_px=self._basin_exclude_radius_px,

--- a/src/spindoctor/nav_technique/nav_technique_body_terminator.py
+++ b/src/spindoctor/nav_technique/nav_technique_body_terminator.py
@@ -30,6 +30,7 @@ from spindoctor.nav_technique.diagnostics import BodyTerminatorDiagnostics
 from spindoctor.nav_technique.dt_fitting import (
     build_polyline_mask,
     coarse_ncc_search,
+    find_secondary_dt_minimum,
     lm_subpixel_refine,
 )
 from spindoctor.nav_technique.feasibility import NavFeasibilityReport
@@ -165,6 +166,9 @@ class BodyTerminatorNav(NavTechnique):
         self._model_error_floor_px = load_model_error_floor(self.tuning, self.name)
         self._at_edge_tolerance_px = float(self.tuning['at_edge_tolerance_px'])
         self._rotation_at_edge_fraction = float(self.tuning['rotation_at_edge_fraction'])
+        self._basin_cost_ratio_threshold = float(self.tuning['basin_cost_ratio_threshold'])
+        self._basin_exclude_radius_px = float(self.tuning['basin_exclude_radius_px'])
+        self._basin_cost_epsilon_px = float(self.tuning['basin_cost_epsilon_px'])
 
     def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
         """Return whether the input set carries a usable terminator arc.
@@ -366,6 +370,40 @@ class BodyTerminatorNav(NavTechnique):
                 or inlier_fraction < self._spurious_min_inlier_fraction
                 or lm_displacement_px > self._spurious_max_lm_displacement_px
             )
+            # Basin second-opinion (#125): a textured surface can offer the
+            # DT fit a rival alignment (crater shadow, albedo boundary) that
+            # every technique-level residual metric scores as clean.  Scan
+            # the search window for a competing basin; when its cost rivals
+            # the converged cost the fit is not unimodal and the result is
+            # spurious.  Skipped when already spurious or disabled.
+            secondary_basin_distance_px = 0.0
+            secondary_basin_cost_ratio = 0.0
+            if not spurious and self._basin_cost_ratio_threshold > 0.0:
+                basin = find_secondary_dt_minimum(
+                    edge_dt,
+                    vertices,
+                    converged_offset_vu=(dv_final, du_final),
+                    search_window_vu=(margin_v, margin_u),
+                    exclude_radius_px=self._basin_exclude_radius_px,
+                )
+                if basin is not None:
+                    denominator = max(basin.converged_cost_px, self._basin_cost_epsilon_px)
+                    secondary_basin_cost_ratio = basin.cost_px / denominator
+                    secondary_basin_distance_px = basin.distance_px
+                    if secondary_basin_cost_ratio < self._basin_cost_ratio_threshold:
+                        spurious = True
+                        self.logger.info(
+                            'Competing DT basin at (%d, %d) px (distance %.1f px) has cost '
+                            '%.3f px vs converged %.3f px (ratio %.3f < %.3f): fit is not '
+                            'unimodal, marking spurious',
+                            basin.offset_vu[0],
+                            basin.offset_vu[1],
+                            basin.distance_px,
+                            basin.cost_px,
+                            basin.converged_cost_px,
+                            secondary_basin_cost_ratio,
+                            self._basin_cost_ratio_threshold,
+                        )
             visible_terminator_arc_fraction = _aggregate_visible_arc_fraction(eligible_features)
             mean_phase = float(np.mean(phase_factors)) if phase_factors else 0.0
             mean_albedo = float(np.mean(albedo_penalties)) if albedo_penalties else 0.0
@@ -375,6 +413,8 @@ class BodyTerminatorNav(NavTechnique):
                 dt_fit_rms_px=float(result.rms_px),
                 lm_iterations=int(result.iterations),
                 tukey_inlier_count=int(result.inlier_count),
+                secondary_basin_distance_px=secondary_basin_distance_px,
+                secondary_basin_cost_ratio=secondary_basin_cost_ratio,
             )
             confidence_context = _TerminatorConfidenceContext(
                 at_edge=at_edge,

--- a/tests/spindoctor/nav_technique/test_dt_fitting.py
+++ b/tests/spindoctor/nav_technique/test_dt_fitting.py
@@ -17,6 +17,7 @@ from spindoctor.nav_technique.dt_fitting import (
     LMRefineResult,
     RidgeRefineResult,
     coarse_ncc_search,
+    find_secondary_dt_minimum,
     gradient_ridge_refine,
     information_matrix_to_covariance,
     lm_subpixel_refine,
@@ -1031,3 +1032,68 @@ def test_lm_subpixel_refine_final_gradient_ridge_requires_gradient() -> None:
             use_polarity=False,
             final_gradient_ridge=True,
         )
+
+
+# --- find_secondary_dt_minimum (issue #125) ---
+
+
+def _two_line_dt(shape: tuple[int, int], u1: int, u2: int) -> np.ndarray:
+    """DT with zero cost along two vertical lines at columns ``u1`` and ``u2``."""
+    us = np.arange(shape[1], dtype=np.float64)
+    row = np.minimum(np.abs(us - u1), np.abs(us - u2))
+    return np.tile(row, (shape[0], 1))
+
+
+def _vertical_polyline(u: float, v_lo: int, v_hi: int) -> np.ndarray:
+    vs = np.arange(v_lo, v_hi, dtype=np.float64)
+    return np.stack([vs, np.full_like(vs, u)], axis=-1)
+
+
+def test_find_secondary_dt_minimum_reports_competing_line() -> None:
+    """A second zero-cost line inside the window is reported as a rival basin."""
+    dt = _two_line_dt((100, 100), u1=30, u2=50)
+    vertices = _vertical_polyline(30.0, 20, 80)
+    basin = find_secondary_dt_minimum(
+        dt,
+        vertices,
+        converged_offset_vu=(0.0, 0.0),
+        search_window_vu=(2, 40),
+        exclude_radius_px=5.0,
+    )
+    assert basin is not None
+    assert basin.offset_vu == (0, 20)
+    assert basin.distance_px == pytest.approx(20.0)
+    assert basin.cost_px == pytest.approx(0.0)
+    assert basin.converged_cost_px == pytest.approx(0.0)
+
+
+def test_find_secondary_dt_minimum_exclude_radius_hides_converged_basin() -> None:
+    """Shifts inside the exclusion radius never count as rivals."""
+    dt = _two_line_dt((100, 100), u1=30, u2=30)  # single line: unimodal surface
+    vertices = _vertical_polyline(30.0, 20, 80)
+    basin = find_secondary_dt_minimum(
+        dt,
+        vertices,
+        converged_offset_vu=(0.0, 0.0),
+        search_window_vu=(2, 40),
+        exclude_radius_px=5.0,
+    )
+    assert basin is not None
+    # The best rival sits just outside the exclusion radius with a cost equal
+    # to its column distance from the single zero line -- clearly worse than
+    # the perfect converged fit.
+    assert basin.cost_px >= 5.0
+    assert basin.distance_px > 5.0
+
+
+def test_find_secondary_dt_minimum_empty_polyline_returns_none() -> None:
+    """An empty polyline yields no basin verdict."""
+    dt = _two_line_dt((50, 50), u1=10, u2=30)
+    basin = find_secondary_dt_minimum(
+        dt,
+        np.zeros((0, 2), dtype=np.float64),
+        converged_offset_vu=(0.0, 0.0),
+        search_window_vu=(2, 10),
+        exclude_radius_px=5.0,
+    )
+    assert basin is None

--- a/tests/spindoctor/nav_technique/test_dt_fitting.py
+++ b/tests/spindoctor/nav_technique/test_dt_fitting.py
@@ -1045,6 +1045,7 @@ def _two_line_dt(shape: tuple[int, int], u1: int, u2: int) -> np.ndarray:
 
 
 def _vertical_polyline(u: float, v_lo: int, v_hi: int) -> np.ndarray:
+    """Vertical polyline of vertices at column ``u`` spanning rows ``[v_lo, v_hi)``."""
     vs = np.arange(v_lo, v_hi, dtype=np.float64)
     return np.stack([vs, np.full_like(vs, u)], axis=-1)
 
@@ -1081,9 +1082,12 @@ def test_find_secondary_dt_minimum_exclude_radius_hides_converged_basin() -> Non
     assert basin is not None
     # The best rival sits just outside the exclusion radius with a cost equal
     # to its column distance from the single zero line -- clearly worse than
-    # the perfect converged fit.
-    assert basin.cost_px >= 5.0
-    assert basin.distance_px > 5.0
+    # the perfect converged fit. The minimum eligible cost is exactly 5.0
+    # (du = +/-5 needs |dv| >= 1 to clear the 5.0 px exclusion radius), and
+    # the cost-then-distance tie-break lands on (dv, du) = (+/-1, +/-5) at
+    # distance sqrt(26).
+    assert basin.cost_px == pytest.approx(5.0)
+    assert basin.distance_px == pytest.approx(math.sqrt(26.0))
 
 
 def test_find_secondary_dt_minimum_empty_polyline_returns_none() -> None:

--- a/tests/spindoctor/nav_technique/test_nav_technique_body_terminator.py
+++ b/tests/spindoctor/nav_technique/test_nav_technique_body_terminator.py
@@ -463,3 +463,63 @@ def test_body_terminator_nav_3dof_emits_3x3_covariance(
     assert result.sigma_rotation_rad is not None
     # No rotation planted; convergence stays well inside the 5 degree cap.
     assert abs(result.rotation_rad) < np.deg2rad(5.0)
+
+
+def test_body_terminator_nav_marks_spurious_on_competing_basin(
+    disc_image: DiscImageFactory,
+    arc_polyline: ArcPolylineFactory,
+    make_terminator_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    """A rival edge in the search window makes the fit non-unimodal (issue #125).
+
+    Two identical discs sit 30 px apart, so the model arc aligns equally well
+    with either disc's edge.  The technique cannot know which basin is the
+    true one; the basin second-opinion must mark the result spurious and
+    report the rival in the diagnostics.
+    """
+    shape = (200, 200)
+    center_a = (100.0, 80.0)
+    center_b = (100.0, 110.0)
+    radius = 15.0
+    image = np.maximum(
+        disc_image(shape, center_a, radius),
+        disc_image(shape, center_b, radius),
+    )
+    vertices, outward = arc_polyline(
+        center_a, radius, 80, _TERMINATOR_ANGLE_START, _TERMINATOR_ANGLE_END
+    )
+    feature = make_terminator_feature('moonA', vertices=vertices, outward_normals=outward)
+    technique = BodyTerminatorNav()
+    context = make_nav_context(image)
+    result = technique.navigate([feature], context)
+    assert result.spurious is True
+    diagnostics = result.diagnostics
+    assert isinstance(diagnostics, BodyTerminatorDiagnostics)
+    assert diagnostics.secondary_basin_cost_ratio > 0.0
+    assert diagnostics.secondary_basin_cost_ratio < 1.2
+    assert diagnostics.secondary_basin_distance_px > 5.0
+
+
+def test_body_terminator_nav_clean_fit_reports_costly_secondary_basin(
+    disc_image: DiscImageFactory,
+    arc_polyline: ArcPolylineFactory,
+    make_terminator_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+) -> None:
+    """A single-disc scene stays non-spurious and reports a costly rival basin."""
+    shape = (200, 200)
+    image_center = (100.0, 100.0)
+    radius = 30.0
+    image = disc_image(shape, image_center, radius)
+    vertices, outward = arc_polyline(
+        image_center, radius, 80, _TERMINATOR_ANGLE_START, _TERMINATOR_ANGLE_END
+    )
+    feature = make_terminator_feature('moonA', vertices=vertices, outward_normals=outward)
+    technique = BodyTerminatorNav()
+    context = make_nav_context(image)
+    result = technique.navigate([feature], context)
+    assert result.spurious is False
+    diagnostics = result.diagnostics
+    assert isinstance(diagnostics, BodyTerminatorDiagnostics)
+    assert diagnostics.secondary_basin_cost_ratio >= 1.2

--- a/tests/spindoctor/nav_technique/test_nav_technique_body_terminator.py
+++ b/tests/spindoctor/nav_technique/test_nav_technique_body_terminator.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import math
+from typing import Any
+
 import numpy as np
 import pytest
 from tests.spindoctor.nav_technique.conftest import (
@@ -16,7 +19,16 @@ from spindoctor.feature.feature_type import NavFeatureType
 from spindoctor.feature.flags import TerminatorArcFlags
 from spindoctor.feature.geometry import TerminatorPolyline
 from spindoctor.nav_orchestrator.nav_context import NavContext
+from spindoctor.nav_technique import nav_technique_body_terminator
 from spindoctor.nav_technique.diagnostics import BodyTerminatorDiagnostics
+from spindoctor.nav_technique.dt_fitting import (
+    LMRefineResult,
+    SecondaryBasin,
+    _rotate_directions,
+    _rotate_vertices,
+    find_secondary_dt_minimum,
+    lm_subpixel_refine,
+)
 from spindoctor.nav_technique.nav_technique_body_terminator import (
     BodyTerminatorNav,
     _aggregate_terminator_features,
@@ -496,9 +508,13 @@ def test_body_terminator_nav_marks_spurious_on_competing_basin(
     assert result.spurious is True
     diagnostics = result.diagnostics
     assert isinstance(diagnostics, BodyTerminatorDiagnostics)
+    assert diagnostics.secondary_basin_cost_ratio is not None
     assert diagnostics.secondary_basin_cost_ratio > 0.0
     assert diagnostics.secondary_basin_cost_ratio < 1.2
-    assert diagnostics.secondary_basin_distance_px > 5.0
+    # The rival basin is the second disc, 30 px away in u; the scan's integer
+    # grid puts it at that separation (within the converged fit's sub-pixel
+    # residual), not merely anywhere past the 5 px exclusion radius.
+    assert diagnostics.secondary_basin_distance_px == pytest.approx(30.0, abs=1.5)
 
 
 def test_body_terminator_nav_clean_fit_reports_costly_secondary_basin(
@@ -522,4 +538,70 @@ def test_body_terminator_nav_clean_fit_reports_costly_secondary_basin(
     assert result.spurious is False
     diagnostics = result.diagnostics
     assert isinstance(diagnostics, BodyTerminatorDiagnostics)
+    assert diagnostics.secondary_basin_cost_ratio is not None
     assert diagnostics.secondary_basin_cost_ratio >= 1.2
+
+
+def test_body_terminator_nav_basin_scan_scores_rotated_geometry(
+    disc_image: DiscImageFactory,
+    arc_polyline: ArcPolylineFactory,
+    make_terminator_feature: NavFeatureFactory,
+    make_nav_context: NavContextFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With rotation fitted, the basin scan scores the rotated geometry.
+
+    The LM evaluates the DT at the rotated vertex positions, so handing the
+    unrotated polyline to :func:`find_secondary_dt_minimum` would inflate the
+    converged cost and could mark a good rotated fit as non-unimodal. The
+    model arc is pre-rotated about its pivot so the fit must recover a
+    nonzero rotation; the spy asserts the basin scan then received exactly
+    the vertices rotated by the fitted angle.
+    """
+    shape = (200, 200)
+    image_center = (100.0, 100.0)
+    radius = 30.0
+    image = disc_image(shape, image_center, radius)
+    vertices, outward = arc_polyline(
+        image_center, radius, 80, _TERMINATOR_ANGLE_START, _TERMINATOR_ANGLE_END
+    )
+    theta0 = math.radians(3.0)
+    pivot = (float(vertices[:, 0].mean()), float(vertices[:, 1].mean()))
+    feature = make_terminator_feature(
+        'moonA',
+        vertices=_rotate_vertices(vertices, pivot, theta0),
+        outward_normals=_rotate_directions(outward, theta0),
+    )
+
+    captured: dict[str, Any] = {}
+    real_lm = lm_subpixel_refine
+    real_basin = find_secondary_dt_minimum
+
+    def spy_lm(**kwargs: Any) -> LMRefineResult:
+        """Capture the vertices and fitted rotation of the real LM refine."""
+        captured['lm_vertices'] = kwargs['vertices_vu']
+        result = real_lm(**kwargs)
+        captured['rotation_rad'] = result.rotation_rad
+        return result
+
+    def spy_basin(
+        image_edge_dt: np.ndarray, vertices_vu: np.ndarray, **kwargs: Any
+    ) -> SecondaryBasin | None:
+        """Capture the vertices handed to the real basin scan."""
+        captured['basin_vertices'] = vertices_vu
+        return real_basin(image_edge_dt, vertices_vu, **kwargs)
+
+    monkeypatch.setattr(nav_technique_body_terminator, 'lm_subpixel_refine', spy_lm)
+    monkeypatch.setattr(nav_technique_body_terminator, 'find_secondary_dt_minimum', spy_basin)
+
+    technique = BodyTerminatorNav()
+    context = make_nav_context(image, fit_camera_rotation=True, max_rotation_deg=5.0)
+    result = technique.navigate([feature], context)
+    assert result.spurious is False
+    assert 'basin_vertices' in captured
+    fitted_theta = float(captured['rotation_rad'])
+    assert fitted_theta != 0.0
+    lm_vertices = captured['lm_vertices']
+    lm_pivot = (float(lm_vertices[:, 0].mean()), float(lm_vertices[:, 1].mean()))
+    expected = _rotate_vertices(lm_vertices, lm_pivot, fitted_theta)
+    np.testing.assert_allclose(captured['basin_vertices'], expected, atol=1.0e-12)


### PR DESCRIPTION
Stacked on #217. Review only the last commit; rebase after each squash-merge below it.

## Problem (#125)

`BodyTerminatorNav` mis-convergence has no per-technique signal: a fit locked onto a crater shadow or a second body's edge shows small `dt_fit_rms_px`, healthy Tukey inliers, and moderate LM iterations, so confidence comes out high. The fallback tier only protects when a limb/disc primary exists on the same body — when terminator is the lone body-feature technique (small body, hidden limb, gated disc), the ensemble accepts a confident wrong answer.

## Change (issue's Option A)

- `dt_fitting.find_secondary_dt_minimum`: samples mean per-vertex DT cost at every integer shift in the coarse search window (same min-support guard as `coarse_ncc_search`, bilinear DT sampling, in-bounds masking so clamped edge values can't fake a basin) and returns the best rival farther than `basin_exclude_radius_px` from the converged offset. Ties break to the nearest rival for determinism on cost plateaus.
- `BodyTerminatorNav`: when the rival's cost is below `basin_cost_ratio_threshold` (default **1.2**) × converged cost (denominator floored at `basin_cost_epsilon_px` = 0.25 px so near-perfect fits aren't vetoed by numerical noise), the result is marked **spurious**. Rival distance and cost ratio land on `BodyTerminatorDiagnostics` (`secondary_basin_distance_px`, `secondary_basin_cost_ratio`) and the metadata JSON. Scan is skipped when the result is already spurious or the threshold is 0 (disable knob).
- Applied to the terminator only: it is the technique with no other mis-convergence signal (the issue's scope). Extending to limb/ring is possible but calibration-sensitive; deferred with #179.

Known false-negative trade-off (from the issue): genuinely rotationally-ambiguous scenes (two equally-valid basins) now report spurious — which is the honest answer for a technique that cannot know which basin is right.

## #179 status

Not implemented here — the polarity-weighted coarse score changes all three DT techniques' seeding and needs its own calibration pass. This gate closes part of #179's blast radius for the terminator (the confident-wrong endpoint); commented there.

## Testing

- `find_secondary_dt_minimum` unit tests (rival line reported with exact offset/distance/cost; exclusion radius honored; empty polyline → None).
- Technique-level regression: two identical discs 30 px apart → `spurious=True` with ratio < 1.2 and rival distance > 5 px; single-disc scene stays non-spurious with ratio ≥ 1.2.
- Full unit suite 1860 green; sim integration suites 106 green, zero baseline changes (the sim body model emits no TERMINATOR_ARC, so sim behavior is untouched by construction).
- Dev guide: mis-convergence paragraph + three new tuning keys documented. Sphinx -W clean.

Fixes #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KW6fkURsA2zgrWFKjbR5JY

## Updates since the initial description

- **Docs pass**: `find_secondary_dt_minimum` and `SecondaryBasin` added to the `dt_fitting` public-surface listing in the dev guide.

## Operator checklist

- **Pre-merge: nothing.** Merge after #217 merges, the rebase lands, and CI is green.
- **Post-merge: nothing.** #125 auto-closes via the description — verify it did.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a robustness check that detects competing alignment solutions and flags ambiguous fits as spurious.
  - Added diagnostic reporting for competing basin distance and cost ratio.
  - Added configurable thresholds for enabling and tuning the check.

- **Documentation**
  - Documented the new tuning options and exported distance-transform fitting APIs.

- **Tests**
  - Added coverage for competing basins, exclusion behavior, empty inputs, and single- versus dual-target scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Updates since the initial description

**Review follow-ups (CodeRabbit), commit 9e4152b** — see the inline replies for per-comment dispositions:

- **Rotation-consistency fix (real defect):** with `fit_camera_rotation` on (Galileo/Voyager), the basin scan scored the unrotated polyline while the LM had converged on rotated geometry, inflating the converged cost and biasing `secondary_basin_cost_ratio` toward falsely marking good rotated fits spurious. The scan now receives `_rotate_vertices(vertices, pivot, fitted_theta)`; a spy-based wiring test pins the contract.
- `secondary_basin_distance_px` / `secondary_basin_cost_ratio` use `None` as the not-measured sentinel (0.0 is a legitimate measurement); curator emits JSON null.
- Dev-guide mentions use `:attr:`/`:class:` roles; the exclude-radius and two-disc tests assert exact expected values (cost 5.0 at distance sqrt(26); rival at ~30 px); test helper docstring added.
- One suggestion declined with rationale (vectorizing the one-shot basin scan).
