### PR TITLE
docs: reconcile plans to post-merge state

### DIFF
--- a/plans/COHORT_CURATION_PLAN.md
+++ b/plans/COHORT_CURATION_PLAN.md
@@ -211,8 +211,8 @@ batch per PR keeps the vote-to-merge mapping clean).
 **Stage E — baselines and consumption.** After sidecar PRs merge, seed
 regression baselines (`python -m tests.integration.update_baselines`), then
 hand off per consumer: calibration diagnostics collection for the
-real-anchored confidence recalibration (#230; the interim sim-anchored pass
-landed via #173 — reliability diagrams against measured error anchors, never
+real-anchored confidence recalibration (#230; the sim-anchored interim
+pass is done — reliability diagrams against measured error anchors, never
 tier-midpoint fitting), agreement-study runs per WS-1's harness plan (#225),
 plate solves on the star-field cohort for distortion validation (#228). CI stays tiered per WS-4's
 "Library consumers and CI tiers" note: the full library and all offline

--- a/plans/COHORT_CURATION_PLAN.md
+++ b/plans/COHORT_CURATION_PLAN.md
@@ -211,9 +211,9 @@ batch per PR keeps the vote-to-merge mapping clean).
 **Stage E — baselines and consumption.** After sidecar PRs merge, seed
 regression baselines (`python -m tests.integration.update_baselines`), then
 hand off per consumer: calibration diagnostics collection for the
-real-anchored confidence recalibration (#230; the sim-anchored interim
-pass is done — reliability diagrams against measured error anchors, never
-tier-midpoint fitting), agreement-study runs per WS-1's harness plan (#225),
+real-anchored confidence recalibration (#230 — reliability diagrams
+against measured error anchors, never tier-midpoint fitting; the
+sim-anchored interim pass is done), agreement-study runs per WS-1's harness plan (#225),
 plate solves on the star-field cohort for distortion validation (#228). CI stays tiered per WS-4's
 "Library consumers and CI tiers" note: the full library and all offline
 analyses never run per-PR.

--- a/plans/ENGINEERING_PLAN.md
+++ b/plans/ENGINEERING_PLAN.md
@@ -54,8 +54,8 @@ member cannot claim a tier better than that axis's honest sigma allows.
 geometry (rank-1 ring + blob) asserts the fused offset tracks the
 absolute constraint on the along-edge axis and the tier reflects the
 honest per-axis sigma. Existing rank-1 tests
-(`tests/spindoctor/nav_orchestrator/`, the `ring_only_flat` machinery
-from the rank-1 stack PR) stay green.
+(`tests/spindoctor/nav_orchestrator/`, the `ring_only_flat` machinery)
+stay green.
 
 ### #222 — Second-pass refinement votes as an independent opinion
 
@@ -121,8 +121,9 @@ guessed.
 
 ### #128 / #150 — Limb navigation redesign and the ~0.1 px systematic
 
-The strategic pair behind several symptoms (#125's mis-convergence
-class, #187 chaotic rotators). #150 is the measured ~0.09-0.13 px limb bias: the
+The strategic pair behind several symptoms (the terminator
+mis-convergence class, #187 chaotic rotators). #150 is the measured
+~0.09-0.13 px limb bias: the
 model predicts the geometric silhouette while the image's gradient ridge
 sits ~0.1 px inside it (PSF), so `gradient_ridge_refine` is disabled for
 the limb technique (`config_510_techniques.yaml`) while ring edges run
@@ -173,7 +174,7 @@ design document, not code.
   merge: `util/calibration/library_crosscheck.py` over the full library,
   every per-image delta accounted for; `sd_stats_ingest` /
   `sd_stats_report` over campaign outputs as the accuracy checkpoint
-  (both from the merged #35 system).
+  (both from the statistics system).
 
 ## Track D — Capability completion
 
@@ -277,12 +278,11 @@ asserts the generated half matches the registries.
   construction. Do these before Track D's PDS4/backplane build-out.
 - **#243** — direct tests for `nav_model/stars/conflicts.py`
   (`_check_one_star`, `mark_body_and_ring_conflicts`) with synthetic
-  geometry; the per-pixel occlusion tests from the #145 fix cover only
-  the occlusion-fraction path.
+  geometry; the existing per-pixel occlusion tests cover only the
+  occlusion-fraction path.
 - **#174** — regression baselines beyond the single frame: seed
   baselines for the full library (`python -m
-  tests.integration.update_baselines --all`) once the pending stack's
-  offset-affecting changes are merged, and commit them with the
+  tests.integration.update_baselines --all`) and commit them with the
   per-image diff accounted for.
 - **#177** — unit tests for `spindoctor.support.summary_png`.
 - **#178** — missing dev-guide pages: filters, uncertainty (write

--- a/plans/ENGINEERING_PLAN.md
+++ b/plans/ENGINEERING_PLAN.md
@@ -282,8 +282,9 @@ asserts the generated half matches the registries.
   occlusion-fraction path.
 - **#174** — regression baselines beyond the single frame: seed
   baselines for the full library (`python -m
-  tests.integration.update_baselines --all`) and commit them with the
-  per-image diff accounted for.
+  tests.integration.update_baselines --all`, which requires
+  `PDS3_HOLDINGS_DIR`) and commit them with the per-image diff
+  accounted for.
 - **#177** — unit tests for `spindoctor.support.summary_png`.
 - **#178** — missing dev-guide pages: filters, uncertainty (write
   after #230 makes sigmas load-bearing), troubleshooting.

--- a/plans/PROGRAM_PLAN.md
+++ b/plans/PROGRAM_PLAN.md
@@ -3,8 +3,7 @@
 *The top-level plan of record for all remaining work. It is written to be
 readable without knowledge of the code internals or the statistical
 methodology; the detail lives in the three sub-plans it points to. Last
-reconciled 2026-07-12, immediately after the nine-PR stack (#208,
-#213-#220) was prepared for merge.*
+reconciled 2026-07-12.*
 
 **Document map** (what to read for what):
 
@@ -45,25 +44,21 @@ uncertainties is not finished, it is merely running.
 
 The engineering core is built and healthy: the full navigation architecture
 (nine autonomous techniques plus manual), reprojection, backplanes,
-simulation, statistics reporting, and strict quality gates (typing,
-linting, ~1,700 tests) are in place. PDS4 bundle generation exists only
+simulation, rank-1 (single-axis) ring support, the statistics system
+(`sd_stats_ingest` / `sd_stats_report`), and strict quality gates (typing,
+linting, ~1,900 tests) are in place. PDS4 bundle generation exists only
 as partially implemented machinery (see Track D). An independent project
 review (2026-07-08) rated the engineering strong and the self-assessment
 honest.
 
 What the same review identified as the single real deficit still stands,
 half-addressed: **the validation program is designed but mostly not yet
-run.** Since that review, the first slice landed — the confidence formulas
-are now calibrated against simulated scenes with planted, known-truth
-offsets (PR #208), so confidence values are no longer arbitrary defaults.
-But the simulation's realism is itself unproven, which is why every output
-still carries a `confidence_provisional` marker. Turning that provisional
-story into a defensible one is Track A, the largest remaining block.
-
-Pending merges: the PR stack #208-#220 delivers the sim-anchored
-calibration, a set of navigation-correctness fixes, rank-1 (single-axis)
-ring support, and the statistics system. This plan assumes those merges;
-the issue index marks what they close.
+run.** The first slice is in place — the confidence formulas are calibrated
+against simulated scenes with planted, known-truth offsets, so confidence
+values are no longer arbitrary defaults. But the simulation's realism is
+itself unproven, which is why every output still carries a
+`confidence_provisional` marker. Turning that provisional story into a
+defensible one is Track A, the largest remaining block.
 
 The curated image library — the raw material for both regression testing
 and validation — stands at 62 operator-verified images (Cassini and
@@ -142,9 +137,9 @@ its section names):
    only the finer per-technique separation.
 6. **Wire real images into CI** (#229; WS-4) — a small cached tier on
    every PR, the full suite on a schedule.
-7. **Re-anchor confidence on real evidence** (#230, successor to #173;
-   WS-5) — re-run the existing calibration tooling against the agreement
-   study's measurements; retire the provisional marker.
+7. **Re-anchor confidence on real evidence** (#230; WS-5) — re-run the
+   existing calibration tooling against the agreement study's
+   measurements; retire the provisional marker.
 8. **Close the accuracy tail** (#233 measured star SNR and constant
    sensitivity, WS-9; #150/#128 the known ~0.1 px limb bias, WS-10; #234
    realistic noise for calibrated images, WS-13; #232 end-product
@@ -166,7 +161,7 @@ answer or fails on a navigable scene.
 
 **Why:** these defects poison the validation data (Track A consumes the
 navigator's output at scale) and are exactly what a user hits first.
-Most of this track landed in the pending stack; what remains:
+The known defects:
 
 - **#221** — a one-axis ring measurement outvotes an absolute
   position constraint, reporting a wrong answer at high confidence. Top
@@ -183,6 +178,9 @@ Most of this track landed in the pending stack; what remains:
 - **#237 / #238** — two unexplained triage failures (a multi-body trio, a
   Voyager scattered-light quintet); each is one debugging session.
 - **#239** — operator decision: how to treat bodies smaller than ~5 px.
+- **#210** — the NCC techniques' covariances are orders of magnitude
+  over-tight; the covariance-model review remains open even though the
+  original coverage symptom is fixed.
 - **#24, #130, #132, #133, #180** — smaller technique-quality and
   diagnosability items (#180 wires a per-image reason through every
   failure site — cheap and it makes debugging the rest of the track
@@ -195,11 +193,12 @@ before the agreement study consumes ensemble output at scale.
 
 **Goal:** navigation quality is continuously measured, not assumed.
 
-The statistics system itself (#35) is in the pending stack. Remaining:
-the library coverage-matrix invariant (#240), and the standing practice
-of re-running the library cross-check after every calibration-affecting
-change. Small track, mostly done, listed separately because it is the
-program's QA instrument.
+The statistics system (`sd_stats_ingest` / `sd_stats_report`) is built,
+tested, and documented in the user guide. Remaining: the library
+coverage-matrix invariant (#240), and the standing practice of re-running
+the library cross-check after every calibration-affecting change. Small
+track, mostly done, listed separately because it is the program's QA
+instrument.
 
 ### Track D — Capability completion (decision gates first)
 
@@ -285,7 +284,7 @@ star-navigation bug fixes (#19, #18) can start any time.
 
 ## 5. Suggested global order
 
-1. **Now (after the stack merges):** Track A items 1-4 start in parallel
+1. **Now:** Track A items 1-4 start in parallel
    (library growth, simulator design proposal, estimator proof,
    distortion validation). Track B's #221/#222. The Track D decisions go
    to the operator as a batch — they cost nothing to decide early and
@@ -321,20 +320,16 @@ and the five decision gates, not by any implementation.
 ## 7. Issue index
 
 Every open issue, by track. **Bold** = created 2026-07-12 during this
-reconciliation. Issues expected to close when the pending stack
-merges: #12, #35, #124, #125, #136, #145, #146, #202, #203, #209 (auto-close),
-plus #173, #204, #211 to be closed manually, and #210 to be closed or
-rescoped at the operator's discretion (its coverage symptom is fixed; the
-covariance-model review remains).
+reconciliation.
 
 | Track | Issues |
 |---|---|
 | A — validation & calibration | #84, #150, #153, #172, #174, #176, #223, **#224**, **#225**, **#226**, **#227**, **#228**, **#229**, **#230**, **#232**, **#233**, **#234**, **#235** |
-| B — navigation correctness | #24, #25, #128, #130, #132, #133, #179, #180, #221, #222, **#237**, **#238**, **#239** |
-| C — statistics & QA | **#240** (and the merged #35 system as standing practice) |
+| B — navigation correctness | #24, #25, #128, #130, #132, #133, #179, #180, #210, #221, #222, **#237**, **#238**, **#239** |
+| C — statistics & QA | **#240** (plus the standing cross-check and campaign-report practice) |
 | D — capability completion | #28, #30, #47, #50, #53, #54, #55, #57, #60, #63, #66, #67, #69, #70, #71, #72, #73, #74, #75, #76, #77, #79, #93, #108, #118, #126, #139, #141, #142, #188, **#231**, **#236** |
 | E — test & docs debt | #122, #129, #177, #178, **#241**, **#242**, **#243**, **#244**, **#245** |
-| F — instruments, features, hardening | #2, #13, #15, #17, #18, #19, #21, #22, #23, #27, #33, #34, #38, #39, #43, #65, #78, #82, #81, #83, #92, #96, #97, #98, #99, #100, #101, #102, #103, #104, #105, #107, #109, #110, #119, #135, #137, #140, #143, #144, #147, #151, #152, #155, #157, #158, #181, #182, #183, #184, #185, #186, #187, #212 |
+| F — instruments, features, hardening | #2, #13, #15, #17, #18, #19, #21, #22, #23, #27, #33, #34, #38, #39, #43, #65, #78, #82, #81, #83, #92, #96, #97, #98, #99, #100, #101, #102, #103, #104, #105, #107, #109, #110, #119, #134, #135, #137, #138, #140, #143, #144, #147, #151, #152, #155, #157, #158, #181, #182, #183, #184, #185, #186, #187, #212 |
 
 Cross-listed items (listed once above, noted here): #150/#128 serve both
 Track A's limb-bias workstream and Track B's redesign; #103/#134/#126
@@ -347,6 +342,6 @@ infrastructure delivered as Track E test work.
 *History: this plan supersedes `plans/archive/ROADMAP_2026-07-12.md` (the
 issue-ordered pipeline build-out) and
 `plans/archive/FULL_PROGRAM_AFTER_MANUAL_WORK_2026-07-11.md` (the
-post-stack task inventory), consolidating both into one top-level view.
+six-track task inventory), consolidating both into one top-level view.
 The validation methodology and the curation playbook were already single
 documents and remain in place as the detail layer.*

--- a/plans/VALIDATION_AND_CALIBRATION_PLAN.md
+++ b/plans/VALIDATION_AND_CALIBRATION_PLAN.md
@@ -713,8 +713,8 @@ The curated library's operator-assigned `confidence_tier` labels serve as
 plausibility cross-checks and regression expectations for the calibrated
 output; they are never fit targets.
 
-**Problem.** `confidence`/`confidence_tier` are emitted per image but the sigmoid
-coefficients and tiers are uncalibrated defaults
+**Problem.** `confidence`/`confidence_tier` are emitted per image; the sigmoid
+coefficients and tiers are sim-anchored but not yet real-anchored
 (`nav_technique/confidence*.py`, `confidence_config.py`,
 `config_510_techniques.yaml`).
 

--- a/plans/VALIDATION_AND_CALIBRATION_PLAN.md
+++ b/plans/VALIDATION_AND_CALIBRATION_PLAN.md
@@ -8,12 +8,11 @@ each critical-report finding mapped to the workstream(s) that retire it.*
 
 ---
 
-**Premise.** The core rewrite architecture is stable (AUTONAV phases 0-9 plus the
-phase-10 hardening are merged); this plan is *calibration and validation*, not
-architecture change, so the validation effort targets stable code. The open
-phase-10 content — the curated image library, the confidence calibration, and the
-body-shape table — is exactly the WS-3/WS-5 territory below, sequenced by `plans/PROGRAM_PLAN.md`
-Track A. There is **no fixed accuracy specification** —
+**Premise.** The core architecture is stable; this plan is *calibration and
+validation*, not architecture change, so the validation effort targets stable
+code. The remaining open content — growing the curated image library and the
+real-anchored confidence calibration — is exactly the WS-3/WS-5 territory
+below, sequenced by `plans/PROGRAM_PLAN.md` Track A. There is **no fixed accuracy specification** —
 the goal is to characterize the best accuracy the system actually achieves,
 honestly and with its uncertainty, not to clear a numeric bar.
 
@@ -58,9 +57,9 @@ overlap, the methodology here is binding and the cross-track ordering there is
 binding.
 
 **Status note (2026-07-12).** Complete and out of the workstream list: WS-11
-(degenerate-rotation reporting) and WS-14 (provenance) shipped in PR #200;
-WS-5's interim half shipped in PR #208 — the confidence formulas and tier
-boundaries are now *sim-anchored* (fitted against simulated planted-truth
+(degenerate-rotation reporting) and WS-14 (provenance) are done;
+WS-5's interim half is done — the confidence formulas and tier
+boundaries are *sim-anchored* (fitted against simulated planted-truth
 recovery by the `util/calibration/` tooling), with `confidence_provisional`
 still true pending the real-anchored pass (#230). WS-6's honesty half (docs no
 longer overclaim) is done; the capability matrix remains (#231). Every
@@ -68,7 +67,7 @@ still-open workstream now has a tracking issue (cross-map below).
 
 **Two shared decisions, declared once:**
 
-- **Confidence-calibration methodology (binding for #230, formerly #173).** Confidence is
+- **Confidence-calibration methodology (binding for #230).** Confidence is
   calibrated per WS-5: per-technique reliability diagrams against measured error
   anchors (WS-1 per-technique covariance where identifiable, pairwise combined
   covariance elsewhere, WS-2 sim recovery error where no multi-object cohort
@@ -89,22 +88,22 @@ carry the methodology and acceptance criteria):
 | Workstream | GitHub issue(s) | Note |
 |---|---|---|
 | WS-0 | #224 | Estimator identifiability + bias-independence. |
-| WS-1 | #225 | The agreement study. The merged statistics system (#35) reports metadata statistics and consumes WS-1's per-frame disagreement metric; it is not the agreement study. |
+| WS-1 | #225 | The agreement study. The statistics system reports metadata statistics and consumes WS-1's per-frame disagreement metric; it is not the agreement study. |
 | WS-1b | #226 | Reprojection consistency. |
 | WS-2 | #227 (+ #223, #153, #84) | Sim de-circularization + realism. |
 | WS-17 | #228 | Distortion validation. |
 | WS-3 | #172, #174, #235 | 47-image stage first (#172), then the >=120 growth target (#235); discovery/review workflow in `plans/COHORT_CURATION_PLAN.md`. |
 | WS-4 | #229 | CI integration tiers. |
-| WS-5 | #230 (sim-anchored half done via #173/PR #208), #176 | Real-anchored recalibration once WS-1 anchors exist. |
+| WS-5 | #230 (sim-anchored half done), #176 | Real-anchored recalibration once WS-1 anchors exist. |
 | WS-6 | #231 | Capability matrix (docs-honesty half already done). |
 | WS-7 | #60 | Titan: implement or scope out. |
 | WS-8 | #53, #67 | Output bundles for all four instruments (required). PDS4 input (#34) is availability-contingent and not required for completion. |
 | WS-9 | #233, #130, #176 | Measured star SNR + sensitivity tests (#233); constants inventory (#176); limiting magnitudes (#130). |
 | WS-10 | #150, #128 | Limb bias root cause and redesign. |
-| WS-11 | done (PR #200) | Degenerate-rotation reporting. |
+| WS-11 | done | Degenerate-rotation reporting. |
 | WS-12 | #93 | Instrument appendices. |
 | WS-13 | #234 (+ #153) | Detector-noise model for the I/F render path. |
-| WS-14 | done (PR #200) | Provenance block complete. |
+| WS-14 | done | Provenance block complete. |
 | WS-15 | #236, #103, #134, #126 | Thread safety, profiling, batch-parallel throughput. |
 | WS-18 | #232 (+ #28, #66 partial) | End-product accuracy checks. |
 
@@ -708,7 +707,7 @@ provisioning in CI is the hard part; a cached fixture bundle is the mitigation.
 **Closes:** "ships a confidence it admits is meaningless."
 **Tracked by:** #230 (the real-anchored calibration — this workstream defines
 its methodology, binding per the relationship section above; the sim-anchored
-interim landed via #173 / PR #208) and #176
+interim is done) and #176
 (constants into config, which lands before calibration writes coefficients).
 The curated library's operator-assigned `confidence_tier` labels serve as
 plausibility cross-checks and regression expectations for the calibrated


### PR DESCRIPTION
Reconciles the four live plans to the current state of main, with no references to the delivered PR stack or to issues closed during its merges — the plans now read as a fresh statement of what remains.

## Changes

- **PROGRAM_PLAN.md** — the pending-merges paragraph is gone; "where we stand" describes main as it is (sim-anchored calibration in place, rank-1 ring support, statistics system built and documented, ~1,900 tests). The issue index is regenerated against the live issue list — exact coverage of all 130 open issues verified programmatically — and gains #210 (covariance-model review, now a Track B item), #134, and #138, which were open but previously unindexed.
- **ENGINEERING_PLAN.md** — status phrasing made state-based; references to closed issues in test/context notes replaced with descriptions of the current code.
- **VALIDATION_AND_CALIBRATION_PLAN.md** — status note and cross-map updated (WS-11/WS-14 done, WS-5 sim-anchored half done); premise paragraph refreshed; closed-issue provenance dropped.
- **COHORT_CURATION_PLAN.md** — Stage E hand-off wording updated for the completed sim-anchored interim.

## Operator checklist

No manual actions. Doc-only; merge whenever CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KW6fkURsA2zgrWFKjbR5JY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated planning documents to reflect the latest calibration and validation status.
  * Clarified that interim, simulation-based confidence calibration is complete and real-world recalibration remains in progress.
  * Refreshed engineering health, testing, known defects, statistics-system, and workstream status information.
  * Updated baseline guidance and removed outdated references to pending changes and prior implementation milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->