### PR TITLE
docs,test: PR #213 review follow-ups

### DIFF
--- a/docs/dev_guide/dev_guide_techniques_ring_edge.rst
+++ b/docs/dev_guide/dev_guide_techniques_ring_edge.rst
@@ -21,7 +21,8 @@ is unobservable. The technique projects the returned covariance to be *exactly* 
 information exists the fused result carries
 :attr:`~spindoctor.support.status_reason.NavStatusReason.RANK_1_ONLY` with the offset
 reported as the minimum-norm representative along the edge and the unobservable axis
-surfaced through ``sigma_along_unobservable_px``.
+surfaced through
+:attr:`~spindoctor.nav_orchestrator.nav_result.NavResult.sigma_along_unobservable_px`.
 
 Feasibility passes when at least one offered ``RING_EDGE`` has a non-empty polyline. A single
 non-empty edge is sufficient — even an all-flat scene produces a useful rank-1 constraint.
@@ -52,8 +53,9 @@ per-vertex normals' outer-product sum (polarity-sign-independent) and ``sigma_n^
 covariance's marginal variance along it. Exact singularity is the representation the
 ensemble is built around: ``pinvh`` keeps the normal-axis measurement when forming the
 information matrix, the combine's rank-deficiency test fires, and the unobservable axis is
-reported through the ``sigma_along_unobservable_px`` sentinel rather than an inflated
-per-axis sigma.
+reported through the
+:attr:`~spindoctor.nav_orchestrator.nav_result.NavResult.sigma_along_unobservable_px`
+sentinel rather than an inflated per-axis sigma.
 
 Multi-edge inputs at different orbital radii share the same ring-plane normal but sample
 different points around the projected ring; the joint information matrix becomes full-rank

--- a/src/spindoctor/dataset/dataset_pds3.py
+++ b/src/spindoctor/dataset/dataset_pds3.py
@@ -814,12 +814,15 @@ class DataSetPDS3(DataSet):
             Returns:
                 A tuple ``(imagefile, past_end)``. ``imagefile`` is the constructed
                 ``ImageFile`` if the row passes every filter, or None if it is filtered
