### PR TITLE
feat: stats report drill-down, BOTSIM check, timing, CSV export

### DIFF
--- a/docs/user_guide/user_guide_statistics.rst
+++ b/docs/user_guide/user_guide_statistics.rst
@@ -42,6 +42,12 @@ Every ingestible document must carry ``observation.image_name`` and
 document it writes). A document missing either field is logged, skipped, and
 counted as an error, exactly like a file that fails to parse.
 
+The database is disposable, and there is no schema migration: opening a
+database whose ``images`` table does not match the current column set raises
+an error naming the mismatched columns. The remedy is always the same --
+delete the database file and re-run ``sd_stats_ingest`` (the source of truth
+is the metadata documents, so nothing is lost).
+
 Database schema
 ---------------
 

--- a/docs/user_guide/user_guide_statistics.rst
+++ b/docs/user_guide/user_guide_statistics.rst
@@ -37,6 +37,11 @@ image's row and its child rows rather than duplicating them. Malformed files
 are logged and skipped; the exit status is nonzero only when nothing at all
 was ingested.
 
+Every ingestible document must carry ``observation.image_name`` and
+``observation.instrument`` (the pipeline records both in every metadata
+document it writes). A document missing either field is logged, skipped, and
+counted as an error, exactly like a file that fails to parse.
+
 Database schema
 ---------------
 
@@ -62,8 +67,8 @@ its row and children.
    * - ``instrument``
      - TEXT
      - ``coiss`` / ``vgiss`` / ``gossi`` / ``nhlorri`` / ``sim``, from the
-       metadata document's ``observation.instrument`` field (filename-shape
-       classification is the fallback for documents that lack the field).
+       metadata document's ``observation.instrument`` field (required; a
+       document without it is skipped as an ingest error).
    * - ``image_path``
      - TEXT
      - Absolute path of the source image at navigate time.
@@ -107,6 +112,19 @@ its row and children.
    * - ``noise_sigma``
      - REAL
      - Image-classifier noise estimate.
+   * - ``image_shape_v``, ``image_shape_u``
+     - INTEGER
+     - Pixel dimensions of the image data (V then U), from the metadata
+       document's ``observation.image_shape`` field; NULL when the image
+       never loaded (e.g. a read error).
+   * - ``run_start``, ``run_end``
+     - TEXT
+     - UTC ISO8601 run start and end of the navigation of this image, from
+       the metadata document's ``timing`` section; start is captured before
+       the image load and end after navigation (or at error time).
+   * - ``elapsed_s``
+     - REAL
+     - Wall-clock seconds between ``run_start`` and ``run_end``.
    * - ``config_hash``
      - TEXT
      - sha256 of the fully-resolved configuration used for the run.
@@ -244,15 +262,40 @@ Reporting
 ---------
 
 ``sd_stats_report [--db PATH] [--output-dir DIR] [--instrument NAME]
-[--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD]`` writes ``report.md`` and
-its charts into the output directory. All filters combine; dates are
-inclusive UTC image dates, so a single day's run is
-``--start-date D --end-date D``. The same inputs always produce the same
+[--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--min-image NAME]
+[--max-image NAME] [--top-n N] [--filelists] [--suspect-fraction F]
+[--csv]`` writes ``report.md`` and its charts into the output directory.
+All filters combine and apply to every section; dates are inclusive UTC
+image dates, so a single day's run is ``--start-date D --end-date D``.
+``--min-image`` / ``--max-image`` bound the numeric portion of the image
+name (the first digit run in the basename, so ``--min-image N1454725799``
+and ``--min-image 1454725799`` are equivalent); both bounds are inclusive
+and either may be given alone. The same inputs always produce the same
 numbers and the same charts.
+
+Three options control drill-down output:
+
+- ``--top-n N`` makes each categorical section (failure reasons, failure
+  taxonomy, ensemble exclusions, suspect offsets) list up to N example
+  image names per category, caps the suspect-offset and worst-BOTSIM-pair
+  tables at N rows, and lists the N slowest images.
+- ``--filelists`` writes one plain-text file per category (one image name
+  per line, the full list rather than the top N) into the ``filelists/``
+  subdirectory of the output directory, ready to feed back into re-runs
+  and triage scripts.
+- ``--csv`` writes ``images.csv`` next to ``report.md``: one row per image
+  with every ``images`` column plus per-image technique and feature-source
+  counts, for pandas or spreadsheet analysis.
 
 The report contains:
 
 - **Success / failure counts** with a breakdown of failure reasons.
+- **Failure taxonomy by image content** — failed images classified from
+  their recorded feature inventory (``stars-only``, ``single-body``,
+  ``multi-body``, ``rings-only``, ``body+rings``, ``no-features``), with a
+  per-category failure-reason breakdown and a per-body table of how often
+  each named body appears in failed versus successful images (a body with
+  a high failure share points at a modeling problem for that body).
 - **Technique usage** — runs, non-spurious runs, and mean confidence per
   technique.
 - **Model and source usage** — which bodies, rings, and star catalogs
@@ -260,7 +303,23 @@ The report contains:
   reliability gate.
 - **Offset statistics** — mean, median, standard deviation, minimum, and
   maximum of the fused V and U offsets over successful images, with
-  histograms.
+  histograms, plus the same statistics grouped by (instrument, image size).
+- **Suspect offsets** — successful images whose fused offset reaches at
+  least ``--suspect-fraction`` (default 0.9) of the instrument's per-axis
+  maximum expected pointing offset (the configured ``extfov_margin_vu``
+  search margin; for Cassini ISS the NAC/WAC margin chosen from the image
+  name) on either axis. An offset pinned near the search boundary may be a
+  correlation artifact, so these images deserve operator review. When a
+  limit cannot be resolved for an image (unknown instrument, no recorded
+  image shape), the report says so rather than silently skipping it.
+- **BOTSIM pair consistency (Cassini ISS)** — BOTSIM observations shutter
+  the NAC and WAC simultaneously and the image names share one
+  spacecraft-clock count. One WAC pixel is ten NAC pixels, so a consistent
+  pair satisfies NAC offset = 10 x WAC offset per axis; the section reports
+  the count, median, and 95th percentile of the ``NAC - 10 x WAC``
+  residuals over pairs where both frames navigated successfully, and (with
+  ``--top-n``) the worst pairs. This is an end-to-end accuracy check that
+  needs no ground truth.
 - **Cross-technique agreement** — for every technique pair, the median and
   95th-percentile Euclidean distance between their offsets on images where
   both produced non-spurious results.
@@ -273,3 +332,7 @@ The report contains:
   tier.
 - **Ensemble outlier exclusions** — how often the ensemble excluded a
   technique from the consensus, and which techniques.
+- **Run-time statistics** — minimum, maximum, mean, median, standard
+  deviation, and total of the per-image wall-clock run times, a run-time
+  histogram, and (with ``--top-n``) the slowest images. The section is
+  omitted when no ingested document carries timing data.

