### PR TITLE
fix: bound BodyBlobNav kernel memory (#202 Helene OOM)

### DIFF
--- a/docs/dev_guide/dev_guide_techniques_body_blob.rst
+++ b/docs/dev_guide/dev_guide_techniques_body_blob.rst
@@ -66,7 +66,7 @@ bounding box on the body before the centroid is taken:
   shift is expressed in lit-centroid terms and matches the residual the centroid step forms.
 
 Both templates clamp their radius to the frame's half-diagonal
-(:func:`~spindoctor.nav_technique.nav_technique_body_blob._clamped_kernel_radius`): a template
+(``_clamped_kernel_radius``): a template
 larger than the frame adds no localization information, while the kernel array and its FFT
 convolution allocate memory quadratically in the predicted diameter — a mostly off-frame gas
 giant predicts tens of thousands of pixels and exhausted RAM before the clamp (issue #202).

--- a/docs/dev_guide/dev_guide_techniques_body_blob.rst
+++ b/docs/dev_guide/dev_guide_techniques_body_blob.rst
@@ -65,6 +65,12 @@ bounding box on the body before the centroid is taken:
   body's *lit* centroid (which on a crescent sits off the geometric center), so the recovered
   shift is expressed in lit-centroid terms and matches the residual the centroid step forms.
 
+Both templates clamp their radius to the frame's half-diagonal
+(:func:`~spindoctor.nav_technique.nav_technique_body_blob._clamped_kernel_radius`): a template
+larger than the frame adds no localization information, while the kernel array and its FFT
+convolution allocate memory quadratically in the predicted diameter — a mostly off-frame gas
+giant predicts tens of thousands of pixels and exhausted RAM before the clamp (issue #202).
+
 The crescent template needs the sub-solar direction. It is undefined near full phase (the lit
 and geometric centroids coincide), where the disc kernel is used anyway, and is reported as
 ``(0, 0)`` then. If a body is past half phase yet carries no direction (its illumination

--- a/src/spindoctor/nav_technique/nav_technique_body_blob.py
+++ b/src/spindoctor/nav_technique/nav_technique_body_blob.py
@@ -278,6 +278,30 @@ def _kernel_centroid_offset(kernel: NDArrayFloatType) -> tuple[float, float]:
     return (centroid_v - (n_v - 1) / 2.0, centroid_u - (n_u - 1) / 2.0)
 
 
+def _clamped_kernel_radius(predicted_diameter_px: float, image_shape: tuple[int, ...]) -> float:
+    """Matched-filter kernel radius bounded by the image footprint.
+
+    The template scales with the predicted body diameter, but a template
+    larger than the frame adds no localization information (every in-window
+    shift sees the same uniform coverage) while the kernel array and its FFT
+    convolution allocate memory quadratically in the diameter.  A mostly
+    off-frame gas giant predicts a diameter of tens of thousands of pixels,
+    which exhausted RAM before this clamp (issue #202).  The frame's
+    half-diagonal is the largest radius at which the template's shape can
+    still influence the correlation inside the frame.
+
+    Parameters:
+        predicted_diameter_px: Predicted body diameter in pixels.
+        image_shape: ``(H, W)`` shape of the extfov signal image.
+
+    Returns:
+        ``max(predicted_diameter_px / 2, 1)`` clamped to the image
+        half-diagonal.
+    """
+    radius = max(predicted_diameter_px / 2.0, 1.0)
+    return min(radius, math.hypot(image_shape[0], image_shape[1]) / 2.0)
+
+
 def _coarse_disc_offset(
     image_signal: NDArrayFloatType,
     predicted_center_vu: tuple[float, float],
@@ -287,11 +311,12 @@ def _coarse_disc_offset(
     """Coarse integer offset from a filled-disc matched filter.
 
     Convenience wrapper around :func:`_coarse_correlation_offset` for the
-    at-least-half-lit case: builds a filled disc of the predicted radius and
+    at-least-half-lit case: builds a filled disc of the predicted radius
+    (clamped to the image footprint; see :func:`_clamped_kernel_radius`) and
     correlates it.  See :func:`_coarse_correlation_offset` for the offset
     convention and degenerate-window handling.
     """
-    radius = max(predicted_diameter_px / 2.0, 1.0)
+    radius = _clamped_kernel_radius(predicted_diameter_px, image_signal.shape)
     return _coarse_correlation_offset(
         image_signal, _disc_kernel(radius), predicted_center_vu, margin_vu
     )
@@ -310,10 +335,11 @@ def _coarse_crescent_offset(
     Builds a Lambertian-crescent template at the body's phase and sub-solar
     direction (:func:`_crescent_kernel`) and correlates it, so a high-phase
     body displaced beyond its predicted bounding box is located without a
-    full lit disc to correlate.  See :func:`_coarse_correlation_offset` for
-    the offset convention and degenerate-window handling.
+    full lit disc to correlate.  The radius is clamped to the image footprint
+    (:func:`_clamped_kernel_radius`).  See :func:`_coarse_correlation_offset`
+    for the offset convention and degenerate-window handling.
     """
-    radius = max(predicted_diameter_px / 2.0, 1.0)
+    radius = _clamped_kernel_radius(predicted_diameter_px, image_signal.shape)
     kernel = _crescent_kernel(radius, math.radians(phase_deg), sub_solar_dir_vu)
     return _coarse_correlation_offset(image_signal, kernel, predicted_center_vu, margin_vu)
 

--- a/tests/spindoctor/nav_technique/test_nav_technique_body_blob.py
+++ b/tests/spindoctor/nav_technique/test_nav_technique_body_blob.py
@@ -19,6 +19,7 @@ from spindoctor.nav_technique.diagnostics import BodyBlobDiagnostics
 from spindoctor.nav_technique.nav_technique import ROTATION_UNOBSERVABLE_VARIANCE
 from spindoctor.nav_technique.nav_technique_body_blob import (
     BodyBlobNav,
+    _clamped_kernel_radius,
     _coarse_crescent_offset,
     _coarse_disc_offset,
     _crescent_kernel,
@@ -731,3 +732,34 @@ def test_body_blob_uses_installed_prior_to_seed_bbox(
     result = technique.navigate([feature], context)
     assert result.offset_px[0] == pytest.approx(planted_dv, abs=0.5)
     assert result.offset_px[1] == pytest.approx(planted_du, abs=0.5)
+
+
+# --- kernel-radius clamp (issue #202) ---
+
+
+def test_clamped_kernel_radius_passes_small_bodies_through() -> None:
+    """A body smaller than the frame keeps its predicted radius."""
+    assert _clamped_kernel_radius(12.0, (256, 256)) == pytest.approx(6.0)
+
+
+def test_clamped_kernel_radius_bounds_huge_bodies_to_frame() -> None:
+    """A predicted diameter far beyond the frame clamps to the half-diagonal."""
+    radius = _clamped_kernel_radius(50_000.0, (256, 256))
+    assert radius == pytest.approx(math.hypot(256, 256) / 2.0)
+
+
+def test_coarse_disc_offset_bounded_for_offframe_giant() -> None:
+    """A mostly off-frame giant's blob must not allocate a body-sized kernel.
+
+    Before the clamp, a predicted diameter of tens of thousands of pixels
+    (an off-frame gas giant) built a kernel quadratic in the diameter and
+    exhausted memory inside fftconvolve (issue #202: N1646315051 grew past
+    61 GB RSS).  With the clamp the correlation runs against a frame-sized
+    template and completes in bounded memory.
+    """
+    image = np.zeros((128, 128), dtype=np.float64)
+    image[40:90, 30:80] = 50.0
+    offset = _coarse_disc_offset(image, (64.0, 64.0), 40_000.0, (32, 32))
+    assert isinstance(offset, tuple)
+    assert abs(offset[0]) <= 32
+    assert abs(offset[1]) <= 32

--- a/tests/spindoctor/nav_technique/test_nav_technique_body_blob.py
+++ b/tests/spindoctor/nav_technique/test_nav_technique_body_blob.py
@@ -775,9 +775,15 @@ def test_coarse_crescent_offset_bounded_for_offframe_giant() -> None:
     """
     image = np.zeros((128, 128), dtype=np.float64)
     image[40:90, 30:80] = 50.0
-    offset = _coarse_crescent_offset(
-        image, (64.0, 64.0), 40_000.0, 120.0, (0.0, -1.0), (32, 32)
+    offset = _coarse_crescent_offset(image, (64.0, 64.0), 40_000.0, 120.0, (0.0, -1.0), (32, 32))
+    # Completing at all on a 128x128 frame proves the clamp: unclamped, the
+    # 40,000 px diameter would allocate a 40k x 40k kernel before the FFT.
+    # The returned shift is the margin-bounded correlation peak plus the
+    # crescent kernel's lit-centroid compensation, so the bound includes it.
+    radius = _clamped_kernel_radius(40_000.0, (128, 128))
+    centroid_v, centroid_u = _kernel_centroid_offset(
+        _crescent_kernel(radius, math.radians(120.0), (0.0, -1.0))
     )
     assert isinstance(offset, tuple)
-    assert abs(offset[0]) <= 32
-    assert abs(offset[1]) <= 32
+    assert abs(offset[0]) <= 32 + abs(centroid_v) + 1.0
+    assert abs(offset[1]) <= 32 + abs(centroid_u) + 1.0

--- a/tests/spindoctor/nav_technique/test_nav_technique_body_blob.py
+++ b/tests/spindoctor/nav_technique/test_nav_technique_body_blob.py
@@ -763,3 +763,21 @@ def test_coarse_disc_offset_bounded_for_offframe_giant() -> None:
     assert isinstance(offset, tuple)
     assert abs(offset[0]) <= 32
     assert abs(offset[1]) <= 32
+
+
+def test_coarse_crescent_offset_bounded_for_offframe_giant() -> None:
+    """The crescent path clamps its kernel exactly like the disc path.
+
+    ``_coarse_crescent_offset`` builds its own template, so removing the
+    clamp there would regress independently of the disc caller: an
+    off-frame giant at high phase would again allocate a kernel quadratic
+    in the predicted diameter inside fftconvolve (issue #202).
+    """
+    image = np.zeros((128, 128), dtype=np.float64)
+    image[40:90, 30:80] = 50.0
+    offset = _coarse_crescent_offset(
+        image, (64.0, 64.0), 40_000.0, 120.0, (0.0, -1.0), (32, 32)
+    )
+    assert isinstance(offset, tuple)
+    assert abs(offset[0]) <= 32
+    assert abs(offset[1]) <= 32


### PR DESCRIPTION
Stacked on #218. Review only the last commit; rebase after each squash-merge below it.

## Root cause (#202)

Reproduced both halves today under a 16 GB cgroup cap:

- **`main` @ 477605b**: `sd_offset coiss_saturn N1646315051` pins at the 16 GB cap inside `TECHNIQUE: BodyBlobNav`, "Consuming **2** BODY_BLOB features" — the second blob is **SATURN**, emitted by the old mean-brightness reliability gate even though the planet is essentially off-frame.
- **This stack**: the same frame completes in 110 s (`status=success`, medium, offset (−7.57, 86.97) from Helene's blob) because the #209 detection-SNR gates never emit the Saturn blob.

The allocation itself: `BodyBlobNav`'s coarse acquisition builds a disc/crescent matched-filter kernel sized by `predicted_diameter_px` with **no bound**. Saturn on a NAC frame at 2.4 M km predicts a diameter of tens of thousands of pixels → the kernel array plus `fftconvolve`'s padded FFT buffers grow quadratically in the diameter → 61.7 GB RSS and an OOM kill on a 62 GB machine.

## Fix

`_clamped_kernel_radius`: the template radius is clamped to the frame's half-diagonal — the largest radius at which the template's shape can still influence the correlation inside the frame. Both the disc and crescent wrappers use it. This is defense in depth: the #209 gates already keep off-frame giants out of the technique, but any future huge-diameter blob that passes the gates (a close flyby, a relaxed gate) now correlates against a frame-sized template in bounded memory instead of taking down the batch run.

## Testing

- Unit tests: small bodies pass through unclamped; a 50,000 px predicted diameter clamps to the half-diagonal; `_coarse_disc_offset` with a 40,000 px giant on a 128² frame completes instantly in bounded memory (pre-fix this single call would attempt a ~13 GB kernel).
- `tests/spindoctor/nav_technique` + `nav_model`: 719 green. ruff/mypy clean.
- End-to-end: N1646315051 navigates on this stack (110 s, medium). The `util/cohort_curation/triage_stage_b.py --skip-names N1646315051` workaround can be retired after this merges.

Fixes #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KW6fkURsA2zgrWFKjbR5JY

## Updates since the initial description

- **Docs pass**: the blob technique dev-guide page documents the coarse-kernel radius clamp and its #202 rationale.

## Operator checklist

- **Pre-merge: nothing.** Merge after #218 merges, the rebase lands, and CI is green.
- **Post-merge: nothing for you.** #202 auto-closes via the description — verify it did. (Retiring the triage `--skip-names` workaround in the cohort tooling is agent work, not yours.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented coarse image-matching templates from growing excessively for very large or off-frame bodies.
  * Reduced the risk of excessive memory usage while preserving localization for normally sized bodies.
  * Applied the safeguard consistently to disc and crescent detection paths.

* **Documentation**
  * Documented template-size limits and their impact on localization and memory usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Updates since the initial description

**Review follow-ups (CodeRabbit), commits 5c18466 + 11f3bba** — the dev guide references the private clamp helper as an inline literal (unresolvable under autodoc), and the crescent matched-filter path gains its own off-frame-giant clamp regression test (its offset bound includes the crescent kernel's lit-centroid compensation, which the disc path doesn't have).