-                out. ``past_end`` is True if ``img_num`` exceeds ``img_end_num``. Image
-                numbers are monotonic only within one camera's rows -- an index can
-                interleave camera streams (COISS sorts all N* rows before all W* rows,
-                resetting the numeric sequence partway through the volume) -- so a True
-                value means only that *this row's* camera stream has passed the end of
-                the range, not that the scan as a whole can stop.
+                out. ``past_end`` is True if ``img_num`` exceeds ``img_end_num``. Index
+                rows are time-ordered but not strictly monotonic in image number:
+                measured over the full COISS archive (2026-07-12), 16 of 126 volumes
+                contain a few local inversions -- mostly simultaneous NAC/WAC exposure
+                pairs where the wide-angle row appears one count after its narrow-angle
+                partner, plus out-of-order runs of up to ~500 counts in the early
+                cruise volumes (COISS_1001-1003) -- so a True value means only that
+                *this row* is past the end of the range, not that the scan as a whole
+                can stop.
             """
             label_filespec = self._get_label_filespec_from_index(row)
             img_filespec = self._get_image_filespec_from_label_filespec(label_filespec)
@@ -905,13 +908,16 @@ class DataSetPDS3(DataSet):
                     num_yields += 1
             return
 
-        # Sequential scanning over the requested volumes in order. Image numbers are
-        # monotonic within one camera's rows, but an index can interleave camera
-        # streams (COISS sorts all N* rows before all W* rows, resetting the numeric
-        # sequence partway through the volume), so a single past-the-end row must not
-        # stop the scan. When image numbers are monotonic across volumes, the scan
-        # stops after the first volume in which every row is past the end of the
-        # requested range; otherwise every requested volume is scanned.
+        # Sequential scanning over the requested volumes in order. Index rows are
+        # time-ordered but not strictly monotonic in image number (COISS volumes
+        # carry rare local inversions: simultaneous NAC/WAC exposure pairs whose
+        # wide-angle row sorts one count late, and out-of-order runs in the early
+        # cruise volumes), so a single past-the-end row must not stop the scan;
+        # every row is range-filtered individually. When image numbers are
+        # monotonic across volumes, the scan stops after the first volume in which
+        # every row is past the end of the requested range; otherwise (Voyager,
+        # whose FDS counts roll over between encounter volume sets) every
+        # requested volume is scanned.
         num_yields = 0
         for search_vol in valid_volumes:
             rows, index_tab_url = _read_index_rows(search_vol)

--- a/src/spindoctor/dataset/dataset_pds3.py
+++ b/src/spindoctor/dataset/dataset_pds3.py
@@ -916,8 +916,9 @@ class DataSetPDS3(DataSet):
         # every row is range-filtered individually. When image numbers are
         # monotonic across volumes, the scan stops after the first volume in which
         # every row is past the end of the requested range; otherwise (Voyager,
-        # whose FDS counts roll over between encounter volume sets) every
-        # requested volume is scanned.
+        # whose FDS counts roll over between encounter volume sets) no
+        # image-number-based stop applies and every requested volume is scanned,
+        # though a requested result limit can still end the scan early.
         num_yields = 0
         for search_vol in valid_volumes:
             rows, index_tab_url = _read_index_rows(search_vol)

--- a/src/spindoctor/nav_technique/nav_technique_ring_edge.py
+++ b/src/spindoctor/nav_technique/nav_technique_ring_edge.py
@@ -367,10 +367,11 @@ class RingEdgeNav(NavTechnique):
                 # happens to enter and leave the frame — a false
                 # constraint.  Rebuild the translation covariance as the
                 # LM's marginal variance along the aggregate edge normal
-                # plus an effectively infinite tangent variance, so the
-                # ensemble's rank-deficiency test fires and the result
-                # surfaces as ``rank_1_only`` instead of a confidently
-                # full-rank fix (issue #203).
+                # with the tangent variance exactly zero (the Moore-Penrose
+                # null-space convention), so the ensemble's rank-deficiency
+                # test fires and the tangent axis is reported through the
+                # ``sigma_along_unobservable_px = inf`` sentinel instead of
+                # a confidently full-rank fix (issue #203).
                 covariance = _rank1_projected_covariance(covariance, polarity_normals)
             per_edge_rms_mean = per_edge_rms_summed / float(max(edge_count, 1))
             diagnostics = RingEdgeDiagnostics(

--- a/tests/integration/test_image_library.py
+++ b/tests/integration/test_image_library.py
@@ -252,9 +252,9 @@ def test_load_sidecar_accepts_rank_1_constraint(tmp_path: Path) -> None:
     constraint = sidecar.ground_truth.constraint
     assert constraint is not None
     assert constraint.type == 'rank_1'
-    assert constraint.normal_angle_deg == 60.0
-    assert constraint.offset_along_normal_px == 3.435
-    assert constraint.uncertainty_px == 0.4
+    assert constraint.normal_angle_deg == pytest.approx(60.0)
+    assert constraint.offset_along_normal_px == pytest.approx(3.435)
+    assert constraint.uncertainty_px == pytest.approx(0.4)
 
 
 def test_load_sidecar_constraint_absent_is_none(tmp_path: Path) -> None:

--- a/tests/integration/test_sim_algorithmic_invariants.py
+++ b/tests/integration/test_sim_algorithmic_invariants.py
@@ -42,12 +42,14 @@ import math
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import pytest
 
 from spindoctor.nav_model import build_models_for_obs
 from spindoctor.nav_orchestrator import NavOrchestrator
 from spindoctor.obs.obs_inst_sim import ObsSim
 from spindoctor.sim.scene import iter_scene_paths, load_sim_scene
+from spindoctor.support.status_reason import NavStatusReason
 
 # Recovery tolerance in pixels.  The disc/correlation techniques converge to a
 # few tenths of a pixel on these clean scenes; 1.0 px is a safe invariant bound.
@@ -207,10 +209,6 @@ def test_rank1_scene_reports_rank_1_only(path: Path) -> None:
     the ``sigma_along_unobservable_px`` sentinel; the fused covariance is
     exactly rank-deficient (the technique projects it onto the edge normal).
     """