--- a/src/spindoctor/cli/sd_offset.py
+++ b/src/spindoctor/cli/sd_offset.py
@@ -249,12 +249,16 @@ def _run_manual_pass(
     that ``navigate_image_files`` uses, so the per-image stdout / file
     handlers are attached during prepare + dialog.
     """
-    from datetime import datetime
+    from datetime import UTC, datetime
     from itertools import islice
 
     from spindoctor.config import IMAGE_LOGGER, image_log_handlers
     from spindoctor.nav_technique import run_manual_nav
-    from spindoctor.navigate_image_files import build_metadata_from_result, write_summary_png
+    from spindoctor.navigate_image_files import (
+        build_metadata_from_result,
+        build_timing_section,
+        write_summary_png,
+    )
 
     assert DATASET is not None
     # Bound the dataset traversal to at most six items: we only need to
@@ -301,6 +305,7 @@ def _run_manual_pass(
 
     try:
         with IMAGE_LOGGER.open(str(image_url), handler=local_handlers):
+            run_start = datetime.now(UTC)
             obs = cast(ObsSnapshotInst, obs_class.from_file(image_url, **extra_params))
             result = run_manual_nav(obs, config=DEFAULT_CONFIG)
             if result is None:
@@ -313,11 +318,15 @@ def _run_manual_pass(
             dv, du = result.offset_px
             IMAGE_LOGGER.info('Manual nav: offset_dv_px=%.4f, offset_du_px=%.4f', dv, du)
             if write_output_files:
+                # The timing section's elapsed time is the manual-nav wall
+                # time: image load + dialog interaction until accept.
                 metadata = build_metadata_from_result(
                     result,
                     image_path,
                     image_name,
                     instrument=obs_class_to_inst_name(obs_class),
+                    image_shape=(int(obs.data.shape[0]), int(obs.data.shape[1])),
+                    timing=build_timing_section(run_start, datetime.now(UTC)),
                 )
                 IMAGE_LOGGER.info('Writing metadata to %s', public_metadata_file)
                 public_metadata_file.write_text(json_as_string(metadata))

--- a/src/spindoctor/cli/stats/__init__.py
+++ b/src/spindoctor/cli/stats/__init__.py
@@ -8,11 +8,18 @@ Two programs cooperate over a local SQLite database:
   loads it into a normalized SQLite database.  Ingestion is idempotent: one
   row per image, keyed by image name, updated in place when the same image is
   ingested again.
-- ``sd_stats_report`` (:mod:`spindoctor.cli.stats.report`) queries the
-  database and emits a deterministic report (Markdown text plus PNG charts):
-  success/failure counts with failure reasons, technique and model usage,
-  per-body and per-ring appearance/usage, offset statistics, cross-technique
-  agreement, and confidence-tier calibration against observed agreement.
+- ``sd_stats_report`` (:mod:`spindoctor.cli.stats.report`, with section
+  builders in :mod:`spindoctor.cli.stats.report_sections` and shared helpers
+  in :mod:`spindoctor.cli.stats.report_common`) queries the database and
+  emits a deterministic report (Markdown text plus PNG charts):
+  success/failure counts with failure reasons, a failure taxonomy by scene
+  content with per-body failure shares, technique and model usage, offset
+  statistics (overall and by instrument/image size), a suspect-offset screen
+  against the configured search limits, Cassini BOTSIM NAC/WAC pair
+  consistency, cross-technique agreement, confidence-tier calibration
+  against observed agreement, and run-time statistics.  Optional drill-down
+  flags list example images per category, write per-category filelists, and
+  export a one-row-per-image CSV.
 
 Both are cron-friendly single commands and work over any date range and any
 instrument.

--- a/src/spindoctor/cli/stats/classify.py
+++ b/src/spindoctor/cli/stats/classify.py
@@ -1,52 +1,8 @@
-"""Image-name classification and time helpers for the statistics system."""
-
-import re
+"""Time helpers for the statistics system."""
 
 import julian
 
-__all__ = ['date_from_image_et', 'instrument_from_image_name']
-
-# Filename shapes for the four supported instruments, tested against the bare
-# image name with any calibration suffix and extension removed:
-#   Cassini ISS      N1454725799_1 / W1728613298_8
-#   Voyager ISS      C3250013 (7-digit FDS)
-#   Galileo SSI      C0349632000R / C0059881800S (10-digit SCLK + R/S)
-#   New Horizons     lor_0003103486_0x630_sci
-_COISS_RE = re.compile(r'^[NW]\d{10}(_\d+)?$')
-_VGISS_RE = re.compile(r'^C\d{7}$')
-_GOSSI_RE = re.compile(r'^C\d{10}[A-Z]?$')
-_NHLORRI_RE = re.compile(r'^LOR_\d+.*$')
-
-
-def instrument_from_image_name(image_name: str) -> str:
-    """Classify an image filename into one of the supported instruments.
-
-    Fallback only: ingest prefers the ``observation.instrument`` field the
-    pipeline records in each metadata document and calls this just for
-    documents that lack the field.
-
-    Parameters:
-        image_name: Image filename, with or without directory, calibration
-            suffix, or extension (``N1454725799_1_CALIB.IMG`` and
-            ``N1454725799_1`` classify identically).
-
-    Returns:
-        One of ``'coiss'``, ``'vgiss'``, ``'gossi'``, ``'nhlorri'``, or
-        ``'unknown'``.
-    """
-    name = image_name.rsplit('/', 1)[-1].upper()
-    name = name.split('.', 1)[0]
-    for suffix in ('_CALIB', '_GEOMED', '_CLEANED', '_RAW'):
-        name = name.removesuffix(suffix)
-    if _COISS_RE.match(name):
-        return 'coiss'
-    if _VGISS_RE.match(name):
-        return 'vgiss'
-    if _GOSSI_RE.match(name):
-        return 'gossi'
-    if _NHLORRI_RE.match(name):
-        return 'nhlorri'
-    return 'unknown'
+__all__ = ['date_from_image_et']
 
 
 def date_from_image_et(image_et: float | None) -> str | None:

--- a/src/spindoctor/cli/stats/ingest.py
+++ b/src/spindoctor/cli/stats/ingest.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 
 from filecache import FCPath
 
-from spindoctor.cli.stats.classify import date_from_image_et, instrument_from_image_name
+from spindoctor.cli.stats.classify import date_from_image_et
 from spindoctor.cli.stats.schema import open_stats_db, upsert_image
 from spindoctor.config import MAIN_LOGGER
 
@@ -25,6 +25,23 @@ def _finite_or_none(value: Any) -> float | None:
         return None
     out = float(value)
     return out if math.isfinite(out) else None
+
+
+def _str_or_none(value: Any) -> str | None:
+    """Coerce a JSON value to a non-empty string, or None."""
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _image_shape(value: Any) -> tuple[int | None, int | None]:
+    """Per-axis ``(v, u)`` pixel dimensions from a metadata image_shape list."""
+    if not isinstance(value, (list, tuple)) or len(value) != 2:
+        return None, None
+    try:
+        return int(value[0]), int(value[1])
+    except (TypeError, ValueError):
+        return None, None
 
 
 def _sigma_from_covariance(covariance: Any) -> tuple[float | None, float | None]:
@@ -74,18 +91,16 @@ def rows_from_metadata(
         :func:`~spindoctor.cli.stats.schema.upsert_image`.
 
     Raises:
-        ValueError: If the document lacks the observation image name.
+        ValueError: If the document lacks the observation image name or the
+            observation instrument.
     """
     observation = metadata.get('observation') or {}
     image_name = observation.get('image_name')
     if not image_name:
         raise ValueError(f'{source_file}: metadata lacks observation.image_name')
-    # The pipeline records the instrument in the metadata itself; the
-    # filename-shape classifier is the fallback for documents that lack
-    # the field.
     instrument = observation.get('instrument')
     if not isinstance(instrument, str) or not instrument:
-        instrument = instrument_from_image_name(str(image_name))
+        raise ValueError(f'{source_file}: metadata lacks observation.instrument')
     nav = metadata.get('navigation_result') or {}
     provenance = nav.get('provenance') or {}
     classifier = nav.get('image_classifier') or {}
@@ -93,6 +108,8 @@ def rows_from_metadata(
     sigma = nav.get('sigma_px') or [None, None]
     image_et = _finite_or_none(provenance.get('image_et'))
     per_technique = nav.get('per_technique') or []
+    timing = metadata.get('timing') or {}
+    shape_v, shape_u = _image_shape(observation.get('image_shape'))
 
     image_row: dict[str, Any] = {
         'image_name': image_name,
@@ -112,6 +129,11 @@ def rows_from_metadata(
         'excluded_from_consensus': json.dumps(sorted(nav.get('excluded_from_consensus') or [])),
         'image_class': classifier.get('class'),
         'noise_sigma': _finite_or_none(classifier.get('noise_sigma')),
+        'image_shape_v': shape_v,
+        'image_shape_u': shape_u,
+        'run_start': _str_or_none(timing.get('start_iso8601')),
+        'run_end': _str_or_none(timing.get('end_iso8601')),
+        'elapsed_s': _finite_or_none(timing.get('elapsed_s')),
         'config_hash': provenance.get('config_hash'),
         'git_sha': provenance.get('spindoctor_git_sha'),
         'pipeline_run': provenance.get('pipeline_run_iso8601'),

--- a/src/spindoctor/cli/stats/report.py
+++ b/src/spindoctor/cli/stats/report.py
@@ -7,89 +7,39 @@ import math
 import sqlite3
 import statistics
 from pathlib import Path
-from typing import Any
 
+from spindoctor.cli.stats.report_common import (
+    ReportContext,
+    add_drilldown,
+    connector,
+    fmt,
+    image_number_from_name,
+    offset_stats,
+    percentile,
+    register_image_number_function,
+    rows,
+    where_clause,
+    write_bar_chart,
+    write_offset_hist,
+)
+from spindoctor.cli.stats.report_sections import (
+    add_botsim_section,
+    add_failure_taxonomy_section,
+    add_offset_by_group_section,
+    add_runtime_section,
+    add_suspect_offset_section,
+    write_csv_export,
+)
 from spindoctor.cli.stats.schema import open_stats_db
 from spindoctor.config import MAIN_LOGGER
 
 __all__ = ['build_report', 'main_report']
 
 
-def _where_clause(
-    *,
-    instrument: str | None,
-    start_date: str | None,
-    end_date: str | None,
-    alias: str = '',
-) -> tuple[str, list[str]]:
-    """Build the images-table filter shared by every query.
-
-    Parameters:
-        instrument: Optional instrument filter value.
-        start_date: Optional inclusive UTC start date (``YYYY-MM-DD``).
-        end_date: Optional inclusive UTC end date (``YYYY-MM-DD``).
-        alias: Table alias prefix (e.g. ``'i.'``) qualifying the column
-            names, for queries that join the ``images`` table.
-
-    Returns:
-        ``(where, params)`` where ``where`` is ``''`` or a leading-space
-        ``' WHERE ...'`` fragment and ``params`` the bound values.
-    """
-    clauses: list[str] = []
-    params: list[str] = []
-    if instrument is not None:
-        clauses.append(f'{alias}instrument = ?')
-        params.append(instrument)
-    if start_date is not None:
-        clauses.append(f'{alias}image_date >= ?')
-        params.append(start_date)
-    if end_date is not None:
-        clauses.append(f'{alias}image_date <= ?')
-        params.append(end_date)
-    if len(clauses) == 0:
-        return '', []
-    return ' WHERE ' + ' AND '.join(clauses), params
-
-
-def _connector(where: str) -> str:
-    """The keyword joining an extra condition onto a ``_where_clause`` result."""
-    return ' AND ' if len(where) > 0 else ' WHERE '
-
-
-def _rows(conn: sqlite3.Connection, sql: str, params: list[str]) -> list[tuple[Any, ...]]:
-    """Execute a query and return all result rows as a list."""
-    return list(conn.execute(sql, params))
-
-
-def _fmt(value: float | None, digits: int = 3) -> str:
-    """Format a float for a Markdown table cell."""
-    if value is None:
-        return '-'
-    return f'{value:.{digits}f}'
-
-
-def _offset_stats(values: list[float]) -> dict[str, float] | None:
-    """Mean / median / stdev / min / max summary of a value list."""
-    if len(values) == 0:
-        return None
-    return {
-        'mean': statistics.fmean(values),
-        'median': statistics.median(values),
-        'stdev': statistics.stdev(values) if len(values) > 1 else 0.0,
-        'min': min(values),
-        'max': max(values),
-    }
-
-
 def _pairwise_disagreements(
-    conn: sqlite3.Connection, where: str, params: list[str]
+    ctx: ReportContext,
 ) -> tuple[dict[tuple[str, str], list[float]], dict[str, list[float]]]:
     """Cross-technique agreement data.
-
-    Parameters:
-        conn: Open statistics database connection.
-        where: ``_where_clause`` fragment built with ``alias='i.'``.
-        params: Bound values matching ``where``.
 
     Returns:
         ``(per_pair, per_image_rank)`` where ``per_pair`` maps a sorted
@@ -103,14 +53,16 @@ def _pairwise_disagreements(
     sql = (
         'SELECT t.image_name, i.confidence_rank, t.technique_name, t.offset_dv, t.offset_du '
         'FROM techniques t JOIN images i ON i.image_name = t.image_name'
-        + where
-        + _connector(where)
+        + ctx.where_i
+        + connector(ctx.where_i)
         + 't.spurious = 0 AND t.offset_dv IS NOT NULL AND t.offset_du IS NOT NULL '
         'ORDER BY t.image_name, t.technique_name'
     )
     per_pair: dict[tuple[str, str], list[float]] = {}
     per_image_rank: dict[str, list[float]] = {}
-    for _image_name, group in itertools.groupby(_rows(conn, sql, params), key=lambda r: r[0]):
+    for _image_name, group in itertools.groupby(
+        rows(ctx.conn, sql, ctx.params_i), key=lambda r: r[0]
+    ):
         entries = list(group)
         if len(entries) < 2:
             continue
@@ -126,223 +78,155 @@ def _pairwise_disagreements(
     return per_pair, per_image_rank
 
 
-def _percentile(values: list[float], fraction: float) -> float:
-    """Nearest-rank percentile of a non-empty value list.
-
-    Parameters:
-        values: Non-empty list of values.
-        fraction: Percentile as a fraction in ``[0, 1]`` (e.g. ``0.95``).
-
-    Returns:
-        The nearest-rank percentile value.
-    """
-    ordered = sorted(values)
-    index = min(len(ordered) - 1, max(0, math.ceil(fraction * len(ordered)) - 1))
-    return ordered[index]
-
-
-def _import_pyplot() -> Any:
-    """Import matplotlib with the deterministic Agg backend and return pyplot."""
-    import matplotlib
-
-    matplotlib.use('Agg')
-    import matplotlib.pyplot as plt
-
-    return plt
-
-
-def _write_bar_chart(
-    path: Path, labels: list[str], counts: list[int], *, title: str, xlabel: str
-) -> None:
-    """Write a horizontal bar chart PNG (deterministic, Agg backend)."""
-    plt = _import_pyplot()
-    fig, ax = plt.subplots(figsize=(8, max(2.0, 0.4 * len(labels) + 1.0)))
-    positions = range(len(labels))
-    ax.barh(list(positions), counts, color='#4878d0')
-    ax.set_yticks(list(positions))
-    ax.set_yticklabels(labels)
-    ax.invert_yaxis()
-    ax.set_xlabel(xlabel)
-    ax.set_title(title)
-    fig.tight_layout()
-    fig.savefig(path, dpi=100)
-    plt.close(fig)
-
-
-def _write_offset_hist(path: Path, dv: list[float], du: list[float]) -> None:
-    """Write the V/U offset histogram PNG."""
-    plt = _import_pyplot()
-    fig, axes = plt.subplots(1, 2, figsize=(10, 4))
-    for ax, values, label in ((axes[0], dv, 'dV (px)'), (axes[1], du, 'dU (px)')):
-        if len(values) > 0:
-            ax.hist(values, bins=40, color='#4878d0')
-        ax.set_xlabel(label)
-        ax.set_ylabel('images')
-    fig.suptitle('Fused offset distribution (successful images)')
-    fig.tight_layout()
-    fig.savefig(path, dpi=100)
-    plt.close(fig)
-
-
-def build_report(
-    conn: sqlite3.Connection,
-    output_dir: Path,
-    *,
-    instrument: str | None = None,
-    start_date: str | None = None,
-    end_date: str | None = None,
-) -> Path:
-    """Query the statistics database and write ``report.md`` plus charts.
-
-    Parameters:
-        conn: Open statistics database connection.
-        output_dir: Directory receiving ``report.md`` and the PNG charts
-            (created if missing).
-        instrument: Optional instrument filter (``coiss`` / ``vgiss`` /
-            ``gossi`` / ``nhlorri``).
-        start_date: Optional inclusive UTC start date (``YYYY-MM-DD``).
-        end_date: Optional inclusive UTC end date (``YYYY-MM-DD``).
-
-    Returns:
-        The path of the written ``report.md``.
-    """
-    output_dir.mkdir(parents=True, exist_ok=True)
-    where, params = _where_clause(instrument=instrument, start_date=start_date, end_date=end_date)
-    # Joined queries alias the images table as ``i``; same filter, qualified.
-    where_i, params_i = _where_clause(
-        instrument=instrument, start_date=start_date, end_date=end_date, alias='i.'
-    )
-    lines: list[str] = ['# Navigation statistics report', '']
-    filters = [
-        f'instrument = {instrument}' if instrument is not None else None,
-        f'from {start_date}' if start_date is not None else None,
-        f'to {end_date}' if end_date is not None else None,
-    ]
-    active = [f for f in filters if f is not None]
-    lines.append(f'Filters: {", ".join(active) if len(active) > 0 else "none (full database)"}')
-    lines.append('')
-
-    # --- Success / failure counts -----------------------------------------
-    status_rows = _rows(
-        conn,
-        f'SELECT status, COUNT(*) FROM images{where} GROUP BY status ORDER BY status',
-        params,
+def _add_status_sections(ctx: ReportContext) -> None:
+    """Append the success/failure counts and the failure-reason breakdown."""
+    status_rows = rows(
+        ctx.conn,
+        f'SELECT status, COUNT(*) FROM images{ctx.where} GROUP BY status ORDER BY status',
+        ctx.params,
     )
     total = sum(r[1] for r in status_rows)
-    lines += ['## Success / failure', '', '| status | images | fraction |', '|---|---|---|']
+    ctx.lines += ['## Success / failure', '', '| status | images | fraction |', '|---|---|---|']
     for status, count in status_rows:
-        lines.append(f'| {status} | {count} | {count / total:.3f} |' if total > 0 else '')
-    lines += ['', f'Total images: {total}', '']
-    _write_bar_chart(
-        output_dir / 'status_counts.png',
+        ctx.lines.append(f'| {status} | {count} | {count / total:.3f} |' if total > 0 else '')
+    ctx.lines += ['', f'Total images: {total}', '']
+    write_bar_chart(
+        ctx.output_dir / 'status_counts.png',
         [str(r[0]) for r in status_rows],
         [int(r[1]) for r in status_rows],
         title='Navigation status',
         xlabel='images',
     )
-    lines += ['![status](status_counts.png)', '']
+    ctx.lines += ['![status](status_counts.png)', '']
 
-    reason_rows = _rows(
-        conn,
-        f'SELECT status_reason, COUNT(*) FROM images{where}'
-        + _connector(where)
+    reason_rows = rows(
+        ctx.conn,
+        f'SELECT status_reason, COUNT(*) FROM images{ctx.where}'
+        + connector(ctx.where)
         + "status != 'success' GROUP BY status_reason ORDER BY COUNT(*) DESC, status_reason",
-        params,
+        ctx.params,
     )
     if len(reason_rows) > 0:
-        lines += ['### Failure reasons', '', '| reason | images |', '|---|---|']
-        lines += [f'| {reason or "(none)"} | {count} |' for reason, count in reason_rows]
-        lines.append('')
-        _write_bar_chart(
-            output_dir / 'failure_reasons.png',
+        ctx.lines += ['### Failure reasons', '', '| reason | images |', '|---|---|']
+        ctx.lines += [f'| {reason or "(none)"} | {count} |' for reason, count in reason_rows]
+        ctx.lines.append('')
+        name_rows = rows(
+            ctx.conn,
+            f'SELECT status_reason, image_name FROM images{ctx.where}'
+            + connector(ctx.where)
+            + "status != 'success' ORDER BY image_name",
+            ctx.params,
+        )
+        names_by_reason: dict[str, list[str]] = {}
+        for reason, image_name in name_rows:
+            names_by_reason.setdefault(str(reason or '(none)'), []).append(str(image_name))
+        add_drilldown(
+            ctx,
+            [
+                (str(reason or '(none)'), names_by_reason.get(str(reason or '(none)'), []))
+                for reason, _count in reason_rows
+            ],
+            label='reason',
+            stub_prefix='failure_reason',
+        )
+        write_bar_chart(
+            ctx.output_dir / 'failure_reasons.png',
             [str(r[0] or '(none)') for r in reason_rows],
             [int(r[1]) for r in reason_rows],
             title='Failure reasons',
             xlabel='images',
         )
-        lines += ['![failure reasons](failure_reasons.png)', '']
+        ctx.lines += ['![failure reasons](failure_reasons.png)', '']
 
-    # --- Technique usage ----------------------------------------------------
-    tech_rows = _rows(
-        conn,
+
+def _add_technique_usage_section(ctx: ReportContext) -> None:
+    """Append per-technique run counts and mean confidence."""
+    tech_rows = rows(
+        ctx.conn,
         'SELECT t.technique_name, COUNT(*), SUM(1 - t.spurious), AVG(t.confidence) '
         'FROM techniques t JOIN images i ON i.image_name = t.image_name'
-        + where_i
+        + ctx.where_i
         + ' GROUP BY t.technique_name ORDER BY COUNT(*) DESC, t.technique_name',
-        params_i,
+        ctx.params_i,
     )
-    lines += [
+    ctx.lines += [
         '## Technique usage',
         '',
         '| technique | runs | non-spurious | mean confidence |',
         '|---|---|---|---|',
     ]
     for name, runs, good, mean_conf in tech_rows:
-        lines.append(f'| {name} | {runs} | {good} | {_fmt(mean_conf)} |')
-    lines.append('')
+        ctx.lines.append(f'| {name} | {runs} | {good} | {fmt(mean_conf)} |')
+    ctx.lines.append('')
     if len(tech_rows) > 0:
-        _write_bar_chart(
-            output_dir / 'technique_usage.png',
+        write_bar_chart(
+            ctx.output_dir / 'technique_usage.png',
             [str(r[0]) for r in tech_rows],
             [int(r[1]) for r in tech_rows],
             title='Technique runs',
             xlabel='runs',
         )
-        lines += ['![technique usage](technique_usage.png)', '']
+        ctx.lines += ['![technique usage](technique_usage.png)', '']
 
-    # --- Model / body / ring usage -------------------------------------------
-    source_rows = _rows(
-        conn,
+
+def _add_source_usage_section(ctx: ReportContext) -> None:
+    """Append the per-model / per-source feature-usage table."""
+    source_rows = rows(
+        ctx.conn,
         'SELECT s.source_model, s.source_name, COUNT(DISTINCT s.image_name), '
         'SUM(s.n_features), SUM(s.n_gated) '
         'FROM feature_sources s JOIN images i ON i.image_name = s.image_name'
-        + where_i
+        + ctx.where_i
         + ' GROUP BY s.source_model, s.source_name '
         'ORDER BY s.source_model, COUNT(DISTINCT s.image_name) DESC, s.source_name',
-        params_i,
+        ctx.params_i,
     )
-    lines += [
+    ctx.lines += [
         '## Model and source usage',
         '',
         '| model | source | images | features | gated |',
         '|---|---|---|---|---|',
     ]
     for model, name, n_images, n_features, n_gated in source_rows:
-        lines.append(f'| {model} | {name} | {n_images} | {n_features} | {n_gated} |')
-    lines.append('')
+        ctx.lines.append(f'| {model} | {name} | {n_images} | {n_features} | {n_gated} |')
+    ctx.lines.append('')
 
-    # --- Offset statistics ---------------------------------------------------
-    offset_rows = _rows(
-        conn,
-        f'SELECT offset_dv, offset_du FROM images{where}'
-        + _connector(where)
+
+def _add_offset_section(ctx: ReportContext) -> None:
+    """Append the fused-offset statistics table and histogram."""
+    offset_rows = rows(
+        ctx.conn,
+        f'SELECT offset_dv, offset_du FROM images{ctx.where}'
+        + connector(ctx.where)
         + "status = 'success' AND offset_dv IS NOT NULL",
-        params,
+        ctx.params,
     )
     dv = [float(r[0]) for r in offset_rows]
     du = [float(r[1]) for r in offset_rows]
-    lines += [
+    ctx.lines += [
         '## Offset statistics (successful images)',
         '',
         '| axis | n | mean | median | stdev | min | max |',
         '|---|---|---|---|---|---|---|',
     ]
     for axis, values in (('dV', dv), ('dU', du)):
-        stats = _offset_stats(values)
+        stats = offset_stats(values)
         if stats is None:
-            lines.append(f'| {axis} | 0 | - | - | - | - | - |')
+            ctx.lines.append(f'| {axis} | 0 | - | - | - | - | - |')
         else:
-            lines.append(
-                f'| {axis} | {len(values)} | {_fmt(stats["mean"])} | {_fmt(stats["median"])} '
-                f'| {_fmt(stats["stdev"])} | {_fmt(stats["min"])} | {_fmt(stats["max"])} |'
+            ctx.lines.append(
+                f'| {axis} | {len(values)} | {fmt(stats["mean"])} | {fmt(stats["median"])} '
+                f'| {fmt(stats["stdev"])} | {fmt(stats["min"])} | {fmt(stats["max"])} |'
             )
-    lines.append('')
-    _write_offset_hist(output_dir / 'offsets_hist.png', dv, du)
-    lines += ['![offsets](offsets_hist.png)', '']
+    ctx.lines.append('')
+    write_offset_hist(ctx.output_dir / 'offsets_hist.png', dv, du)
+    ctx.lines += ['![offsets](offsets_hist.png)', '']
 
-    # --- Cross-technique agreement -------------------------------------------
-    per_pair, per_image_rank = _pairwise_disagreements(conn, where_i, params_i)
-    lines += [
+
+def _add_agreement_sections(ctx: ReportContext) -> None:
+    """Append the cross-technique agreement and confidence-calibration tables."""
+    per_pair, per_image_rank = _pairwise_disagreements(ctx)
+    ctx.lines += [
         '## Cross-technique agreement',
         '',
         'Euclidean distance between per-technique offsets on images where both',
@@ -353,21 +237,20 @@ def build_report(
     ]
     for pair in sorted(per_pair):
         deltas = per_pair[pair]
-        lines.append(
+        ctx.lines.append(
             f'| {pair[0]} vs {pair[1]} | {len(deltas)} | '
-            f'{_fmt(statistics.median(deltas))} | {_fmt(_percentile(deltas, 0.95))} |'
+            f'{fmt(statistics.median(deltas))} | {fmt(percentile(deltas, 0.95))} |'
         )
-    lines.append('')
+    ctx.lines.append('')
 
-    # --- Confidence calibration ------------------------------------------------
-    rank_rows = _rows(
-        conn,
-        f'SELECT confidence_rank, COUNT(*) FROM images{where}'
-        + _connector(where)
+    rank_rows = rows(
+        ctx.conn,
+        f'SELECT confidence_rank, COUNT(*) FROM images{ctx.where}'
+        + connector(ctx.where)
         + 'confidence_rank IS NOT NULL GROUP BY confidence_rank ORDER BY confidence_rank',
-        params,
+        ctx.params,
     )
-    lines += [
+    ctx.lines += [
         '## Confidence calibration (agreement as accuracy proxy)',
         '',
         'For each confidence tier: how well the techniques that fed the fused',
@@ -380,46 +263,198 @@ def build_report(
     ]
     for rank, count in rank_rows:
         disagreements = per_image_rank.get(str(rank), [])
-        lines.append(
+        ctx.lines.append(
             f'| {rank} | {count} | {len(disagreements)} | '
-            f'{_fmt(statistics.median(disagreements)) if disagreements else "-"} | '
-            f'{_fmt(_percentile(disagreements, 0.95)) if disagreements else "-"} |'
+            f'{fmt(statistics.median(disagreements)) if disagreements else "-"} | '
+            f'{fmt(percentile(disagreements, 0.95)) if disagreements else "-"} |'
         )
-    lines.append('')
+    ctx.lines.append('')
     if len(per_image_rank) > 0:
         ordered_ranks = sorted(per_image_rank)
-        _write_bar_chart(
-            output_dir / 'agreement_by_tier.png',
+        write_bar_chart(
+            ctx.output_dir / 'agreement_by_tier.png',
             ordered_ranks,
             [len(per_image_rank[r]) for r in ordered_ranks],
             title='Images with cross-technique agreement data, by tier',
             xlabel='images',
         )
-        lines += ['![agreement by tier](agreement_by_tier.png)', '']
+        ctx.lines += ['![agreement by tier](agreement_by_tier.png)', '']
 
-    # --- Consensus exclusions ---------------------------------------------------
-    excluded_rows = _rows(
-        conn,
-        f'SELECT excluded_from_consensus, COUNT(*) FROM images{where}'
-        + _connector(where)
+
+def _add_exclusions_section(ctx: ReportContext) -> None:
+    """Append the ensemble outlier-exclusion breakdown."""
+    excluded_rows = rows(
+        ctx.conn,
+        f'SELECT excluded_from_consensus, COUNT(*) FROM images{ctx.where}'
+        + connector(ctx.where)
         + "excluded_from_consensus != '[]' "
         'GROUP BY excluded_from_consensus ORDER BY COUNT(*) DESC, excluded_from_consensus',
-        params,
+        ctx.params,
     )
-    if len(excluded_rows) > 0:
-        lines += [
-            '## Ensemble outlier exclusions',
-            '',
-            '| excluded techniques | images |',
-            '|---|---|',
-        ]
-        for raw, count in excluded_rows:
-            names = ', '.join(json.loads(raw)) or '(none)'
-            lines.append(f'| {names} | {count} |')
-        lines.append('')
+    if len(excluded_rows) == 0:
+        return
+    ctx.lines += [
+        '## Ensemble outlier exclusions',
+        '',
+        '| excluded techniques | images |',
+        '|---|---|',
+    ]
+    for raw, count in excluded_rows:
+        names = ', '.join(json.loads(raw)) or '(none)'
+        ctx.lines.append(f'| {names} | {count} |')
+    ctx.lines.append('')
+    name_rows = rows(
+        ctx.conn,
+        f'SELECT excluded_from_consensus, image_name FROM images{ctx.where}'
+        + connector(ctx.where)
+        + "excluded_from_consensus != '[]' ORDER BY image_name",
+        ctx.params,
+    )
+    names_by_exclusion: dict[str, list[str]] = {}
+    for raw, image_name in name_rows:
+        label = ', '.join(json.loads(raw)) or '(none)'
+        names_by_exclusion.setdefault(label, []).append(str(image_name))
+    ordered_labels = [', '.join(json.loads(raw)) or '(none)' for raw, _count in excluded_rows]
+    add_drilldown(
+        ctx,
+        [(label, names_by_exclusion.get(label, [])) for label in ordered_labels],
+        label='exclusion set',
+        stub_prefix='excluded',
+    )
+
+
+def _image_bound(value: str | None, *, option: str) -> int | None:
+    """Parse a ``--min-image`` / ``--max-image`` value into its numeric bound.
+
+    Parameters:
+        value: Image name (``N1454725799``) or bare number, or None.
+        option: Option name for the error message.
+
+    Returns:
+        The integer bound, or None when ``value`` is None.
+
+    Raises:
+        ValueError: If the value contains no digits.
+    """
+    if value is None:
+        return None
+    number = image_number_from_name(value)
+    if number is None:
+        raise ValueError(f'{option} value {value!r} contains no digits')
+    return number
+
+
+def build_report(
+    conn: sqlite3.Connection,
+    output_dir: Path,
+    *,
+    instrument: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    min_image: str | None = None,
+    max_image: str | None = None,
+    top_n: int = 0,
+    filelists: bool = False,
+    suspect_fraction: float = 0.9,
+    csv_export: bool = False,
+) -> Path:
+    """Query the statistics database and write ``report.md`` plus charts.
+
+    The report is deterministic: the same database and options always
+    produce byte-identical Markdown.  All filters combine and apply to
+    every section.
+
+    Parameters:
+        conn: Open statistics database connection.
+        output_dir: Directory receiving ``report.md``, the PNG charts, and
+            (with ``filelists`` / ``csv_export``) the ``filelists/``
+            subdirectory and ``images.csv`` (created if missing).
+        instrument: Optional instrument filter (``coiss`` / ``vgiss`` /
+            ``gossi`` / ``nhlorri``).
+        start_date: Optional inclusive UTC start date (``YYYY-MM-DD``).
+        end_date: Optional inclusive UTC end date (``YYYY-MM-DD``).
+        min_image: Optional inclusive lower bound on the numeric portion
+            of the image name; an image name (``N1454725799``) or a bare
+            number.
+        max_image: Optional inclusive upper bound on the numeric portion
+            of the image name.
+        top_n: When positive, categorical sections list up to this many
+            example image names per category, the suspect-offset and
+            worst-BOTSIM-pair tables are capped at this many rows, and the
+            slowest images are listed.
+        filelists: When True, write one plain-text file per category (one
+            image name per line, full list) under ``filelists/``.
+        suspect_fraction: Fraction of the per-axis maximum expected
+            pointing offset at or beyond which a fused offset is flagged
+            as suspect.
+        csv_export: When True, write the flattened one-row-per-image
+            ``images.csv`` next to ``report.md``.
+
+    Returns:
+        The path of the written ``report.md``.
+
+    Raises:
+        ValueError: If ``min_image`` or ``max_image`` contains no digits.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    register_image_number_function(conn)
+    min_image_num = _image_bound(min_image, option='min_image')
+    max_image_num = _image_bound(max_image, option='max_image')
+    where, params = where_clause(
+        instrument=instrument,
+        start_date=start_date,
+        end_date=end_date,
+        min_image_num=min_image_num,
+        max_image_num=max_image_num,
+    )
+    # Joined queries alias the images table as ``i``; same filter, qualified.
+    where_i, params_i = where_clause(
+        instrument=instrument,
+        start_date=start_date,
+        end_date=end_date,
+        min_image_num=min_image_num,
+        max_image_num=max_image_num,
+        alias='i.',
+    )
+    ctx = ReportContext(
+        conn=conn,
+        output_dir=output_dir,
+        where=where,
+        params=params,
+        where_i=where_i,
+        params_i=params_i,
+        top_n=top_n,
+        filelists=filelists,
+        suspect_fraction=suspect_fraction,
+    )
+    ctx.lines += ['# Navigation statistics report', '']
+    filters = [
+        f'instrument = {instrument}' if instrument is not None else None,
+        f'from {start_date}' if start_date is not None else None,
+        f'to {end_date}' if end_date is not None else None,
+        f'image number >= {min_image_num}' if min_image_num is not None else None,
+        f'image number <= {max_image_num}' if max_image_num is not None else None,
+    ]
+    active = [f for f in filters if f is not None]
+    ctx.lines.append(f'Filters: {", ".join(active) if len(active) > 0 else "none (full database)"}')
+    ctx.lines.append('')
+
+    _add_status_sections(ctx)
+    add_failure_taxonomy_section(ctx)
+    _add_technique_usage_section(ctx)
+    _add_source_usage_section(ctx)
+    _add_offset_section(ctx)
+    add_offset_by_group_section(ctx)
+    add_suspect_offset_section(ctx)
+    add_botsim_section(ctx)
+    _add_agreement_sections(ctx)
+    _add_exclusions_section(ctx)
+    add_runtime_section(ctx)
+    if csv_export:
+        write_csv_export(ctx)
 
     report_path = output_dir / 'report.md'
-    report_path.write_text('\n'.join(lines) + '\n', encoding='utf-8')
+    report_path.write_text('\n'.join(ctx.lines) + '\n', encoding='utf-8')
     return report_path
 
 
@@ -457,6 +492,49 @@ def main_report(cmdline: list[str] | None = None) -> int:
     parser.add_argument(
         '--end-date', default=None, metavar='YYYY-MM-DD', help='Inclusive UTC end date'
     )
+    parser.add_argument(
+        '--min-image',
+        default=None,
+        metavar='NAME',
+        help='Inclusive lower bound on the numeric portion of the image name '
+        '(an image name like N1454725799 or a bare number)',
+    )
+    parser.add_argument(
+        '--max-image',
+        default=None,
+        metavar='NAME',
+        help='Inclusive upper bound on the numeric portion of the image name',
+    )
+    parser.add_argument(
+        '--top-n',
+        type=int,
+        default=0,
+        metavar='N',
+        help='List up to N example image names per category in categorical '
+        'sections, cap the suspect-offset and worst-BOTSIM-pair tables at N '
+        'rows, and list the N slowest images (default: 0 = off)',
+    )
+    parser.add_argument(
+        '--filelists',
+        action='store_true',
+        default=False,
+        help='Write one plain-text file per category (one image name per '
+        'line, full list) into the filelists/ subdirectory of the output dir',
+    )
+    parser.add_argument(
+        '--suspect-fraction',
+        type=float,
+        default=0.9,
+        metavar='F',
+        help='Flag successful offsets at or beyond this fraction of the '
+        'per-axis maximum expected pointing offset (default: %(default)s)',
+    )
+    parser.add_argument(
+        '--csv',
+        action='store_true',
+        default=False,
+        help='Write a flattened one-row-per-image images.csv next to report.md',
+    )
     arguments = parser.parse_args(cmdline)
 
     conn = open_stats_db(arguments.db)
@@ -467,7 +545,15 @@ def main_report(cmdline: list[str] | None = None) -> int:
             instrument=arguments.instrument,
             start_date=arguments.start_date,
             end_date=arguments.end_date,
+            min_image=arguments.min_image,
+            max_image=arguments.max_image,
+            top_n=arguments.top_n,
+            filelists=arguments.filelists,
+            suspect_fraction=arguments.suspect_fraction,
+            csv_export=arguments.csv,
         )
+    except ValueError as exc:
+        parser.error(str(exc))
     finally:
         conn.close()
     MAIN_LOGGER.info('Wrote %s', report_path)

--- a/src/spindoctor/cli/stats/report.py
+++ b/src/spindoctor/cli/stats/report.py
@@ -8,6 +8,8 @@ import sqlite3
 import statistics
 from pathlib import Path
 
+from filecache import FCPath
+
 from spindoctor.cli.stats.report_common import (
     ReportContext,
     add_drilldown,
@@ -346,7 +348,7 @@ def _image_bound(value: str | None, *, option: str) -> int | None:
 
 def build_report(
     conn: sqlite3.Connection,
-    output_dir: Path,
+    output_dir: str | Path | FCPath,
     *,
     instrument: str | None = None,
     start_date: str | None = None,
@@ -357,7 +359,7 @@ def build_report(
     filelists: bool = False,
     suspect_fraction: float = 0.9,
     csv_export: bool = False,
-) -> Path:
+) -> FCPath:
     """Query the statistics database and write ``report.md`` plus charts.
 
     The report is deterministic: the same database and options always
@@ -368,7 +370,8 @@ def build_report(
         conn: Open statistics database connection.
         output_dir: Directory receiving ``report.md``, the PNG charts, and
             (with ``filelists`` / ``csv_export``) the ``filelists/``
-            subdirectory and ``images.csv`` (created if missing).
+            subdirectory and ``images.csv`` (created if missing).  A local
+            directory or any URL the ``filecache`` layer accepts.
         instrument: Optional instrument filter (``coiss`` / ``vgiss`` /
             ``gossi`` / ``nhlorri``).
         start_date: Optional inclusive UTC start date (``YYYY-MM-DD``).
@@ -396,7 +399,7 @@ def build_report(
     Raises:
         ValueError: If ``min_image`` or ``max_image`` contains no digits.
     """
-    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = FCPath(output_dir)
     register_image_number_function(conn)
     min_image_num = _image_bound(min_image, option='min_image')
     max_image_num = _image_bound(max_image, option='max_image')
@@ -418,7 +421,7 @@ def build_report(
     )
     ctx = ReportContext(
         conn=conn,
-        output_dir=output_dir,
+        output_dir=output_path,
         where=where,
         params=params,
         where_i=where_i,
@@ -453,7 +456,7 @@ def build_report(
     if csv_export:
         write_csv_export(ctx)
 
-    report_path = output_dir / 'report.md'
+    report_path = output_path / 'report.md'
     report_path.write_text('\n'.join(ctx.lines) + '\n', encoding='utf-8')
     return report_path
 
@@ -478,7 +481,8 @@ def main_report(cmdline: list[str] | None = None) -> int:
     parser.add_argument(
         '--output-dir',
         default='nav_stats_report',
-        help='Directory receiving report.md and charts (default: %(default)s)',
+        help='Directory (local path or filecache URL) receiving report.md and charts '
+        '(default: %(default)s)',
     )
     parser.add_argument(
         '--instrument',
@@ -541,7 +545,7 @@ def main_report(cmdline: list[str] | None = None) -> int:
     try:
         report_path = build_report(
             conn,
-            Path(arguments.output_dir),
+            arguments.output_dir,
             instrument=arguments.instrument,
             start_date=arguments.start_date,
             end_date=arguments.end_date,

--- a/src/spindoctor/cli/stats/report_common.py
+++ b/src/spindoctor/cli/stats/report_common.py
@@ -5,8 +5,10 @@ import re
 import sqlite3
 import statistics
 from dataclasses import dataclass, field
-from pathlib import Path
+from io import BytesIO
 from typing import Any
+
+from filecache import FCPath
 
 __all__ = [
     'ReportContext',
@@ -72,7 +74,8 @@ class ReportContext:
         conn: Open statistics database connection (with the
             ``image_number`` SQL function registered).
         output_dir: Directory receiving ``report.md``, charts, and the
-            optional ``filelists/`` subdirectory.
+            optional ``filelists/`` subdirectory; a local directory or
+            any URL the ``filecache`` layer accepts.
         where: Images-table filter from :func:`where_clause` (empty string
             or a leading-space ``' WHERE ...'`` fragment).
         params: Bind values matching ``where``.
@@ -89,7 +92,7 @@ class ReportContext:
     """
 
     conn: sqlite3.Connection
-    output_dir: Path
+    output_dir: FCPath
     where: str
     params: list[Any]
     where_i: str
@@ -110,8 +113,6 @@ class ReportContext:
         Returns:
             The path of the written file, relative to ``output_dir``.
         """
-        filelists_dir = self.output_dir / 'filelists'
-        filelists_dir.mkdir(parents=True, exist_ok=True)
         relative = f'filelists/{safe_filename(stub)}.txt'
         (self.output_dir / relative).write_text(
             ''.join(f'{name}\n' for name in names), encoding='utf-8'
@@ -318,13 +319,31 @@ def import_pyplot() -> Any:
     return plt
 
 
+def _save_figure(fig: Any, plt: Any, path: FCPath) -> None:
+    """Render a figure to PNG bytes and write them through ``FCPath``.
+
+    Rendering to a buffer first means the destination can be a local path
+    or any URL the ``filecache`` layer accepts.
+
+    Parameters:
+        fig: Matplotlib figure to write.
+        plt: The pyplot module (from :func:`import_pyplot`); the figure is
+            closed here.
+        path: Destination PNG path.
+    """
+    buffer = BytesIO()
+    fig.savefig(buffer, dpi=100, format='png')
+    plt.close(fig)
+    path.write_bytes(buffer.getvalue())
+
+
 def write_bar_chart(
-    path: Path, labels: list[str], counts: list[int], *, title: str, xlabel: str
+    path: FCPath, labels: list[str], counts: list[int], *, title: str, xlabel: str
 ) -> None:
     """Write a horizontal bar chart PNG (deterministic, Agg backend).
 
     Parameters:
-        path: Destination PNG path.
+        path: Destination PNG path (local or ``filecache`` URL).
         labels: One bar label per row, top to bottom.
         counts: Bar lengths matching ``labels``.
         title: Chart title.
@@ -340,15 +359,14 @@ def write_bar_chart(
     ax.set_xlabel(xlabel)
     ax.set_title(title)
     fig.tight_layout()
-    fig.savefig(path, dpi=100)
-    plt.close(fig)
+    _save_figure(fig, plt, path)
 
 
-def write_offset_hist(path: Path, dv: list[float], du: list[float]) -> None:
+def write_offset_hist(path: FCPath, dv: list[float], du: list[float]) -> None:
     """Write the V/U offset histogram PNG.
 
     Parameters:
-        path: Destination PNG path.
+        path: Destination PNG path (local or ``filecache`` URL).
         dv: Fused V-axis offsets (pixels) of successful images.
         du: Fused U-axis offsets (pixels) of successful images.
     """
@@ -361,15 +379,14 @@ def write_offset_hist(path: Path, dv: list[float], du: list[float]) -> None:
         ax.set_ylabel('images')
     fig.suptitle('Fused offset distribution (successful images)')
     fig.tight_layout()
-    fig.savefig(path, dpi=100)
-    plt.close(fig)
+    _save_figure(fig, plt, path)
 
 
-def write_value_hist(path: Path, values: list[float], *, title: str, xlabel: str) -> None:
+def write_value_hist(path: FCPath, values: list[float], *, title: str, xlabel: str) -> None:
     """Write a single-panel histogram PNG for a value list.
 
     Parameters:
-        path: Destination PNG path.
+        path: Destination PNG path (local or ``filecache`` URL).
         values: Values to histogram; an empty list produces empty axes.
         title: Chart title.
         xlabel: X-axis label.
@@ -382,5 +399,4 @@ def write_value_hist(path: Path, values: list[float], *, title: str, xlabel: str
     ax.set_ylabel('images')
     ax.set_title(title)
     fig.tight_layout()
-    fig.savefig(path, dpi=100)
-    plt.close(fig)
+    _save_figure(fig, plt, path)

--- a/src/spindoctor/cli/stats/report_common.py
+++ b/src/spindoctor/cli/stats/report_common.py
@@ -1,0 +1,315 @@
+"""Shared context, query, formatting, and chart helpers for the statistics report."""
+
+import math
+import re
+import sqlite3
+import statistics
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    'ReportContext',
+    'add_drilldown',
+    'connector',
+    'fmt',
+    'image_number_from_name',
+    'offset_stats',
+    'percentile',
+    'register_image_number_function',
+    'rows',
+    'safe_filename',
+    'where_clause',
+    'write_bar_chart',
+    'write_offset_hist',
+    'write_value_hist',
+]
+
+
+_IMAGE_NUMBER_RE = re.compile(r'\d+')
+
+
+def image_number_from_name(image_name: str | None) -> int | None:
+    """Numeric portion (first digit run) of an image name's basename.
+
+    ``N1454725799_1_CALIB.IMG`` yields ``1454725799``;
+    ``lor_0003103486_0x630_sci`` yields ``3103486`` (leading zeros drop in
+    the integer).  This is the value the ``--min-image`` / ``--max-image``
+    range filter compares.
+
+    Parameters:
+        image_name: Image name or path, or None.
+
+    Returns:
+        The integer value of the first digit run, or None when the name is
+        None or contains no digits.
+    """
+    if image_name is None:
+        return None
+    match = _IMAGE_NUMBER_RE.search(image_name.rsplit('/', 1)[-1])
+    if match is None:
+        return None
+    return int(match.group(0))
+
+
+def register_image_number_function(conn: sqlite3.Connection) -> None:
+    """Register the deterministic ``image_number`` SQL function on a connection.
+
+    The image-number range filter clauses produced by :func:`where_clause`
+    call this function, so it must be registered before those clauses run.
+
+    Parameters:
+        conn: Open statistics database connection.
+    """
+    conn.create_function('image_number', 1, image_number_from_name, deterministic=True)
+
+
+@dataclass
+class ReportContext:
+    """Mutable state threaded through every report section builder.
+
+    Parameters:
+        conn: Open statistics database connection (with the
+            ``image_number`` SQL function registered).
+        output_dir: Directory receiving ``report.md``, charts, and the
+            optional ``filelists/`` subdirectory.
+        where: Images-table filter from :func:`where_clause` (empty string
+            or a leading-space ``' WHERE ...'`` fragment).
+        params: Bind values matching ``where``.
+        where_i: The same filter built with ``alias='i.'`` for queries
+            that join the ``images`` table as ``i``.
+        params_i: Bind values matching ``where_i``.
+        lines: Markdown lines accumulated so far.
+        top_n: When positive, categorical sections list up to this many
+            example image names per category.
+        filelists: When True, categorical sections write one plain-text
+            file per category under ``filelists/``.
+        suspect_fraction: Fraction of the per-axis search limit at or
+            beyond which a fused offset is flagged as suspect.
+    """
+
+    conn: sqlite3.Connection
+    output_dir: Path
+    where: str
+    params: list[Any]
+    where_i: str
+    params_i: list[Any]
+    lines: list[str] = field(default_factory=list)
+    top_n: int = 0
+    filelists: bool = False
+    suspect_fraction: float = 0.9
+
+    def write_filelist(self, stub: str, names: list[str]) -> str:
+        """Write one image name per line into ``filelists/<stub>.txt``.
+
+        Parameters:
+            stub: Category identifier; sanitized into a filesystem-safe
+                filename.
+            names: Image names to write (written in the given order).
+
+        Returns:
+            The path of the written file, relative to ``output_dir``.
+        """
+        filelists_dir = self.output_dir / 'filelists'
+        filelists_dir.mkdir(parents=True, exist_ok=True)
+        relative = f'filelists/{safe_filename(stub)}.txt'
+        (self.output_dir / relative).write_text(
+            ''.join(f'{name}\n' for name in names), encoding='utf-8'
+        )
+        return relative
+
+
+def where_clause(
+    *,
+    instrument: str | None,
+    start_date: str | None,
+    end_date: str | None,
+    min_image_num: int | None = None,
+    max_image_num: int | None = None,
+    alias: str = '',
+) -> tuple[str, list[Any]]:
+    """Build the images-table filter shared by every query.
+
+    Parameters:
+        instrument: Optional instrument filter value.
+        start_date: Optional inclusive UTC start date (``YYYY-MM-DD``).
+        end_date: Optional inclusive UTC end date (``YYYY-MM-DD``).
+        min_image_num: Optional inclusive lower bound on the numeric
+            portion of the image name (requires
+            :func:`register_image_number_function`).
+        max_image_num: Optional inclusive upper bound on the numeric
+            portion of the image name.
+        alias: Table alias prefix (e.g. ``'i.'``) qualifying the column
+            names, for queries that join the ``images`` table.
+
+    Returns:
+        ``(where, params)`` where ``where`` is ``''`` or a leading-space
+        ``' WHERE ...'`` fragment and ``params`` the bound values.
+    """
+    clauses: list[str] = []
+    params: list[Any] = []
+    if instrument is not None:
+        clauses.append(f'{alias}instrument = ?')
+        params.append(instrument)
+    if start_date is not None:
+        clauses.append(f'{alias}image_date >= ?')
+        params.append(start_date)
+    if end_date is not None:
+        clauses.append(f'{alias}image_date <= ?')
+        params.append(end_date)
+    if min_image_num is not None:
+        clauses.append(f'image_number({alias}image_name) >= ?')
+        params.append(min_image_num)
+    if max_image_num is not None:
+        clauses.append(f'image_number({alias}image_name) <= ?')
+        params.append(max_image_num)
+    if len(clauses) == 0:
+        return '', []
+    return ' WHERE ' + ' AND '.join(clauses), params
+
+
+def connector(where: str) -> str:
+    """The keyword joining an extra condition onto a ``where_clause`` result."""
+    return ' AND ' if len(where) > 0 else ' WHERE '
+
+
+def rows(conn: sqlite3.Connection, sql: str, params: list[Any]) -> list[tuple[Any, ...]]:
+    """Execute a query and return all result rows as a list."""
+    return list(conn.execute(sql, params))
+
+
+def fmt(value: float | None, digits: int = 3) -> str:
+    """Format a float for a Markdown table cell."""
+    if value is None:
+        return '-'
+    return f'{value:.{digits}f}'
+
+
+def offset_stats(values: list[float]) -> dict[str, float] | None:
+    """Mean / median / stdev / min / max summary of a value list."""
+    if len(values) == 0:
+        return None
+    return {
+        'mean': statistics.fmean(values),
+        'median': statistics.median(values),
+        'stdev': statistics.stdev(values) if len(values) > 1 else 0.0,
+        'min': min(values),
+        'max': max(values),
+    }
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    """Nearest-rank percentile of a non-empty value list.
+
+    Parameters:
+        values: Non-empty list of values.
+        fraction: Percentile as a fraction in ``[0, 1]`` (e.g. ``0.95``).
+
+    Returns:
+        The nearest-rank percentile value.
+    """
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, math.ceil(fraction * len(ordered)) - 1))
+    return ordered[index]
+
+
+def safe_filename(stub: str) -> str:
+    """Collapse a category label into a filesystem-safe filename stub."""
+    cleaned = re.sub(r'[^A-Za-z0-9._-]+', '_', stub).strip('_')
+    return cleaned or 'unnamed'
+
+
+def add_drilldown(
+    ctx: ReportContext,
+    categories: list[tuple[str, list[str]]],
+    *,
+    label: str,
+    stub_prefix: str,
+) -> None:
+    """Append per-category example names and write per-category filelists.
+
+    Honors ``ctx.top_n`` (examples shown inline, alphabetically first N)
+    and ``ctx.filelists`` (full alphabetical lists written to
+    ``filelists/``).  Does nothing when both are off.
+
+    Parameters:
+        ctx: Report context.
+        categories: ``(category_label, image_names)`` pairs in the order
+            they should be listed; names are sorted here.
+        label: Human-readable singular noun for the category kind, used
+            in the "Examples (up to N per ...)" line.
+        stub_prefix: Filelist filename prefix; the category label is
+            appended.
+    """
+    categories = [(name, sorted(names)) for name, names in categories if len(names) > 0]
+    if len(categories) == 0:
+        return
+    if ctx.top_n > 0:
+        ctx.lines.append(f'Examples (up to {ctx.top_n} per {label}):')
+        ctx.lines.append('')
+        for name, names in categories:
+            ctx.lines.append(f'- {name}: {", ".join(names[: ctx.top_n])}')
+        ctx.lines.append('')
+    if ctx.filelists:
+        references = [
+            ctx.write_filelist(f'{stub_prefix}_{name}', names) for name, names in categories
+        ]
+        ctx.lines.append(f'Full lists: {", ".join(references)}')
+        ctx.lines.append('')
+
+
+def import_pyplot() -> Any:
+    """Import matplotlib with the deterministic Agg backend and return pyplot."""
+    import matplotlib
+
+    matplotlib.use('Agg')
+    import matplotlib.pyplot as plt
+
+    return plt
+
+
+def write_bar_chart(
+    path: Path, labels: list[str], counts: list[int], *, title: str, xlabel: str
+) -> None:
+    """Write a horizontal bar chart PNG (deterministic, Agg backend)."""
+    plt = import_pyplot()
+    fig, ax = plt.subplots(figsize=(8, max(2.0, 0.4 * len(labels) + 1.0)))
+    positions = range(len(labels))
+    ax.barh(list(positions), counts, color='#4878d0')
+    ax.set_yticks(list(positions))
+    ax.set_yticklabels(labels)
+    ax.invert_yaxis()
+    ax.set_xlabel(xlabel)
+    ax.set_title(title)
+    fig.tight_layout()
+    fig.savefig(path, dpi=100)
+    plt.close(fig)
+
+
+def write_offset_hist(path: Path, dv: list[float], du: list[float]) -> None:
+    """Write the V/U offset histogram PNG."""
+    plt = import_pyplot()
+    fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+    for ax, values, label in ((axes[0], dv, 'dV (px)'), (axes[1], du, 'dU (px)')):
+        if len(values) > 0:
+            ax.hist(values, bins=40, color='#4878d0')
+        ax.set_xlabel(label)
+        ax.set_ylabel('images')
+    fig.suptitle('Fused offset distribution (successful images)')
+    fig.tight_layout()
+    fig.savefig(path, dpi=100)
+    plt.close(fig)
+
+
+def write_value_hist(path: Path, values: list[float], *, title: str, xlabel: str) -> None:
+    """Write a single-panel histogram PNG for a value list."""
+    plt = import_pyplot()
+    fig, ax = plt.subplots(figsize=(8, 4))
+    if len(values) > 0:
+        ax.hist(values, bins=40, color='#4878d0')
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel('images')
+    ax.set_title(title)
+    fig.tight_layout()
+    fig.savefig(path, dpi=100)
+    plt.close(fig)

--- a/src/spindoctor/cli/stats/report_common.py
+++ b/src/spindoctor/cli/stats/report_common.py
@@ -169,24 +169,59 @@ def where_clause(
 
 
 def connector(where: str) -> str:
-    """The keyword joining an extra condition onto a ``where_clause`` result."""
+    """The keyword joining an extra condition onto a ``where_clause`` result.
+
+    Parameters:
+        where: A filter fragment from :func:`where_clause` (empty string
+            or a leading-space ``' WHERE ...'`` fragment).
+
+    Returns:
+        ``' AND '`` when ``where`` already has conditions, else
+        ``' WHERE '``.
+    """
     return ' AND ' if len(where) > 0 else ' WHERE '
 
 
 def rows(conn: sqlite3.Connection, sql: str, params: list[Any]) -> list[tuple[Any, ...]]:
-    """Execute a query and return all result rows as a list."""
+    """Execute a query and return all result rows as a list.
+
+    Parameters:
+        conn: Open statistics database connection.
+        sql: SQL statement with ``?`` placeholders.
+        params: Bind values matching the placeholders.
+
+    Returns:
+        All result rows, in query order.
+    """
     return list(conn.execute(sql, params))
 
 
 def fmt(value: float | None, digits: int = 3) -> str:
-    """Format a float for a Markdown table cell."""
+    """Format a float for a Markdown table cell.
+
+    Parameters:
+        value: Value to format, or None.
+        digits: Decimal places.
+
+    Returns:
+        The fixed-point string, or ``'-'`` for None.
+    """
     if value is None:
         return '-'
     return f'{value:.{digits}f}'
 
 
 def offset_stats(values: list[float]) -> dict[str, float] | None:
-    """Mean / median / stdev / min / max summary of a value list."""
+    """Mean / median / stdev / min / max summary of a value list.
+
+    Parameters:
+        values: Values to summarize; may be empty.
+
+    Returns:
+        A dict with ``mean`` / ``median`` / ``stdev`` / ``min`` / ``max``
+        keys (``stdev`` is 0.0 for a single value), or None when
+        ``values`` is empty.
+    """
     if len(values) == 0:
         return None
     return {
@@ -214,7 +249,17 @@ def percentile(values: list[float], fraction: float) -> float:
 
 
 def safe_filename(stub: str) -> str:
-    """Collapse a category label into a filesystem-safe filename stub."""
+    """Collapse a category label into a filesystem-safe filename stub.
+
+    Parameters:
+        stub: Arbitrary category label (may contain spaces, slashes,
+            punctuation).
+
+    Returns:
+        The label with every run of unsafe characters replaced by ``_``
+        and leading/trailing underscores stripped; ``'unnamed'`` when
+        nothing survives.
+    """
     cleaned = re.sub(r'[^A-Za-z0-9._-]+', '_', stub).strip('_')
     return cleaned or 'unnamed'
 
@@ -259,7 +304,12 @@ def add_drilldown(
 
 
 def import_pyplot() -> Any:
-    """Import matplotlib with the deterministic Agg backend and return pyplot."""
+    """Import matplotlib with the deterministic Agg backend and return pyplot.
+
+    Returns:
+        The ``matplotlib.pyplot`` module, with the backend forced to Agg
+        so chart output is identical with or without a display.
+    """
     import matplotlib
 
     matplotlib.use('Agg')
@@ -271,7 +321,15 @@ def import_pyplot() -> Any:
 def write_bar_chart(
     path: Path, labels: list[str], counts: list[int], *, title: str, xlabel: str
 ) -> None:
-    """Write a horizontal bar chart PNG (deterministic, Agg backend)."""
+    """Write a horizontal bar chart PNG (deterministic, Agg backend).
+
+    Parameters:
+        path: Destination PNG path.
+        labels: One bar label per row, top to bottom.
+        counts: Bar lengths matching ``labels``.
+        title: Chart title.
+        xlabel: X-axis label.
+    """
     plt = import_pyplot()
     fig, ax = plt.subplots(figsize=(8, max(2.0, 0.4 * len(labels) + 1.0)))
     positions = range(len(labels))
@@ -287,7 +345,13 @@ def write_bar_chart(
 
 
 def write_offset_hist(path: Path, dv: list[float], du: list[float]) -> None:
-    """Write the V/U offset histogram PNG."""
+    """Write the V/U offset histogram PNG.
+
+    Parameters:
+        path: Destination PNG path.
+        dv: Fused V-axis offsets (pixels) of successful images.
+        du: Fused U-axis offsets (pixels) of successful images.
+    """
     plt = import_pyplot()
     fig, axes = plt.subplots(1, 2, figsize=(10, 4))
     for ax, values, label in ((axes[0], dv, 'dV (px)'), (axes[1], du, 'dU (px)')):
@@ -302,7 +366,14 @@ def write_offset_hist(path: Path, dv: list[float], du: list[float]) -> None:
 
 
 def write_value_hist(path: Path, values: list[float], *, title: str, xlabel: str) -> None:
-    """Write a single-panel histogram PNG for a value list."""
+    """Write a single-panel histogram PNG for a value list.
+
+    Parameters:
+        path: Destination PNG path.
+        values: Values to histogram; an empty list produces empty axes.
+        title: Chart title.
+        xlabel: X-axis label.
+    """
     plt = import_pyplot()
     fig, ax = plt.subplots(figsize=(8, 4))
     if len(values) > 0:

--- a/src/spindoctor/cli/stats/report_sections.py
+++ b/src/spindoctor/cli/stats/report_sections.py
@@ -4,8 +4,10 @@ import csv
 import math
 import re
 import statistics
-from pathlib import Path
+from io import StringIO
 from typing import Any
+
+from filecache import FCPath
 
 from spindoctor.cli.stats.report_common import (
     ReportContext,
@@ -515,7 +517,7 @@ def add_offset_by_group_section(ctx: ReportContext) -> None:
 # ---------------------------------------------------------------------------
 
 
-def write_csv_export(ctx: ReportContext) -> Path:
+def write_csv_export(ctx: ReportContext) -> FCPath:
     """Write a flattened one-row-per-image CSV next to ``report.md``.
 
     Columns are the ``images`` table columns (schema order) plus
@@ -537,12 +539,13 @@ def write_csv_export(ctx: ReportContext) -> Path:
         ctx.params_i,
     )
     csv_path = ctx.output_dir / 'images.csv'
-    with csv_path.open('w', newline='', encoding='utf-8') as handle:
-        writer = csv.writer(handle)
-        writer.writerow(
-            [*IMAGE_COLUMNS, 'n_technique_rows', 'n_feature_sources', 'n_features', 'n_gated']
-        )
-        writer.writerows(csv_rows)
+    buffer = StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(
+        [*IMAGE_COLUMNS, 'n_technique_rows', 'n_feature_sources', 'n_features', 'n_gated']
+    )
+    writer.writerows(csv_rows)
+    csv_path.write_text(buffer.getvalue(), encoding='utf-8')
     ctx.lines += [
         '## CSV export',
         '',

--- a/src/spindoctor/cli/stats/report_sections.py
+++ b/src/spindoctor/cli/stats/report_sections.py
@@ -1,0 +1,552 @@
+"""Report sections: failure taxonomy, suspect offsets, BOTSIM, run time, CSV export."""
+
+import csv
+import math
+import re
+import statistics
+from pathlib import Path
+from typing import Any
+
+from spindoctor.cli.stats.report_common import (
+    ReportContext,
+    add_drilldown,
+    connector,
+    fmt,
+    percentile,
+    rows,
+    write_value_hist,
+)
+from spindoctor.cli.stats.schema import IMAGE_COLUMNS
+from spindoctor.config import DEFAULT_CONFIG, Config
+
+__all__ = [
+    'add_botsim_section',
+    'add_failure_taxonomy_section',
+    'add_offset_by_group_section',
+    'add_runtime_section',
+    'add_suspect_offset_section',
+    'resolve_offset_limit',
+    'write_csv_export',
+]
+
+
+# ---------------------------------------------------------------------------
+# Suspect-offset screen
+# ---------------------------------------------------------------------------
+
+# Config section per instrument holding ``extfov_margin_vu`` (the per-axis
+# maximum expected pointing offset the search allows for).  Cassini ISS is
+# handled separately because its sections are nested per detector and split
+# between raw and CALIB blocks.
+_INSTRUMENT_CONFIG_SECTIONS = {
+    'gossi': 'galileo_ssi',
+    'nhlorri': 'newhorizons_lorri',
+    'sim': 'sim',
+    'vgiss': 'voyager_iss',
+}
+
+
+def resolve_offset_limit(
+    instrument: str,
+    image_name: str,
+    image_shape_v: int | None,
+    *,
+    config: Config | None = None,
+) -> tuple[float, float] | str:
+    """Resolve the per-axis maximum expected pointing offset for one image.
+
+    The limit is the configured ``extfov_margin_vu`` search margin for the
+    instrument (for Cassini ISS: per detector, chosen from the image-name
+    prefix ``N``/``W`` and the raw-vs-CALIB config block; for margin tables
+    keyed by image size, the recorded ``image_shape_v`` selects the entry).
+
+    Parameters:
+        instrument: Registered instrument name from the database.
+        image_name: Image name (used to pick the Cassini ISS detector and
+            config block).
+        image_shape_v: Recorded V-axis image size, or None when the
+            database row has no shape.
+        config: Configuration to read; None uses ``DEFAULT_CONFIG``.
+
+    Returns:
+        ``(limit_v, limit_u)`` in pixels, or a human-readable string
+        explaining why the limit could not be resolved.
+    """
+    config = config or DEFAULT_CONFIG
+    if instrument == 'coiss':
+        section_name = 'cassini_iss_calib' if '_CALIB' in image_name.upper() else 'cassini_iss'
+        detector = {'N': 'nac', 'W': 'wac'}.get(image_name.rsplit('/', 1)[-1][:1].upper())
+        if detector is None:
+            return 'cannot determine NAC/WAC from the image name'
+        section = config.category(section_name)
+        detector_config = section.get(detector) if section else None
+        entry = detector_config.get('extfov_margin_vu') if detector_config else None
+        source = f'{section_name}.{detector}'
+    else:
+        if instrument not in _INSTRUMENT_CONFIG_SECTIONS:
+            return f'no configured search limit for instrument {instrument!r}'
+        section_name = _INSTRUMENT_CONFIG_SECTIONS[instrument]
+        section = config.category(section_name)
+        entry = section.get('extfov_margin_vu') if section else None
+        source = section_name
+    if entry is None:
+        return f'config section {source!r} has no extfov_margin_vu'
+    if isinstance(entry, dict):
+        if image_shape_v is None:
+            return 'image shape not recorded in the database'
+        if image_shape_v not in entry:
+            return f'{source!r} has no extfov_margin_vu entry for image size {image_shape_v}'
+        entry = entry[image_shape_v]
+    limit_v = float(entry[0])
+    limit_u = float(entry[1])
+    if limit_v <= 0.0 or limit_u <= 0.0:
+        return f'{source!r} extfov_margin_vu is not positive'
+    return limit_v, limit_u
+
+
+def add_suspect_offset_section(ctx: ReportContext) -> None:
+    """Flag successful images whose fused offset sits near the search limit.
+
+    An offset at the edge of the search box is as likely to be a
+    correlation artifact as a real pointing error, so any image with
+    ``|dV|`` or ``|dU|`` at or beyond ``suspect_fraction`` times the
+    per-axis limit is listed for operator review.
+    """
+    image_rows = rows(
+        ctx.conn,
+        f'SELECT image_name, instrument, offset_dv, offset_du, image_shape_v '
+        f'FROM images{ctx.where}'
+        + connector(ctx.where)
+        + "status = 'success' AND offset_dv IS NOT NULL AND offset_du IS NOT NULL "
+        'ORDER BY image_name',
+        ctx.params,
+    )
+    ctx.lines += [
+        '## Suspect offsets (near the search limit)',
+        '',
+        f'Successful images whose fused offset reaches at least '
+        f'{ctx.suspect_fraction:.2f} of the per-axis maximum expected pointing '
+        'offset (the configured extfov search margin) on either axis.  These '
+        'offsets may be correlation artifacts pinned to the search boundary.',
+        '',
+    ]
+    suspects: list[tuple[float, str, str, float, float, float, str]] = []
+    unresolved: dict[str, int] = {}
+    for image_name, instrument, dv, du, shape_v in image_rows:
+        limit = resolve_offset_limit(str(instrument), str(image_name), shape_v)
+        if isinstance(limit, str):
+            reason = f'{instrument}: {limit}'
+            unresolved[reason] = unresolved.get(reason, 0) + 1
+            continue
+        limit_v, limit_u = limit
+        ratio = max(abs(float(dv)) / limit_v, abs(float(du)) / limit_u)
+        if ratio >= ctx.suspect_fraction:
+            suspects.append(
+                (
+                    ratio,
+                    str(image_name),
+                    str(instrument),
+                    float(dv),
+                    float(du),
+                    math.hypot(float(dv), float(du)),
+                    f'({fmt(limit_v, 1)}, {fmt(limit_u, 1)})',
+                )
+            )
+    suspects.sort(key=lambda s: (-s[0], s[1]))
+    ctx.lines.append(f'Suspect images: {len(suspects)} of {len(image_rows)} screened.')
+    ctx.lines.append('')
+    if len(suspects) > 0:
+        shown = suspects[: ctx.top_n] if ctx.top_n > 0 else suspects
+        ctx.lines += [
+            '| image | instrument | dV | dU | magnitude | limit (v, u) |',
+            '|---|---|---|---|---|---|',
+        ]
+        for _ratio, name, instrument, dv, du, magnitude, limit_text in shown:
+            ctx.lines.append(
+                f'| {name} | {instrument} | {fmt(dv)} | {fmt(du)} | '
+                f'{fmt(magnitude)} | {limit_text} |'
+            )
+        ctx.lines.append('')
+        add_drilldown(
+            ctx,
+            [('suspect', [s[1] for s in suspects])],
+            label='category',
+            stub_prefix='suspect_offsets',
+        )
+    if len(unresolved) > 0:
+        ctx.lines.append('Search limit could not be resolved for some images:')
+        ctx.lines.append('')
+        for reason in sorted(unresolved):
+            ctx.lines.append(f'- {reason} ({unresolved[reason]} image(s))')
+        ctx.lines.append('')
+
+
+# ---------------------------------------------------------------------------
+# BOTSIM pair consistency (Cassini ISS)
+# ---------------------------------------------------------------------------
+
+_BOTSIM_NAME_RE = re.compile(r'^([NW])(\d{10})')
+
+
+def add_botsim_section(ctx: ReportContext) -> None:
+    """Compare NAC and WAC offsets over simultaneously shuttered Cassini pairs.
+
+    BOTSIM observations shutter both cameras at once, so the two frames
+    share one spacecraft-clock count and see the same pointing.  One WAC
+    pixel is ten NAC pixels; a consistent pair therefore satisfies
+    ``NAC offset ~= 10 x WAC offset`` per axis, making the per-axis
+    residual ``NAC - 10 x WAC`` an end-to-end accuracy check that needs
+    no ground truth.
+    """
+    image_rows = rows(
+        ctx.conn,
+        f'SELECT image_name, status, offset_dv, offset_du FROM images{ctx.where}'
+        + connector(ctx.where)
+        + "instrument = 'coiss' ORDER BY image_name",
+        ctx.params,
+    )
+    by_clock: dict[str, dict[str, tuple[str, str, Any, Any]]] = {}
+    for image_name, status, dv, du in image_rows:
+        match = _BOTSIM_NAME_RE.match(str(image_name).rsplit('/', 1)[-1].upper())
+        if match is None:
+            continue
+        camera, clock = match.group(1), match.group(2)
+        by_clock.setdefault(clock, {}).setdefault(camera, (str(image_name), str(status), dv, du))
+    pairs = {clock: entry for clock, entry in by_clock.items() if len(entry) == 2}
+    residuals: list[tuple[float, str, str, str, float, float]] = []
+    for clock in sorted(pairs):
+        nac = pairs[clock]['N']
+        wac = pairs[clock]['W']
+        if nac[1] != 'success' or wac[1] != 'success':
+            continue
+        if None in (nac[2], nac[3], wac[2], wac[3]):
+            continue
+        residual_dv = float(nac[2]) - 10.0 * float(wac[2])
+        residual_du = float(nac[3]) - 10.0 * float(wac[3])
+        residuals.append(
+            (math.hypot(residual_dv, residual_du), clock, nac[0], wac[0], residual_dv, residual_du)
+        )
+    ctx.lines += [
+        '## BOTSIM pair consistency (Cassini ISS)',
+        '',
+        'BOTSIM observations shutter the NAC and WAC simultaneously (the image',
+        'names share one spacecraft-clock count).  One WAC pixel is ten NAC',
+        'pixels, so a consistent pair satisfies NAC offset ~= 10 x WAC offset',
+        'per axis.  Residuals below are NAC - 10 x WAC, in NAC pixels.',
+        '',
+        '| metric | value |',
+        '|---|---|',
+        f'| pairs identified | {len(pairs)} |',
+        f'| pairs with both navigated | {len(residuals)} |',
+    ]
+    if len(residuals) > 0:
+        magnitudes = [r[0] for r in residuals]
+        ctx.lines += [
+            f'| median residual (px) | {fmt(statistics.median(magnitudes))} |',
+            f'| p95 residual (px) | {fmt(percentile(magnitudes, 0.95))} |',
+        ]
+    ctx.lines.append('')
+    if len(residuals) > 0 and ctx.top_n > 0:
+        residuals.sort(key=lambda r: (-r[0], r[1]))
+        ctx.lines += [
+            f'Worst {min(ctx.top_n, len(residuals))} pair(s):',
+            '',
+            '| clock | NAC image | WAC image | residual dV | residual dU | residual |',
+            '|---|---|---|---|---|---|',
+        ]
+        for magnitude, clock, nac_name, wac_name, residual_dv, residual_du in residuals[
+            : ctx.top_n
+        ]:
+            ctx.lines.append(
+                f'| {clock} | {nac_name} | {wac_name} | {fmt(residual_dv)} | '
+                f'{fmt(residual_du)} | {fmt(magnitude)} |'
+            )
+        ctx.lines.append('')
+
+
+# ---------------------------------------------------------------------------
+# Failure taxonomy by image content
+# ---------------------------------------------------------------------------
+
+_CONTENT_CATEGORIES = (
+    'stars-only',
+    'single-body',
+    'multi-body',
+    'rings-only',
+    'body+rings',
+    'no-features',
+)
+
+
+def _source_kind(source_model: str) -> str:
+    """Coarse feature-source kind (``stars`` / ``rings`` / ``body``) of a model name."""
+    kind = source_model.split(':', 1)[0].lower()
+    if kind in ('star', 'stars'):
+        return 'stars'
+    if kind.startswith('ring'):
+        return 'rings'
+    return 'body'
+
+
+def _content_category(entries: list[tuple[str, str]]) -> str:
+    """Classify an image's ``(source_model, source_name)`` inventory."""
+    if len(entries) == 0:
+        return 'no-features'
+    body_names = {name for model, name in entries if _source_kind(model) == 'body'}
+    has_rings = any(_source_kind(model) == 'rings' for model, _ in entries)
+    if len(body_names) > 0 and has_rings:
+        return 'body+rings'
+    if has_rings:
+        return 'rings-only'
+    if len(body_names) == 1:
+        return 'single-body'
+    if len(body_names) > 1:
+        return 'multi-body'
+    return 'stars-only'
+
+
+def add_failure_taxonomy_section(ctx: ReportContext) -> None:
+    """Classify failed images by scene content and localize per-body problems.
+
+    Content comes from the ``feature_sources`` inventory recorded per
+    image; a body whose failure share is far above its peers points at a
+    modeling problem for that body rather than a pipeline-wide issue.
+    """
+    failed_rows = rows(
+        ctx.conn,
+        f'SELECT image_name, status_reason FROM images{ctx.where}'
+        + connector(ctx.where)
+        + "status != 'success' ORDER BY image_name",
+        ctx.params,
+    )
+    if len(failed_rows) == 0:
+        return
+    source_rows = rows(
+        ctx.conn,
+        'SELECT i.image_name, i.status, s.source_model, s.source_name '
+        'FROM feature_sources s JOIN images i ON i.image_name = s.image_name'
+        + ctx.where_i
+        + ' ORDER BY i.image_name, s.source_model, s.source_name',
+        ctx.params_i,
+    )
+    sources_by_image: dict[str, list[tuple[str, str]]] = {}
+    for image_name, _status, source_model, source_name in source_rows:
+        sources_by_image.setdefault(str(image_name), []).append(
+            (str(source_model), str(source_name))
+        )
+
+    by_category: dict[str, list[str]] = {category: [] for category in _CONTENT_CATEGORIES}
+    reason_counts: dict[tuple[str, str], int] = {}
+    for image_name, status_reason in failed_rows:
+        category = _content_category(sources_by_image.get(str(image_name), []))
+        by_category[category].append(str(image_name))
+        key = (category, str(status_reason or '(none)'))
+        reason_counts[key] = reason_counts.get(key, 0) + 1
+
+    ctx.lines += [
+        '## Failure taxonomy by image content',
+        '',
+        'Failed images classified by what the feature inventory says was in',
+        'the scene.',
+        '',
+        '| content | failed images |',
+        '|---|---|',
+    ]
+    for category in _CONTENT_CATEGORIES:
+        if len(by_category[category]) > 0:
+            ctx.lines.append(f'| {category} | {len(by_category[category])} |')
+    ctx.lines += [
+        '',
+        '| content | reason | images |',
+        '|---|---|---|',
+    ]
+    for category in _CONTENT_CATEGORIES:
+        in_category = sorted(
+            ((reason, count) for (cat, reason), count in reason_counts.items() if cat == category),
+            key=lambda item: (-item[1], item[0]),
+        )
+        for reason, count in in_category:
+            ctx.lines.append(f'| {category} | {reason} | {count} |')
+    ctx.lines.append('')
+    add_drilldown(
+        ctx,
+        [(category, by_category[category]) for category in _CONTENT_CATEGORIES],
+        label='content category',
+        stub_prefix='failed_content',
+    )
+
+    # Per-body failure shares over all images (successful and failed).
+    body_status: dict[str, dict[str, set[str]]] = {}
+    for image_name, status, source_model, source_name in source_rows:
+        if _source_kind(str(source_model)) != 'body' or str(source_name) == '(none)':
+            continue
+        buckets = body_status.setdefault(str(source_name), {'failed': set(), 'success': set()})
+        bucket = 'success' if str(status) == 'success' else 'failed'
+        buckets[bucket].add(str(image_name))
+    if len(body_status) > 0:
+        ranked = sorted(
+            body_status.items(),
+            key=lambda item: (
+                -len(item[1]['failed']) / (len(item[1]['failed']) + len(item[1]['success'])),
+                -len(item[1]['failed']),
+                item[0],
+            ),
+        )
+        ctx.lines += [
+            '### Per-body failure shares',
+            '',
+            'How often each named body appears in failed versus successful',
+            'images; a body with a high failure share is a modeling problem.',
+            '',
+            '| body | failed images | successful images | failure share |',
+            '|---|---|---|---|',
+        ]
+        for body, buckets in ranked:
+            n_failed = len(buckets['failed'])
+            n_success = len(buckets['success'])
+            share = n_failed / (n_failed + n_success)
+            ctx.lines.append(f'| {body} | {n_failed} | {n_success} | {share:.3f} |')
+        ctx.lines.append('')
+        add_drilldown(
+            ctx,
+            [(body, sorted(buckets['failed'])) for body, buckets in ranked if buckets['failed']],
+            label='body',
+            stub_prefix='failed_body',
+        )
+
+
+# ---------------------------------------------------------------------------
+# Run-time statistics
+# ---------------------------------------------------------------------------
+
+
+def add_runtime_section(ctx: ReportContext) -> None:
+    """Summarize per-image run times; skipped when no timing data exists."""
+    timing_rows = rows(
+        ctx.conn,
+        f'SELECT image_name, instrument, elapsed_s FROM images{ctx.where}'
+        + connector(ctx.where)
+        + 'elapsed_s IS NOT NULL ORDER BY image_name',
+        ctx.params,
+    )
+    if len(timing_rows) == 0:
+        return
+    elapsed = [float(r[2]) for r in timing_rows]
+    ctx.lines += [
+        '## Run-time statistics',
+        '',
+        '| metric | value |',
+        '|---|---|',
+        f'| images with timing | {len(elapsed)} |',
+        f'| total (s) | {fmt(sum(elapsed))} |',
+        f'| min (s) | {fmt(min(elapsed))} |',
+        f'| max (s) | {fmt(max(elapsed))} |',
+        f'| mean (s) | {fmt(statistics.fmean(elapsed))} |',
+        f'| median (s) | {fmt(statistics.median(elapsed))} |',
+        f'| stdev (s) | {fmt(statistics.stdev(elapsed) if len(elapsed) > 1 else 0.0)} |',
+        '',
+    ]
+    write_value_hist(
+        ctx.output_dir / 'runtime_hist.png',
+        elapsed,
+        title='Per-image run time',
+        xlabel='elapsed (s)',
+    )
+    ctx.lines += ['![run time](runtime_hist.png)', '']
+    if ctx.top_n > 0:
+        slowest = sorted(timing_rows, key=lambda r: (-float(r[2]), str(r[0])))[: ctx.top_n]
+        ctx.lines += [
+            f'Slowest {len(slowest)} image(s):',
+            '',
+            '| image | instrument | elapsed (s) |',
+            '|---|---|---|',
+        ]
+        for image_name, instrument, seconds in slowest:
+            ctx.lines.append(f'| {image_name} | {instrument} | {fmt(float(seconds))} |')
+        ctx.lines.append('')
+
+
+# ---------------------------------------------------------------------------
+# Per-instrument / per-image-size offset breakdown
+# ---------------------------------------------------------------------------
+
+
+def add_offset_by_group_section(ctx: ReportContext) -> None:
+    """Break the fused-offset statistics down by (instrument, image size)."""
+    image_rows = rows(
+        ctx.conn,
+        f'SELECT instrument, image_shape_v, image_shape_u, offset_dv, offset_du '
+        f'FROM images{ctx.where}'
+        + connector(ctx.where)
+        + "status = 'success' AND offset_dv IS NOT NULL AND offset_du IS NOT NULL "
+        'ORDER BY instrument, image_shape_v, image_shape_u',
+        ctx.params,
+    )
+    groups: dict[tuple[str, str], list[tuple[float, float]]] = {}
+    for instrument, shape_v, shape_u, dv, du in image_rows:
+        size = f'{shape_v}x{shape_u}' if shape_v is not None and shape_u is not None else '(none)'
+        groups.setdefault((str(instrument), size), []).append((float(dv), float(du)))
+    if len(groups) == 0:
+        return
+    ctx.lines += [
+        '### By instrument and image size',
+        '',
+        '| instrument | size (v x u) | n '
+        '| dV mean | dV stdev | dV min | dV max '
+        '| dU mean | dU stdev | dU min | dU max |',
+        '|---|---|---|---|---|---|---|---|---|---|---|',
+    ]
+    for instrument, size in sorted(groups):
+        offsets = groups[(instrument, size)]
+        dv = [o[0] for o in offsets]
+        du = [o[1] for o in offsets]
+        stdev_dv = statistics.stdev(dv) if len(dv) > 1 else 0.0
+        stdev_du = statistics.stdev(du) if len(du) > 1 else 0.0
+        ctx.lines.append(
+            f'| {instrument} | {size} | {len(offsets)} '
+            f'| {fmt(statistics.fmean(dv))} | {fmt(stdev_dv)} | {fmt(min(dv))} | {fmt(max(dv))} '
+            f'| {fmt(statistics.fmean(du))} | {fmt(stdev_du)} | {fmt(min(du))} | {fmt(max(du))} |'
+        )
+    ctx.lines.append('')
+
+
+# ---------------------------------------------------------------------------
+# CSV export
+# ---------------------------------------------------------------------------
+
+
+def write_csv_export(ctx: ReportContext) -> Path:
+    """Write a flattened one-row-per-image CSV next to ``report.md``.
+
+    Columns are the ``images`` table columns (schema order) plus
+    ``n_technique_rows``, ``n_feature_sources``, ``n_features``, and
+    ``n_gated`` aggregates, ordered by image name.
+
+    Returns:
+        The path of the written ``images.csv``.
+    """
+    columns = ', '.join(f'i.{column}' for column in IMAGE_COLUMNS)
+    csv_rows = rows(
+        ctx.conn,
+        f'SELECT {columns}, '
+        '(SELECT COUNT(*) FROM techniques t WHERE t.image_name = i.image_name), '
+        '(SELECT COUNT(*) FROM feature_sources s WHERE s.image_name = i.image_name), '
+        '(SELECT TOTAL(s.n_features) FROM feature_sources s WHERE s.image_name = i.image_name), '
+        '(SELECT TOTAL(s.n_gated) FROM feature_sources s WHERE s.image_name = i.image_name) '
+        'FROM images i' + ctx.where_i + ' ORDER BY i.image_name',
+        ctx.params_i,
+    )
+    csv_path = ctx.output_dir / 'images.csv'
+    with csv_path.open('w', newline='', encoding='utf-8') as handle:
+        writer = csv.writer(handle)
+        writer.writerow(
+            [*IMAGE_COLUMNS, 'n_technique_rows', 'n_feature_sources', 'n_features', 'n_gated']
+        )
+        writer.writerows(csv_rows)
+    ctx.lines += [
+        '## CSV export',
+        '',
+        f'One row per image: images.csv ({len(csv_rows)} row(s)).',
+        '',
+    ]
+    return csv_path

--- a/src/spindoctor/cli/stats/schema.py
+++ b/src/spindoctor/cli/stats/schema.py
@@ -127,14 +127,36 @@ _SOURCES_COLUMNS = frozenset(
 def open_stats_db(db_path: str | Path) -> sqlite3.Connection:
     """Open (creating if necessary) the statistics database.
 
+    There is no schema migration: a database whose ``images`` table does
+    not match the current column set is rejected with instructions to
+    delete the file and re-ingest (ingestion is cheap and idempotent, so
+    the database is always disposable).
+
     Parameters:
         db_path: Filesystem path of the SQLite database.
 
     Returns:
         An open connection with foreign keys enabled and the schema applied.
+
+    Raises:
+        ValueError: If the database exists with a different ``images``
+            column set.
     """
     conn = sqlite3.connect(str(db_path))
     conn.execute('PRAGMA foreign_keys = ON')
+    # Check any pre-existing images table BEFORE applying the schema
+    # script -- the script's index statements fail confusingly against a
+    # table with a different column set.
+    found = {row[1] for row in conn.execute('PRAGMA table_info(images)')}
+    if len(found) > 0 and found != _IMAGES_COLUMNS:
+        missing = ', '.join(sorted(_IMAGES_COLUMNS - found)) or '(none)'
+        extra = ', '.join(sorted(found - _IMAGES_COLUMNS)) or '(none)'
+        conn.close()
+        raise ValueError(
+            f'{db_path}: images table does not match the current schema '
+            f'(missing: {missing}; unexpected: {extra}). Delete the database '
+            f'file and re-run sd_stats_ingest.'
+        )
     conn.executescript(_SCHEMA)
     return conn
 

--- a/src/spindoctor/cli/stats/schema.py
+++ b/src/spindoctor/cli/stats/schema.py
@@ -4,7 +4,7 @@ import sqlite3
 from pathlib import Path
 from typing import Any
 
-__all__ = ['open_stats_db', 'upsert_image']
+__all__ = ['IMAGE_COLUMNS', 'open_stats_db', 'upsert_image']
 
 # One row per image (keyed by image name), with normalized child tables for
 # per-technique results and per-source feature usage.  Re-ingesting an image
@@ -28,6 +28,11 @@ CREATE TABLE IF NOT EXISTS images (
     excluded_from_consensus TEXT,
     image_class TEXT,
     noise_sigma REAL,
+    image_shape_v INTEGER,
+    image_shape_u INTEGER,
+    run_start TEXT,
+    run_end TEXT,
+    elapsed_s REAL,
     config_hash TEXT,
     git_sha TEXT,
     pipeline_run TEXT,
@@ -60,31 +65,38 @@ CREATE INDEX IF NOT EXISTS idx_techniques_image ON techniques(image_name);
 CREATE INDEX IF NOT EXISTS idx_sources_image ON feature_sources(image_name);
 """
 
-_IMAGES_COLUMNS = frozenset(
-    {
-        'image_name',
-        'instrument',
-        'image_path',
-        'image_et',
-        'image_date',
-        'status',
-        'status_reason',
-        'offset_dv',
-        'offset_du',
-        'sigma_dv',
-        'sigma_du',
-        'confidence',
-        'confidence_rank',
-        'n_techniques',
-        'excluded_from_consensus',
-        'image_class',
-        'noise_sigma',
-        'config_hash',
-        'git_sha',
-        'pipeline_run',
-        'source_file',
-    }
+# Column order of the ``images`` table, kept in sync with ``_SCHEMA``.  The
+# CSV export uses this so its column order is stable and documented.
+IMAGE_COLUMNS: tuple[str, ...] = (
+    'image_name',
+    'instrument',
+    'image_path',
+    'image_et',
+    'image_date',
+    'status',
+    'status_reason',
+    'offset_dv',
+    'offset_du',
+    'sigma_dv',
+    'sigma_du',
+    'confidence',
+    'confidence_rank',
+    'n_techniques',
+    'excluded_from_consensus',
+    'image_class',
+    'noise_sigma',
+    'image_shape_v',
+    'image_shape_u',
+    'run_start',
+    'run_end',
+    'elapsed_s',
+    'config_hash',
+    'git_sha',
+    'pipeline_run',
+    'source_file',
 )
+
+_IMAGES_COLUMNS = frozenset(IMAGE_COLUMNS)
 _TECHNIQUES_COLUMNS = frozenset(
     {
         'image_name',

--- a/src/spindoctor/navigate_image_files.py
+++ b/src/spindoctor/navigate_image_files.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from datetime import datetime
+from datetime import UTC, datetime
 from io import BytesIO
 from pathlib import Path
 from typing import Any, cast
@@ -38,7 +38,12 @@ from spindoctor.support.file import json_as_string
 from spindoctor.support.misc import log_run_environment
 from spindoctor.support.summary_png import render_annotated_summary_rgb
 
-__all__ = ['build_metadata_from_result', 'navigate_image_files', 'write_summary_png']
+__all__ = [
+    'build_metadata_from_result',
+    'build_timing_section',
+    'navigate_image_files',
+    'write_summary_png',
+]
 
 
 _SPICE_DATA_HINTS = (
@@ -46,6 +51,41 @@ _SPICE_DATA_HINTS = (
     'SPICE(SPKINSUFFDATA)',
     'SPICE(NOFRAMECONNECT)',
 )
+
+
+def _iso8601_utc(moment: datetime) -> str:
+    """UTC ISO8601 string (``Z`` suffix) for a timezone-aware datetime.
+
+    Parameters:
+        moment: Timezone-aware datetime to format.
+
+    Returns:
+        The moment rendered in UTC as ``YYYY-MM-DDTHH:MM:SS.ffffffZ``.
+    """
+    return moment.astimezone(UTC).isoformat().replace('+00:00', 'Z')
+
+
+def build_timing_section(start: datetime, end: datetime) -> dict[str, Any]:
+    """Build the ``timing`` metadata section from run start and end moments.
+
+    Every metadata document carries this section so downstream statistics
+    (``sd_stats_ingest`` / ``sd_stats_report``) can aggregate per-image run
+    times.
+
+    Parameters:
+        start: Timezone-aware run start (captured before the image load).
+        end: Timezone-aware run end (captured after navigation, or at
+            error time).
+
+    Returns:
+        Dict with ``start_iso8601`` and ``end_iso8601`` (UTC ISO8601
+        strings) and ``elapsed_s`` (float seconds).
+    """
+    return {
+        'start_iso8601': _iso8601_utc(start),
+        'end_iso8601': _iso8601_utc(end),
+        'elapsed_s': (end - start).total_seconds(),
+    }
 
 
 def navigate_image_files(
@@ -90,6 +130,7 @@ def navigate_image_files(
         the curated JSON-friendly dict.
     """
     logger = IMAGE_LOGGER
+    run_start = datetime.now(UTC)
 
     if len(image_files.image_files) != 1:
         logger.error(
@@ -102,6 +143,8 @@ def navigate_image_files(
             'status_exception': (
                 f'Expected exactly one image per batch; got {len(image_files.image_files)}'
             ),
+            'observation': {'instrument': obs_class_to_inst_name(obs_class)},
+            'timing': build_timing_section(run_start, datetime.now(UTC)),
         }
 
     image_file = image_files.image_files[0]
@@ -128,7 +171,12 @@ def navigate_image_files(
                 snapshot = obs_class.from_file(image_url, **extra_params)
             except (OSError, RuntimeError) as exc:
                 metadata = _metadata_for_load_error(
-                    image_path, image_name, exc, logger, instrument=instrument
+                    image_path,
+                    image_name,
+                    exc,
+                    logger=logger,
+                    instrument=instrument,
+                    timing=build_timing_section(run_start, datetime.now(UTC)),
                 )
                 if write_output_files:
                     public_metadata_file.write_text(json_as_string(metadata))
@@ -141,8 +189,14 @@ def navigate_image_files(
                 only_techniques=nav_techniques or '*',
             )
             nav_result = orchestrator.navigate(snapshot_inst)
+            data_shape = snapshot_inst.data.shape
             metadata = build_metadata_from_result(
-                nav_result, image_path, image_name, instrument=instrument
+                nav_result,
+                image_path,
+                image_name,
+                instrument=instrument,
+                image_shape=(int(data_shape[0]), int(data_shape[1])),
+                timing=build_timing_section(run_start, datetime.now(UTC)),
             )
             if write_output_files:
                 logger.info('Writing metadata to %s', public_metadata_file)
@@ -159,11 +213,15 @@ def _metadata_for_load_error(
     image_path: Path,
     image_name: str,
     exc: BaseException,
-    logger: Any,
     *,
+    logger: Any,
     instrument: str,
+    timing: dict[str, Any],
 ) -> dict[str, Any]:
-    """Build a metadata dict for an image-load or kernel-coverage failure."""
+    """Build a metadata dict for an image-load or kernel-coverage failure.
+
+    No image shape is recorded because the load never produced pixel data.
+    """
     message = str(exc)
     if any(hint in message for hint in _SPICE_DATA_HINTS):
         logger.exception('No SPICE kernel available for "%s": %s', image_path, message)
@@ -180,6 +238,7 @@ def _metadata_for_load_error(
             'image_name': image_name,
             'instrument': instrument,
         },
+        'timing': timing,
     }
 
 
@@ -189,6 +248,8 @@ def build_metadata_from_result(
     image_name: str,
     *,
     instrument: str,
+    image_shape: tuple[int, int] | None = None,
+    timing: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the JSON metadata dict from a NavResult.
 
@@ -204,16 +265,27 @@ def build_metadata_from_result(
         instrument: Registered instrument name for the observation class
             (see :func:`spindoctor.obs.obs_class_to_inst_name`); written to
             the ``observation.instrument`` field.
+        image_shape: ``(v, u)`` pixel dimensions of the loaded image data;
+            written to the ``observation.image_shape`` field.  None omits
+            the field.
+        timing: Run-timing section from :func:`build_timing_section`;
+            written to the top-level ``timing`` field.  None omits the
+            field.
     """
+    observation: dict[str, Any] = {
+        'image_path': str(image_path),
+        'image_name': image_name,
+        'instrument': instrument,
+    }
+    if image_shape is not None:
+        observation['image_shape'] = [int(image_shape[0]), int(image_shape[1])]
     metadata: dict[str, Any] = {
         'status': result.status,
-        'observation': {
-            'image_path': str(image_path),
-            'image_name': image_name,
-            'instrument': instrument,
-        },
+        'observation': observation,
         'navigation_result': build_metadata_dict(result),
     }
+    if timing is not None:
+        metadata['timing'] = timing
     if result.offset_px is not None:
         metadata['offset'] = list(result.offset_px)
     metadata['confidence'] = result.confidence

--- a/tests/spindoctor/cli/stats/test_stats.py
+++ b/tests/spindoctor/cli/stats/test_stats.py
@@ -240,6 +240,17 @@ def test_upsert_image_rejects_unknown_column(tmp_path: Path) -> None:
     conn.close()
 
 
+def test_open_stats_db_rejects_mismatched_schema(tmp_path: Path) -> None:
+    """A database with a different images column set is rejected, not migrated."""
+    db_path = tmp_path / 'stats.sqlite3'
+    conn = sqlite3.connect(str(db_path))
+    conn.execute('CREATE TABLE images (image_name TEXT PRIMARY KEY, status TEXT)')
+    conn.commit()
+    conn.close()
+    with pytest.raises(ValueError, match='Delete the database file'):
+        open_stats_db(db_path)
+
+
 # --- ingestion ---
 
 

--- a/tests/spindoctor/cli/stats/test_stats.py
+++ b/tests/spindoctor/cli/stats/test_stats.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from filecache import FCPath
 
 from spindoctor.cli.stats.classify import date_from_image_et
 from spindoctor.cli.stats.ingest import ingest_metadata_files, main_ingest, rows_from_metadata
@@ -418,6 +419,19 @@ def test_build_report_writes_markdown_and_charts(tmp_path: Path) -> None:
     assert (out / 'status_counts.png').exists()
     assert (out / 'technique_usage.png').exists()
     assert (out / 'offsets_hist.png').exists()
+
+
+def test_build_report_accepts_fcpath_output_dir(tmp_path: Path) -> None:
+    """Every report artifact (markdown, charts, filelists, CSV) writes via FCPath."""
+    conn = _populated_db(tmp_path)
+    out = FCPath(str(tmp_path / 'report'))
+    report_path = build_report(conn, out, top_n=2, filelists=True, csv_export=True)
+    conn.close()
+    assert 'Total images: 3' in report_path.read_text(encoding='utf-8')
+    assert (tmp_path / 'report' / 'status_counts.png').exists()
+    assert (tmp_path / 'report' / 'images.csv').exists()
+    filelists = sorted(p.name for p in (tmp_path / 'report' / 'filelists').glob('*.txt'))
+    assert len(filelists) > 0
 
 
 def test_build_report_instrument_filter(tmp_path: Path) -> None:

--- a/tests/spindoctor/cli/stats/test_stats.py
+++ b/tests/spindoctor/cli/stats/test_stats.py
@@ -9,9 +9,11 @@ from typing import Any
 
 import pytest
 
-from spindoctor.cli.stats.classify import date_from_image_et, instrument_from_image_name
+from spindoctor.cli.stats.classify import date_from_image_et
 from spindoctor.cli.stats.ingest import ingest_metadata_files, main_ingest, rows_from_metadata
 from spindoctor.cli.stats.report import build_report, main_report
+from spindoctor.cli.stats.report_common import image_number_from_name
+from spindoctor.cli.stats.report_sections import resolve_offset_limit
 from spindoctor.cli.stats.schema import open_stats_db, upsert_image
 
 
@@ -27,11 +29,14 @@ def _metadata(
     per_technique: list[dict[str, Any]] | None = None,
     excluded: list[str] | None = None,
     image_et: float = 0.0,
+    image_shape: list[int] | None = None,
+    elapsed_s: float | None = 3.25,
 ) -> dict[str, Any]:
     """Build a minimal metadata document in the navigate_image_files shape.
 
     ``instrument=None`` omits the ``observation.instrument`` field to model
-    a metadata document that predates the field.
+    a malformed document.  ``elapsed_s=None`` omits the ``timing`` section;
+    ``image_shape=None`` omits ``observation.image_shape``.
     """
     if offset is None and status == 'success':
         offset = [1.5, -2.5]
@@ -41,7 +46,9 @@ def _metadata(
     }
     if instrument is not None:
         observation['instrument'] = instrument
-    return {
+    if image_shape is not None:
+        observation['image_shape'] = image_shape
+    doc: dict[str, Any] = {
         'status': status,
         'observation': observation,
         'navigation_result': {
@@ -59,7 +66,7 @@ def _metadata(
                 {
                     'feature_id': 'body_disc:IAPETUS',
                     'feature_type': 'BODY_DISC',
-                    'source_model': 'body',
+                    'source_model': 'body:IAPETUS',
                     'gated': False,
                 },
                 {
@@ -78,6 +85,13 @@ def _metadata(
             },
         },
     }
+    if elapsed_s is not None:
+        doc['timing'] = {
+            'start_iso8601': '2026-07-11T00:00:00Z',
+            'end_iso8601': '2026-07-11T00:00:03.250000Z',
+            'elapsed_s': elapsed_s,
+        }
+    return doc
 
 
 def _technique(
@@ -106,22 +120,14 @@ def _write_metadata(root: Path, name: str, doc: dict[str, Any]) -> Path:
     return path
 
 
-# --- classification ---
+def _upsert(conn: sqlite3.Connection, doc: dict[str, Any]) -> None:
+    """Flatten a metadata document and upsert it into the database."""
+    image_row, technique_rows, source_rows = rows_from_metadata(doc, source_file='x.json')
+    with conn:
+        upsert_image(conn, image_row, technique_rows=technique_rows, source_rows=source_rows)
 
 
-@pytest.mark.parametrize(
-    ('image_name', 'expected'),
-    [
-        ('N1454725799_1_CALIB.IMG', 'coiss'),
-        ('W1728613298_8.IMG', 'coiss'),
-        ('C3250013_GEOMED.IMG', 'vgiss'),
-        ('C0349632000R.IMG', 'gossi'),
-        ('lor_0003103486_0x630_sci.fit', 'nhlorri'),
-        ('mystery.dat', 'unknown'),
-    ],
-)
-def test_instrument_from_image_name(image_name: str, expected: str) -> None:
-    assert instrument_from_image_name(image_name) == expected
+# --- classification helpers ---
 
 
 def test_date_from_image_et_j2000() -> None:
@@ -130,6 +136,21 @@ def test_date_from_image_et_j2000() -> None:
 
 def test_date_from_image_et_none() -> None:
     assert date_from_image_et(None) is None
+
+
+@pytest.mark.parametrize(
+    ('image_name', 'expected'),
+    [
+        ('N1454725799_1_CALIB.IMG', 1454725799),
+        ('/some/dir/W1728613298_8.IMG', 1728613298),
+        ('lor_0003103486_0x630_sci.fit', 3103486),
+        ('1454725799', 1454725799),
+        ('no-digits-here', None),
+        (None, None),
+    ],
+)
+def test_image_number_from_name(image_name: str | None, expected: int | None) -> None:
+    assert image_number_from_name(image_name) == expected
 
 
 # --- flattening ---
@@ -165,18 +186,18 @@ def test_rows_from_metadata_requires_image_name() -> None:
         rows_from_metadata({'observation': {}}, source_file='x.json')
 
 
-def test_rows_from_metadata_prefers_recorded_instrument() -> None:
-    """The recorded observation.instrument wins over the filename shape."""
+def test_rows_from_metadata_requires_instrument() -> None:
+    """A document without observation.instrument is rejected."""
+    doc = _metadata(instrument=None)
+    with pytest.raises(ValueError, match=r'lacks observation\.instrument'):
+        rows_from_metadata(doc, source_file='x.json')
+
+
+def test_rows_from_metadata_uses_recorded_instrument() -> None:
+    """The recorded observation.instrument is stored verbatim."""
     doc = _metadata(instrument='sim')
     image_row, _, _ = rows_from_metadata(doc, source_file='x.json')
     assert image_row['instrument'] == 'sim'
-
-
-def test_rows_from_metadata_instrument_falls_back_to_filename() -> None:
-    """A document without observation.instrument classifies by filename."""
-    doc = _metadata(instrument=None)
-    image_row, _, _ = rows_from_metadata(doc, source_file='x.json')
-    assert image_row['instrument'] == 'coiss'
 
 
 def test_rows_from_metadata_null_status_falls_back() -> None:
@@ -185,6 +206,28 @@ def test_rows_from_metadata_null_status_falls_back() -> None:
     doc['status'] = None
     image_row, _, _ = rows_from_metadata(doc, source_file='x.json')
     assert image_row['status'] == 'success'
+
+
+def test_rows_from_metadata_records_timing_and_shape() -> None:
+    """Timing and image-shape metadata land in the image row."""
+    doc = _metadata(image_shape=[1024, 512], elapsed_s=7.5)
+    image_row, _, _ = rows_from_metadata(doc, source_file='x.json')
+    assert image_row['run_start'] == '2026-07-11T00:00:00Z'
+    assert image_row['run_end'] == '2026-07-11T00:00:03.250000Z'
+    assert image_row['elapsed_s'] == pytest.approx(7.5)
+    assert image_row['image_shape_v'] == 1024
+    assert image_row['image_shape_u'] == 512
+
+
+def test_rows_from_metadata_tolerates_missing_timing_and_shape() -> None:
+    """Documents without timing or image_shape ingest with NULL columns."""
+    doc = _metadata(elapsed_s=None, image_shape=None)
+    image_row, _, _ = rows_from_metadata(doc, source_file='x.json')
+    assert image_row['run_start'] is None
+    assert image_row['run_end'] is None
+    assert image_row['elapsed_s'] is None
+    assert image_row['image_shape_v'] is None
+    assert image_row['image_shape_u'] is None
 
 
 def test_upsert_image_rejects_unknown_column(tmp_path: Path) -> None:
@@ -241,14 +284,24 @@ def test_ingest_skips_malformed_file(tmp_path: Path) -> None:
     conn.close()
 
 
+def test_ingest_counts_missing_instrument_as_error(tmp_path: Path) -> None:
+    """A document without observation.instrument is skipped and counted."""
+    root = tmp_path / 'results'
+    _write_metadata(root, 'N1454725799_1_CALIB', _metadata(instrument=None))
+    _write_metadata(root, 'N1454725800_1_CALIB', _metadata(image_name='N1454725800_1_CALIB.IMG'))
+    conn = open_stats_db(tmp_path / 'stats.sqlite3')
+    n_ingested, n_errors = ingest_metadata_files(conn, [str(root)])
+    assert n_ingested == 1
+    assert n_errors == 1
+    names = [r[0] for r in conn.execute('SELECT image_name FROM images')]
+    assert names == ['N1454725800_1_CALIB.IMG']
+    conn.close()
+
+
 def test_upsert_replaces_children(tmp_path: Path) -> None:
     conn = open_stats_db(tmp_path / 'stats.sqlite3')
-    doc = _metadata(per_technique=[_technique('BodyLimbNav', (1.0, 1.0))])
-    image_row, technique_rows, source_rows = rows_from_metadata(doc, source_file='x.json')
-    upsert_image(conn, image_row, technique_rows=technique_rows, source_rows=source_rows)
-    doc = _metadata(per_technique=[])
-    image_row, technique_rows, source_rows = rows_from_metadata(doc, source_file='x.json')
-    upsert_image(conn, image_row, technique_rows=technique_rows, source_rows=source_rows)
+    _upsert(conn, _metadata(per_technique=[_technique('BodyLimbNav', (1.0, 1.0))]))
+    _upsert(conn, _metadata(per_technique=[]))
     count = conn.execute('SELECT COUNT(*) FROM techniques').fetchone()[0]
     assert count == 0
     conn.close()
@@ -265,6 +318,40 @@ def test_main_ingest_cli(tmp_path: Path) -> None:
     conn.close()
 
 
+# --- offset-limit resolution ---
+
+
+def test_resolve_offset_limit_coiss_nac_by_size() -> None:
+    """Cassini NAC CALIB limits come from the per-size margin table."""
+    limit = resolve_offset_limit('coiss', 'N1454725799_1_CALIB.IMG', 1024)
+    assert limit == (50.0, 140.0)
+
+
+def test_resolve_offset_limit_coiss_wac() -> None:
+    """Cassini WAC limits use the wac detector block."""
+    limit = resolve_offset_limit('coiss', 'W1454725799_1_CALIB.IMG', 512)
+    assert limit == (5.0, 10.0)
+
+
+def test_resolve_offset_limit_requires_shape_for_size_tables() -> None:
+    """A size-keyed margin table cannot resolve without a recorded shape."""
+    result = resolve_offset_limit('coiss', 'N1454725799_1_CALIB.IMG', None)
+    assert result == 'image shape not recorded in the database'
+
+
+def test_resolve_offset_limit_unknown_instrument() -> None:
+    result = resolve_offset_limit('mystery', 'X123.IMG', 1024)
+    assert isinstance(result, str)
+    assert 'no configured search limit' in result
+
+
+def test_resolve_offset_limit_missing_size_entry() -> None:
+    """A size with no margin entry reports the failure instead of guessing."""
+    result = resolve_offset_limit('vgiss', 'C3250013_GEOMED.IMG', 1024)
+    assert isinstance(result, str)
+    assert 'no extfov_margin_vu entry for image size 1024' in result
+
+
 # --- reporting ---
 
 
@@ -273,6 +360,7 @@ def _populated_db(tmp_path: Path) -> sqlite3.Connection:
     docs = [
         _metadata(
             image_name='N1000000001_1_CALIB.IMG',
+            image_shape=[1024, 1024],
             per_technique=[
                 _technique('BodyDiscCorrelateNav', (1.5, -2.5)),
                 _technique('BodyLimbNav', (1.7, -2.3)),
@@ -280,6 +368,7 @@ def _populated_db(tmp_path: Path) -> sqlite3.Connection:
         ),
         _metadata(
             image_name='N1000000002_1_CALIB.IMG',
+            image_shape=[1024, 1024],
             confidence=0.3,
             confidence_rank='medium',
             per_technique=[_technique('StarUniqueMatchNav', (0.1, 0.2))],
@@ -294,11 +383,11 @@ def _populated_db(tmp_path: Path) -> sqlite3.Connection:
             confidence=0.0,
             confidence_rank='failed',
             image_et=-6.0e8,
+            image_shape=[1000, 1000],
         ),
     ]
     for doc in docs:
-        image_row, technique_rows, source_rows = rows_from_metadata(doc, source_file='x.json')
-        upsert_image(conn, image_row, technique_rows=technique_rows, source_rows=source_rows)
+        _upsert(conn, doc)
     return conn
 
 
@@ -327,7 +416,7 @@ def test_build_report_instrument_filter(tmp_path: Path) -> None:
     conn.close()
     text = report_path.read_text(encoding='utf-8')
     assert '| failed | 1 |' in text
-    assert 'success' not in text.split('## Technique usage')[0].split('## Success')[1]
+    assert 'success' not in text.split('## Failure taxonomy')[0].split('## Success')[1]
 
 
 def test_build_report_date_filter_excludes_out_of_range(tmp_path: Path) -> None:
@@ -340,12 +429,231 @@ def test_build_report_date_filter_excludes_out_of_range(tmp_path: Path) -> None:
     assert 'Total images: 2' in text
 
 
+def test_build_report_min_image_filter(tmp_path: Path) -> None:
+    """min_image keeps only images whose numeric portion is at or above it."""
+    conn = _populated_db(tmp_path)
+    out = tmp_path / 'report'
+    report_path = build_report(conn, out, min_image='N1000000002')
+    conn.close()
+    text = report_path.read_text(encoding='utf-8')
+    assert 'Total images: 1' in text
+    assert 'image number >= 1000000002' in text
+
+
+def test_build_report_max_image_filter(tmp_path: Path) -> None:
+    """max_image keeps only images whose numeric portion is at or below it."""
+    conn = _populated_db(tmp_path)
+    out = tmp_path / 'report'
+    report_path = build_report(conn, out, max_image='5000000')
+    conn.close()
+    text = report_path.read_text(encoding='utf-8')
+    # Only the Voyager frame (3250013) falls at or below 5000000.
+    assert 'Total images: 1' in text
+    assert '| failed | 1 |' in text
+
+
+def test_build_report_rejects_digitless_image_bound(tmp_path: Path) -> None:
+    conn = _populated_db(tmp_path)
+    with pytest.raises(ValueError, match='contains no digits'):
+        build_report(conn, tmp_path / 'report', min_image='nodigits')
+    conn.close()
+
+
+def test_report_failure_taxonomy_section(tmp_path: Path) -> None:
+    """Failed images classify by content; bodies get failure shares."""
+    conn = _populated_db(tmp_path)
+    out = tmp_path / 'report'
+    report_path = build_report(conn, out)
+    conn.close()
+    text = report_path.read_text(encoding='utf-8')
+    assert '## Failure taxonomy by image content' in text
+    # The failed Voyager frame recorded one body (IAPETUS) and stars.
+    assert '| single-body | 1 |' in text
+    assert '| single-body | no_features_extracted | 1 |' in text
+    assert '### Per-body failure shares' in text
+    assert '| IAPETUS | 1 | 2 | 0.333 |' in text
+
+
+def test_report_offset_by_group_section(tmp_path: Path) -> None:
+    """Offsets additionally break down by (instrument, image size)."""
+    conn = _populated_db(tmp_path)
+    out = tmp_path / 'report'
+    report_path = build_report(conn, out)
+    conn.close()
+    text = report_path.read_text(encoding='utf-8')
+    assert '### By instrument and image size' in text
+    assert '| coiss | 1024x1024 | 2 ' in text
+
+
+def test_report_suspect_offset_section(tmp_path: Path) -> None:
+    """An offset near the NAC search margin is flagged as suspect."""
+    conn = _populated_db(tmp_path)
+    # NAC 1024 CALIB margin is (50, 140); |dV| = 49 is 0.98 of the limit.
+    _upsert(
+        conn,
+        _metadata(
+            image_name='N1000000003_1_CALIB.IMG',
+            image_shape=[1024, 1024],
+            offset=[49.0, 10.0],
+        ),
+    )
+    out = tmp_path / 'report'
+    report_path = build_report(conn, out)
+    conn.close()
+    text = report_path.read_text(encoding='utf-8')
+    assert '## Suspect offsets (near the search limit)' in text
+    assert 'Suspect images: 1 of 3 screened.' in text
+    assert '| N1000000003_1_CALIB.IMG | coiss | 49.000 | 10.000 |' in text
+    assert '(50.0, 140.0)' in text
+
+
+def test_report_suspect_offset_reports_unresolved_limits(tmp_path: Path) -> None:
+    """Images whose search limit cannot be resolved are called out."""
+    conn = open_stats_db(tmp_path / 'stats.sqlite3')
+    _upsert(conn, _metadata(image_name='X9999999.IMG', instrument='mystery'))
+    out = tmp_path / 'report'
+    report_path = build_report(conn, out)
+    conn.close()
+    text = report_path.read_text(encoding='utf-8')
+    assert 'Search limit could not be resolved for some images:' in text
+    assert "mystery: no configured search limit for instrument 'mystery' (1 image(s))" in text
+
+
+def _botsim_db(tmp_path: Path) -> sqlite3.Connection:
+    """Two BOTSIM pairs: one consistent, one with a 2 px NAC-scale residual."""
+    conn = open_stats_db(tmp_path / 'stats.sqlite3')
+    docs = [
+        _metadata(
+            image_name='N1454725799_1_CALIB.IMG', image_shape=[1024, 1024], offset=[10.0, -20.0]
+        ),
+        _metadata(
+            image_name='W1454725799_1_CALIB.IMG', image_shape=[1024, 1024], offset=[1.0, -2.0]
+        ),
+        _metadata(
+            image_name='N1454725900_1_CALIB.IMG', image_shape=[1024, 1024], offset=[12.0, -20.0]
+        ),
+        _metadata(
+            image_name='W1454725900_1_CALIB.IMG', image_shape=[1024, 1024], offset=[1.0, -2.0]
+        ),
+        # A pair whose WAC frame failed: identified but not compared.
+        _metadata(
+            image_name='N1454726000_1_CALIB.IMG', image_shape=[1024, 1024], offset=[1.0, 1.0]
+        ),
+        _metadata(
+            image_name='W1454726000_1_CALIB.IMG',
+            status='failed',
+            status_reason='no_features_extracted',
+            offset=None,
+            confidence=0.0,
+            confidence_rank='failed',
+        ),
+    ]
+    for doc in docs:
+        _upsert(conn, doc)
+    return conn
+
+
+def test_report_botsim_section(tmp_path: Path) -> None:
+    conn = _botsim_db(tmp_path)
+    out = tmp_path / 'report'
+    report_path = build_report(conn, out, top_n=5)
+    conn.close()
+    text = report_path.read_text(encoding='utf-8')
+    assert '## BOTSIM pair consistency (Cassini ISS)' in text
+    assert '| pairs identified | 3 |' in text
+    assert '| pairs with both navigated | 2 |' in text
+    # Residuals are 0.0 (consistent pair) and 2.0 (12 - 10*1), median 1.0.
+    assert '| median residual (px) | 1.000 |' in text
+    assert '| p95 residual (px) | 2.000 |' in text
+    # Worst-pairs table leads with the 2 px pair.
+    assert (
+        '| 1454725900 | N1454725900_1_CALIB.IMG | W1454725900_1_CALIB.IMG '
+        '| 2.000 | 0.000 | 2.000 |' in text
+    )
+
+
+def test_report_runtime_section(tmp_path: Path) -> None:
+    conn = _populated_db(tmp_path)
+    out = tmp_path / 'report'
+    report_path = build_report(conn, out, top_n=2)
+    conn.close()
+    text = report_path.read_text(encoding='utf-8')
+    assert '## Run-time statistics' in text
+    assert '| images with timing | 3 |' in text
+    assert '| total (s) | 9.750 |' in text
+    assert '| median (s) | 3.250 |' in text
+    assert 'Slowest 2 image(s):' in text
+    assert (out / 'runtime_hist.png').exists()
+
+
+def test_report_runtime_section_skipped_without_timing(tmp_path: Path) -> None:
+    """No ingested timing data: the run-time section is omitted."""
+    conn = open_stats_db(tmp_path / 'stats.sqlite3')
+    _upsert(conn, _metadata(elapsed_s=None))
+    out = tmp_path / 'report'
+    report_path = build_report(conn, out)
+    conn.close()
+    text = report_path.read_text(encoding='utf-8')
+    assert '## Run-time statistics' not in text
+    assert not (out / 'runtime_hist.png').exists()
+
+
+def test_report_top_n_lists_examples(tmp_path: Path) -> None:
+    """top_n adds example image names to the categorical sections."""
+    conn = _populated_db(tmp_path)
+    out = tmp_path / 'report'
+    report_path = build_report(conn, out, top_n=5)
+    conn.close()
+    text = report_path.read_text(encoding='utf-8')
+    assert 'Examples (up to 5 per reason):' in text
+    assert '- no_features_extracted: C3250013_GEOMED.IMG' in text
+    assert '- BodyBlobNav: N1000000002_1_CALIB.IMG' in text
+
+
+def test_report_filelists_written(tmp_path: Path) -> None:
+    """filelists writes one full image-name list per category."""
+    conn = _populated_db(tmp_path)
+    out = tmp_path / 'report'
+    report_path = build_report(conn, out, filelists=True)
+    conn.close()
+    text = report_path.read_text(encoding='utf-8')
+    reason_list = out / 'filelists' / 'failure_reason_no_features_extracted.txt'
+    assert reason_list.exists()
+    assert reason_list.read_text(encoding='utf-8') == 'C3250013_GEOMED.IMG\n'
+    excluded_list = out / 'filelists' / 'excluded_BodyBlobNav.txt'
+    assert excluded_list.exists()
+    assert excluded_list.read_text(encoding='utf-8') == 'N1000000002_1_CALIB.IMG\n'
+    assert 'filelists/failure_reason_no_features_extracted.txt' in text
+
+
+def test_report_csv_export(tmp_path: Path) -> None:
+    """csv_export writes a one-row-per-image CSV with aggregate counts."""
+    conn = _populated_db(tmp_path)
+    out = tmp_path / 'report'
+    report_path = build_report(conn, out, csv_export=True)
+    conn.close()
+    text = report_path.read_text(encoding='utf-8')
+    assert 'images.csv (3 row(s))' in text
+    csv_lines = (out / 'images.csv').read_text(encoding='utf-8').splitlines()
+    assert len(csv_lines) == 4
+    header = csv_lines[0].split(',')
+    assert header[0] == 'image_name'
+    assert 'elapsed_s' in header
+    assert header[-4:] == ['n_technique_rows', 'n_feature_sources', 'n_features', 'n_gated']
+    # Rows are ordered by image name; the Voyager frame sorts first.
+    assert csv_lines[1].startswith('C3250013_GEOMED.IMG,vgiss,')
+
+
 def test_report_is_deterministic(tmp_path: Path) -> None:
     conn = _populated_db(tmp_path)
     out_a = tmp_path / 'a'
     out_b = tmp_path / 'b'
-    text_a = build_report(conn, out_a).read_text(encoding='utf-8')
-    text_b = build_report(conn, out_b).read_text(encoding='utf-8')
+    text_a = build_report(conn, out_a, top_n=3, filelists=True, csv_export=True).read_text(
+        encoding='utf-8'
+    )
+    text_b = build_report(conn, out_b, top_n=3, filelists=True, csv_export=True).read_text(
+        encoding='utf-8'
+    )
     conn.close()
     assert text_a == text_b
 
@@ -357,3 +665,32 @@ def test_main_report_cli(tmp_path: Path) -> None:
     exit_code = main_report(['--db', str(tmp_path / 'stats.sqlite3'), '--output-dir', str(out)])
     assert exit_code == 0
     assert (out / 'report.md').exists()
+
+
+def test_main_report_cli_new_flags(tmp_path: Path) -> None:
+    """The drill-down, range, suspect, and CSV flags parse and take effect."""
+    conn = _populated_db(tmp_path)
+    conn.close()
+    out = tmp_path / 'report'
+    exit_code = main_report(
+        [
+            '--db',
+            str(tmp_path / 'stats.sqlite3'),
+            '--output-dir',
+            str(out),
+            '--top-n',
+            '3',
+            '--filelists',
+            '--csv',
+            '--suspect-fraction',
+            '0.8',
+            '--min-image',
+            '1',
+        ]
+    )
+    assert exit_code == 0
+    assert (out / 'images.csv').exists()
+    assert (out / 'filelists').is_dir()
+    text = (out / 'report.md').read_text(encoding='utf-8')
+    assert 'at least 0.80 of the per-axis maximum expected pointing' in text
+    assert 'image number >= 1' in text

--- a/tests/spindoctor/test_navigate_image_files.py
+++ b/tests/spindoctor/test_navigate_image_files.py
@@ -13,6 +13,7 @@ end-to-end against a synthetic ``Annotations`` collection.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from io import BytesIO
 from pathlib import Path
 from typing import Any
@@ -27,6 +28,7 @@ from spindoctor.nav_orchestrator.image_classifier_result import NavImageClassifi
 from spindoctor.nav_orchestrator.nav_result import NavResult
 from spindoctor.nav_orchestrator.provenance import Provenance
 from spindoctor.navigate_image_files import (
+    build_timing_section,
     navigate_image_files,
     write_summary_png,
 )
@@ -117,6 +119,10 @@ def test_navigate_image_files_no_features_path(tmp_path: Path) -> None:
     assert metadata['confidence'] == 0.0
     # The fake observation class is not in the instrument registry.
     assert metadata['observation']['instrument'] == 'unknown'
+    assert metadata['observation']['image_shape'] == [32, 32]
+    assert metadata['timing']['elapsed_s'] >= 0.0
+    assert metadata['timing']['start_iso8601'].endswith('Z')
+    assert metadata['timing']['end_iso8601'].endswith('Z')
     assert 'navigation_result' in metadata
     nav_result = metadata['navigation_result']
     # Without registered real-scene models the classifier still runs.
@@ -172,6 +178,9 @@ def test_navigate_image_files_image_load_failure_records_status(tmp_path: Path) 
     assert metadata['status_error'] == 'image_read_error'
     assert 'cannot read fixture image' in metadata['status_exception']
     assert metadata['observation']['instrument'] == 'unknown'
+    # The image never loaded, so no shape is recorded; timing still is.
+    assert 'image_shape' not in metadata['observation']
+    assert metadata['timing']['elapsed_s'] >= 0.0
 
 
 def test_navigate_image_files_spice_load_failure_records_missing_kernel(
@@ -445,3 +454,16 @@ def test_navigate_image_files_rejects_multi_image_batch(tmp_path: Path) -> None:
     )
     assert success is False
     assert metadata['status_error'] == 'expected_one_image_per_batch'
+    # Even the validation early-return records the instrument and timing.
+    assert metadata['observation']['instrument'] == 'unknown'
+    assert metadata['timing']['elapsed_s'] >= 0.0
+
+
+def test_build_timing_section_formats_utc() -> None:
+    """The timing section carries UTC ISO8601 strings and float seconds."""
+    start = datetime(2026, 7, 11, 12, 0, 0, tzinfo=UTC)
+    end = datetime(2026, 7, 11, 12, 0, 2, 500000, tzinfo=UTC)
+    timing = build_timing_section(start, end)
+    assert timing['start_iso8601'] == '2026-07-11T12:00:00Z'
+    assert timing['end_iso8601'] == '2026-07-11T12:00:02.500000Z'
+    assert timing['elapsed_s'] == 2.5


### PR DESCRIPTION
Final PR of the Track B statistics stack. Builds on #247 (`pr213-review-followups`) and merges LAST in the stack.

## Report features (`sd_stats_report`)

1. **Drill-down + filelists** — `--top-n N` lists up to N example image names per category in every categorical section (failure reasons, failure taxonomy, ensemble exclusions, suspect offsets) and caps the suspect-offset / worst-BOTSIM-pair tables and slowest-image list. `--filelists` writes one plain-text file per category (full list, one image name per line) into `filelists/` for feeding back into re-runs and triage.
2. **Suspect-offset screen** — `--suspect-fraction F` (default 0.9) flags successful images whose fused offset reaches F of the instrument's per-axis maximum expected pointing offset (the configured `extfov_margin_vu` search margin; Cassini ISS resolves NAC/WAC and raw-vs-CALIB from the image name, size-keyed tables from the recorded image shape). Unresolvable limits are reported per instrument instead of silently skipped.
3. **BOTSIM pair consistency (Cassini ISS)** — pairs NAC/WAC frames sharing a spacecraft-clock count and reports per-axis residuals `NAC - 10 x WAC` (pair counts, median, p95, and worst pairs with `--top-n`) as an end-to-end accuracy check needing no ground truth.
4. **Failure taxonomy by image content** — failed images classified from `feature_sources` (stars-only / single-body / multi-body / rings-only / body+rings / no-features) with per-category reason breakdowns, plus a per-body failure-share table that localizes modeling problems to specific bodies.
5. **Run-time statistics** — min/max/mean/median/stdev/total of per-image elapsed seconds, a histogram PNG, and the N slowest images; the section is omitted when no timing data exists.
6. **Per-instrument / per-image-size offset breakdown** — the offset statistics additionally grouped by (instrument, image size), one row per group with data.
7. **CSV export** — `--csv` writes `images.csv` (every `images` column plus technique/feature-source aggregates, ordered by image name) next to `report.md`.

Plus an operator-requested filter: `--min-image` / `--max-image` bound the numeric portion of the image name (same digits the BOTSIM pairing uses; accepts `N1454725799` or a bare number) via a registered deterministic `image_number` SQL function, combining with the instrument/date filters in every section.

Reports remain deterministic (same DB + options -> byte-identical `report.md`), and all sections respect `--instrument` / `--start-date` / `--end-date`.

## Metadata additions (`navigate_image_files`, manual path in `sd_offset`)

- Every metadata document records a top-level `timing` section (`start_iso8601`, `end_iso8601` UTC, `elapsed_s` float), captured before the image load and after navigation or at error time — the load-error and batch-validation paths get timing too.
- The multi-image-batch validation early return now records `observation.instrument`, so every document this module returns identifies its instrument.
- Success/failed documents record `observation.image_shape` (`[v, u]`); the manual-nav path writes the same sections with elapsed = load + dialog wall time.

## Ingest / schema

- `observation.instrument` is **required**: a document without it raises ValueError and is logged, skipped, and counted as an ingest error, exactly like a missing image name. The filename-shape classifier (`instrument_from_image_name` and its regexes) is removed.
- The `images` table gains `image_shape_v`, `image_shape_u`, `run_start`, `run_end`, `elapsed_s` (NULL-tolerant; no migration — delete and re-ingest).
- `report.py` split into `report.py` (orchestration + core sections), `report_sections.py` (new sections), `report_common.py` (context, filters, chart helpers); all modules stay well under 1000 lines.
- User guide updated: schema tables cover the new columns, and the reporting section documents every new flag and section.

## Validation

- `ruff check src tests` / `ruff format --check src tests`: pass
- `mypy src tests` (strict): pass
- `pytest -n auto --dist=loadfile` (full unit suite): 1924 passed
- `sphinx-build -W -b html docs docs/_build`: pass

## Operator checklist

- No manual post-merge actions beyond normal merge order: this PR merges **LAST** in the stack, after #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KW6fkURsA2zgrWFKjbR5JY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded statistics reports with image-range filters, top-result limits, filelists, CSV export, runtime metrics, suspect-offset analysis, failure taxonomy, and additional consistency and calibration sections.
  * Reports now include image dimensions and navigation timing when available.
  * Navigation metadata records UTC start/end times, elapsed duration, and image dimensions.

* **Bug Fixes**
  * Metadata without a recorded instrument is now skipped and counted as an ingestion error.

* **Documentation**
  * Updated the user guide with revised ingestion requirements, schema details, and reporting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->