### PR TITLE
ci: stop downloading SPICE/star catalogs from cloud buckets

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -81,9 +81,13 @@ jobs:
         run: |
           export PDS3_HOLDINGS_DIR=https://pds-rings.seti.org/holdings
           export PDS4_HOLDINGS_DIR=https://pds-rings.seti.org/pds4
-          export OOPS_RESOURCES=https://storage.googleapis.com/rms-node-oops-resources
-          export UCAC4_PATH=https://storage.googleapis.com/rms-node-star-catalogs/UCAC4
-          export YBSC_PATH=https://storage.googleapis.com/rms-node-star-catalogs/YBSC
+          # OOPS_RESOURCES / UCAC4_PATH / YBSC_PATH are deliberately NOT set:
+          # the SPICE and star-catalog trees live in cloud buckets whose bulk
+          # egress is prohibitively expensive, so public access is off and
+          # automated runs must not download them. Tests marked
+          # REQUIRES_EXTERNAL_DATA (tests/config.py) skip without
+          # OOPS_RESOURCES; run them locally against a local copy of the
+          # oops resources directory.
           # loadfile keeps each test file on one xdist worker; PyQt6 + default load
           # scheduling has caused worker crashes when tests from the same file ran
           # in different processes.

--- a/tests/config.py
+++ b/tests/config.py
@@ -4,12 +4,27 @@ import os
 
 import pytest
 
-# Tests importing this marker exercise real image reading against external
-# holdings and SPICE/oops resources; they cannot run without these env vars
-# (CI sets them in .github/workflows/run-tests.yml).
+# Tests importing these markers exercise real image reading against external
+# data trees. Two tiers:
+#
+# REQUIRES_EXTERNAL_DATA needs the oops/SPICE resource tree (OOPS_RESOURCES)
+# in addition to the PDS3 holdings. The resource tree is not publicly
+# downloadable (bulk egress from its cloud bucket is prohibitively
+# expensive, so public access is off), which is why CI does not set
+# OOPS_RESOURCES: these tests run only locally, against a local copy of
+# the oops resources directory.
+#
+# REQUIRES_PDS3_HOLDINGS needs only the PDS3 holdings tree, which is served
+# by the PDS Ring-Moon Systems Node; CI sets PDS3_HOLDINGS_DIR, so these
+# tests run in automated environments too.
 REQUIRES_EXTERNAL_DATA = pytest.mark.skipif(
     'OOPS_RESOURCES' not in os.environ or 'PDS3_HOLDINGS_DIR' not in os.environ,
     reason='requires OOPS_RESOURCES and PDS3_HOLDINGS_DIR (external holdings/resources)',
+)
+
+REQUIRES_PDS3_HOLDINGS = pytest.mark.skipif(
+    'PDS3_HOLDINGS_DIR' not in os.environ,
+    reason='requires PDS3_HOLDINGS_DIR (PDS3 holdings)',
 )
 
 # TODO: Update to use PDS3_HOLDINGS_DIR

--- a/tests/spindoctor/dataset/test_dataset_pds3_cassini_iss.py
+++ b/tests/spindoctor/dataset/test_dataset_pds3_cassini_iss.py
@@ -3,12 +3,12 @@ from typing import Any
 
 import pytest
 from filecache import FCPath
-from tests.config import REQUIRES_EXTERNAL_DATA
+from tests.config import REQUIRES_PDS3_HOLDINGS
 
 import spindoctor.dataset.dataset_pds3_cassini_iss as dscoiss
 from spindoctor.dataset.dataset import ImageFile
 
-pytestmark = REQUIRES_EXTERNAL_DATA
+pytestmark = REQUIRES_PDS3_HOLDINGS
 
 
 @pytest.fixture

--- a/tests/spindoctor/dataset/test_dataset_pds3_galileo_ssi.py
+++ b/tests/spindoctor/dataset/test_dataset_pds3_galileo_ssi.py
@@ -1,9 +1,9 @@
 import pytest
-from tests.config import REQUIRES_EXTERNAL_DATA
+from tests.config import REQUIRES_PDS3_HOLDINGS
 
 import spindoctor.dataset.dataset_pds3_galileo_ssi as dsgossi
 
-pytestmark = REQUIRES_EXTERNAL_DATA
+pytestmark = REQUIRES_PDS3_HOLDINGS
 
 
 @pytest.fixture

--- a/tests/spindoctor/dataset/test_dataset_pds3_newhorizons_lorri.py
+++ b/tests/spindoctor/dataset/test_dataset_pds3_newhorizons_lorri.py
@@ -1,9 +1,9 @@
 import pytest
-from tests.config import REQUIRES_EXTERNAL_DATA
+from tests.config import REQUIRES_PDS3_HOLDINGS
 
 import spindoctor.dataset.dataset_pds3_newhorizons_lorri as dsnhlor
 
-pytestmark = REQUIRES_EXTERNAL_DATA
+pytestmark = REQUIRES_PDS3_HOLDINGS
 
 
 @pytest.fixture

--- a/tests/spindoctor/dataset/test_dataset_pds3_voyager_iss.py
+++ b/tests/spindoctor/dataset/test_dataset_pds3_voyager_iss.py
@@ -1,9 +1,9 @@
 import pytest
-from tests.config import REQUIRES_EXTERNAL_DATA
+from tests.config import REQUIRES_PDS3_HOLDINGS
 
 import spindoctor.dataset.dataset_pds3_voyager_iss as dsvgiss
 
-pytestmark = REQUIRES_EXTERNAL_DATA
+pytestmark = REQUIRES_PDS3_HOLDINGS
 
 
 @pytest.fixture


### PR DESCRIPTION
**Hotfix, based directly on `main` — merge before #218** (the remaining stack rebases onto it; #218's current CI failure is this exact problem).

CI runs were downloading the SPICE kernel tree and star catalogs from the cloud buckets on every test job, running up large egress bills; public access to those buckets is now off. This PR makes automated runs self-sufficient:

- `.github/workflows/run-tests.yml` no longer exports `OOPS_RESOURCES` / `UCAC4_PATH` / `YBSC_PATH` (comment in the workflow explains why). `PDS3_HOLDINGS_DIR` / `PDS4_HOLDINGS_DIR` stay — they point at the Ring-Moon Systems Node server, not the buckets.
- Tests marked `REQUIRES_EXTERNAL_DATA` (the obs/inst files, which need SPICE) now skip in CI and run only locally against a local copy of the oops resources directory — the marker mechanics already supported this; CI just stops opting in.
- The four PDS3 **dataset** test files move to a new `REQUIRES_PDS3_HOLDINGS` marker (holdings only): they never needed SPICE, so index-scan coverage — including the #136/#12 fixes — stays exercised in CI.

The default sim-tier suite is unaffected (it never touched the network).

## Validation

- Full suite in the CI-simulated environment (`PDS3_HOLDINGS_DIR` set, no bucket vars): **1822 passed, 42 skipped**, zero cloud-bucket access.
- Same gated files with the full local environment: **95 passed** (nothing lost locally).
- `ruff` / `mypy` clean on touched files.

Follow-up context recorded on #229 (CI integration tiers): any future real-image CI tier must use cached fixtures or a free-to-download host for the SPICE subset — the operator may relocate the oops resources to a free host later.

## Operator checklist

- **Pre-merge: nothing.** CI on this PR itself should be green (it no longer needs the buckets).
- **Post-merge: nothing.** I rebase the remaining stack (#218, #219, #220, #246, #247) onto it immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KW6fkURsA2zgrWFKjbR5JY