-    import numpy as np
-
-    from spindoctor.support.status_reason import NavStatusReason
-
     result = _navigate(load_sim_scene(path))
     assert result.status == 'success'
     assert result.status_reason == NavStatusReason.RANK_1_ONLY
@@ -230,8 +228,6 @@ def test_rank1_scene_recovers_normal_component(path: Path) -> None:
     recovery error onto the observable axis — the fused covariance's only
     non-null eigenvector — and bounds that component alone.
     """
-    import numpy as np
-
     scene = load_sim_scene(path)
     result = _navigate(scene)
     assert result.offset_px is not None


### PR DESCRIPTION
Eleventh PR in the stack; base is `plan-consolidation` (#246). Addresses the four CodeRabbit review comments that were still open when #213 was squash-merged (per-thread replies posted there):

1. **`dev_guide_techniques_ring_edge.rst`** — `sigma_along_unobservable_px` is now a `:attr:` cross-reference to `NavResult` at both mention sites (lines 24 and 55), matching the existing `NavStatusReason.RANK_1_ONLY` treatment.
2. **`nav_technique_ring_edge.py`** — the rank-1 call-site comment no longer claims an "effectively infinite tangent variance": the projected covariance's tangent variance is exactly **zero** (Moore-Penrose null-space convention); the `inf` appears externally as the ensemble's `sigma_along_unobservable_px` sentinel. The comment now says exactly that.
3. **`tests/integration/test_image_library.py`** — the sidecar constraint float assertions use `pytest.approx`, matching the sibling test in `test_library_entry.py`.
4. **`tests/integration/test_sim_algorithmic_invariants.py`** — `numpy` and `NavStatusReason` moved to module-level imports; the two inline imports removed.

## Validation

- `ruff check` / `ruff format --check` clean on the three touched Python files; `mypy` (strict) clean.
- `pytest tests/integration/test_image_library.py tests/integration/test_sim_algorithmic_invariants.py -m ""`: 88 passed.
- `sphinx-build -W`: clean (the new `:attr:` targets resolve).

## Updates since the initial description

**Index-ordering rationale correction (operator request), commit 2b786e8** — the two comments in `dataset_pds3.py` restating #136's `N*`-then-`W*` sort premise are rewritten to the measured reality: COISS metadata indexes are time-ordered with NAC/WAC interleaved; 110 of 126 real volumes are fully monotonic in image number and 16 carry a few local inversions (simultaneous-exposure NAC/WAC pairs one count apart, plus out-of-order runs in COISS_1001-1003). No code change — the per-row filtering and the Voyager across-volume gate are correct under the measured ordering (worst-case old-code loss on Cassini was 12 frames; the Voyager FDS rollover remains the large real failure mode). Full measurement posted on #136.

## Operator checklist

- **Pre-merge: nothing.** Merge last, after #246 merges, the rebase lands, and CI is green.
- **Post-merge: nothing.** No issues close with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KW6fkURsA2zgrWFKjbR5JY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Ring Edge navigation rank-1 behavior, including rank-deficient covariance handling and the unobservable-axis sentinel semantics.
  * Improved dataset scanning guidance for end-of-range behavior, including how sequential volume stopping depends on image-number monotonicity across volumes.
  * Updated developer-guide cross-references for clearer attribute linking.
* **Tests**
  * Relaxed numeric equality checks for rank-1 constraints to be tolerant of floating-point parsing differences.
  * Simplified module-level imports in simulation invariants tests without changing assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->