### PR TITLE
test,fix: spec-first backend test suites + 16 conformance fixes

### DIFF
--- a/docs/dev_guide/dev_guide_reprojection.rst
+++ b/docs/dev_guide/dev_guide_reprojection.rst
@@ -157,8 +157,8 @@ These propagate through the pipeline as follows:
    save/load round-trip.
 
 ``image_number`` is always ``uint16`` regardless of the dtype kwargs, capping
-a single mosaic at 65,535 contributing images. ``add()`` raises
-``OverflowError`` when that limit is exceeded.
+a single mosaic at 65,536 contributing images (image numbers 0 through
+65,535). ``add()`` raises ``OverflowError`` when that limit is exceeded.
 
 Serialization
 -------------
@@ -274,7 +274,7 @@ Implementations provided:
   ``cos(incidence)``, clamped at a minimum threshold to avoid division by
   near-zero values.
 - :class:`~spindoctor.reproj.photometric_model.LommelSeeligerModel`: divides by
-  ``cos(incidence) / (cos(incidence) + cos(emission))``.
+  ``2 * cos(incidence) / (cos(incidence) + cos(emission))``.
 - :class:`~spindoctor.reproj.photometric_model.MinnaertModel`: applies the
   Minnaert law ``cos(incidence)^k * cos(emission)^(k-1)`` for a
   user-specified exponent ``k``.

--- a/src/spindoctor/annotation/annotation_text_info.py
+++ b/src/spindoctor/annotation/annotation_text_info.py
@@ -210,6 +210,7 @@ class AnnotationTextInfo:
         # with existing text or the avoid mask. If it doesn't conflict, put the text
         # (and optionally, arrow) and quit. This gives priority to the positions
         # earliest in the list.
+        placed = False
         for text_pos, text_v, text_u in self.text_loc:
             text_v = text_v + ext_offset_v
             text_u = text_u + ext_offset_u
@@ -371,10 +372,8 @@ class AnnotationTextInfo:
             if ann_num_mask is not None:
                 ann_num_mask[v0_margin:v1_margin, u0_margin:u1_margin] = ann_num + 1
 
+            placed = True
             if not show_all_positions:
                 break
-        else:
-            if not show_all_positions:
-                return False
 
-        return True
+        return placed

--- a/src/spindoctor/cli/backplanes/backplanes_bodies.py
+++ b/src/spindoctor/cli/backplanes/backplanes_bodies.py
@@ -1,3 +1,4 @@
+import hashlib
 from typing import Any
 
 import numpy as np
@@ -37,7 +38,10 @@ def _create_simulated_body_backplane(
 
     full = np.zeros(snapshot.data.shape, dtype=np.float32)
     full_mask = np.zeros(snapshot.data.shape, dtype=bool)
-    seed = abs(hash((body_name, backplane_name))) % (2**32)
+    # hashlib, not hash(): str hashing is salted per interpreter run and the
+    # simulated values must be deterministic
+    digest = hashlib.sha256(f'{body_name}:{backplane_name}'.encode()).digest()
+    seed = int.from_bytes(digest[:8], 'big') % (2**32)
     rng = np.random.default_rng(seed)
     val = float(rng.uniform(1.0, 100.0))
     sub_mask = None

--- a/src/spindoctor/cli/backplanes/merge.py
+++ b/src/spindoctor/cli/backplanes/merge.py
@@ -1,9 +1,27 @@
+import hashlib
 from typing import Any
 
 import cspyce
 import numpy as np
 
 from spindoctor.obs import ObsSnapshot
+
+
+def fake_naif_id(body_name: str) -> int:
+    """Return a deterministic fake NAIF ID for an unknown simulated body.
+
+    The ID is derived from a hashlib digest, not ``hash()``, because str
+    hashing is salted per interpreter run and the ID must be reproducible
+    across processes.
+
+    Parameters:
+        body_name: The (unknown) body name to synthesize an ID for.
+
+    Returns:
+        An int in the range [10000, 30000), stable across processes.
+    """
+    digest = hashlib.sha256(str(body_name).encode('utf-8')).digest()
+    return 10000 + (int.from_bytes(digest[:8], 'big') % 20000)
 
 
 def merge_sources_into_master(
@@ -20,7 +38,7 @@ def merge_sources_into_master(
         rings_result: The rings result from create_ring_backplanes (dict keyed by metadata key).
 
     Returns:
-        A tuple containing the master by type, body id map, and merge info.
+        A tuple containing the master arrays by backplane type and the body id map.
     """
 
     height, width = snapshot.data.shape
@@ -49,7 +67,7 @@ def merge_sources_into_master(
         except Exception:
             if snapshot.is_simulated:
                 # Unknown body name; create a deterministic fake NAIF ID in int32 range
-                naif_id = 10000 + (abs(hash(body_name)) % 20000)
+                naif_id = fake_naif_id(body_name)
             else:
                 raise  # This is a real problem
         body_sources.append(
@@ -85,9 +103,10 @@ def merge_sources_into_master(
         for body_source in body_sources:
             body_types.update(body_source['arrays'].keys())
 
-        # 1) Body backplanes: use nearest body among bodies only; rings do not affect these
+        # 1) Body backplanes: use nearest body among bodies only; rings do not affect these.
+        # Unclaimed pixels stay zero (the writer omits all-zero planes).
         for bp_type in sorted(body_types):
-            master = np.full((height, width), np.nan, dtype=np.float32)
+            master = np.zeros((height, width), dtype=np.float32)
             for body_idx, body_source in enumerate(body_sources):
                 arrays = body_source['arrays']
                 masks = body_source['masks']
@@ -117,9 +136,12 @@ def merge_sources_into_master(
         ring_distance: np.ndarray = rings_result['distance']
 
         for bp_type in sorted(ring_arrays.keys()):
+            if bp_type == 'distance':
+                # Merge-ordering input only; never a product backplane HDU
+                continue
             if bp_type not in ring_arrays or bp_type not in ring_masks:
                 raise ValueError(f'Backplane type {bp_type} array or mask not found for rings')
-            master = np.full((height, width), np.nan, dtype=np.float32)
+            master = np.zeros((height, width), dtype=np.float32)
             src_vals = ring_arrays[bp_type]
             src_mask = ring_masks[bp_type]
             # occlusion: if any body is present and nearer than ring, mask out ring

--- a/src/spindoctor/cli/backplanes/writer.py
+++ b/src/spindoctor/cli/backplanes/writer.py
@@ -53,8 +53,11 @@ def write_fits(
         if rp['name'] != 'distance':  # not written as a master backplane type
             units_map[rp['name']] = rp.get('units', '')
 
-    # Filter out zero-only backplanes
-    filtered_master = {k: v for k, v in master_by_type.items() if np.any(v != 0.0)}
+    # Filter out backplanes with no valid pixels (unclaimed pixels are zero;
+    # non-finite values never count as valid)
+    filtered_master = {
+        k: v for k, v in master_by_type.items() if np.any((v != 0.0) & np.isfinite(v))
+    }
 
     for name, arr in filtered_master.items():
         hdu = fits.ImageHDU(data=arr.astype('float32'), name=name.upper())

--- a/src/spindoctor/config/config_helper.py
+++ b/src/spindoctor/config/config_helper.py
@@ -84,7 +84,7 @@ def get_pds4_bundle_results_root(arguments: argparse.Namespace, config: Config) 
 
     First look in arguments.bundle_results_root, then in
     config.environment.bundle_results_root, then in the environment variable
-    BUNDLE_RESULTS_ROOT.
+    NAV_BUNDLE_RESULTS_ROOT.
 
     Parameters:
         arguments: The parsed arguments. config: The configuration possibly containing the
@@ -130,7 +130,7 @@ def load_default_and_user_config(arguments: argparse.Namespace, config: Config) 
         if arguments.config_file:
             for config_file in arguments.config_file:
                 config.update_config(config_file)
-        return
+            return
     except AttributeError:
         pass
     # If they didn't, load the default config file

--- a/src/spindoctor/reproj/_serialization.py
+++ b/src/spindoctor/reproj/_serialization.py
@@ -26,8 +26,8 @@ fits
     dtype names, 2-tuples of scalars encoded as paired header keys) are stored in the
     PrimaryHDU header. Each array (and its mask when applicable) occupies
     a separate ImageHDU named ``<FIELDNAME>`` and ``<FIELDNAME>_MASK``.
-    Tuple-of-string payloads use a 1-D ``uint8`` ImageHDU (UTF-8 with ``NUL``
-    separators between entries).
+    Tuple-of-string payloads use a 1-D ``uint8`` ImageHDU (UTF-8 with a ``NUL``
+    terminator after every entry, so the entry count is unambiguous).
 
 Schema evolution
 ----------------
@@ -72,13 +72,18 @@ def tuple_of_strings_field(value: Any) -> tuple[str, ...]:
         flat = np.ravel(value)
         if flat.size == 0:
             return ()
-        # FITS: UTF-8 bytes written by ``_fits_encode_value`` for tuple-of-strings fields.
+        # FITS: UTF-8 bytes written by ``_fits_encode_value`` for tuple-of-strings
+        # fields; every entry carries a trailing NUL terminator.
         if flat.dtype == np.uint8:
             raw = flat.tobytes()
             if not raw:
                 return ()
+            if not raw.endswith(b'\0'):
+                raise ValueError(
+                    'Malformed tuple-of-strings FITS payload: missing entry terminator'
+                )
             try:
-                return tuple(p.decode('utf-8') for p in raw.split(b'\0'))
+                return tuple(p.decode('utf-8') for p in raw.split(b'\0')[:-1])
             except UnicodeDecodeError as exc:
                 _logger.error(
                     'Invalid UTF-8 in FITS tuple-of-strings buffer (%d bytes)',
@@ -456,6 +461,24 @@ def save_fits(
     fcpath.upload()
 
 
+def _fits_encode_header_scalar(hdr: Any, name: str, value: Any) -> None:
+    """Encode one scalar into a FITS header, handling non-finite floats.
+
+    FITS headers cannot hold NaN/inf values; a non-finite float is written
+    under ``<NAME>_NONF`` as its string form and reconstructed by
+    :func:`load_fits`.
+
+    Parameters:
+        hdr: The PrimaryHDU header.
+        name: Header keyword (already uppercased/suffixed by the caller).
+        value: The bool, int, float, or str value to write.
+    """
+    if isinstance(value, float) and not np.isfinite(value):
+        hdr[name + '_NONF'] = repr(value)
+    else:
+        hdr[name] = bool(value) if isinstance(value, bool) else value
+
+
 def _fits_encode_value(
     hdr: Any,
     hdus: list[Any],
@@ -487,12 +510,11 @@ def _fits_encode_value(
     elif isinstance(value, np.dtype):
         hdr[name] = value.str
     elif isinstance(value, tuple) and (len(value) == 0 or isinstance(value[0], str)):
-        # ImageHDU cannot represent NumPy Unicode dtypes; store UTF-8 bytes (uint8).
-        if len(value) == 0:
-            raw_arr = np.zeros((0,), dtype=np.uint8)
-        else:
-            raw = '\0'.join(str(s) for s in value).encode('utf-8')
-            raw_arr = np.frombuffer(raw, dtype=np.uint8).copy()
+        # ImageHDU cannot represent NumPy Unicode dtypes; store UTF-8 bytes
+        # (uint8) with a NUL terminator after EVERY entry, so N entries carry
+        # N terminators and ``('',)`` stays distinguishable from ``()``.
+        raw = ''.join(str(s) + '\0' for s in value).encode('utf-8')
+        raw_arr = np.frombuffer(raw, dtype=np.uint8).copy()
         hdus.append(fits.ImageHDU(data=_fits_image_hdu_data(raw_arr), name=name))
     elif isinstance(value, tuple):
         if len(value) != 2:
@@ -500,13 +522,13 @@ def _fits_encode_value(
                 f'Field {name!r}: only 2-tuples are supported for FITS header encoding, '
                 f'got tuple of length {len(value)}'
             )
-        hdr[name + '_0'] = value[0]
-        hdr[name + '_1'] = value[1]
+        _fits_encode_header_scalar(hdr, name + '_0', value[0])
+        _fits_encode_header_scalar(hdr, name + '_1', value[1])
     elif isinstance(value, dict):
         for k, v in value.items():
             _fits_encode_value(hdr, hdus, f'{name}__{k.upper()}', v)
     elif isinstance(value, (bool, int, float)):
-        hdr[name] = bool(value) if isinstance(value, bool) else value
+        _fits_encode_header_scalar(hdr, name, value)
     elif isinstance(value, str):
         hdr[name] = value
     else:
@@ -621,6 +643,12 @@ def load_fits(
         for name, data in hdu_map.items():
             if name not in result:
                 result[name] = data
+
+    # Reconstruct non-finite float header values first (written as
+    # ``<NAME>_NONF`` string cards because FITS headers cannot hold NaN/inf),
+    # so the tuple reconstruction below sees the plain ``_0``/``_1`` keys.
+    for k in [k for k in result if k.endswith('_NONF')]:
+        result[k[:-5]] = float(result.pop(k))
 
     # Post-process header scalars: reconstruct tuples and None sentinels
     keys_to_delete: list[str] = []

--- a/src/spindoctor/reproj/bodies.py
+++ b/src/spindoctor/reproj/bodies.py
@@ -14,6 +14,7 @@ import numpy.ma as ma
 import oops
 import polymath
 from scipy.ndimage import maximum_filter
+from scipy.ndimage import zoom as ndimage_zoom
 
 from spindoctor.config import IMAGE_LOGGER
 from spindoctor.reproj._serialization import (
@@ -1122,7 +1123,15 @@ class BodyMosaic:
 
         if not mask_only:
             ok_body_mask_inv = np.logical_or(ok_body_mask_inv, ma.getmaskarray(bp_phase))
-            ok_body_mask_inv = np.logical_or(ok_body_mask_inv, zero_mask)
+            if zero_mask.shape == ok_body_mask_inv.shape:
+                ok_body_mask_inv = np.logical_or(ok_body_mask_inv, zero_mask)
+            else:
+                # Full-frame backplane with a subimage crop: embed the
+                # subimage-shaped zero mask; everything outside the subimage
+                # has no data and is invalid.
+                zero_mask_full = np.ones(ok_body_mask_inv.shape, dtype=np.bool_)
+                zero_mask_full[v_min : v_max + 1, u_min : u_max + 1] = zero_mask
+                ok_body_mask_inv = np.logical_or(ok_body_mask_inv, zero_mask_full)
 
         ok_body_mask = np.logical_not(ok_body_mask_inv)
 
@@ -1206,8 +1215,13 @@ class BodyMosaic:
         goodvmask = np.logical_and(v_pixels >= v_min, v_pixels <= v_max)
         goodmask = goodumask & goodvmask & ~pixmask
 
-        good_u = (u_pixels[goodmask] - u_min).astype('int')
-        good_v = (v_pixels[goodmask] - v_min).astype('int')
+        # Keep the fractional pixel positions: integer indices serve the mask
+        # and backplane lookups, while the fractions drive sub-pixel sampling
+        # when zoom > 1.
+        good_u_frac = u_pixels[goodmask] - u_min
+        good_v_frac = v_pixels[goodmask] - v_min
+        good_u = good_u_frac.astype('int')
+        good_v = good_v_frac.astype('int')
         good_lat = lat_bins[goodmask]
         good_lon = lon_bins[goodmask]
 
@@ -1252,6 +1266,8 @@ class BodyMosaic:
         goodmask2 = subimg[good_v, good_u] != 0.0
         good_u = good_u[goodmask2]
         good_v = good_v[goodmask2]
+        good_u_frac = good_u_frac[goodmask2]
+        good_v_frac = good_v_frac[goodmask2]
         good_lat = good_lat[goodmask2]
         good_lon = good_lon[goodmask2]
 
@@ -1267,6 +1283,8 @@ class BodyMosaic:
             ok_on_detector = ok_body_mask[good_v + v_min, good_u + u_min]
         good_u = good_u[ok_on_detector]
         good_v = good_v[ok_on_detector]
+        good_u_frac = good_u_frac[ok_on_detector]
+        good_v_frac = good_v_frac[ok_on_detector]
         good_lat = good_lat[ok_on_detector]
         good_lon = good_lon[ok_on_detector]
 
@@ -1280,10 +1298,19 @@ class BodyMosaic:
 
         # Zoom for interpolation (always copy when zoom==1: ``subimg`` may alias
         # ``obs.data``, which can be read-only mmap, and we must not mutate the obs.)
+        # The zoomed image must be interpolated, not block-replicated: sampling
+        # it at the fractional pixel positions is what gives zoom > 1 its
+        # documented sub-pixel meaning.
         if self._zoom == 1:
             zoom_data = np.array(subimg, copy=True)
         else:
-            zoom_data = array_zoom(subimg, (self._zoom, self._zoom))
+            zoom_data = ndimage_zoom(
+                np.asarray(subimg, dtype=np.float64),
+                self._zoom,
+                order=1,
+                mode='nearest',
+                grid_mode=True,
+            )
             if not zoom_data.flags.writeable:
                 zoom_data = np.array(zoom_data, copy=True)
 
@@ -1295,7 +1322,8 @@ class BodyMosaic:
         zoom_data[bad_data_mask_zoom] = 0.0
 
         interp_data = zoom_data[
-            (good_v * self._zoom).astype('int'), (good_u * self._zoom).astype('int')
+            np.floor(good_v_frac * self._zoom).astype('int'),
+            np.floor(good_u_frac * self._zoom).astype('int'),
         ]
 
         # Apply photometric correction if requested
@@ -1527,12 +1555,13 @@ class BodyMosaic:
         replace_mask = np.logical_and(replace_mask, limits_ok)
 
         if copy_slop > 0:
-            # Expand the replace mask using the slop radius
+            # Expand the replace mask using the slop radius: candidate pixels
+            # within the slop radius of a winning pixel are also copied, as
+            # long as they pass the limits themselves.
             replace_full = np.zeros((self._n_lat, self._n_lon), dtype=np.bool_)
             replace_full[rows, cols] = replace_mask
             replace_full = maximum_filter(replace_full, copy_slop * 2 + 1)
-            replace_mask_2d = replace_full[rows, cols]
-            replace_mask = replace_mask & replace_mask_2d
+            replace_mask = replace_full[rows, cols] & limits_ok
 
         r_rows = rows[replace_mask]
         r_cols = cols[replace_mask]
@@ -1573,10 +1602,19 @@ class BodyMosaic:
         if self._n_lat == 0 or not np.any(self._has_data):
             return None
 
-        lat_min = self._lat_min_bin * self._lat_resolution - math.pi / 2.0
-        lat_max = (self._lat_min_bin + self._n_lat - 1) * self._lat_resolution - math.pi / 2.0
-        lon_min = self._lon_min_bin * self._lon_resolution
-        lon_max = ((self._lon_min_bin + self._n_lon - 1) % self._n_full_lon) * self._lon_resolution
+        # Bounds of the valid data, not of the (possibly larger) internal
+        # buffer: an all-masked contribution can grow the buffer without
+        # adding any data.
+        data_rows = np.flatnonzero(np.any(self._has_data, axis=1))
+        data_cols = np.flatnonzero(np.any(self._has_data, axis=0))
+        lat_min = (self._lat_min_bin + int(data_rows[0])) * self._lat_resolution - math.pi / 2.0
+        lat_max = (self._lat_min_bin + int(data_rows[-1])) * self._lat_resolution - math.pi / 2.0
+        lon_min = (
+            (self._lon_min_bin + int(data_cols[0])) % self._n_full_lon
+        ) * self._lon_resolution
+        lon_max = (
+            (self._lon_min_bin + int(data_cols[-1])) % self._n_full_lon
+        ) * self._lon_resolution
         return (lat_min, lat_max), (lon_min, lon_max)
 
     def to_bounded(

--- a/src/spindoctor/reproj/rings.py
+++ b/src/spindoctor/reproj/rings.py
@@ -956,10 +956,12 @@ class RingMosaic:
 
         bp_radius = bp.ring_radius(ring_body_name)
         bp_longitude = bp.ring_longitude(ring_body_name)
-        min_bp_radius = bp_radius.min()
-        max_bp_radius = bp_radius.max()
-        min_bp_longitude = bp_longitude.min()
-        max_bp_longitude = bp_longitude.max()
+        # builtins=True: a polymath Scalar comparison result cannot index a
+        # numpy array, so force plain floats here.
+        min_bp_radius = bp_radius.min(builtins=True)
+        max_bp_radius = bp_radius.max(builtins=True)
+        min_bp_longitude = bp_longitude.min(builtins=True)
+        max_bp_longitude = bp_longitude.max(builtins=True)
 
         goodr = (radii >= min_bp_radius) & (radii <= max_bp_radius)
         goodl = (longitudes >= min_bp_longitude) & (longitudes <= max_bp_longitude)
@@ -1150,6 +1152,9 @@ class RingMosaic:
                 limit=(end_u + 0.5, end_v + 0.5),
                 swap=True,
             )
+            # Every backplane product below is region-shaped; crop the data to
+            # match so masks and the region-relative pixel indices stay aligned.
+            data = data[start_v : end_v + 1, start_u : end_u + 1]
 
         bp = oops.backplane.Backplane(obs, meshgrid)
 

--- a/tests/spindoctor/annotation/__init__.py
+++ b/tests/spindoctor/annotation/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for :mod:`spindoctor.annotation`."""

--- a/tests/spindoctor/annotation/test_annotation_text_info.py
+++ b/tests/spindoctor/annotation/test_annotation_text_info.py
@@ -1,0 +1,700 @@
+"""Tests for :mod:`spindoctor.annotation.annotation_text_info`.
+
+Covers the ``AnnotationTextInfo`` accessors and string form, the cached
+``_load_font`` helper, and the ``_draw_text`` placement contract: each of the
+twelve anchor / arrow position constants places the text on the documented
+side of the reference point, earlier locations in ``text_loc`` win, the
+avoid mask and the shared annotation-number mask veto conflicting spots, and
+text that would run off the image edge is skipped without drawing or
+crashing.
+
+The tests render into small in-memory RGB canvases and assert pixel-level
+facts (ink present inside the expected bounding box, nothing outside it)
+instead of comparing golden images. Fonts come from matplotlib's bundled
+DejaVuSans.ttf (matplotlib is a required dependency), so no system font,
+network, or SPICE resource is touched.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import matplotlib
+import numpy as np
+import pytest
+from PIL import Image, ImageDraw, ImageFont
+
+from spindoctor.annotation.annotation_text_info import (
+    TEXTINFO_BOTTOM,
+    TEXTINFO_BOTTOM_ARROW,
+    TEXTINFO_BOTTOM_LEFT,
+    TEXTINFO_BOTTOM_RIGHT,
+    TEXTINFO_CENTER,
+    TEXTINFO_LEFT,
+    TEXTINFO_LEFT_ARROW,
+    TEXTINFO_RIGHT,
+    TEXTINFO_RIGHT_ARROW,
+    TEXTINFO_TOP,
+    TEXTINFO_TOP_ARROW,
+    TEXTINFO_TOP_LEFT,
+    TEXTINFO_TOP_RIGHT,
+    AnnotationTextInfo,
+    TextLocInfo,
+    _load_font,
+)
+from spindoctor.support.types import NDArrayBoolType, NDArrayIntType
+
+FONT_DIR = str(Path(matplotlib.get_data_path()) / 'fonts' / 'ttf')
+FONT_NAME = 'DejaVuSans.ttf'
+
+# Pixel tolerance for ink-inside-bounding-box assertions.
+TOL = 1
+
+# Arrow geometry from the placement contract: a 15-pixel leader plus a
+# 2-pixel gap separates the text from the reference point.
+ARROW_SPAN = 17
+
+
+def _make_info(
+    text: str = 'Hello',
+    *,
+    locs: list[TextLocInfo],
+    ref_vu: tuple[int, int] | None = (50, 50),
+    color: tuple[int, ...] = (255, 0, 0),
+    font_size: int = 10,
+) -> AnnotationTextInfo:
+    """Build an ``AnnotationTextInfo`` with test-friendly defaults.
+
+    Parameters:
+        text: The annotation text.
+        locs: Candidate text locations in priority order.
+        ref_vu: Reference point (v, u) or None for an unanchored label.
+        color: RGB color tuple for the text.
+        font_size: Font size in points.
+
+    Returns:
+        The configured ``AnnotationTextInfo`` instance.
+    """
+
+    return AnnotationTextInfo(text, locs, ref_vu, color=color, font=FONT_NAME, font_size=font_size)
+
+
+class _Canvas:
+    """A small in-memory render target mirroring ``Annotations._add_text``.
+
+    Parameters:
+        shape: The (v, u) canvas shape in pixels.
+        track_text: Whether to allocate the annotation-number mask that makes
+            successive placements avoid each other.
+    """
+
+    def __init__(self, shape: tuple[int, int] = (100, 100), *, track_text: bool = True) -> None:
+        self.shape = shape
+        self.text_layer: NDArrayIntType = np.zeros((*shape, 3), dtype=np.uint8)
+        self.graphic_layer: NDArrayIntType = np.zeros((*shape, 3), dtype=np.uint8)
+        self.ann_num_mask: NDArrayIntType | None = (
+            np.zeros((*shape, 3), dtype=np.int64) if track_text else None
+        )
+        self._image = Image.fromarray(self.text_layer, mode='RGB')
+        self._draw = ImageDraw.Draw(self._image)
+
+    def place(
+        self,
+        text_info: AnnotationTextInfo,
+        *,
+        ann_num: int = 0,
+        extfov: tuple[int, int] = (0, 0),
+        offset: tuple[float, float] = (0.0, 0.0),
+        avoid_mask: NDArrayBoolType | None = None,
+        show_all_positions: bool = False,
+    ) -> bool:
+        """Run ``_draw_text`` against this canvas.
+
+        Parameters:
+            text_info: The annotation text to place.
+            ann_num: Annotation number recorded in the placement mask.
+            extfov: Extended field-of-view margins (v, u).
+            offset: Navigation offset (dv, du) applied to coordinates.
+            avoid_mask: Optional mask of pixels the text must not cover.
+            show_all_positions: Whether to draw every valid candidate location.
+
+        Returns:
+            The boolean result of ``_draw_text``.
+        """
+
+        return text_info._draw_text(
+            ann_num=ann_num,
+            extfov=extfov,
+            offset=offset,
+            avoid_mask=avoid_mask,
+            text_layer=self.text_layer,
+            graphic_layer=self.graphic_layer,
+            ann_num_mask=self.ann_num_mask,
+            text_draw=self._draw,
+            tt_dir=FONT_DIR,
+            show_all_positions=show_all_positions,
+        )
+
+    @property
+    def text_pixels(self) -> NDArrayIntType:
+        """The rendered text layer as a (v, u, 3) uint8 array."""
+
+        return np.array(self._image, dtype=np.uint8)
+
+
+def _ink_rows_cols(pixels: NDArrayIntType) -> tuple[NDArrayIntType, NDArrayIntType]:
+    """Return the row and column indices of every non-black pixel.
+
+    Parameters:
+        pixels: A (v, u, 3) image array.
+
+    Returns:
+        Two arrays holding the v and u indices of pixels with any nonzero
+        channel.
+    """
+
+    rows, cols = np.nonzero(pixels.max(axis=2))
+    return rows, cols
+
+
+def _text_extent(text: str, font_size: int) -> tuple[int, int]:
+    """Measure the rendered extent of ``text`` with the test font.
+
+    Parameters:
+        text: The text to measure.
+        font_size: Font size in points.
+
+    Returns:
+        The (height, width) of the ink bounding box in pixels.
+    """
+
+    font = ImageFont.truetype(os.path.join(FONT_DIR, FONT_NAME), font_size)
+    draw = ImageDraw.Draw(Image.new('RGB', (1, 1)))
+    x0, y0, x1, y1 = draw.textbbox((0, 0), text, anchor='la', font=font)
+    return int(y1 - y0), int(x1 - x0)
+
+
+def _expected_text_box(
+    position: str, anchor_v: int, anchor_u: int, height: int, width: int
+) -> tuple[int, int, int, int]:
+    """Compute the contractual ink bounding box for a placement constant.
+
+    Encodes the documented meaning of each anchor: ``left`` puts the text to
+    the left of the reference point (vertically centered), ``top_right``
+    above and to the right, ``center`` centered on it, and the ``*_arrow``
+    variants push the text a further leader-plus-gap span away.
+
+    Parameters:
+        position: One of the twelve TEXTINFO placement constants.
+        anchor_v: The v coordinate the location entry names.
+        anchor_u: The u coordinate the location entry names.
+        height: Rendered text height in pixels.
+        width: Rendered text width in pixels.
+
+    Returns:
+        Inclusive (v_min, v_max, u_min, u_max) bounds for the text ink.
+    """
+
+    half_v = height // 2
+    half_u = width // 2
+    if position == TEXTINFO_LEFT:
+        return anchor_v - half_v, anchor_v - half_v + height, anchor_u - width, anchor_u
+    if position == TEXTINFO_LEFT_ARROW:
+        return (
+            anchor_v - half_v,
+            anchor_v - half_v + height,
+            anchor_u - width - ARROW_SPAN,
+            anchor_u - ARROW_SPAN,
+        )
+    if position == TEXTINFO_RIGHT:
+        return anchor_v - half_v, anchor_v - half_v + height, anchor_u, anchor_u + width
+    if position == TEXTINFO_RIGHT_ARROW:
+        return (
+            anchor_v - half_v,
+            anchor_v - half_v + height,
+            anchor_u + ARROW_SPAN,
+            anchor_u + width + ARROW_SPAN,
+        )
+    if position == TEXTINFO_TOP:
+        return anchor_v - height, anchor_v, anchor_u - half_u, anchor_u - half_u + width
+    if position == TEXTINFO_TOP_ARROW:
+        return (
+            anchor_v - height - ARROW_SPAN,
+            anchor_v - ARROW_SPAN,
+            anchor_u - half_u,
+            anchor_u - half_u + width,
+        )
+    if position == TEXTINFO_BOTTOM:
+        return anchor_v, anchor_v + height, anchor_u - half_u, anchor_u - half_u + width
+    if position == TEXTINFO_BOTTOM_ARROW:
+        return (
+            anchor_v + ARROW_SPAN,
+            anchor_v + height + ARROW_SPAN,
+            anchor_u - half_u,
+            anchor_u - half_u + width,
+        )
+    if position == TEXTINFO_CENTER:
+        return (
+            anchor_v - half_v,
+            anchor_v - half_v + height,
+            anchor_u - half_u,
+            anchor_u - half_u + width,
+        )
+    if position == TEXTINFO_TOP_LEFT:
+        return anchor_v - height, anchor_v, anchor_u - width, anchor_u
+    if position == TEXTINFO_TOP_RIGHT:
+        return anchor_v - height, anchor_v, anchor_u, anchor_u + width
+    if position == TEXTINFO_BOTTOM_LEFT:
+        return anchor_v, anchor_v + height, anchor_u - width, anchor_u
+    if position == TEXTINFO_BOTTOM_RIGHT:
+        return anchor_v, anchor_v + height, anchor_u, anchor_u + width
+    raise ValueError(f'Unexpected test position {position!r}')
+
+
+def _assert_ink_within(pixels: NDArrayIntType, box: tuple[int, int, int, int]) -> None:
+    """Assert that ink exists and every ink pixel lies inside ``box``.
+
+    Parameters:
+        pixels: A (v, u, 3) image array.
+        box: Inclusive (v_min, v_max, u_min, u_max) bounds, expanded by the
+            module tolerance before comparison.
+    """
+
+    rows, cols = _ink_rows_cols(pixels)
+    assert rows.size > 0
+    assert int(rows.min()) >= box[0] - TOL
+    assert int(rows.max()) <= box[1] + TOL
+    assert int(cols.min()) >= box[2] - TOL
+    assert int(cols.max()) <= box[3] + TOL
+
+
+# ---------------------------------------------------------------------------
+# Accessors, string form, TextLocInfo
+# ---------------------------------------------------------------------------
+
+
+def test_properties_return_constructor_values() -> None:
+    """Each documented property echoes the constructor argument."""
+
+    locs = [TextLocInfo(TEXTINFO_CENTER, 50, 50)]
+    info = _make_info('Mimas', locs=locs, ref_vu=(12, 34), font_size=14)
+    assert info.text == 'Mimas'
+    assert info.text_loc == locs
+    assert info.ref_vu == (12, 34)
+    assert info.color == (255, 0, 0)
+    assert info.font == FONT_NAME
+    assert info.font_size == 14
+
+
+def test_rgba_color_roundtrips() -> None:
+    """A four-component RGBA color is stored and returned unchanged."""
+
+    info = AnnotationTextInfo(
+        'x',
+        [TextLocInfo(TEXTINFO_CENTER, 50, 50)],
+        None,
+        color=(1, 2, 3, 4),
+        font=FONT_NAME,
+        font_size=10,
+    )
+    assert info.color == (1, 2, 3, 4)
+
+
+def test_str_summarizes_text_and_placement() -> None:
+    """The string form names the class, the text, and the reference point."""
+
+    info = _make_info('Enceladus', locs=[TextLocInfo(TEXTINFO_CENTER, 5, 6)], ref_vu=(5, 6))
+    rendered = str(info)
+    assert 'AnnotationTextInfo' in rendered
+    assert 'Enceladus' in rendered
+    assert 'Ref vu: (5, 6)' in rendered
+
+
+def test_str_truncates_after_ten_locations() -> None:
+    """More than ten candidate locations are elided with an ellipsis."""
+
+    locs = [TextLocInfo(TEXTINFO_CENTER, v, v) for v in range(11)]
+    info = _make_info(locs=locs)
+    assert str(info).endswith('...')
+
+
+def test_str_short_location_list_is_not_truncated() -> None:
+    """Ten or fewer candidate locations are all shown."""
+
+    locs = [TextLocInfo(TEXTINFO_CENTER, v, v) for v in range(10)]
+    info = _make_info(locs=locs)
+    assert '...' not in str(info)
+
+
+def test_repr_matches_str() -> None:
+    """``__repr__`` delegates to ``__str__``."""
+
+    info = _make_info(locs=[TextLocInfo(TEXTINFO_CENTER, 50, 50)])
+    assert repr(info) == str(info)
+
+
+def test_text_loc_info_field_names() -> None:
+    """``TextLocInfo`` carries a placement label and its (v, u) coordinates."""
+
+    assert TextLocInfo._fields == ('label', 'label_v', 'label_u')
+
+
+# ---------------------------------------------------------------------------
+# _load_font
+# ---------------------------------------------------------------------------
+
+
+def test_load_font_returns_freetype_font() -> None:
+    """A valid path and size yield a PIL FreeTypeFont."""
+
+    font = _load_font(os.path.join(FONT_DIR, FONT_NAME), 10)
+    assert isinstance(font, ImageFont.FreeTypeFont)
+
+
+def test_load_font_caches_identical_arguments() -> None:
+    """Repeated loads of the same path and size return the cached object."""
+
+    first = _load_font(os.path.join(FONT_DIR, FONT_NAME), 11)
+    second = _load_font(os.path.join(FONT_DIR, FONT_NAME), 11)
+    assert first is second
+
+
+def test_load_font_distinct_sizes_are_not_shared() -> None:
+    """The cache is keyed on size as well as path."""
+
+    small = _load_font(os.path.join(FONT_DIR, FONT_NAME), 9)
+    large = _load_font(os.path.join(FONT_DIR, FONT_NAME), 21)
+    assert small is not large
+
+
+def test_load_font_missing_file_raises_with_config_hint() -> None:
+    """A bad path raises FileNotFoundError naming the path and the config key."""
+
+    bad_path = os.path.join(FONT_DIR, 'NoSuchFont.ttf')
+    with pytest.raises(FileNotFoundError, match=r'NoSuchFont\.ttf.*truetype_font_dir'):
+        _load_font(bad_path, 12)
+
+
+# ---------------------------------------------------------------------------
+# _draw_text: anchor placement contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'position',
+    [
+        TEXTINFO_LEFT,
+        TEXTINFO_RIGHT,
+        TEXTINFO_TOP,
+        TEXTINFO_BOTTOM,
+        TEXTINFO_CENTER,
+        TEXTINFO_TOP_LEFT,
+        TEXTINFO_TOP_RIGHT,
+        TEXTINFO_BOTTOM_LEFT,
+        TEXTINFO_BOTTOM_RIGHT,
+    ],
+)
+def test_plain_positions_place_ink_on_documented_side(position: str) -> None:
+    """Each non-arrow constant places all ink in the documented region.
+
+    Parameters:
+        position: The TEXTINFO placement constant under test.
+    """
+
+    height, width = _text_extent('Hello', 10)
+    canvas = _Canvas()
+    info = _make_info(locs=[TextLocInfo(position, 50, 50)])
+    placed = canvas.place(info)
+    assert placed is True
+    _assert_ink_within(canvas.text_pixels, _expected_text_box(position, 50, 50, height, width))
+
+
+@pytest.mark.parametrize(
+    'position',
+    [TEXTINFO_LEFT_ARROW, TEXTINFO_RIGHT_ARROW, TEXTINFO_TOP_ARROW, TEXTINFO_BOTTOM_ARROW],
+)
+def test_arrow_positions_offset_text_and_draw_leader(position: str) -> None:
+    """Arrow constants push the text out and draw a leader in the graphic layer.
+
+    The text sits a leader-plus-gap span beyond the plain anchor position and
+    the arrow ink stays inside the corridor between the text and the
+    reference point.
+
+    Parameters:
+        position: The TEXTINFO arrow placement constant under test.
+    """
+
+    height, width = _text_extent('Hello', 10)
+    canvas = _Canvas()
+    info = _make_info(locs=[TextLocInfo(position, 50, 50)])
+    placed = canvas.place(info)
+    assert placed is True
+    _assert_ink_within(canvas.text_pixels, _expected_text_box(position, 50, 50, height, width))
+
+    arrow_rows, arrow_cols = _ink_rows_cols(canvas.graphic_layer)
+    assert arrow_rows.size > 0
+    if position in (TEXTINFO_LEFT_ARROW, TEXTINFO_RIGHT_ARROW):
+        assert int(arrow_rows.min()) >= 50 - 7
+        assert int(arrow_rows.max()) <= 50 + 7
+        if position == TEXTINFO_LEFT_ARROW:
+            assert int(arrow_cols.min()) >= 50 - ARROW_SPAN
+            assert int(arrow_cols.max()) <= 50 + 2
+        else:
+            assert int(arrow_cols.min()) >= 50 - 2
+            assert int(arrow_cols.max()) <= 50 + ARROW_SPAN
+    else:
+        assert int(arrow_cols.min()) >= 50 - 7
+        assert int(arrow_cols.max()) <= 50 + 7
+        if position == TEXTINFO_TOP_ARROW:
+            assert int(arrow_rows.min()) >= 50 - ARROW_SPAN
+            assert int(arrow_rows.max()) <= 50 + 2
+        else:
+            assert int(arrow_rows.min()) >= 50 - 2
+            assert int(arrow_rows.max()) <= 50 + ARROW_SPAN
+
+
+def test_ink_uses_requested_color_channels() -> None:
+    """Pure red text leaves the green and blue channels untouched."""
+
+    canvas = _Canvas()
+    info = _make_info(locs=[TextLocInfo(TEXTINFO_CENTER, 50, 50)], color=(255, 0, 0))
+    canvas.place(info)
+    pixels = canvas.text_pixels
+    assert int(pixels[:, :, 0].max()) > 0
+    assert int(pixels[:, :, 1].max()) == 0
+    assert int(pixels[:, :, 2].max()) == 0
+
+
+def test_offset_and_extfov_shift_the_anchor() -> None:
+    """Location coordinates are extended-FOV values shifted by offset - extfov.
+
+    With extfov margins (10, 10) and a navigation offset of (5, -3), an
+    anchor at extended coordinates (60, 60) lands at display coordinates
+    (55, 47).
+
+    """
+
+    height, width = _text_extent('Hello', 10)
+    canvas = _Canvas()
+    info = _make_info(locs=[TextLocInfo(TEXTINFO_CENTER, 60, 60)], ref_vu=(60, 60))
+    placed = canvas.place(info, extfov=(10, 10), offset=(5.0, -3.0))
+    assert placed is True
+    box = _expected_text_box(TEXTINFO_CENTER, 55, 47, height, width)
+    _assert_ink_within(canvas.text_pixels, box)
+
+
+def test_ref_vu_none_places_normally() -> None:
+    """An unanchored label (ref_vu None) skips the FOV check and still places."""
+
+    canvas = _Canvas()
+    info = _make_info(locs=[TextLocInfo(TEXTINFO_CENTER, 50, 50)], ref_vu=None)
+    placed = canvas.place(info)
+    assert placed is True
+    rows, _ = _ink_rows_cols(canvas.text_pixels)
+    assert rows.size > 0
+
+
+# ---------------------------------------------------------------------------
+# _draw_text: priority, collision avoidance
+# ---------------------------------------------------------------------------
+
+
+def test_first_valid_location_wins() -> None:
+    """Locations earlier in text_loc take priority; only the first is drawn."""
+
+    canvas = _Canvas()
+    info = _make_info(
+        locs=[TextLocInfo(TEXTINFO_CENTER, 30, 30), TextLocInfo(TEXTINFO_CENTER, 70, 70)],
+        ref_vu=(30, 30),
+    )
+    placed = canvas.place(info)
+    assert placed is True
+    rows, _ = _ink_rows_cols(canvas.text_pixels)
+    assert int(rows.max()) < 50
+
+
+def test_show_all_positions_draws_every_valid_location() -> None:
+    """show_all_positions renders the text at each candidate that fits."""
+
+    canvas = _Canvas()
+    info = _make_info(
+        locs=[TextLocInfo(TEXTINFO_CENTER, 30, 30), TextLocInfo(TEXTINFO_CENTER, 70, 70)],
+        ref_vu=(30, 30),
+    )
+    placed = canvas.place(info, show_all_positions=True)
+    assert placed is True
+    rows, _ = _ink_rows_cols(canvas.text_pixels)
+    assert int(rows.min()) < 50
+    assert int(rows.max()) > 50
+
+
+def test_avoid_mask_forces_fallback_location() -> None:
+    """A masked-off first choice pushes the text to the next candidate."""
+
+    canvas = _Canvas()
+    avoid = np.zeros(canvas.shape, dtype=bool)
+    avoid[10:50, 10:60] = True
+    info = _make_info(
+        locs=[TextLocInfo(TEXTINFO_CENTER, 30, 30), TextLocInfo(TEXTINFO_CENTER, 70, 70)],
+        ref_vu=(30, 30),
+    )
+    placed = canvas.place(info, avoid_mask=avoid)
+    assert placed is True
+    rows, _ = _ink_rows_cols(canvas.text_pixels)
+    assert int(rows.min()) > 50
+
+
+def test_avoid_mask_everywhere_returns_false() -> None:
+    """With every candidate masked off the text is not placed at all."""
+
+    canvas = _Canvas()
+    avoid = np.ones(canvas.shape, dtype=bool)
+    info = _make_info(
+        locs=[TextLocInfo(TEXTINFO_CENTER, 30, 30), TextLocInfo(TEXTINFO_CENTER, 70, 70)],
+        ref_vu=(30, 30),
+    )
+    placed = canvas.place(info, avoid_mask=avoid)
+    assert placed is False
+    rows, _ = _ink_rows_cols(canvas.text_pixels)
+    assert rows.size == 0
+
+
+def test_ann_num_mask_records_placement() -> None:
+    """A successful placement stamps ann_num + 1 into the shared mask."""
+
+    canvas = _Canvas()
+    info = _make_info(locs=[TextLocInfo(TEXTINFO_CENTER, 50, 50)])
+    canvas.place(info, ann_num=3)
+    assert canvas.ann_num_mask is not None
+    assert int(canvas.ann_num_mask.max()) == 4
+
+
+def test_second_annotation_avoids_first() -> None:
+    """Text already stamped into the mask pushes later text to its fallback."""
+
+    canvas = _Canvas()
+    first = _make_info(locs=[TextLocInfo(TEXTINFO_CENTER, 30, 30)], ref_vu=(30, 30))
+    placed_first = canvas.place(first, ann_num=0)
+    assert placed_first is True
+    before = canvas.text_pixels
+
+    second = _make_info(
+        locs=[TextLocInfo(TEXTINFO_CENTER, 30, 30), TextLocInfo(TEXTINFO_CENTER, 70, 70)],
+        ref_vu=(30, 30),
+    )
+    placed_second = canvas.place(second, ann_num=1)
+    assert placed_second is True
+    new_ink = canvas.text_pixels.astype(np.int64) - before.astype(np.int64)
+    rows, _ = np.nonzero(new_ink.max(axis=2) > 0)
+    assert rows.size > 0
+    assert int(rows.min()) > 50
+
+
+# ---------------------------------------------------------------------------
+# _draw_text: edges and degenerate inputs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'anchor',
+    [(1, 1), (1, 50), (1, 98), (50, 1), (50, 98), (98, 1), (98, 50), (98, 98)],
+)
+def test_anchor_at_image_edge_fails_cleanly(anchor: tuple[int, int]) -> None:
+    """Text that would cross any image edge is skipped without drawing.
+
+    Parameters:
+        anchor: The (v, u) anchor point near an edge or corner of the canvas.
+    """
+
+    canvas = _Canvas()
+    info = _make_info(locs=[TextLocInfo(TEXTINFO_CENTER, anchor[0], anchor[1])], ref_vu=anchor)
+    placed = canvas.place(info)
+    assert placed is False
+    rows, _ = _ink_rows_cols(canvas.text_pixels)
+    assert rows.size == 0
+
+
+@pytest.mark.parametrize('ref_vu', [(150, 50), (50, 150)])
+def test_ref_point_outside_fov_skips_without_drawing(ref_vu: tuple[int, int]) -> None:
+    """A reference point outside the layer is not labeled but counts as done.
+
+    ``_draw_text`` documents returning True only on successful placement, but
+    an off-FOV reference is deliberately treated as 'nothing to label' (the
+    in-code comment) so the caller does not warn about it.
+
+    Parameters:
+        ref_vu: The out-of-bounds reference point.
+    """
+
+    canvas = _Canvas()
+    info = _make_info(locs=[TextLocInfo(TEXTINFO_CENTER, 50, 50)], ref_vu=ref_vu)
+    placed = canvas.place(info)
+    assert placed is True
+    rows, _ = _ink_rows_cols(canvas.text_pixels)
+    assert rows.size == 0
+
+
+def test_empty_text_places_without_ink() -> None:
+    """An empty string is accepted and renders no pixels."""
+
+    canvas = _Canvas()
+    info = _make_info('', locs=[TextLocInfo(TEXTINFO_CENTER, 50, 50)])
+    placed = canvas.place(info)
+    assert placed is True
+    rows, _ = _ink_rows_cols(canvas.text_pixels)
+    assert rows.size == 0
+
+
+def test_multiline_text_renders_taller_than_single_line() -> None:
+    """A two-line label occupies a taller ink span than its first line alone."""
+
+    single = _Canvas()
+    single.place(_make_info('AB', locs=[TextLocInfo(TEXTINFO_CENTER, 50, 50)], font_size=12))
+    single_rows, _ = _ink_rows_cols(single.text_pixels)
+
+    multi = _Canvas()
+    placed = multi.place(
+        _make_info('AB\nCD', locs=[TextLocInfo(TEXTINFO_CENTER, 50, 50)], font_size=12)
+    )
+    assert placed is True
+    multi_rows, _ = _ink_rows_cols(multi.text_pixels)
+    single_span = int(single_rows.max()) - int(single_rows.min())
+    multi_span = int(multi_rows.max()) - int(multi_rows.min())
+    assert multi_span > single_span
+
+
+def test_unknown_position_label_raises() -> None:
+    """A location entry with an unrecognized label raises ValueError."""
+
+    canvas = _Canvas()
+    info = _make_info(locs=[TextLocInfo('diagonal', 50, 50)])
+    with pytest.raises(ValueError, match='Unknown text position: diagonal'):
+        canvas.place(info)
+
+
+def test_empty_location_list_returns_false() -> None:
+    """With no candidate locations at all the text cannot be placed."""
+
+    canvas = _Canvas()
+    info = _make_info(locs=[])
+    placed = canvas.place(info)
+    assert placed is False
+
+
+def test_show_all_positions_reports_failure_when_nothing_fits() -> None:
+    """Per the Returns contract, no successful placement must yield False.
+
+    The docstring says the method returns 'True if the text was successfully
+    placed, False otherwise', but with show_all_positions=True the for-else
+    fallthrough skips the failure return and reports True even though nothing
+    was drawn.
+
+    """
+
+    canvas = _Canvas()
+    info = _make_info(locs=[TextLocInfo(TEXTINFO_CENTER, 1, 1)], ref_vu=None)
+    placed = canvas.place(info, show_all_positions=True)
+    rows, _ = _ink_rows_cols(canvas.text_pixels)
+    assert rows.size == 0
+    assert placed is False

--- a/tests/spindoctor/cli/backplanes/conftest.py
+++ b/tests/spindoctor/cli/backplanes/conftest.py
@@ -1,0 +1,327 @@
+"""Shared hermetic fixtures for the backplane pipeline test suite.
+
+The backplane backend is driven by an ``ObsSnapshot`` plus a ``Config``.  Real
+observations require SPICE kernels and PDS holdings, neither of which is available
+in CI, so these helpers build genuine ``oops`` snapshots on the built-in SSB path
+and J2000 frame (no kernels needed) plus duck-typed stand-ins for the pieces that
+would otherwise reach SPICE: the per-image body inventory, the full-frame
+``oops.Backplane``, and the configuration object.
+"""
+
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+import oops
+from oops.observation.snapshot import Snapshot
+
+from spindoctor.config import Config
+from spindoctor.obs import Obs, ObsSnapshotInst
+from spindoctor.support.types import PathLike
+
+
+class HermeticObs(ObsSnapshotInst):
+    """Hermetic ``ObsSnapshotInst`` that needs no SPICE kernels or holdings.
+
+    Wraps a real ``oops`` Snapshot on the built-in SSB path and J2000 frame with a
+    FlatFOV, so the geometry-free code paths (FOV clipping, meshgrid construction,
+    ``oops.Backplane`` instantiation) exercise genuine oops objects.  The
+    ``_closest_planet`` attribute is stamped onto the wrapped Snapshot before
+    construction, which bypasses the SPICE-driven closest-planet search in
+    ``ObsSnapshot.__init__``.
+
+    A canned inventory dict stands in for the SPICE-driven ``Snapshot.inventory``
+    so the non-simulated body path can run hermetically; requested body lists are
+    recorded on ``inventory_calls``.
+    """
+
+    sim_inventory: dict[str, Any]
+    sim_body_mask_map: dict[str, Any]
+    sim_body_order_near_to_far: list[str]
+    sim_body_index_map: Any
+
+    def __init__(
+        self,
+        snapshot: Snapshot,
+        *,
+        canned_inventory: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Wrap a Snapshot, then attach the canned inventory and call recorder.
+
+        Parameters:
+            snapshot: The oops Snapshot to wrap (its ``__dict__`` is absorbed).
+            canned_inventory: Inventory dict returned by :meth:`inventory`; None
+                makes any inventory call an error.
+            **kwargs: Forwarded to ``ObsSnapshotInst`` (notably ``simulated`` and
+                ``extfov_margin_vu``).
+        """
+        super().__init__(snapshot, **kwargs)
+        # Must be set after super().__init__: ObsSnapshot replaces self.__dict__.
+        self._canned_inventory = canned_inventory
+        self.inventory_calls: list[list[str]] = []
+
+    @staticmethod
+    def from_file(
+        path: PathLike,
+        *,
+        config: Config | None = None,
+        extfov_margin_vu: tuple[int, int] | None = None,
+        **kwargs: Any,
+    ) -> Obs:
+        """Unsupported; tests construct HermeticObs directly via make_snapshot.
+
+        Parameters:
+            path: Ignored.
+            config: Ignored.
+            extfov_margin_vu: Ignored.
+            **kwargs: Ignored.
+        """
+        raise NotImplementedError('HermeticObs is constructed directly in tests')
+
+    def star_min_usable_vmag(self) -> float:
+        """Return a fixed lower star magnitude bound (unused by backplanes)."""
+        return 0.0
+
+    def star_max_usable_vmag(self) -> float:
+        """Return a fixed upper star magnitude bound (unused by backplanes)."""
+        return 30.0
+
+    def get_public_metadata(self) -> dict[str, Any]:
+        """Return an empty public-metadata dict (unused by backplanes)."""
+        return {}
+
+    def inventory(self, bodies: list[str], **kwargs: Any) -> dict[str, Any]:
+        """Return the canned inventory, recording the requested body list.
+
+        Parameters:
+            bodies: Body names the caller asked to inventory.
+            **kwargs: Ignored (e.g. ``return_type``).
+        """
+        self.inventory_calls.append(list(bodies))
+        if self._canned_inventory is None:
+            raise RuntimeError('HermeticObs was built without a canned inventory')
+        return self._canned_inventory
+
+
+def make_snapshot(
+    *,
+    shape_vu: tuple[int, int] = (10, 12),
+    closest_planet: str | None = 'SATURN',
+    simulated: bool = False,
+    sim_inventory: dict[str, Any] | None = None,
+    sim_body_mask_map: dict[str, Any] | None = None,
+    sim_body_order_near_to_far: list[str] | None = None,
+    sim_body_index_map: Any = None,
+    canned_inventory: dict[str, Any] | None = None,
+) -> HermeticObs:
+    """Build a hermetic snapshot observation with zero-filled image data.
+
+    Parameters:
+        shape_vu: Image shape as (rows, columns).
+        closest_planet: Planet name stamped as ``_closest_planet`` (None for a
+            no-planet observation).
+        simulated: Whether the observation reports ``is_simulated``.
+        sim_inventory: Simulated per-body inventory dict.
+        sim_body_mask_map: Simulated body-name to full-frame boolean mask map.
+        sim_body_order_near_to_far: Simulated body names ordered near to far.
+        sim_body_index_map: Simulated full-frame per-pixel body index map.
+        canned_inventory: Inventory dict served by ``HermeticObs.inventory``.
+
+    Returns:
+        A fully constructed :class:`HermeticObs`.
+    """
+    size_v, size_u = shape_vu
+    fov = oops.fov.FlatFOV((0.001, 0.001), (size_u, size_v))
+    snapshot = Snapshot(
+        axes=('v', 'u'),
+        tstart=0.0,
+        texp=1.0,
+        fov=fov,
+        path='SSB',
+        frame='J2000',
+    )
+    snapshot.insert_subfield('data', np.zeros(shape_vu, dtype=np.float32))
+    snapshot._closest_planet = closest_planet
+    obs = HermeticObs(
+        snapshot,
+        canned_inventory=canned_inventory,
+        extfov_margin_vu=(0, 0),
+        simulated=simulated,
+    )
+    obs.sim_inventory = sim_inventory if sim_inventory is not None else {}
+    obs.sim_body_mask_map = sim_body_mask_map if sim_body_mask_map is not None else {}
+    obs.sim_body_order_near_to_far = (
+        sim_body_order_near_to_far if sim_body_order_near_to_far is not None else []
+    )
+    obs.sim_body_index_map = sim_body_index_map
+    return obs
+
+
+def inventory_entry(
+    *,
+    u_min: int,
+    u_max: int,
+    v_min: int,
+    v_max: int,
+    body_range: float,
+    center_uv: tuple[float, float] | None = None,
+    u_pixel_size: float | None = None,
+    v_pixel_size: float | None = None,
+) -> dict[str, Any]:
+    """Build a per-body inventory entry in the shape the backplane code consumes.
+
+    Parameters:
+        u_min: Unclipped bounding-box minimum u pixel.
+        u_max: Unclipped bounding-box maximum u pixel.
+        v_min: Unclipped bounding-box minimum v pixel.
+        v_max: Unclipped bounding-box maximum v pixel.
+        body_range: Distance from the observer to the body in km.
+        center_uv: Optional (u, v) body center used by the writer sidecar.
+        u_pixel_size: Optional apparent body size in u pixels.
+        v_pixel_size: Optional apparent body size in v pixels.
+
+    Returns:
+        Inventory dict with the unclipped bounding-box and range keys.
+    """
+    entry: dict[str, Any] = {
+        'u_min_unclipped': u_min,
+        'u_max_unclipped': u_max,
+        'v_min_unclipped': v_min,
+        'v_max_unclipped': v_max,
+        'range': body_range,
+    }
+    if center_uv is not None:
+        entry['center_uv'] = [center_uv[0], center_uv[1]]
+    if u_pixel_size is not None:
+        entry['u_pixel_size'] = u_pixel_size
+    if v_pixel_size is not None:
+        entry['v_pixel_size'] = v_pixel_size
+    return entry
+
+
+class StubVals:
+    """Stand-in for an oops Scalar result exposing only the ``mvals`` masked array."""
+
+    def __init__(self, mvals: Any) -> None:
+        """Wrap a masked array.
+
+        Parameters:
+            mvals: The ``numpy.ma.MaskedArray`` to expose as ``mvals``.
+        """
+        self.mvals = mvals
+
+
+class FakeRingBackplane:
+    """Fake full-frame ``oops.Backplane`` whose methods return canned masked arrays.
+
+    Configured with a mapping from method name to masked array; attribute lookup for
+    a configured method returns a callable that records ``(method, target, kwargs)``
+    in ``calls`` and returns the canned array wrapped in :class:`StubVals`.
+    """
+
+    def __init__(self, method_values: dict[str, Any]) -> None:
+        """Store the canned per-method masked arrays.
+
+        Parameters:
+            method_values: Mapping from oops Backplane method name to the
+                ``numpy.ma.MaskedArray`` the method should return.
+        """
+        self.method_values = method_values
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def __getattr__(self, method: str) -> Callable[..., StubVals]:
+        """Resolve a configured method name to a recording callable.
+
+        Parameters:
+            method: The oops Backplane method name being looked up.
+        """
+        method_values = self.__dict__['method_values']
+        if method not in method_values:
+            raise AttributeError(method)
+
+        def _call(target: str, **kwargs: Any) -> StubVals:
+            self.calls.append((method, target, dict(kwargs)))
+            return StubVals(method_values[method])
+
+        return _call
+
+
+BodyValuesFn = Callable[[str, str, tuple[int, int]], Any]
+
+
+def make_fake_body_backplane_cls(values_fn: BodyValuesFn) -> type:
+    """Build a fake ``oops.Backplane`` class for the per-body meshgrid path.
+
+    The returned class mimics ``Backplane(obs, meshgrid=...)``: any method name
+    resolves to a callable taking the body name, and the callable returns a
+    :class:`StubVals` wrapping ``values_fn(method, body_name, meshgrid_shape_vu)``.
+
+    Parameters:
+        values_fn: Callback mapping (method, body_name, meshgrid shape (nv, nu))
+            to the ``numpy.ma.MaskedArray`` to return.
+
+    Returns:
+        A class suitable for monkeypatching over
+        ``spindoctor.cli.backplanes.backplanes_bodies.Backplane``.
+    """
+
+    class _FakeBodyBackplane:
+        def __init__(self, obs: Any, meshgrid: Any = None) -> None:
+            self.meshgrid_shape = cast('tuple[int, int]', tuple(int(x) for x in meshgrid.shape))
+
+        def __getattr__(self, method: str) -> Callable[[str], StubVals]:
+            shape = self.__dict__['meshgrid_shape']
+
+            def _call(body_name: str) -> StubVals:
+                return StubVals(values_fn(method, body_name, shape))
+
+            return _call
+
+    return _FakeBodyBackplane
+
+
+class FakeBackplanesConfig:
+    """Duck-typed ``Config`` stand-in exposing only what the backplane modules read.
+
+    ``backplanes`` is a namespace whose ``bodies`` / ``rings`` attributes exist only
+    when configured, matching the modules' getattr-with-default access pattern.
+    Satellite queries are recorded on ``satellites_calls``.
+    """
+
+    def __init__(
+        self,
+        *,
+        bodies: list[dict[str, Any]] | None = None,
+        rings: list[dict[str, Any]] | None = None,
+        satellites: dict[str, list[str]] | None = None,
+    ) -> None:
+        """Build the fake config.
+
+        Parameters:
+            bodies: ``backplanes.bodies`` entry list, or None to omit the attribute.
+            rings: ``backplanes.rings`` entry list, or None to omit the attribute.
+            satellites: Planet name to satellite-name-list map for
+                :meth:`satellites`.
+        """
+        self.backplanes = SimpleNamespace()
+        if bodies is not None:
+            self.backplanes.bodies = bodies
+        if rings is not None:
+            self.backplanes.rings = rings
+        self._satellites = satellites if satellites is not None else {}
+        self.satellites_calls: list[str] = []
+
+    def satellites(self, planet: str) -> list[str]:
+        """Record and answer a satellite-list query.
+
+        Parameters:
+            planet: Planet name being queried.
+        """
+        self.satellites_calls.append(planet)
+        return list(self._satellites.get(planet.upper(), []))
+
+    def as_config(self) -> Config:
+        """Return self cast to ``Config`` for passing into typed call sites."""
+        return cast(Config, self)

--- a/tests/spindoctor/cli/backplanes/conftest.py
+++ b/tests/spindoctor/cli/backplanes/conftest.py
@@ -242,6 +242,12 @@ class FakeRingBackplane:
             raise AttributeError(method)
 
         def _call(target: str, **kwargs: Any) -> StubVals:
+            """Record the invocation and return the canned array for this method.
+
+            Parameters:
+                target: The oops target key the method is evaluated on.
+                **kwargs: Additional method keyword arguments, recorded verbatim.
+            """
             self.calls.append((method, target, dict(kwargs)))
             return StubVals(method_values[method])
 
@@ -268,13 +274,31 @@ def make_fake_body_backplane_cls(values_fn: BodyValuesFn) -> type:
     """
 
     class _FakeBodyBackplane:
+        """Fake per-body oops Backplane that answers every method via ``values_fn``."""
+
         def __init__(self, obs: Any, meshgrid: Any = None) -> None:
+            """Capture the meshgrid shape; the observation itself is unused.
+
+            Parameters:
+                obs: The observation the real Backplane would wrap (ignored).
+                meshgrid: The oops Meshgrid whose shape sizes the returned arrays.
+            """
             self.meshgrid_shape = cast('tuple[int, int]', tuple(int(x) for x in meshgrid.shape))
 
         def __getattr__(self, method: str) -> Callable[[str], StubVals]:
+            """Resolve any method name to a callable that evaluates ``values_fn``.
+
+            Parameters:
+                method: The oops Backplane method name being looked up.
+            """
             shape = self.__dict__['meshgrid_shape']
 
             def _call(body_name: str) -> StubVals:
+                """Return the canned array for this method, body, and meshgrid shape.
+
+                Parameters:
+                    body_name: The body the backplane method is evaluated for.
+                """
                 return StubVals(values_fn(method, body_name, shape))
 
             return _call

--- a/tests/spindoctor/cli/backplanes/test_backplanes.py
+++ b/tests/spindoctor/cli/backplanes/test_backplanes.py
@@ -100,28 +100,28 @@ def test_default_config_angle_backplanes_declare_radians() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _image_files(tmp_path: Path, *stubs: str) -> ImageFiles:
+def _image_files(images_root: FCPath, *stubs: str) -> ImageFiles:
     """Build an ImageFiles batch with one local image file per stub.
 
     Parameters:
-        tmp_path: Directory that receives the placeholder image files.
+        images_root: Directory that receives the placeholder image files.
         *stubs: Results path stubs, one per image.
     """
     files = []
     for stub in stubs or ('IMG1',):
-        img = tmp_path / f'{stub}.IMG'
+        img = images_root / f'{stub}.IMG'
         img.write_bytes(b'')
         files.append(
             ImageFile(
-                image_file_url=FCPath(str(img)),
-                label_file_url=FCPath(str(img)),
+                image_file_url=img,
+                label_file_url=img,
                 results_path_stub=stub,
             )
         )
     return ImageFiles(image_files=files)
 
 
-def _write_nav_metadata(nav_root: Path, stub: str, doc: dict[str, Any]) -> None:
+def _write_nav_metadata(nav_root: FCPath, stub: str, doc: dict[str, Any]) -> None:
     """Write a navigation metadata JSON for the given stub.
 
     Parameters:
@@ -132,14 +132,14 @@ def _write_nav_metadata(nav_root: Path, stub: str, doc: dict[str, Any]) -> None:
     (nav_root / f'{stub}_metadata.json').write_text(json.dumps(doc))
 
 
-def _roots(tmp_path: Path) -> tuple[Path, Path]:
+def _roots(root: FCPath) -> tuple[FCPath, FCPath]:
     """Create and return (nav_results_root, backplane_results_root) directories.
 
     Parameters:
-        tmp_path: pytest-provided temporary directory.
+        root: Temporary directory the roots are created under.
     """
-    nav_root = tmp_path / 'nav'
-    bp_root = tmp_path / 'bp'
+    nav_root = root / 'nav'
+    bp_root = root / 'bp'
     nav_root.mkdir()
     bp_root.mkdir()
     return nav_root, bp_root
@@ -158,6 +158,8 @@ def _obs_class_for(obs: Any) -> tuple[type[ObsSnapshotInst], list[dict[str, Any]
     from_file_calls: list[dict[str, Any]] = []
 
     class _DriverObs(HermeticObs):
+        """HermeticObs whose from_file records its arguments and returns ``obs``."""
+
         calls: ClassVar[list[dict[str, Any]]] = from_file_calls
 
         @staticmethod
@@ -168,6 +170,14 @@ def _obs_class_for(obs: Any) -> tuple[type[ObsSnapshotInst], list[dict[str, Any]
             extfov_margin_vu: tuple[int, int] | None = None,
             **kwargs: Any,
         ) -> Obs:
+            """Record the call and return the fixed observation.
+
+            Parameters:
+                path: Image file path requested by the driver (recorded).
+                config: Ignored.
+                extfov_margin_vu: Extended-FOV margin requested (recorded).
+                **kwargs: Ignored.
+            """
             from_file_calls.append({'path': path, 'extfov_margin_vu': extfov_margin_vu})
             return cast(Obs, obs)
 
@@ -187,20 +197,46 @@ def _stub_pipeline(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
     sentinel_master: dict[str, Any] = {'sentinel_plane': np.ones(SHAPE_VU, dtype=np.float32)}
 
     def fake_bodies(snapshot: Any, config: Any, *, logger: Any) -> dict[str, Any]:
+        """Record the snapshot and return a one-body sentinel bodies_result.
+
+        Parameters:
+            snapshot: The observation handed to the body stage (recorded).
+            config: Ignored.
+            logger: Ignored.
+        """
         calls['bodies'].append(snapshot)
         return {'FAKEBODY': {}}
 
     def fake_rings(snapshot: Any, config: Any, *, logger: Any) -> None:
+        """Record the snapshot and report no ring backplanes.
+
+        Parameters:
+            snapshot: The observation handed to the ring stage (recorded).
+            config: Ignored.
+            logger: Ignored.
+        """
         calls['rings'].append(snapshot)
         return None
 
     def fake_merge(
         snapshot: Any, *, bodies_result: Any, rings_result: Any
     ) -> tuple[dict[str, Any], np.ndarray]:
+        """Record the per-source results and return the sentinel master arrays.
+
+        Parameters:
+            snapshot: The observation handed to the merge (sizes the ID map).
+            bodies_result: Body-stage result (recorded).
+            rings_result: Ring-stage result (recorded).
+        """
         calls['merge'].append({'bodies_result': bodies_result, 'rings_result': rings_result})
         return sentinel_master, np.zeros(snapshot.data.shape, dtype=np.int32)
 
     def fake_write(**kwargs: Any) -> None:
+        """Record the writer keyword arguments without writing anything.
+
+        Parameters:
+            **kwargs: The write_fits keyword arguments (recorded verbatim).
+        """
         calls['write'].append(kwargs)
 
     monkeypatch.setattr(backplanes_mod, 'create_body_backplanes', fake_bodies)
@@ -216,11 +252,11 @@ def _run(
     metadata: dict[str, Any] | None,
     obs: Any | None = None,
     write_output_files: bool = True,
-) -> tuple[Any, list[dict[str, Any]], Path, Path]:
+) -> tuple[Any, list[dict[str, Any]], FCPath, FCPath]:
     """Prepare roots and metadata, run the driver, and return the pieces.
 
     Parameters:
-        tmp_path: pytest-provided temporary directory.
+        tmp_path: pytest-provided temporary directory, wrapped once into FCPath.
         metadata: Nav metadata document to write; None writes nothing.
         obs: Observation returned by from_file; defaults to a fresh simulated
             HermeticObs.
@@ -230,16 +266,17 @@ def _run(
         The observation, the recorded from_file calls, the nav root, and the
         backplane root.
     """
-    nav_root, bp_root = _roots(tmp_path)
+    root = FCPath(tmp_path)
+    nav_root, bp_root = _roots(root)
     if metadata is not None:
         _write_nav_metadata(nav_root, 'IMG1', metadata)
     snapshot = obs if obs is not None else make_snapshot(shape_vu=SHAPE_VU, simulated=True)
     obs_class, from_file_calls = _obs_class_for(snapshot)
     generate_backplanes_image_files(
         obs_class,
-        _image_files(tmp_path, 'IMG1'),
-        nav_results_root=FCPath(str(nav_root)),
-        backplane_results_root=FCPath(str(bp_root)),
+        _image_files(root, 'IMG1'),
+        nav_results_root=nav_root,
+        backplane_results_root=bp_root,
         write_output_files=write_output_files,
     )
     return snapshot, from_file_calls, nav_root, bp_root
@@ -256,14 +293,15 @@ def test_driver_rejects_multi_image_batches(tmp_path: Path) -> None:
     Parameters:
         tmp_path: pytest-provided temporary directory.
     """
-    nav_root, bp_root = _roots(tmp_path)
+    root = FCPath(tmp_path)
+    nav_root, bp_root = _roots(root)
     obs_class, _ = _obs_class_for(make_snapshot(shape_vu=SHAPE_VU, simulated=True))
     with pytest.raises(ValueError, match='exactly one image per batch'):
         generate_backplanes_image_files(
             obs_class,
-            _image_files(tmp_path, 'IMG1', 'IMG2'),
-            nav_results_root=FCPath(str(nav_root)),
-            backplane_results_root=FCPath(str(bp_root)),
+            _image_files(root, 'IMG1', 'IMG2'),
+            nav_results_root=nav_root,
+            backplane_results_root=bp_root,
         )
 
 
@@ -283,15 +321,16 @@ def test_driver_invalid_metadata_json_raises(tmp_path: Path) -> None:
     Parameters:
         tmp_path: pytest-provided temporary directory.
     """
-    nav_root, bp_root = _roots(tmp_path)
+    root = FCPath(tmp_path)
+    nav_root, bp_root = _roots(root)
     (nav_root / 'IMG1_metadata.json').write_text('this is not json')
     obs_class, _ = _obs_class_for(make_snapshot(shape_vu=SHAPE_VU, simulated=True))
     with pytest.raises(json.JSONDecodeError):
         generate_backplanes_image_files(
             obs_class,
-            _image_files(tmp_path, 'IMG1'),
-            nav_results_root=FCPath(str(nav_root)),
-            backplane_results_root=FCPath(str(bp_root)),
+            _image_files(root, 'IMG1'),
+            nav_results_root=nav_root,
+            backplane_results_root=bp_root,
         )
 
 
@@ -435,7 +474,7 @@ def test_driver_writes_fits_under_backplane_root(
     _, _, _, bp_root = _run(tmp_path, metadata={'status': 'success', 'offset': [0.0, 0.0]})
     assert len(calls['write']) == 1
     fits_file_path = calls['write'][0]['fits_file_path']
-    assert str(fits_file_path) == str(bp_root / 'IMG1_backplanes.fits')
+    assert fits_file_path.as_posix() == (bp_root / 'IMG1_backplanes.fits').as_posix()
 
 
 def test_driver_passes_merge_outputs_to_writer(
@@ -514,7 +553,7 @@ def test_end_to_end_simulated_image_writes_expected_fits(tmp_path: Path) -> None
     )
     fits_path = bp_root / 'IMG1_backplanes.fits'
     assert fits_path.exists()
-    with fits.open(fits_path) as hdul:
+    with fits.open(fits_path.get_local_path()) as hdul:
         names = [hdu.name for hdu in hdul]
         assert names[1] == 'BODY_ID_MAP'
         assert set(names[1:]) == {'BODY_ID_MAP'} | EXPECTED_BODY_HDUS

--- a/tests/spindoctor/cli/backplanes/test_backplanes.py
+++ b/tests/spindoctor/cli/backplanes/test_backplanes.py
@@ -1,0 +1,558 @@
+"""Spec-first tests for the per-image backplane driver and the backplane config.
+
+Contract under test (docs/dev_guide/dev_guide_backplanes.rst "Pipeline overview" and
+"Restrictions and assumptions"): the driver reads the per-image navigation
+``_metadata.json`` from the nav results root, refuses to proceed unless
+``status == 'success'``, builds the snapshot with a zero extended-FOV margin, wraps
+its FOV in an ``OffsetFOV`` carrying the navigated ``(dv, du)`` offset (``(0, 0)``
+with a warning when the offset is None), and hands the per-source results to the
+merge and the writer.  The configured backplane list in
+``config_900_backplanes.yaml`` must name real ``oops.Backplane`` methods and declare
+angle units in radians.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, ClassVar, cast
+
+import cspyce
+import numpy as np
+import oops
+import pytest
+from astropy.io import fits
+from filecache import FCPath
+from oops.backplane import Backplane
+
+from spindoctor.cli.backplanes import backplanes as backplanes_mod
+from spindoctor.cli.backplanes.backplanes import generate_backplanes_image_files
+from spindoctor.config import DEFAULT_CONFIG, Config
+from spindoctor.dataset.dataset import ImageFile, ImageFiles
+from spindoctor.obs import Obs, ObsSnapshotInst
+from spindoctor.support.types import PathLike
+
+from .conftest import HermeticObs, inventory_entry, make_snapshot
+
+SHAPE_VU = (10, 12)
+
+
+# ---------------------------------------------------------------------------
+# Configuration contract (config_900_backplanes.yaml)
+# ---------------------------------------------------------------------------
+
+
+def _config_entries(kind: str) -> list[dict[str, Any]]:
+    """Return the shipping backplane entries of the given kind.
+
+    Parameters:
+        kind: Either 'bodies' or 'rings'.
+    """
+    return cast('list[dict[str, Any]]', getattr(DEFAULT_CONFIG.backplanes, kind))
+
+
+@pytest.mark.parametrize('kind', ['bodies', 'rings'])
+def test_default_config_entries_have_required_fields(kind: str) -> None:
+    """Every shipping backplane entry declares name, method, and units.
+
+    Parameters:
+        kind: The config list under test ('bodies' or 'rings').
+    """
+    entries = _config_entries(kind)
+    assert len(entries) > 0
+    for entry in entries:
+        assert entry.get('name'), f'{kind} entry missing name: {entry}'
+        assert entry.get('method'), f'{kind} entry missing method: {entry}'
+        assert entry.get('units'), f'{kind} entry missing units: {entry}'
+
+
+@pytest.mark.parametrize('kind', ['bodies', 'rings'])
+def test_default_config_methods_exist_on_oops_backplane(kind: str) -> None:
+    """Every configured method resolves to a callable on oops.Backplane.
+
+    The dev guide warns there is no compile-time check on the YAML; this test is
+    that check.
+
+    Parameters:
+        kind: The config list under test ('bodies' or 'rings').
+    """
+    for entry in _config_entries(kind):
+        method = entry['method']
+        assert callable(getattr(Backplane, method, None)), (
+            f'{kind} backplane {entry["name"]} names unknown oops method {method}'
+        )
+
+
+def test_default_config_angle_backplanes_declare_radians() -> None:
+    """Angle-valued backplanes (angles, longitudes, latitudes) are declared in rad.
+
+    The viewer converts BUNIT=rad HDUs to degrees for display; a mislabeled angle
+    plane would silently ship wrong units.
+    """
+    angle_names = {'body_longitude', 'body_latitude', 'ring_longitude'}
+    for kind in ('bodies', 'rings'):
+        for entry in _config_entries(kind):
+            name = entry['name']
+            if name.endswith('_angle') or name in angle_names:
+                assert entry['units'] == 'rad', f'{name} must declare rad units'
+
+
+# ---------------------------------------------------------------------------
+# Driver plumbing helpers
+# ---------------------------------------------------------------------------
+
+
+def _image_files(tmp_path: Path, *stubs: str) -> ImageFiles:
+    """Build an ImageFiles batch with one local image file per stub.
+
+    Parameters:
+        tmp_path: Directory that receives the placeholder image files.
+        *stubs: Results path stubs, one per image.
+    """
+    files = []
+    for stub in stubs or ('IMG1',):
+        img = tmp_path / f'{stub}.IMG'
+        img.write_bytes(b'')
+        files.append(
+            ImageFile(
+                image_file_url=FCPath(str(img)),
+                label_file_url=FCPath(str(img)),
+                results_path_stub=stub,
+            )
+        )
+    return ImageFiles(image_files=files)
+
+
+def _write_nav_metadata(nav_root: Path, stub: str, doc: dict[str, Any]) -> None:
+    """Write a navigation metadata JSON for the given stub.
+
+    Parameters:
+        nav_root: The nav results root directory.
+        stub: The results path stub.
+        doc: The metadata document to serialize.
+    """
+    (nav_root / f'{stub}_metadata.json').write_text(json.dumps(doc))
+
+
+def _roots(tmp_path: Path) -> tuple[Path, Path]:
+    """Create and return (nav_results_root, backplane_results_root) directories.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    nav_root = tmp_path / 'nav'
+    bp_root = tmp_path / 'bp'
+    nav_root.mkdir()
+    bp_root.mkdir()
+    return nav_root, bp_root
+
+
+def _obs_class_for(obs: Any) -> tuple[type[ObsSnapshotInst], list[dict[str, Any]]]:
+    """Build an obs class whose from_file returns a fixed observation.
+
+    Parameters:
+        obs: The observation (or arbitrary object) from_file should return.
+
+    Returns:
+        The ObsSnapshotInst subclass and the list that records the keyword
+        arguments of every from_file call.
+    """
+    from_file_calls: list[dict[str, Any]] = []
+
+    class _DriverObs(HermeticObs):
+        calls: ClassVar[list[dict[str, Any]]] = from_file_calls
+
+        @staticmethod
+        def from_file(
+            path: PathLike,
+            *,
+            config: Config | None = None,
+            extfov_margin_vu: tuple[int, int] | None = None,
+            **kwargs: Any,
+        ) -> Obs:
+            from_file_calls.append({'path': path, 'extfov_margin_vu': extfov_margin_vu})
+            return cast(Obs, obs)
+
+    return _DriverObs, from_file_calls
+
+
+def _stub_pipeline(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
+    """Replace the per-source, merge, and writer stages with recorders.
+
+    Parameters:
+        monkeypatch: pytest monkeypatch fixture.
+
+    Returns:
+        Dict of recorded calls per stage ('bodies', 'rings', 'merge', 'write').
+    """
+    calls: dict[str, list[Any]] = {'bodies': [], 'rings': [], 'merge': [], 'write': []}
+    sentinel_master: dict[str, Any] = {'sentinel_plane': np.ones(SHAPE_VU, dtype=np.float32)}
+
+    def fake_bodies(snapshot: Any, config: Any, *, logger: Any) -> dict[str, Any]:
+        calls['bodies'].append(snapshot)
+        return {'FAKEBODY': {}}
+
+    def fake_rings(snapshot: Any, config: Any, *, logger: Any) -> None:
+        calls['rings'].append(snapshot)
+        return None
+
+    def fake_merge(
+        snapshot: Any, *, bodies_result: Any, rings_result: Any
+    ) -> tuple[dict[str, Any], np.ndarray]:
+        calls['merge'].append({'bodies_result': bodies_result, 'rings_result': rings_result})
+        return sentinel_master, np.zeros(snapshot.data.shape, dtype=np.int32)
+
+    def fake_write(**kwargs: Any) -> None:
+        calls['write'].append(kwargs)
+
+    monkeypatch.setattr(backplanes_mod, 'create_body_backplanes', fake_bodies)
+    monkeypatch.setattr(backplanes_mod, 'create_ring_backplanes', fake_rings)
+    monkeypatch.setattr(backplanes_mod, 'merge_sources_into_master', fake_merge)
+    monkeypatch.setattr(backplanes_mod, 'write_fits', fake_write)
+    return calls
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    metadata: dict[str, Any] | None,
+    obs: Any | None = None,
+    write_output_files: bool = True,
+) -> tuple[Any, list[dict[str, Any]], Path, Path]:
+    """Prepare roots and metadata, run the driver, and return the pieces.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+        metadata: Nav metadata document to write; None writes nothing.
+        obs: Observation returned by from_file; defaults to a fresh simulated
+            HermeticObs.
+        write_output_files: Forwarded to the driver.
+
+    Returns:
+        The observation, the recorded from_file calls, the nav root, and the
+        backplane root.
+    """
+    nav_root, bp_root = _roots(tmp_path)
+    if metadata is not None:
+        _write_nav_metadata(nav_root, 'IMG1', metadata)
+    snapshot = obs if obs is not None else make_snapshot(shape_vu=SHAPE_VU, simulated=True)
+    obs_class, from_file_calls = _obs_class_for(snapshot)
+    generate_backplanes_image_files(
+        obs_class,
+        _image_files(tmp_path, 'IMG1'),
+        nav_results_root=FCPath(str(nav_root)),
+        backplane_results_root=FCPath(str(bp_root)),
+        write_output_files=write_output_files,
+    )
+    return snapshot, from_file_calls, nav_root, bp_root
+
+
+# ---------------------------------------------------------------------------
+# Driver behavior
+# ---------------------------------------------------------------------------
+
+
+def test_driver_rejects_multi_image_batches(tmp_path: Path) -> None:
+    """A batch with more than one image is rejected.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    nav_root, bp_root = _roots(tmp_path)
+    obs_class, _ = _obs_class_for(make_snapshot(shape_vu=SHAPE_VU, simulated=True))
+    with pytest.raises(ValueError, match='exactly one image per batch'):
+        generate_backplanes_image_files(
+            obs_class,
+            _image_files(tmp_path, 'IMG1', 'IMG2'),
+            nav_results_root=FCPath(str(nav_root)),
+            backplane_results_root=FCPath(str(bp_root)),
+        )
+
+
+def test_driver_missing_metadata_raises(tmp_path: Path) -> None:
+    """A missing navigation metadata file is a hard error.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    with pytest.raises(FileNotFoundError):
+        _run(tmp_path, metadata=None)
+
+
+def test_driver_invalid_metadata_json_raises(tmp_path: Path) -> None:
+    """Unparseable navigation metadata is a hard error.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    nav_root, bp_root = _roots(tmp_path)
+    (nav_root / 'IMG1_metadata.json').write_text('this is not json')
+    obs_class, _ = _obs_class_for(make_snapshot(shape_vu=SHAPE_VU, simulated=True))
+    with pytest.raises(json.JSONDecodeError):
+        generate_backplanes_image_files(
+            obs_class,
+            _image_files(tmp_path, 'IMG1'),
+            nav_results_root=FCPath(str(nav_root)),
+            backplane_results_root=FCPath(str(bp_root)),
+        )
+
+
+def test_driver_skips_image_with_failed_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An image whose navigation did not succeed is skipped without output.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+        monkeypatch: pytest monkeypatch fixture.
+    """
+    calls = _stub_pipeline(monkeypatch)
+    _, from_file_calls, _, bp_root = _run(
+        tmp_path, metadata={'status': 'error', 'offset': [0.0, 0.0]}
+    )
+    assert from_file_calls == []
+    assert calls['write'] == []
+    assert list(bp_root.iterdir()) == []
+
+
+def test_driver_skips_image_with_missing_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Metadata without a status field is treated as a failed navigation.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+        monkeypatch: pytest monkeypatch fixture.
+    """
+    calls = _stub_pipeline(monkeypatch)
+    _, from_file_calls, _, _ = _run(tmp_path, metadata={'offset': [0.0, 0.0]})
+    assert from_file_calls == []
+    assert calls['write'] == []
+
+
+def test_driver_requires_offset_field(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Successful metadata without an offset field is a hard error.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+        monkeypatch: pytest monkeypatch fixture.
+    """
+    _stub_pipeline(monkeypatch)
+    with pytest.raises(ValueError, match='"offset" field not found'):
+        _run(tmp_path, metadata={'status': 'success'})
+
+
+def test_driver_defaults_none_offset_to_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A None offset falls back to (0, 0) and the pipeline still runs.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+        monkeypatch: pytest monkeypatch fixture.
+    """
+    calls = _stub_pipeline(monkeypatch)
+    snapshot, _, _, _ = _run(tmp_path, metadata={'status': 'success', 'offset': None})
+    assert isinstance(snapshot.fov, oops.fov.OffsetFOV)
+    assert snapshot.fov.uv_offset[0] == 0.0
+    assert snapshot.fov.uv_offset[1] == 0.0
+    assert len(calls['merge']) == 1
+
+
+def test_driver_applies_offset_as_du_dv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The metadata (dv, du) offset becomes an OffsetFOV uv_offset of (du, dv).
+
+    The nav metadata stores offsets in (v, u) order while oops FOVs use (u, v);
+    swapping them is the classic axis bug this test pins down.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+        monkeypatch: pytest monkeypatch fixture.
+    """
+    _stub_pipeline(monkeypatch)
+    snapshot, _, _, _ = _run(tmp_path, metadata={'status': 'success', 'offset': [2.5, -1.25]})
+    assert isinstance(snapshot.fov, oops.fov.OffsetFOV)
+    assert snapshot.fov.uv_offset[0] == -1.25
+    assert snapshot.fov.uv_offset[1] == 2.5
+
+
+def test_driver_reads_image_with_zero_extfov_margin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The snapshot is built on the sensor only (extfov margin (0, 0)).
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+        monkeypatch: pytest monkeypatch fixture.
+    """
+    _stub_pipeline(monkeypatch)
+    _, from_file_calls, _, _ = _run(tmp_path, metadata={'status': 'success', 'offset': [0.0, 0.0]})
+    assert len(from_file_calls) == 1
+    assert from_file_calls[0]['extfov_margin_vu'] == (0, 0)
+
+
+def test_driver_rejects_non_snapshot_observation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An observation that is not an ObsSnapshot is rejected.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+        monkeypatch: pytest monkeypatch fixture.
+    """
+    _stub_pipeline(monkeypatch)
+    with pytest.raises(TypeError, match='Expected ObsSnapshot'):
+        _run(tmp_path, metadata={'status': 'success', 'offset': [0.0, 0.0]}, obs=object())
+
+
+def test_driver_skips_writing_when_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """write_output_files=False runs the pipeline but writes nothing.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+        monkeypatch: pytest monkeypatch fixture.
+    """
+    calls = _stub_pipeline(monkeypatch)
+    _run(
+        tmp_path,
+        metadata={'status': 'success', 'offset': [0.0, 0.0]},
+        write_output_files=False,
+    )
+    assert len(calls['merge']) == 1
+    assert calls['write'] == []
+
+
+def test_driver_writes_fits_under_backplane_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The FITS output path is <backplane_root>/<stub>_backplanes.fits.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+        monkeypatch: pytest monkeypatch fixture.
+    """
+    calls = _stub_pipeline(monkeypatch)
+    _, _, _, bp_root = _run(tmp_path, metadata={'status': 'success', 'offset': [0.0, 0.0]})
+    assert len(calls['write']) == 1
+    fits_file_path = calls['write'][0]['fits_file_path']
+    assert str(fits_file_path) == str(bp_root / 'IMG1_backplanes.fits')
+
+
+def test_driver_passes_merge_outputs_to_writer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The writer receives exactly the master arrays and ID map the merge produced.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+        monkeypatch: pytest monkeypatch fixture.
+    """
+    calls = _stub_pipeline(monkeypatch)
+    _run(tmp_path, metadata={'status': 'success', 'offset': [0.0, 0.0]})
+    write_kwargs = calls['write'][0]
+    assert 'sentinel_plane' in write_kwargs['master_by_type']
+    assert calls['merge'][0]['bodies_result'] == {'FAKEBODY': {}}
+    assert write_kwargs['rings_result'] is None
+
+
+# ---------------------------------------------------------------------------
+# Hermetic end-to-end run on a simulated observation
+# ---------------------------------------------------------------------------
+
+EXPECTED_BODY_HDUS = {
+    'BODY_LONGITUDE',
+    'BODY_LATITUDE',
+    'BODY_INCIDENCE_ANGLE',
+    'BODY_EMISSION_ANGLE',
+    'BODY_PHASE_ANGLE',
+    'BODY_FINEST_RESOLUTION',
+    'BODY_COARSEST_RESOLUTION',
+}
+
+
+def _simulated_mimas_snapshot() -> tuple[HermeticObs, np.ndarray]:
+    """Build a simulated snapshot with one masked body for the end-to-end run.
+
+    Returns:
+        The observation and the full-frame boolean MIMAS mask.
+    """
+    mask = np.zeros(SHAPE_VU, dtype=bool)
+    mask[2:6, 3:7] = True
+    inventory = {
+        'MIMAS': inventory_entry(
+            u_min=3,
+            u_max=6,
+            v_min=2,
+            v_max=5,
+            body_range=500000.0,
+            center_uv=(4.5, 3.5),
+            u_pixel_size=4.0,
+            v_pixel_size=4.0,
+        )
+    }
+    snap = make_snapshot(
+        shape_vu=SHAPE_VU,
+        simulated=True,
+        sim_inventory=inventory,
+        sim_body_mask_map={'MIMAS': mask},
+    )
+    return snap, mask
+
+
+def test_end_to_end_simulated_image_writes_expected_fits(tmp_path: Path) -> None:
+    """A full driver run on a simulated image produces the documented FITS layout.
+
+    Uses the shipping config_900_backplanes.yaml body list, the real per-source,
+    merge, and writer stages, and no SPICE beyond the built-in body-name table.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    snap, mask = _simulated_mimas_snapshot()
+    _, _, _, bp_root = _run(
+        tmp_path, metadata={'status': 'success', 'offset': [1.0, -2.0]}, obs=snap
+    )
+    fits_path = bp_root / 'IMG1_backplanes.fits'
+    assert fits_path.exists()
+    with fits.open(fits_path) as hdul:
+        names = [hdu.name for hdu in hdul]
+        assert names[1] == 'BODY_ID_MAP'
+        assert set(names[1:]) == {'BODY_ID_MAP'} | EXPECTED_BODY_HDUS
+        assert hdul['BODY_LATITUDE'].header['BUNIT'] == 'rad'
+        assert hdul['BODY_FINEST_RESOLUTION'].header['BUNIT'] == 'km/pixel'
+        id_map = hdul['BODY_ID_MAP'].data
+        assert np.all(id_map[mask] == int(cspyce.bodn2c('MIMAS')))
+        assert np.all(id_map[~mask] == 0)
+        assert np.all(hdul['BODY_LATITUDE'].data[mask] > 0.0)
+
+
+def test_end_to_end_simulated_image_applies_offset(tmp_path: Path) -> None:
+    """The end-to-end run wraps the FOV with the navigated (dv, du) offset.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    snap, _ = _simulated_mimas_snapshot()
+    _run(tmp_path, metadata={'status': 'success', 'offset': [1.0, -2.0]}, obs=snap)
+    assert isinstance(snap.fov, oops.fov.OffsetFOV)
+    assert snap.fov.uv_offset[0] == -2.0
+    assert snap.fov.uv_offset[1] == 1.0
+
+
+def test_end_to_end_simulated_image_writes_sidecar(tmp_path: Path) -> None:
+    """The end-to-end run writes the sidecar with per-body stats and inventory.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    snap, _ = _simulated_mimas_snapshot()
+    _, _, _, bp_root = _run(
+        tmp_path, metadata={'status': 'success', 'offset': [1.0, -2.0]}, obs=snap
+    )
+    sidecar = bp_root / 'IMG1_backplane_metadata.json'
+    assert sidecar.exists()
+    metadata = json.loads(sidecar.read_text())
+    body = metadata['bodies']['MIMAS']
+    assert set(body['backplanes']) == {e['name'] for e in _config_entries('bodies')}
+    assert body['center_uv'] == [3.5, 4.5]
+    assert body['center_range'] == 500000.0

--- a/tests/spindoctor/cli/backplanes/test_backplanes_bodies.py
+++ b/tests/spindoctor/cli/backplanes/test_backplanes_bodies.py
@@ -10,6 +10,9 @@ Simulated bodies synthesize a constant value confined to the simulated body mask
 """
 
 import math
+import os
+import subprocess
+import sys
 from typing import Any
 
 import numpy as np
@@ -104,6 +107,53 @@ def test_simulated_body_value_deterministic_within_process() -> None:
     val_first = first['MIMAS']['arrays']['body_latitude'][2, 3]
     val_second = second['MIMAS']['arrays']['body_latitude'][2, 3]
     assert val_first == val_second
+
+
+_SIM_VALUE_SCRIPT = """\
+from types import SimpleNamespace
+
+import numpy as np
+
+from spindoctor.cli.backplanes.backplanes_bodies import _create_simulated_body_backplane
+
+snapshot = SimpleNamespace(
+    data=np.zeros((8, 10), dtype=np.float32),
+    sim_body_mask_map={},
+    sim_body_order_near_to_far=[],
+    sim_body_index_map=None,
+)
+full, _ = _create_simulated_body_backplane(snapshot, 'MIMAS', 'body_latitude', 2, 3, 3, 5)
+print(repr(float(full[2, 3])))
+"""
+
+
+def test_simulated_body_value_deterministic_across_processes() -> None:
+    """The synthesized value must not depend on the interpreter hash seed.
+
+    A value derived from the salted built-in ``hash()`` would vary between
+    interpreter runs; generating it in fresh subprocesses under different
+    PYTHONHASHSEED values detects that, which a within-process rerun cannot.
+    The subprocesses drive ``_create_simulated_body_backplane`` on a minimal
+    stub snapshot and must agree with each other and with the value produced
+    in this process for the same MIMAS / body_latitude inputs.
+    """
+    snap, _ = _sim_snapshot_with_mimas()
+    result = create_body_backplanes(snap, _bodies_config().as_config(), logger=IMAGE_LOGGER)
+    in_process = float(result['MIMAS']['arrays']['body_latitude'][2, 3])
+    values = []
+    for seed in ('1', '2', '3'):
+        env = dict(os.environ)
+        env['PYTHONHASHSEED'] = seed
+        proc = subprocess.run(
+            [sys.executable, '-c', _SIM_VALUE_SCRIPT],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        )
+        values.append(float(proc.stdout.strip()))
+    assert len(set(values)) == 1
+    assert values[0] == in_process
 
 
 def test_simulated_body_distance_from_inventory_range() -> None:
@@ -255,6 +305,13 @@ def _patch_backplane_constant(
     """
 
     def values_fn(method: str, body_name: str, shape: tuple[int, int]) -> Any:
+        """Return a constant masked array, optionally masking the first pixel.
+
+        Parameters:
+            method: The oops Backplane method name (ignored).
+            body_name: The body being evaluated (ignored).
+            shape: The meshgrid shape as (nv, nu).
+        """
         data = np.full(shape, value)
         mask = np.zeros(shape, dtype=bool)
         if masked_corner:
@@ -334,6 +391,13 @@ def test_real_body_no_stats_when_fully_masked(monkeypatch: pytest.MonkeyPatch) -
     """
 
     def values_fn(method: str, body_name: str, shape: tuple[int, int]) -> Any:
+        """Return a fully masked constant array (no valid pixel anywhere).
+
+        Parameters:
+            method: The oops Backplane method name (ignored).
+            body_name: The body being evaluated (ignored).
+            shape: The meshgrid shape as (nv, nu).
+        """
         return ma.MaskedArray(np.full(shape, 1.0), mask=np.ones(shape, dtype=bool))
 
     monkeypatch.setattr(bodies_mod, 'Backplane', make_fake_body_backplane_cls(values_fn))

--- a/tests/spindoctor/cli/backplanes/test_backplanes_bodies.py
+++ b/tests/spindoctor/cli/backplanes/test_backplanes_bodies.py
@@ -1,0 +1,385 @@
+"""Spec-first tests for per-body backplane generation.
+
+Contract under test (docs/dev_guide/dev_guide_backplanes.rst "Bodies"): the body
+step walks the per-image inventory, clips each body's unclipped bounding box into
+the sensor, evaluates the configured methods over a meshgrid restricted to that
+box, masks against the body silhouette, embeds the result into a sensor-shaped
+frame, records the per-body distance for the merge, and computes per-backplane
+min/max statistics (converted from radians to degrees when units are 'rad').
+Simulated bodies synthesize a constant value confined to the simulated body mask.
+"""
+
+import math
+from typing import Any
+
+import numpy as np
+import numpy.ma as ma
+import pytest
+
+from spindoctor.cli.backplanes import backplanes_bodies as bodies_mod
+from spindoctor.cli.backplanes.backplanes_bodies import (
+    _create_simulated_body_backplane,
+    create_body_backplanes,
+)
+from spindoctor.config import IMAGE_LOGGER
+
+from .conftest import (
+    FakeBackplanesConfig,
+    HermeticObs,
+    inventory_entry,
+    make_fake_body_backplane_cls,
+    make_snapshot,
+)
+
+SHAPE_VU = (8, 10)
+
+LAT_CFG = {'name': 'body_latitude', 'method': 'latitude', 'units': 'rad'}
+RES_CFG = {'name': 'body_finest_resolution', 'method': 'finest_resolution', 'units': 'km/pixel'}
+
+
+def _bodies_config(entries: list[dict[str, Any]] | None = None) -> FakeBackplanesConfig:
+    """Build a fake config with the given (or default) body backplane entries.
+
+    Parameters:
+        entries: ``backplanes.bodies`` entries; defaults to latitude only.
+    """
+    return FakeBackplanesConfig(bodies=entries if entries is not None else [LAT_CFG])
+
+
+def _sim_snapshot_with_mimas() -> tuple[HermeticObs, np.ndarray]:
+    """Build a simulated snapshot containing one masked body, MIMAS.
+
+    Returns:
+        The observation and the full-frame boolean MIMAS mask (v 2..3, u 3..5).
+    """
+    mask = np.zeros(SHAPE_VU, dtype=bool)
+    mask[2:4, 3:6] = True
+    inventory = {'MIMAS': inventory_entry(u_min=3, u_max=5, v_min=2, v_max=3, body_range=500000.0)}
+    snap = make_snapshot(
+        shape_vu=SHAPE_VU,
+        simulated=True,
+        sim_inventory=inventory,
+        sim_body_mask_map={'MIMAS': mask},
+    )
+    return snap, mask
+
+
+# ---------------------------------------------------------------------------
+# Simulated path
+# ---------------------------------------------------------------------------
+
+
+def test_simulated_body_values_confined_to_body_mask() -> None:
+    """Simulated backplane values appear only inside the simulated body mask."""
+    snap, mask = _sim_snapshot_with_mimas()
+    result = create_body_backplanes(snap, _bodies_config().as_config(), logger=IMAGE_LOGGER)
+    arr = result['MIMAS']['arrays']['body_latitude']
+    assert arr.shape == SHAPE_VU
+    assert np.all(arr[mask] > 0.0)
+    assert np.all(arr[~mask] == 0.0)
+
+
+def test_simulated_body_mask_matches_sim_mask() -> None:
+    """The returned validity mask equals the simulated body mask."""
+    snap, mask = _sim_snapshot_with_mimas()
+    result = create_body_backplanes(snap, _bodies_config().as_config(), logger=IMAGE_LOGGER)
+    np.testing.assert_array_equal(result['MIMAS']['masks']['body_latitude'], mask)
+
+
+def test_simulated_body_value_is_constant_in_range() -> None:
+    """The synthesized value is a single constant between 1 and 100."""
+    snap, mask = _sim_snapshot_with_mimas()
+    result = create_body_backplanes(snap, _bodies_config().as_config(), logger=IMAGE_LOGGER)
+    values = np.unique(result['MIMAS']['arrays']['body_latitude'][mask])
+    assert len(values) == 1
+    assert 1.0 <= float(values[0]) <= 100.0
+
+
+def test_simulated_body_value_deterministic_within_process() -> None:
+    """The synthesized value is reproducible for the same body/backplane names."""
+    snap, _ = _sim_snapshot_with_mimas()
+    config = _bodies_config().as_config()
+    first = create_body_backplanes(snap, config, logger=IMAGE_LOGGER)
+    second = create_body_backplanes(snap, config, logger=IMAGE_LOGGER)
+    val_first = first['MIMAS']['arrays']['body_latitude'][2, 3]
+    val_second = second['MIMAS']['arrays']['body_latitude'][2, 3]
+    assert val_first == val_second
+
+
+def test_simulated_body_distance_from_inventory_range() -> None:
+    """The per-body merge distance is the inventory range."""
+    snap, _ = _sim_snapshot_with_mimas()
+    result = create_body_backplanes(snap, _bodies_config().as_config(), logger=IMAGE_LOGGER)
+    assert result['MIMAS']['distance'] == 500000.0
+
+
+def test_simulated_body_stats_convert_radians_to_degrees() -> None:
+    """Statistics for a 'rad' plane are reported in degrees."""
+    snap, _ = _sim_snapshot_with_mimas()
+    result = create_body_backplanes(snap, _bodies_config().as_config(), logger=IMAGE_LOGGER)
+    val = float(result['MIMAS']['arrays']['body_latitude'][2, 3])
+    stats = result['MIMAS']['statistics']['body_latitude']
+    assert stats['min'] == pytest.approx(math.degrees(val))
+    assert stats['max'] == pytest.approx(math.degrees(val))
+
+
+def test_simulated_body_stats_keep_non_angle_units() -> None:
+    """Statistics for a non-'rad' plane are not unit converted."""
+    snap, _ = _sim_snapshot_with_mimas()
+    config = _bodies_config([RES_CFG])
+    result = create_body_backplanes(snap, config.as_config(), logger=IMAGE_LOGGER)
+    val = float(result['MIMAS']['arrays']['body_finest_resolution'][2, 3])
+    stats = result['MIMAS']['statistics']['body_finest_resolution']
+    assert stats['min'] == pytest.approx(val)
+
+
+def test_bodies_ordered_by_increasing_range() -> None:
+    """Result bodies are ordered nearest first even if the inventory is not."""
+    mask = np.ones(SHAPE_VU, dtype=bool)
+    inventory = {
+        'FARBODY': inventory_entry(u_min=0, u_max=2, v_min=0, v_max=2, body_range=9.0e5),
+        'NEARBODY': inventory_entry(u_min=4, u_max=6, v_min=4, v_max=6, body_range=1.0e5),
+    }
+    snap = make_snapshot(
+        shape_vu=SHAPE_VU,
+        simulated=True,
+        sim_inventory=inventory,
+        sim_body_mask_map={'FARBODY': mask, 'NEARBODY': mask},
+    )
+    result = create_body_backplanes(snap, _bodies_config().as_config(), logger=IMAGE_LOGGER)
+    assert list(result) == ['NEARBODY', 'FARBODY']
+
+
+def test_body_outside_fov_contributes_nothing() -> None:
+    """A body whose bounding box misses the sensor is skipped entirely."""
+    mask = np.ones(SHAPE_VU, dtype=bool)
+    inventory = {'MIMAS': inventory_entry(u_min=-20, u_max=-10, v_min=2, v_max=3, body_range=1.0e5)}
+    snap = make_snapshot(
+        shape_vu=SHAPE_VU,
+        simulated=True,
+        sim_inventory=inventory,
+        sim_body_mask_map={'MIMAS': mask},
+    )
+    result = create_body_backplanes(snap, _bodies_config().as_config(), logger=IMAGE_LOGGER)
+    assert result == {}
+
+
+def test_body_bounding_box_clipped_into_sensor() -> None:
+    """A bounding box extending beyond the frame is clipped before evaluation."""
+    mask = np.ones(SHAPE_VU, dtype=bool)
+    inventory = {'MIMAS': inventory_entry(u_min=-2, u_max=4, v_min=3, v_max=9, body_range=1.0e5)}
+    snap = make_snapshot(
+        shape_vu=SHAPE_VU,
+        simulated=True,
+        sim_inventory=inventory,
+        sim_body_mask_map={'MIMAS': mask},
+    )
+    result = create_body_backplanes(snap, _bodies_config().as_config(), logger=IMAGE_LOGGER)
+    arr = result['MIMAS']['arrays']['body_latitude']
+    assert np.all(arr[3:8, 0:5] > 0.0)
+    assert np.all(arr[0:3, :] == 0.0)
+    assert np.all(arr[:, 5:] == 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Configuration errors
+# ---------------------------------------------------------------------------
+
+
+def test_missing_bodies_config_section_raises() -> None:
+    """A config without backplanes.bodies is rejected."""
+    snap, _ = _sim_snapshot_with_mimas()
+    config = FakeBackplanesConfig(rings=[])
+    with pytest.raises(ValueError, match='no bodies section'):
+        create_body_backplanes(snap, config.as_config(), logger=IMAGE_LOGGER)
+
+
+def test_body_entry_missing_method_raises() -> None:
+    """A body backplane entry without a method is rejected."""
+    snap, _ = _sim_snapshot_with_mimas()
+    config = _bodies_config([{'name': 'body_latitude', 'units': 'rad'}])
+    with pytest.raises(ValueError, match='"method" is required'):
+        create_body_backplanes(snap, config.as_config(), logger=IMAGE_LOGGER)
+
+
+def test_body_entry_missing_units_raises() -> None:
+    """A body backplane entry without units is rejected."""
+    snap, _ = _sim_snapshot_with_mimas()
+    config = _bodies_config([{'name': 'body_latitude', 'method': 'latitude'}])
+    with pytest.raises(ValueError, match='"units" is required'):
+        create_body_backplanes(snap, config.as_config(), logger=IMAGE_LOGGER)
+
+
+# ---------------------------------------------------------------------------
+# Real (non-simulated) path with a stubbed oops Backplane
+# ---------------------------------------------------------------------------
+
+
+def test_no_closest_planet_returns_no_bodies() -> None:
+    """A real image with no closest planet produces no body backplanes."""
+    snap = make_snapshot(shape_vu=SHAPE_VU, simulated=False, closest_planet=None)
+    result = create_body_backplanes(snap, _bodies_config().as_config(), logger=IMAGE_LOGGER)
+    assert result == {}
+
+
+def test_inventory_queried_for_planet_and_satellites() -> None:
+    """The inventory is built for the closest planet plus its config satellites."""
+    snap = make_snapshot(
+        shape_vu=SHAPE_VU, simulated=False, closest_planet='SATURN', canned_inventory={}
+    )
+    config = FakeBackplanesConfig(bodies=[LAT_CFG], satellites={'SATURN': ['MIMAS', 'ENCELADUS']})
+    create_body_backplanes(snap, config.as_config(), logger=IMAGE_LOGGER)
+    assert snap.inventory_calls == [['SATURN', 'MIMAS', 'ENCELADUS']]
+
+
+def _real_snapshot_with_mimas() -> HermeticObs:
+    """Build a non-simulated snapshot with a canned MIMAS inventory (u 3..6, v 2..4)."""
+    inventory = {'MIMAS': inventory_entry(u_min=3, u_max=6, v_min=2, v_max=4, body_range=200000.0)}
+    return make_snapshot(
+        shape_vu=SHAPE_VU,
+        simulated=False,
+        closest_planet='SATURN',
+        canned_inventory=inventory,
+    )
+
+
+def _patch_backplane_constant(
+    monkeypatch: pytest.MonkeyPatch, *, value: float, masked_corner: bool = False
+) -> None:
+    """Replace the oops Backplane with a fake returning a constant masked array.
+
+    Parameters:
+        monkeypatch: pytest monkeypatch fixture.
+        value: Constant value returned at every meshgrid pixel.
+        masked_corner: Whether to mask the first (local (0, 0)) meshgrid pixel.
+    """
+
+    def values_fn(method: str, body_name: str, shape: tuple[int, int]) -> Any:
+        data = np.full(shape, value)
+        mask = np.zeros(shape, dtype=bool)
+        if masked_corner:
+            mask[0, 0] = True
+        return ma.MaskedArray(data, mask=mask)
+
+    monkeypatch.setattr(bodies_mod, 'Backplane', make_fake_body_backplane_cls(values_fn))
+
+
+def test_real_body_values_embedded_at_bounding_box(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Evaluated values land in the sensor frame exactly at the clipped box.
+
+    Parameters:
+        monkeypatch: pytest monkeypatch fixture.
+    """
+    _patch_backplane_constant(monkeypatch, value=0.75)
+    snap = _real_snapshot_with_mimas()
+    result = create_body_backplanes(snap, _bodies_config().as_config(), logger=IMAGE_LOGGER)
+    arr = result['MIMAS']['arrays']['body_latitude']
+    assert arr[2, 3] == np.float32(0.75)
+    assert arr[4, 6] == np.float32(0.75)
+    assert np.all(arr[5:, :] == 0.0)
+    assert np.all(arr[:2, :] == 0.0)
+    assert np.all(arr[:, 7:] == 0.0)
+
+
+def test_real_body_masked_pixels_fill_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pixels masked by oops are filled with 0.0 and marked invalid.
+
+    Parameters:
+        monkeypatch: pytest monkeypatch fixture.
+    """
+    _patch_backplane_constant(monkeypatch, value=0.75, masked_corner=True)
+    snap = _real_snapshot_with_mimas()
+    result = create_body_backplanes(snap, _bodies_config().as_config(), logger=IMAGE_LOGGER)
+    arr = result['MIMAS']['arrays']['body_latitude']
+    mask = result['MIMAS']['masks']['body_latitude']
+    assert arr[2, 3] == 0.0
+    assert not bool(mask[2, 3])
+    assert arr[2, 4] == np.float32(0.75)
+    assert bool(mask[2, 4])
+
+
+def test_real_body_distance_is_inventory_range(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The merge distance for a real body is the inventory range.
+
+    Parameters:
+        monkeypatch: pytest monkeypatch fixture.
+    """
+    _patch_backplane_constant(monkeypatch, value=0.75)
+    snap = _real_snapshot_with_mimas()
+    result = create_body_backplanes(snap, _bodies_config().as_config(), logger=IMAGE_LOGGER)
+    assert result['MIMAS']['distance'] == 200000.0
+
+
+def test_real_body_stats_convert_radians_to_degrees(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real-path statistics for a 'rad' plane are reported in degrees.
+
+    Parameters:
+        monkeypatch: pytest monkeypatch fixture.
+    """
+    _patch_backplane_constant(monkeypatch, value=0.5)
+    snap = _real_snapshot_with_mimas()
+    result = create_body_backplanes(snap, _bodies_config().as_config(), logger=IMAGE_LOGGER)
+    stats = result['MIMAS']['statistics']['body_latitude']
+    assert stats['min'] == pytest.approx(math.degrees(0.5))
+    assert stats['max'] == pytest.approx(math.degrees(0.5))
+
+
+def test_real_body_no_stats_when_fully_masked(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A plane with no valid pixel gets no statistics entry (arrays still present).
+
+    Parameters:
+        monkeypatch: pytest monkeypatch fixture.
+    """
+
+    def values_fn(method: str, body_name: str, shape: tuple[int, int]) -> Any:
+        return ma.MaskedArray(np.full(shape, 1.0), mask=np.ones(shape, dtype=bool))
+
+    monkeypatch.setattr(bodies_mod, 'Backplane', make_fake_body_backplane_cls(values_fn))
+    snap = _real_snapshot_with_mimas()
+    result = create_body_backplanes(snap, _bodies_config().as_config(), logger=IMAGE_LOGGER)
+    assert 'body_latitude' not in result['MIMAS']['statistics']
+    assert 'body_latitude' in result['MIMAS']['arrays']
+
+
+# ---------------------------------------------------------------------------
+# _create_simulated_body_backplane internals
+# ---------------------------------------------------------------------------
+
+
+def test_simulated_backplane_mask_map_lookup_is_case_insensitive() -> None:
+    """A lower-case body name matches its upper-case mask-map entry."""
+    mask = np.zeros(SHAPE_VU, dtype=bool)
+    mask[2:4, 3:6] = True
+    snap = make_snapshot(shape_vu=SHAPE_VU, simulated=True, sim_body_mask_map={'MIMAS': mask})
+    full, full_mask = _create_simulated_body_backplane(snap, 'mimas', 'body_latitude', 2, 3, 3, 5)
+    assert np.all(full[mask] > 0.0)
+    assert np.all(full_mask == mask)
+
+
+def test_simulated_backplane_index_map_fallback() -> None:
+    """Without a mask map the body's slot in the index map defines the mask."""
+    index_map = np.zeros(SHAPE_VU, dtype=np.int32)
+    index_map[2, 3] = 2
+    index_map[3, 4] = 1
+    snap = make_snapshot(
+        shape_vu=SHAPE_VU,
+        simulated=True,
+        sim_body_order_near_to_far=['ALPHA', 'BETA'],
+        sim_body_index_map=index_map,
+    )
+    full, full_mask = _create_simulated_body_backplane(snap, 'BETA', 'body_latitude', 2, 4, 3, 5)
+    assert full[2, 3] > 0.0
+    assert full[3, 4] == 0.0
+    assert bool(full_mask[2, 3])
+    assert not bool(full_mask[3, 4])
+
+
+def test_simulated_backplane_rect_fallback_fills_whole_box() -> None:
+    """A body absent from every sim structure falls back to filling the rectangle."""
+    snap = make_snapshot(shape_vu=SHAPE_VU, simulated=True)
+    full, full_mask = _create_simulated_body_backplane(snap, 'UNKNOWN', 'body_latitude', 2, 3, 3, 5)
+    assert np.all(full[2:4, 3:6] > 0.0)
+    assert np.all(full_mask[2:4, 3:6])
+    assert np.all(full[4:, :] == 0.0)

--- a/tests/spindoctor/cli/backplanes/test_backplanes_rings.py
+++ b/tests/spindoctor/cli/backplanes/test_backplanes_rings.py
@@ -236,9 +236,9 @@ def test_distance_entry_is_not_written_as_hdu(tmp_path: Path) -> None:
     master, body_id_map = merge_sources_into_master(
         snap, bodies_result={}, rings_result=rings_result
     )
-    fits_path = tmp_path / 'IMG1_backplanes.fits'
+    fits_path = FCPath(tmp_path) / 'IMG1_backplanes.fits'
     write_fits(
-        fits_file_path=FCPath(str(fits_path)),
+        fits_file_path=fits_path,
         snapshot=snap,
         master_by_type=master,
         body_id_map=body_id_map,
@@ -246,5 +246,5 @@ def test_distance_entry_is_not_written_as_hdu(tmp_path: Path) -> None:
         bodies_result={},
         rings_result=rings_result,
     )
-    with fits.open(fits_path) as hdul:
+    with fits.open(fits_path.get_local_path()) as hdul:
         assert 'DISTANCE' not in [hdu.name for hdu in hdul]

--- a/tests/spindoctor/cli/backplanes/test_backplanes_rings.py
+++ b/tests/spindoctor/cli/backplanes/test_backplanes_rings.py
@@ -1,0 +1,250 @@
+"""Spec-first tests for ring backplane generation.
+
+Contract under test (docs/dev_guide/dev_guide_backplanes.rst "Rings" and
+docs/user_guide/user_guide_backplanes.rst): the ring step evaluates the configured
+methods against the snapshot's full-frame Backplane for the closest planet's ring
+system (SATURN uses the SATURN_MAIN_RINGS target), produces per-pixel arrays plus
+a per-pixel distance array for the merge, computes min/max statistics (degrees for
+'rad' units), and treats the special 'distance' entry as merge-ordering data only,
+never as a written FITS HDU.
+"""
+
+import math
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import numpy.ma as ma
+import pytest
+from astropy.io import fits
+from filecache import FCPath
+
+from spindoctor.cli.backplanes.backplanes_rings import create_ring_backplanes
+from spindoctor.cli.backplanes.merge import merge_sources_into_master
+from spindoctor.cli.backplanes.writer import write_fits
+from spindoctor.config import IMAGE_LOGGER
+
+from .conftest import FakeBackplanesConfig, FakeRingBackplane, HermeticObs, make_snapshot
+
+SHAPE_VU = (6, 8)
+
+RADIUS_CFG = {'name': 'ring_radius', 'method': 'ring_radius', 'units': 'km'}
+LON_CFG = {'name': 'ring_longitude', 'method': 'ring_longitude', 'units': 'rad'}
+
+
+def _rings_config(entries: list[dict[str, Any]] | None = None) -> FakeBackplanesConfig:
+    """Build a fake config with the given (or default) ring backplane entries.
+
+    Parameters:
+        entries: ``backplanes.rings`` entries; defaults to ring_radius only.
+    """
+    return FakeBackplanesConfig(rings=entries if entries is not None else [RADIUS_CFG])
+
+
+def _ring_arrays(
+    *, value: float = 100000.0, distance: float = 2.0e6
+) -> tuple[np.ndarray, dict[str, Any]]:
+    """Build the ring validity mask and canned per-method masked arrays.
+
+    The ring is valid on rows 2..3 (all columns); everything else is masked.
+
+    Parameters:
+        value: Ring backplane value inside the valid region.
+        distance: Ring intersection distance inside the valid region.
+
+    Returns:
+        The boolean validity mask and the method-name to masked-array map.
+    """
+    valid = np.zeros(SHAPE_VU, dtype=bool)
+    valid[2:4, :] = True
+    radius = ma.MaskedArray(np.full(SHAPE_VU, value), mask=~valid)
+    longitude = ma.MaskedArray(np.full(SHAPE_VU, 1.5), mask=~valid)
+    dist = ma.MaskedArray(np.full(SHAPE_VU, distance), mask=~valid)
+    return valid, {'ring_radius': radius, 'ring_longitude': longitude, 'distance': dist}
+
+
+def _snapshot_with_fake_bp(
+    method_values: dict[str, Any], *, planet: str = 'SATURN'
+) -> tuple[HermeticObs, FakeRingBackplane]:
+    """Build a real-mode snapshot whose full-frame Backplane is a recording fake.
+
+    Parameters:
+        method_values: Method-name to masked-array map served by the fake.
+        planet: The snapshot's closest planet.
+
+    Returns:
+        The observation and the injected fake Backplane.
+    """
+    snap = make_snapshot(
+        shape_vu=SHAPE_VU, simulated=False, closest_planet=planet, canned_inventory={}
+    )
+    fake = FakeRingBackplane(method_values)
+    snap._bp = cast(Any, fake)
+    return snap, fake
+
+
+def test_simulated_snapshot_returns_none() -> None:
+    """Simulated observations produce no ring backplanes."""
+    snap = make_snapshot(shape_vu=SHAPE_VU, simulated=True)
+    result = create_ring_backplanes(snap, _rings_config().as_config(), logger=IMAGE_LOGGER)
+    assert result is None
+
+
+def test_no_closest_planet_returns_none() -> None:
+    """An observation with no closest planet produces no ring backplanes."""
+    snap = make_snapshot(shape_vu=SHAPE_VU, simulated=False, closest_planet=None)
+    result = create_ring_backplanes(snap, _rings_config().as_config(), logger=IMAGE_LOGGER)
+    assert result is None
+
+
+def test_missing_rings_config_section_raises() -> None:
+    """A config without backplanes.rings is rejected."""
+    snap, _ = _snapshot_with_fake_bp(_ring_arrays()[1])
+    config = FakeBackplanesConfig(bodies=[])
+    with pytest.raises(ValueError, match='no rings section'):
+        create_ring_backplanes(snap, config.as_config(), logger=IMAGE_LOGGER)
+
+
+def test_ring_entry_missing_method_raises() -> None:
+    """A ring backplane entry without a method is rejected."""
+    snap, _ = _snapshot_with_fake_bp(_ring_arrays()[1])
+    config = _rings_config([{'name': 'ring_radius', 'units': 'km'}])
+    with pytest.raises(ValueError, match='"method" is required'):
+        create_ring_backplanes(snap, config.as_config(), logger=IMAGE_LOGGER)
+
+
+def test_ring_entry_missing_units_raises() -> None:
+    """A ring backplane entry without units is rejected."""
+    snap, _ = _snapshot_with_fake_bp(_ring_arrays()[1])
+    config = _rings_config([{'name': 'ring_radius', 'method': 'ring_radius'}])
+    with pytest.raises(ValueError, match='"units" is required'):
+        create_ring_backplanes(snap, config.as_config(), logger=IMAGE_LOGGER)
+
+
+def test_saturn_uses_main_rings_target() -> None:
+    """For Saturn the backplane methods are evaluated on SATURN_MAIN_RINGS."""
+    snap, fake = _snapshot_with_fake_bp(_ring_arrays()[1])
+    result = create_ring_backplanes(snap, _rings_config().as_config(), logger=IMAGE_LOGGER)
+    assert result is not None
+    assert result['target_key'] == 'SATURN_MAIN_RINGS'
+    assert all(call[1] == 'SATURN_MAIN_RINGS' for call in fake.calls)
+
+
+def test_other_planet_uses_ring_system_target() -> None:
+    """For non-Saturn planets the target is <PLANET>_RING_SYSTEM."""
+    snap, fake = _snapshot_with_fake_bp(_ring_arrays()[1], planet='JUPITER')
+    result = create_ring_backplanes(snap, _rings_config().as_config(), logger=IMAGE_LOGGER)
+    assert result is not None
+    assert result['target_key'] == 'JUPITER_RING_SYSTEM'
+    assert all(call[1] == 'JUPITER_RING_SYSTEM' for call in fake.calls)
+
+
+def test_result_records_planet() -> None:
+    """The result carries the closest planet name."""
+    snap, _ = _snapshot_with_fake_bp(_ring_arrays()[1])
+    result = create_ring_backplanes(snap, _rings_config().as_config(), logger=IMAGE_LOGGER)
+    assert result is not None
+    assert result['planet'] == 'SATURN'
+
+
+def test_ring_arrays_nan_filled_outside_mask() -> None:
+    """Ring arrays carry values where valid and NaN where the ring is absent."""
+    valid, method_values = _ring_arrays(value=100000.0)
+    snap, _ = _snapshot_with_fake_bp(method_values)
+    result = create_ring_backplanes(snap, _rings_config().as_config(), logger=IMAGE_LOGGER)
+    assert result is not None
+    arr = result['arrays']['ring_radius']
+    assert np.all(arr[valid] == np.float32(100000.0))
+    assert np.all(np.isnan(arr[~valid]))
+
+
+def test_ring_masks_true_where_valid() -> None:
+    """The returned validity mask is True exactly where oops left pixels unmasked."""
+    valid, method_values = _ring_arrays()
+    snap, _ = _snapshot_with_fake_bp(method_values)
+    result = create_ring_backplanes(snap, _rings_config().as_config(), logger=IMAGE_LOGGER)
+    assert result is not None
+    assert result['arrays']['ring_radius'].shape == SHAPE_VU
+    np.testing.assert_array_equal(result['masks']['ring_radius'], valid)
+
+
+def test_fully_masked_ring_plane_omitted() -> None:
+    """A ring plane with no valid pixel is dropped from arrays, masks, and stats."""
+    all_masked = ma.MaskedArray(np.full(SHAPE_VU, 1.0), mask=np.ones(SHAPE_VU, dtype=bool))
+    _, method_values = _ring_arrays()
+    method_values['ring_radius'] = all_masked
+    snap, _ = _snapshot_with_fake_bp(method_values)
+    result = create_ring_backplanes(snap, _rings_config().as_config(), logger=IMAGE_LOGGER)
+    assert result is not None
+    assert 'ring_radius' not in result['arrays']
+    assert 'ring_radius' not in result['masks']
+    assert 'ring_radius' not in result['statistics']
+
+
+def test_ring_stats_convert_radians_to_degrees() -> None:
+    """Statistics for a 'rad' ring plane are reported in degrees."""
+    _, method_values = _ring_arrays()
+    snap, _ = _snapshot_with_fake_bp(method_values)
+    config = _rings_config([LON_CFG])
+    result = create_ring_backplanes(snap, config.as_config(), logger=IMAGE_LOGGER)
+    assert result is not None
+    stats = result['statistics']['ring_longitude']
+    assert stats['min'] == pytest.approx(math.degrees(1.5))
+    assert stats['max'] == pytest.approx(math.degrees(1.5))
+
+
+def test_ring_stats_keep_km_units() -> None:
+    """Statistics for a km ring plane are not unit converted."""
+    _, method_values = _ring_arrays(value=100000.0)
+    snap, _ = _snapshot_with_fake_bp(method_values)
+    result = create_ring_backplanes(snap, _rings_config().as_config(), logger=IMAGE_LOGGER)
+    assert result is not None
+    assert result['statistics']['ring_radius']['min'] == pytest.approx(100000.0)
+
+
+def test_configured_distance_entry_feeds_merge_distance() -> None:
+    """A configured 'distance' entry populates the per-pixel merge distance."""
+    valid, method_values = _ring_arrays(distance=2.0e6)
+    snap, _ = _snapshot_with_fake_bp(method_values)
+    config = _rings_config([{'name': 'distance', 'method': 'distance', 'units': 'km'}])
+    result = create_ring_backplanes(snap, config.as_config(), logger=IMAGE_LOGGER)
+    assert result is not None
+    assert np.all(result['distance'][valid] == np.float32(2.0e6))
+    assert np.all(np.isinf(result['distance'][~valid]))
+
+
+def test_fallback_distance_computed_when_not_configured() -> None:
+    """Without a configured distance entry the merge distance is computed anyway."""
+    valid, method_values = _ring_arrays(distance=3.0e6)
+    snap, fake = _snapshot_with_fake_bp(method_values)
+    result = create_ring_backplanes(snap, _rings_config().as_config(), logger=IMAGE_LOGGER)
+    assert result is not None
+    assert np.all(result['distance'][valid] == np.float32(3.0e6))
+    assert ('distance', 'SATURN_MAIN_RINGS', {'direction': 'dep'}) in fake.calls
+
+
+def test_distance_entry_is_not_written_as_hdu(tmp_path: Path) -> None:
+    """The special 'distance' ring entry never becomes a FITS HDU.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    _, method_values = _ring_arrays(distance=2.0e6)
+    snap, _ = _snapshot_with_fake_bp(method_values)
+    config = _rings_config([RADIUS_CFG, {'name': 'distance', 'method': 'distance', 'units': 'km'}])
+    rings_result = create_ring_backplanes(snap, config.as_config(), logger=IMAGE_LOGGER)
+    master, body_id_map = merge_sources_into_master(
+        snap, bodies_result={}, rings_result=rings_result
+    )
+    fits_path = tmp_path / 'IMG1_backplanes.fits'
+    write_fits(
+        fits_file_path=FCPath(str(fits_path)),
+        snapshot=snap,
+        master_by_type=master,
+        body_id_map=body_id_map,
+        config=config.as_config(),
+        bodies_result={},
+        rings_result=rings_result,
+    )
+    with fits.open(fits_path) as hdul:
+        assert 'DISTANCE' not in [hdu.name for hdu in hdul]

--- a/tests/spindoctor/cli/backplanes/test_merge.py
+++ b/tests/spindoctor/cli/backplanes/test_merge.py
@@ -1,0 +1,430 @@
+"""Spec-first tests for the distance-aware backplane merge.
+
+Contract under test (docs/dev_guide/dev_guide_backplanes.rst, "Distance-aware
+merge"): every pixel is owned by the source (body or ring) with the smallest
+finite distance along the line of sight; the winner's per-backplane values are
+copied into the master arrays; pixels with no finite distance from any source
+stay zero; a per-pixel BODY_ID_MAP carries the NAIF ID of the winning source,
+with bodies using real NAIF IDs and rings a deterministic ring-system ID.
+"""
+
+import os
+import subprocess
+import sys
+from typing import Any
+
+import cspyce
+import numpy as np
+import pytest
+
+from spindoctor.cli.backplanes.merge import fake_naif_id, merge_sources_into_master
+
+from .conftest import HermeticObs, make_snapshot
+
+SHAPE_VU = (7, 9)
+
+
+def _rect_mask(shape_vu: tuple[int, int], v0: int, v1: int, u0: int, u1: int) -> np.ndarray:
+    """Build a boolean mask that is True on the inclusive rectangle (v0..v1, u0..u1).
+
+    Parameters:
+        shape_vu: Full-frame shape as (rows, columns).
+        v0: First row of the rectangle.
+        v1: Last row of the rectangle (inclusive).
+        u0: First column of the rectangle.
+        u1: Last column of the rectangle (inclusive).
+    """
+    mask = np.zeros(shape_vu, dtype=bool)
+    mask[v0 : v1 + 1, u0 : u1 + 1] = True
+    return mask
+
+
+def _body_entry(
+    shape_vu: tuple[int, int],
+    mask: np.ndarray,
+    *,
+    value: float,
+    distance: float,
+    bp_type: str = 'body_latitude',
+) -> dict[str, Any]:
+    """Build a bodies_result entry with one constant-valued backplane.
+
+    Parameters:
+        shape_vu: Full-frame shape as (rows, columns).
+        mask: Boolean validity mask (True where the body silhouette is).
+        value: Constant backplane value inside the mask.
+        distance: Scalar body distance in km.
+        bp_type: Backplane type name.
+    """
+    arr = np.zeros(shape_vu, dtype=np.float32)
+    arr[mask] = value
+    return {
+        'arrays': {bp_type: arr},
+        'masks': {bp_type: mask},
+        'distance': distance,
+        'statistics': {},
+    }
+
+
+def _rings_result(
+    arrays: dict[str, np.ndarray],
+    masks: dict[str, np.ndarray],
+    distance: np.ndarray,
+) -> dict[str, Any]:
+    """Build a rings_result dict in the shape create_ring_backplanes returns.
+
+    Parameters:
+        arrays: Ring backplane arrays keyed by type name.
+        masks: Ring validity masks keyed by type name.
+        distance: Per-pixel ring distance array (inf where no intersection).
+    """
+    return {
+        'planet': 'SATURN',
+        'target_key': 'SATURN_MAIN_RINGS',
+        'arrays': arrays,
+        'masks': masks,
+        'distance': distance,
+        'statistics': {},
+    }
+
+
+def _ring_only(
+    shape_vu: tuple[int, int],
+    mask: np.ndarray,
+    *,
+    value: float,
+    distance_value: float,
+    bp_type: str = 'ring_radius',
+) -> dict[str, Any]:
+    """Build a rings_result with one constant-valued ring plane.
+
+    Parameters:
+        shape_vu: Full-frame shape as (rows, columns).
+        mask: Boolean validity mask for the ring plane.
+        value: Constant ring backplane value inside the mask.
+        distance_value: Ring distance inside the mask (inf outside).
+        bp_type: Ring backplane type name.
+    """
+    arr = np.full(shape_vu, np.nan, dtype=np.float32)
+    arr[mask] = value
+    distance = np.full(shape_vu, np.inf, dtype=np.float32)
+    distance[mask] = distance_value
+    return _rings_result({bp_type: arr}, {bp_type: mask}, distance)
+
+
+@pytest.fixture
+def snapshot() -> HermeticObs:
+    """Non-simulated hermetic snapshot with a non-square frame."""
+    return make_snapshot(shape_vu=SHAPE_VU, simulated=False)
+
+
+def test_merge_no_sources_returns_empty_master(snapshot: HermeticObs) -> None:
+    """With no bodies and no rings the master dict is empty.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    master, _ = merge_sources_into_master(snapshot, bodies_result={}, rings_result=None)
+    assert master == {}
+
+
+def test_merge_no_sources_id_map_shape_and_zero(snapshot: HermeticObs) -> None:
+    """With no sources the BODY_ID_MAP is all zeros at the sensor shape.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    _, body_id_map = merge_sources_into_master(snapshot, bodies_result={}, rings_result=None)
+    assert body_id_map.shape == SHAPE_VU
+    assert body_id_map.dtype == np.int32
+    assert np.all(body_id_map == 0)
+
+
+def test_merge_single_body_copies_values_inside_silhouette(snapshot: HermeticObs) -> None:
+    """A lone body's values are copied into the master at every valid pixel.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    mask = _rect_mask(SHAPE_VU, 1, 3, 2, 5)
+    bodies = {'SATURN': _body_entry(SHAPE_VU, mask, value=0.5, distance=1.0e6)}
+    master, _ = merge_sources_into_master(snapshot, bodies_result=bodies, rings_result=None)
+    assert np.all(master['body_latitude'][mask] == np.float32(0.5))
+
+
+def test_merge_single_body_id_map_carries_naif_id(snapshot: HermeticObs) -> None:
+    """BODY_ID_MAP carries the body's real NAIF ID at every valid pixel.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    mask = _rect_mask(SHAPE_VU, 1, 3, 2, 5)
+    bodies = {'SATURN': _body_entry(SHAPE_VU, mask, value=0.5, distance=1.0e6)}
+    _, body_id_map = merge_sources_into_master(snapshot, bodies_result=bodies, rings_result=None)
+    assert np.all(body_id_map[mask] == int(cspyce.bodn2c('SATURN')))
+    assert np.all(body_id_map[~mask] == 0)
+
+
+def test_merge_unclaimed_pixels_stay_zero(snapshot: HermeticObs) -> None:
+    """Pixels outside every source silhouette stay zero in the master arrays.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    mask = _rect_mask(SHAPE_VU, 1, 3, 2, 5)
+    bodies = {'SATURN': _body_entry(SHAPE_VU, mask, value=0.5, distance=1.0e6)}
+    master, _ = merge_sources_into_master(snapshot, bodies_result=bodies, rings_result=None)
+    assert np.all(master['body_latitude'][~mask] == 0.0)
+
+
+def test_merge_nearer_body_wins_overlap_values(snapshot: HermeticObs) -> None:
+    """Where two bodies overlap, the one with the smaller range owns the pixel.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    far_mask = _rect_mask(SHAPE_VU, 1, 4, 1, 4)
+    near_mask = _rect_mask(SHAPE_VU, 2, 5, 3, 6)
+    bodies = {
+        'SATURN': _body_entry(SHAPE_VU, far_mask, value=100.0, distance=10.0),
+        'MIMAS': _body_entry(SHAPE_VU, near_mask, value=200.0, distance=5.0),
+    }
+    master, _ = merge_sources_into_master(snapshot, bodies_result=bodies, rings_result=None)
+    overlap = far_mask & near_mask
+    assert np.all(master['body_latitude'][overlap] == np.float32(200.0))
+    assert np.all(master['body_latitude'][far_mask & ~near_mask] == np.float32(100.0))
+    assert np.all(master['body_latitude'][near_mask & ~far_mask] == np.float32(200.0))
+
+
+def test_merge_nearer_body_wins_overlap_id_map(snapshot: HermeticObs) -> None:
+    """The BODY_ID_MAP mirrors per-pixel body ownership in an overlap.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    far_mask = _rect_mask(SHAPE_VU, 1, 4, 1, 4)
+    near_mask = _rect_mask(SHAPE_VU, 2, 5, 3, 6)
+    bodies = {
+        'SATURN': _body_entry(SHAPE_VU, far_mask, value=100.0, distance=10.0),
+        'MIMAS': _body_entry(SHAPE_VU, near_mask, value=200.0, distance=5.0),
+    }
+    _, body_id_map = merge_sources_into_master(snapshot, bodies_result=bodies, rings_result=None)
+    assert np.all(body_id_map[near_mask] == int(cspyce.bodn2c('MIMAS')))
+    assert np.all(body_id_map[far_mask & ~near_mask] == int(cspyce.bodn2c('SATURN')))
+
+
+def test_merge_single_pixel_body(snapshot: HermeticObs) -> None:
+    """A single-pixel body claims exactly one pixel in master and ID map.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    mask = np.zeros(SHAPE_VU, dtype=bool)
+    mask[4, 7] = True
+    bodies = {'MIMAS': _body_entry(SHAPE_VU, mask, value=3.5, distance=1.0e5)}
+    master, body_id_map = merge_sources_into_master(
+        snapshot, bodies_result=bodies, rings_result=None
+    )
+    assert master['body_latitude'][4, 7] == np.float32(3.5)
+    assert int(np.count_nonzero(body_id_map)) == 1
+
+
+def test_merge_inconsistent_masks_within_body_raise(snapshot: HermeticObs) -> None:
+    """Differing per-type masks for one body are rejected.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    mask_a = _rect_mask(SHAPE_VU, 1, 2, 1, 2)
+    mask_b = _rect_mask(SHAPE_VU, 3, 4, 3, 4)
+    arr = np.zeros(SHAPE_VU, dtype=np.float32)
+    bodies = {
+        'SATURN': {
+            'arrays': {'a': arr, 'b': arr},
+            'masks': {'a': mask_a, 'b': mask_b},
+            'distance': 1.0,
+            'statistics': {},
+        }
+    }
+    with pytest.raises(ValueError, match='not all the same'):
+        merge_sources_into_master(snapshot, bodies_result=bodies, rings_result=None)
+
+
+def test_merge_missing_backplane_type_for_body_raises(snapshot: HermeticObs) -> None:
+    """A backplane type present on one body but missing on another is rejected.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    mask = _rect_mask(SHAPE_VU, 1, 2, 1, 2)
+    bodies = {
+        'SATURN': _body_entry(SHAPE_VU, mask, value=1.0, distance=1.0, bp_type='a'),
+        'MIMAS': _body_entry(SHAPE_VU, mask, value=2.0, distance=2.0, bp_type='b'),
+    }
+    with pytest.raises(ValueError, match='not found for body'):
+        merge_sources_into_master(snapshot, bodies_result=bodies, rings_result=None)
+
+
+def test_merge_unknown_body_name_raises_for_real_data(snapshot: HermeticObs) -> None:
+    """A body name unknown to SPICE is a hard error on real (non-simulated) images.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    mask = _rect_mask(SHAPE_VU, 1, 2, 1, 2)
+    bodies = {'NOT_A_BODY_XYZ': _body_entry(SHAPE_VU, mask, value=1.0, distance=1.0)}
+    with pytest.raises(KeyError, match='NOT_A_BODY_XYZ'):
+        merge_sources_into_master(snapshot, bodies_result=bodies, rings_result=None)
+
+
+def test_merge_unknown_simulated_body_gets_fake_id() -> None:
+    """On simulated images an unknown body gets a synthesized int32-range NAIF ID."""
+    sim = make_snapshot(shape_vu=SHAPE_VU, simulated=True)
+    mask = _rect_mask(SHAPE_VU, 1, 2, 1, 2)
+    bodies = {'BLOB_XQZ': _body_entry(SHAPE_VU, mask, value=1.0, distance=1.0)}
+    _, body_id_map = merge_sources_into_master(sim, bodies_result=bodies, rings_result=None)
+    fake_id = int(body_id_map[1, 1])
+    assert fake_id >= 10000
+    assert fake_id < 30000
+
+
+def test_merge_simulated_fake_id_deterministic_across_processes() -> None:
+    """The synthesized fake NAIF ID must not depend on the interpreter hash seed."""
+    expr = "from spindoctor.cli.backplanes.merge import fake_naif_id; print(fake_naif_id('MIMAS'))"
+    ids = []
+    for seed in ('1', '2', '3'):
+        env = dict(os.environ)
+        env['PYTHONHASHSEED'] = seed
+        proc = subprocess.run(
+            [sys.executable, '-c', expr],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        )
+        ids.append(int(proc.stdout.strip()))
+    assert len(set(ids)) == 1
+    assert ids[0] == fake_naif_id('MIMAS')
+
+
+def test_merge_rings_only_fill_valid_pixels(snapshot: HermeticObs) -> None:
+    """With no bodies, ring values are copied wherever the ring plane is valid.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    ring_mask = _rect_mask(SHAPE_VU, 2, 4, 0, 8)
+    rings = _ring_only(SHAPE_VU, ring_mask, value=123456.0, distance_value=2.0e6)
+    master, _ = merge_sources_into_master(snapshot, bodies_result={}, rings_result=rings)
+    assert np.all(master['ring_radius'][ring_mask] == np.float32(123456.0))
+    assert np.all(master['ring_radius'][~ring_mask] == 0.0)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='#251: suspected bug: merge never writes a ring-system NAIF ID into BODY_ID_MAP; '
+    'the dev guide says rings use a deterministic ring-system ID for pixels they win',
+)
+def test_merge_ring_pixels_carry_ring_system_id(snapshot: HermeticObs) -> None:
+    """Pixels won by the ring system carry a non-zero ring ID in BODY_ID_MAP.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    ring_mask = _rect_mask(SHAPE_VU, 2, 4, 0, 8)
+    rings = _ring_only(SHAPE_VU, ring_mask, value=123456.0, distance_value=2.0e6)
+    _, body_id_map = merge_sources_into_master(snapshot, bodies_result={}, rings_result=rings)
+    assert np.all(body_id_map[ring_mask] != 0)
+
+
+def test_merge_body_in_front_occludes_ring(snapshot: HermeticObs) -> None:
+    """A body nearer than the ring plane blanks the ring values at its pixels.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    body_mask = _rect_mask(SHAPE_VU, 2, 3, 2, 4)
+    ring_mask = _rect_mask(SHAPE_VU, 2, 4, 0, 8)
+    bodies = {'MIMAS': _body_entry(SHAPE_VU, body_mask, value=1.5, distance=5.0)}
+    rings = _ring_only(SHAPE_VU, ring_mask, value=99999.0, distance_value=10.0)
+    master, _ = merge_sources_into_master(snapshot, bodies_result=bodies, rings_result=rings)
+    assert np.all(master['ring_radius'][body_mask] == 0.0)
+    assert np.all(master['ring_radius'][ring_mask & ~body_mask] == np.float32(99999.0))
+    assert np.all(master['body_latitude'][body_mask] == np.float32(1.5))
+
+
+def test_merge_ring_in_front_of_body_keeps_ring_values(snapshot: HermeticObs) -> None:
+    """A ring nearer than a body is not occluded: its values survive the merge.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    body_mask = _rect_mask(SHAPE_VU, 2, 3, 2, 4)
+    ring_mask = _rect_mask(SHAPE_VU, 2, 4, 0, 8)
+    bodies = {'MIMAS': _body_entry(SHAPE_VU, body_mask, value=1.5, distance=10.0)}
+    rings = _ring_only(SHAPE_VU, ring_mask, value=99999.0, distance_value=5.0)
+    master, _ = merge_sources_into_master(snapshot, bodies_result=bodies, rings_result=rings)
+    assert np.all(master['ring_radius'][ring_mask] == np.float32(99999.0))
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='#252: suspected bug or doc drift: dev guide says the nearest source owns the '
+    'pixel, but body planes keep the occluded body values when the ring is nearer',
+)
+def test_merge_ring_in_front_of_body_owns_body_plane(snapshot: HermeticObs) -> None:
+    """Body planes are unclaimed where a nearer ring wins the pixel.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    body_mask = _rect_mask(SHAPE_VU, 2, 3, 2, 4)
+    ring_mask = _rect_mask(SHAPE_VU, 2, 4, 0, 8)
+    bodies = {'MIMAS': _body_entry(SHAPE_VU, body_mask, value=1.5, distance=10.0)}
+    rings = _ring_only(SHAPE_VU, ring_mask, value=99999.0, distance_value=5.0)
+    master, _ = merge_sources_into_master(snapshot, bodies_result=bodies, rings_result=rings)
+    assert np.all(master['body_latitude'][body_mask] == 0.0)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='#252: suspected bug or doc drift: BODY_ID_MAP records the occluded body even at '
+    'pixels the dev guide says are won by the nearer ring',
+)
+def test_merge_ring_in_front_of_body_owns_id_map(snapshot: HermeticObs) -> None:
+    """BODY_ID_MAP does not report the body at pixels a nearer ring won.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    body_mask = _rect_mask(SHAPE_VU, 2, 3, 2, 4)
+    ring_mask = _rect_mask(SHAPE_VU, 2, 4, 0, 8)
+    bodies = {'MIMAS': _body_entry(SHAPE_VU, body_mask, value=1.5, distance=10.0)}
+    rings = _ring_only(SHAPE_VU, ring_mask, value=99999.0, distance_value=5.0)
+    _, body_id_map = merge_sources_into_master(snapshot, bodies_result=bodies, rings_result=rings)
+    assert np.all(body_id_map[body_mask] != int(cspyce.bodn2c('MIMAS')))
+
+
+def test_merge_body_ring_type_name_collision_raises(snapshot: HermeticObs) -> None:
+    """A backplane type used by both a body and the rings is rejected.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    mask = _rect_mask(SHAPE_VU, 1, 2, 1, 2)
+    bodies = {'SATURN': _body_entry(SHAPE_VU, mask, value=1.0, distance=1.0, bp_type='shared')}
+    rings = _ring_only(SHAPE_VU, mask, value=2.0, distance_value=0.5, bp_type='shared')
+    with pytest.raises(ValueError, match='already exists in master_by_type'):
+        merge_sources_into_master(snapshot, bodies_result=bodies, rings_result=rings)
+
+
+def test_merge_rings_result_with_no_arrays(snapshot: HermeticObs) -> None:
+    """A rings result carrying no valid planes contributes nothing.
+
+    Parameters:
+        snapshot: Hermetic observation fixture.
+    """
+    rings = _rings_result({}, {}, np.full(SHAPE_VU, np.inf, dtype=np.float32))
+    master, body_id_map = merge_sources_into_master(snapshot, bodies_result={}, rings_result=rings)
+    assert master == {}
+    assert np.all(body_id_map == 0)

--- a/tests/spindoctor/cli/backplanes/test_writer.py
+++ b/tests/spindoctor/cli/backplanes/test_writer.py
@@ -90,7 +90,7 @@ def _write(
     cfg = config if config is not None else _default_config()
     fits_path = tmp_path / f'{stub}_backplanes.fits'
     write_fits(
-        fits_file_path=FCPath(str(fits_path)),
+        fits_file_path=FCPath(fits_path),
         snapshot=snap,
         master_by_type=master,
         body_id_map=id_map,

--- a/tests/spindoctor/cli/backplanes/test_writer.py
+++ b/tests/spindoctor/cli/backplanes/test_writer.py
@@ -1,0 +1,519 @@
+"""Spec-first tests for the backplane FITS + sidecar writer.
+
+Contract under test (docs/dev_guide/dev_guide_backplanes.rst "FITS writer" and
+docs/user_guide/user_guide_backplanes.rst "Outputs"): the FITS file has an empty
+primary HDU, an int32 BODY_ID_MAP as the first image HDU (emitted only when some
+pixel has a non-zero ID), and one float32 ImageHDU per non-all-zero backplane with
+BUNIT taken from the per-backplane config units.  A sidecar
+``<stub>_backplane_metadata.json`` carries per-body inventory information and
+per-backplane statistics.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from filecache import FCPath
+
+from spindoctor.cli.backplanes.writer import write_fits
+
+from .conftest import FakeBackplanesConfig, HermeticObs, inventory_entry, make_snapshot
+
+SHAPE_VU = (6, 11)
+
+
+def _default_config() -> FakeBackplanesConfig:
+    """Build a config declaring one body plane, one ring plane, and ring distance."""
+    return FakeBackplanesConfig(
+        bodies=[{'name': 'body_latitude', 'method': 'latitude', 'units': 'rad'}],
+        rings=[
+            {'name': 'ring_radius', 'method': 'ring_radius', 'units': 'km'},
+            {'name': 'distance', 'method': 'distance', 'units': 'km'},
+        ],
+    )
+
+
+def _master_with(value: float, *, name: str = 'body_latitude') -> dict[str, np.ndarray]:
+    """Build a merge-style master dict: NaN background with one valid pixel.
+
+    Parameters:
+        value: Value stored at pixel (0, 0).
+        name: Backplane type name.
+    """
+    arr = np.full(SHAPE_VU, np.nan, dtype=np.float32)
+    arr[0, 0] = value
+    return {name: arr}
+
+
+def _id_map(naif_id: int = 699) -> np.ndarray:
+    """Build a BODY_ID_MAP with one non-zero pixel.
+
+    Parameters:
+        naif_id: NAIF ID stored at pixel (0, 0).
+    """
+    ids = np.zeros(SHAPE_VU, dtype=np.int32)
+    ids[0, 0] = naif_id
+    return ids
+
+
+def _write(
+    tmp_path: Path,
+    *,
+    master: dict[str, np.ndarray],
+    id_map: np.ndarray,
+    snapshot: HermeticObs | None = None,
+    config: FakeBackplanesConfig | None = None,
+    bodies_result: dict[str, Any] | None = None,
+    rings_result: dict[str, Any] | None = None,
+    stub: str = 'IMG1',
+) -> tuple[Path, Path]:
+    """Invoke write_fits into tmp_path and return the FITS and sidecar paths.
+
+    Parameters:
+        tmp_path: Directory receiving the outputs.
+        master: Master per-type backplane arrays.
+        id_map: Per-pixel NAIF ID map.
+        snapshot: Observation; defaults to a simulated one with an empty inventory.
+        config: Fake config; defaults to :func:`_default_config`.
+        bodies_result: Per-body result dict for the sidecar.
+        rings_result: Ring result dict for the sidecar.
+        stub: Results path stub used in the output file names.
+    """
+    snap = (
+        snapshot
+        if snapshot is not None
+        else make_snapshot(shape_vu=SHAPE_VU, simulated=True, sim_inventory={})
+    )
+    cfg = config if config is not None else _default_config()
+    fits_path = tmp_path / f'{stub}_backplanes.fits'
+    write_fits(
+        fits_file_path=FCPath(str(fits_path)),
+        snapshot=snap,
+        master_by_type=master,
+        body_id_map=id_map,
+        config=cfg.as_config(),
+        bodies_result=bodies_result if bodies_result is not None else {},
+        rings_result=rings_result,
+    )
+    return fits_path, tmp_path / f'{stub}_backplane_metadata.json'
+
+
+def test_write_fits_primary_hdu_is_empty_placeholder(tmp_path: Path) -> None:
+    """The first HDU is a conventional empty primary HDU.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    fits_path, _ = _write(tmp_path, master=_master_with(1.0), id_map=_id_map())
+    with fits.open(fits_path) as hdul:
+        assert isinstance(hdul[0], fits.PrimaryHDU)
+        assert hdul[0].data is None
+
+
+def test_write_fits_body_id_map_is_first_image_hdu(tmp_path: Path) -> None:
+    """BODY_ID_MAP is the first image HDU, before any backplane HDU.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    fits_path, _ = _write(tmp_path, master=_master_with(1.0), id_map=_id_map())
+    with fits.open(fits_path) as hdul:
+        assert hdul[1].name == 'BODY_ID_MAP'
+
+
+def test_write_fits_body_id_map_dtype_and_values(tmp_path: Path) -> None:
+    """BODY_ID_MAP is int32 and round-trips the per-pixel NAIF IDs.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    fits_path, _ = _write(tmp_path, master=_master_with(1.0), id_map=_id_map(699))
+    with fits.open(fits_path) as hdul:
+        assert hdul['BODY_ID_MAP'].data.dtype.name == 'int32'
+        assert int(hdul['BODY_ID_MAP'].data[0, 0]) == 699
+
+
+def test_write_fits_body_id_map_omitted_when_all_zero(tmp_path: Path) -> None:
+    """A BODY_ID_MAP with no non-zero pixel is not written.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    zeros = np.zeros(SHAPE_VU, dtype=np.int32)
+    fits_path, _ = _write(tmp_path, master=_master_with(1.0), id_map=zeros)
+    with fits.open(fits_path) as hdul:
+        assert 'BODY_ID_MAP' not in [hdu.name for hdu in hdul]
+
+
+def test_write_fits_backplane_hdu_name_is_uppercased(tmp_path: Path) -> None:
+    """The configured backplane name becomes an upper-case FITS EXTNAME.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    fits_path, _ = _write(tmp_path, master=_master_with(1.0), id_map=_id_map())
+    with fits.open(fits_path) as hdul:
+        assert 'BODY_LATITUDE' in [hdu.name for hdu in hdul]
+
+
+def test_write_fits_backplane_dtype_float32(tmp_path: Path) -> None:
+    """Backplane HDUs are written as float32.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    fits_path, _ = _write(tmp_path, master=_master_with(1.0), id_map=_id_map())
+    with fits.open(fits_path) as hdul:
+        assert hdul['BODY_LATITUDE'].data.dtype.name == 'float32'
+
+
+def test_write_fits_bunit_from_config_units(tmp_path: Path) -> None:
+    """The BUNIT header comes from the per-backplane config units field.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    master = _master_with(1.0)
+    master.update(_master_with(2.0, name='ring_radius'))
+    fits_path, _ = _write(tmp_path, master=master, id_map=_id_map())
+    with fits.open(fits_path) as hdul:
+        assert hdul['BODY_LATITUDE'].header['BUNIT'] == 'rad'
+        assert hdul['RING_RADIUS'].header['BUNIT'] == 'km'
+
+
+def test_write_fits_no_bunit_for_unconfigured_name(tmp_path: Path) -> None:
+    """A master plane not named in the config gets no BUNIT header.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    fits_path, _ = _write(tmp_path, master=_master_with(1.0, name='mystery'), id_map=_id_map())
+    with fits.open(fits_path) as hdul:
+        assert 'BUNIT' not in hdul['MYSTERY'].header
+
+
+def test_write_fits_all_zero_backplane_omitted(tmp_path: Path) -> None:
+    """A backplane that is entirely zero contributes no HDU.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    master = {'body_latitude': np.zeros(SHAPE_VU, dtype=np.float32)}
+    fits_path, _ = _write(tmp_path, master=master, id_map=_id_map())
+    with fits.open(fits_path) as hdul:
+        assert 'BODY_LATITUDE' not in [hdu.name for hdu in hdul]
+
+
+def test_write_fits_all_invalid_backplane_omitted(tmp_path: Path) -> None:
+    """A backplane with no valid pixel anywhere contributes no HDU.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    master = {'body_latitude': np.full(SHAPE_VU, np.nan, dtype=np.float32)}
+    fits_path, _ = _write(tmp_path, master=master, id_map=_id_map())
+    with fits.open(fits_path) as hdul:
+        assert 'BODY_LATITUDE' not in [hdu.name for hdu in hdul]
+
+
+def test_write_fits_hdus_follow_master_insertion_order(tmp_path: Path) -> None:
+    """Backplane HDUs appear in master-dict insertion order after BODY_ID_MAP.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    master: dict[str, np.ndarray] = {}
+    master.update(_master_with(1.0, name='alpha'))
+    master.update(_master_with(2.0, name='beta'))
+    fits_path, _ = _write(tmp_path, master=master, id_map=_id_map())
+    with fits.open(fits_path) as hdul:
+        names = [hdu.name for hdu in hdul]
+        assert names[2:] == ['ALPHA', 'BETA']
+
+
+def test_write_fits_preserves_non_square_shape(tmp_path: Path) -> None:
+    """Backplane HDU data keeps the sensor's (rows, columns) shape.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    fits_path, _ = _write(tmp_path, master=_master_with(1.0), id_map=_id_map())
+    with fits.open(fits_path) as hdul:
+        assert hdul['BODY_LATITUDE'].data.shape == SHAPE_VU
+
+
+def test_write_fits_empty_pipeline_writes_primary_only(tmp_path: Path) -> None:
+    """No bodies and no rings yields a FITS with just the primary HDU.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    zeros = np.zeros(SHAPE_VU, dtype=np.int32)
+    fits_path, _ = _write(tmp_path, master={}, id_map=zeros)
+    with fits.open(fits_path) as hdul:
+        assert len(hdul) == 1
+
+
+def test_write_fits_empty_pipeline_sidecar(tmp_path: Path) -> None:
+    """No bodies and no rings yields an empty-but-well-formed sidecar.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    zeros = np.zeros(SHAPE_VU, dtype=np.int32)
+    _, sidecar = _write(tmp_path, master={}, id_map=zeros)
+    metadata = json.loads(sidecar.read_text())
+    assert metadata == {'bodies': {}, 'rings': {}}
+
+
+def test_write_fits_overwrites_existing_file(tmp_path: Path) -> None:
+    """Writing twice to the same path succeeds and the second write wins.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    _write(tmp_path, master=_master_with(1.0), id_map=_id_map())
+    fits_path, _ = _write(tmp_path, master=_master_with(2.0, name='ring_radius'), id_map=_id_map())
+    with fits.open(fits_path) as hdul:
+        names = [hdu.name for hdu in hdul]
+        assert 'RING_RADIUS' in names
+        assert 'BODY_LATITUDE' not in names
+
+
+def test_write_fits_sidecar_path_naming(tmp_path: Path) -> None:
+    """The sidecar is named <stub>_backplane_metadata.json next to the FITS file.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    _, sidecar = _write(tmp_path, master=_master_with(1.0), id_map=_id_map(), stub='N123')
+    assert sidecar.name == 'N123_backplane_metadata.json'
+    assert sidecar.exists()
+
+
+def _mimas_setup() -> tuple[HermeticObs, dict[str, Any]]:
+    """Build a simulated snapshot with a MIMAS inventory and its bodies_result."""
+    inventory = {
+        'MIMAS': inventory_entry(
+            u_min=2,
+            u_max=5,
+            v_min=1,
+            v_max=3,
+            body_range=500000.0,
+            center_uv=(3.5, 2.0),
+            u_pixel_size=4.0,
+            v_pixel_size=3.0,
+        )
+    }
+    snap = make_snapshot(shape_vu=SHAPE_VU, simulated=True, sim_inventory=inventory)
+    bodies_result = {
+        'MIMAS': {
+            'arrays': {},
+            'masks': {},
+            'distance': 500000.0,
+            'statistics': {'body_latitude': {'min': -10.0, 'max': 25.0}},
+        }
+    }
+    return snap, bodies_result
+
+
+def test_write_fits_sidecar_body_statistics(tmp_path: Path) -> None:
+    """Per-body min/max statistics are written under bodies.<name>.backplanes.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    snap, bodies_result = _mimas_setup()
+    _, sidecar = _write(
+        tmp_path,
+        master=_master_with(1.0),
+        id_map=_id_map(),
+        snapshot=snap,
+        bodies_result=bodies_result,
+    )
+    metadata = json.loads(sidecar.read_text())
+    assert metadata['bodies']['MIMAS']['backplanes'] == {
+        'body_latitude': {'min': -10.0, 'max': 25.0}
+    }
+
+
+def test_write_fits_sidecar_center_uv_is_swapped_to_vu(tmp_path: Path) -> None:
+    """The sidecar center_uv key actually stores (v, u) swapped from the inventory.
+
+    The inventory carries center_uv as (u, v); the writer swaps to (v, u) while
+    keeping the key name.  This characterizes the on-disk convention consumed by
+    the PDS4 stage; the docs do not specify the ordering.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    snap, bodies_result = _mimas_setup()
+    _, sidecar = _write(
+        tmp_path,
+        master=_master_with(1.0),
+        id_map=_id_map(),
+        snapshot=snap,
+        bodies_result=bodies_result,
+    )
+    metadata = json.loads(sidecar.read_text())
+    assert metadata['bodies']['MIMAS']['center_uv'] == [2.0, 3.5]
+
+
+def test_write_fits_sidecar_center_range_and_size(tmp_path: Path) -> None:
+    """The sidecar carries center_range and size_uv from the inventory.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    snap, bodies_result = _mimas_setup()
+    _, sidecar = _write(
+        tmp_path,
+        master=_master_with(1.0),
+        id_map=_id_map(),
+        snapshot=snap,
+        bodies_result=bodies_result,
+    )
+    metadata = json.loads(sidecar.read_text())
+    assert metadata['bodies']['MIMAS']['center_range'] == 500000.0
+    assert metadata['bodies']['MIMAS']['size_uv'] == [4.0, 3.0]
+
+
+def test_write_fits_sidecar_ring_statistics(tmp_path: Path) -> None:
+    """Ring statistics are written under rings.backplanes.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    rings_result = {
+        'planet': 'SATURN',
+        'target_key': 'SATURN_MAIN_RINGS',
+        'arrays': {},
+        'masks': {},
+        'distance': None,
+        'statistics': {'ring_radius': {'min': 70000.0, 'max': 140000.0}},
+    }
+    _, sidecar = _write(
+        tmp_path, master=_master_with(1.0), id_map=_id_map(), rings_result=rings_result
+    )
+    metadata = json.loads(sidecar.read_text())
+    assert metadata['rings'] == {'backplanes': {'ring_radius': {'min': 70000.0, 'max': 140000.0}}}
+
+
+def test_write_fits_sidecar_omits_body_with_no_content(tmp_path: Path) -> None:
+    """A body with no statistics key and no inventory entry is left out.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    _, sidecar = _write(
+        tmp_path,
+        master=_master_with(1.0),
+        id_map=_id_map(),
+        bodies_result={'GHOST': {'arrays': {}, 'masks': {}, 'distance': 1.0}},
+    )
+    metadata = json.loads(sidecar.read_text())
+    assert 'GHOST' not in metadata['bodies']
+
+
+def test_write_fits_non_simulated_uses_config_satellites(tmp_path: Path) -> None:
+    """For real images the sidecar inventory covers the planet plus its satellites.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    inventory = {'MIMAS': inventory_entry(u_min=2, u_max=5, v_min=1, v_max=3, body_range=500000.0)}
+    snap = make_snapshot(
+        shape_vu=SHAPE_VU,
+        simulated=False,
+        closest_planet='SATURN',
+        canned_inventory=inventory,
+    )
+    config = FakeBackplanesConfig(
+        bodies=[{'name': 'body_latitude', 'method': 'latitude', 'units': 'rad'}],
+        rings=[],
+        satellites={'SATURN': ['MIMAS', 'ENCELADUS']},
+    )
+    _write(
+        tmp_path,
+        master=_master_with(1.0),
+        id_map=_id_map(),
+        snapshot=snap,
+        config=config,
+        bodies_result={'MIMAS': {'statistics': {}}},
+    )
+    assert config.satellites_calls == ['SATURN']
+    assert snap.inventory_calls == [['SATURN', 'MIMAS', 'ENCELADUS']]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='#253: suspected doc drift: dev guide promises per-backplane min/max/mean/'
+    'valid-pixel-count statistics, but the writer stores only min and max',
+)
+def test_write_fits_sidecar_includes_mean_and_valid_count(tmp_path: Path) -> None:
+    """Sidecar statistics include the documented mean field.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    snap, bodies_result = _mimas_setup()
+    _, sidecar = _write(
+        tmp_path,
+        master=_master_with(1.0),
+        id_map=_id_map(),
+        snapshot=snap,
+        bodies_result=bodies_result,
+    )
+    metadata = json.loads(sidecar.read_text())
+    assert 'mean' in metadata['bodies']['MIMAS']['backplanes']['body_latitude']
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='#253: suspected doc drift: dev guide promises per-body NAIF ID and predicted '
+    'bounding box in the sidecar, but the writer stores neither',
+)
+def test_write_fits_sidecar_includes_naif_id(tmp_path: Path) -> None:
+    """The per-body sidecar entry carries the documented NAIF ID.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    snap, bodies_result = _mimas_setup()
+    _, sidecar = _write(
+        tmp_path,
+        master=_master_with(1.0),
+        id_map=_id_map(),
+        snapshot=snap,
+        bodies_result=bodies_result,
+    )
+    metadata = json.loads(sidecar.read_text())
+    body_keys = set(metadata['bodies']['MIMAS'])
+    assert 'naif_id' in body_keys
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='#253: suspected doc drift: dev guide says the sidecar contains per-image '
+    'dataset / instrument / observation metadata, but only bodies and rings are '
+    'written',
+)
+def test_write_fits_sidecar_includes_observation_metadata(tmp_path: Path) -> None:
+    """The sidecar carries per-image metadata beyond the bodies and rings blocks.
+
+    Parameters:
+        tmp_path: pytest-provided temporary directory.
+    """
+    snap, bodies_result = _mimas_setup()
+    _, sidecar = _write(
+        tmp_path,
+        master=_master_with(1.0),
+        id_map=_id_map(),
+        snapshot=snap,
+        bodies_result=bodies_result,
+    )
+    metadata = json.loads(sidecar.read_text())
+    assert len(set(metadata) - {'bodies', 'rings'}) > 0

--- a/tests/spindoctor/config/test_config_helper.py
+++ b/tests/spindoctor/config/test_config_helper.py
@@ -1,0 +1,561 @@
+"""Tests for :mod:`spindoctor.config.config_helper`.
+
+Covers the documented resolution order of the three results-root getters
+(explicit argument, then ``config.environment``, then environment variable)
+and the user-config loading behavior of ``load_default_and_user_config``
+(bundled defaults always; explicit ``--config-file`` paths when given;
+otherwise ``nav_default_config.yaml`` from the current directory).
+
+The tests are hermetic: every test clears the three ``NAV_*_RESULTS_ROOT``
+environment variables via ``monkeypatch``, seeds ``Config`` instances
+directly (never the ``DEFAULT_CONFIG`` singleton), and changes into
+``tmp_path`` before exercising the relative ``nav_default_config.yaml``
+lookup so the repository's real user-config file is never picked up.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from spindoctor.config import Config
+from spindoctor.config.config_helper import (
+    get_backplane_results_root,
+    get_nav_results_root,
+    get_pds4_bundle_results_root,
+    load_default_and_user_config,
+)
+
+RootGetter = Callable[[argparse.Namespace, Config], str]
+
+ALL_ENV_VARS = (
+    'NAV_RESULTS_ROOT',
+    'NAV_BACKPLANE_RESULTS_ROOT',
+    'NAV_BUNDLE_RESULTS_ROOT',
+    'BUNDLE_RESULTS_ROOT',
+)
+
+# (getter, argparse attribute, environment-section key, env var, CLI flag)
+GETTER_CASES = [
+    pytest.param(
+        get_nav_results_root,
+        'nav_results_root',
+        'nav_results_root',
+        'NAV_RESULTS_ROOT',
+        '--nav-results-root',
+        id='nav',
+    ),
+    pytest.param(
+        get_backplane_results_root,
+        'backplane_results_root',
+        'backplane_results_root',
+        'NAV_BACKPLANE_RESULTS_ROOT',
+        '--backplane-results-root',
+        id='backplane',
+    ),
+    pytest.param(
+        get_pds4_bundle_results_root,
+        'bundle_results_root',
+        'bundle_results_root',
+        'NAV_BUNDLE_RESULTS_ROOT',
+        '--bundle-results-root',
+        id='bundle',
+    ),
+]
+
+
+@pytest.fixture(autouse=True)
+def _clear_root_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove every results-root environment variable before each test.
+
+    Parameters:
+        monkeypatch: Pytest fixture used to delete the environment variables
+            for the duration of the test.
+    """
+
+    for env_var in ALL_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+
+
+def _config_with_environment(environment: dict[str, str | None] | None) -> Config:
+    """Build a ``Config`` whose ``environment`` section holds the given keys.
+
+    The internal config dict is seeded directly so ``read_config`` never
+    loads the bundled defaults, keeping the getter tests fast and hermetic.
+
+    Parameters:
+        environment: Mapping to expose as ``config.environment``, or None for
+            an empty section.
+
+    Returns:
+        A ``Config`` instance with only the requested ``environment`` section.
+    """
+
+    config = Config()
+    config._config_dict = {'environment': dict(environment or {})}
+    config._update_attrdicts()
+    return config
+
+
+# ---------------------------------------------------------------------------
+# Root getters: resolution order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(('getter', 'arg_attr', 'config_key', 'env_var', 'cli_flag'), GETTER_CASES)
+def test_getter_argument_wins_over_config_and_env(
+    getter: RootGetter,
+    arg_attr: str,
+    config_key: str,
+    env_var: str,
+    cli_flag: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The parsed-argument value takes precedence over config and env var.
+
+    Parameters:
+        getter: The root getter under test.
+        arg_attr: Name of the argparse attribute the getter reads.
+        config_key: Key in ``config.environment`` the getter reads.
+        env_var: Environment variable the getter reads.
+        cli_flag: CLI flag named in the getter's error message (unused here).
+        monkeypatch: Pytest fixture for environment isolation.
+    """
+
+    monkeypatch.setenv(env_var, '/from/env')
+    config = _config_with_environment({config_key: '/from/config'})
+    arguments = argparse.Namespace(**{arg_attr: '/from/args'})
+    assert getter(arguments, config) == '/from/args'
+
+
+@pytest.mark.parametrize(('getter', 'arg_attr', 'config_key', 'env_var', 'cli_flag'), GETTER_CASES)
+def test_getter_config_wins_over_env_when_argument_is_none(
+    getter: RootGetter,
+    arg_attr: str,
+    config_key: str,
+    env_var: str,
+    cli_flag: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the argument None, ``config.environment`` beats the env var.
+
+    Parameters:
+        getter: The root getter under test.
+        arg_attr: Name of the argparse attribute the getter reads.
+        config_key: Key in ``config.environment`` the getter reads.
+        env_var: Environment variable the getter reads.
+        cli_flag: CLI flag named in the getter's error message (unused here).
+        monkeypatch: Pytest fixture for environment isolation.
+    """
+
+    monkeypatch.setenv(env_var, '/from/env')
+    config = _config_with_environment({config_key: '/from/config'})
+    arguments = argparse.Namespace(**{arg_attr: None})
+    assert getter(arguments, config) == '/from/config'
+
+
+@pytest.mark.parametrize(('getter', 'arg_attr', 'config_key', 'env_var', 'cli_flag'), GETTER_CASES)
+def test_getter_missing_argument_attribute_uses_config(
+    getter: RootGetter,
+    arg_attr: str,
+    config_key: str,
+    env_var: str,
+    cli_flag: str,
+) -> None:
+    """A namespace without the attribute at all falls through to the config.
+
+    Parameters:
+        getter: The root getter under test.
+        arg_attr: Name of the argparse attribute the getter reads (unused here).
+        config_key: Key in ``config.environment`` the getter reads.
+        env_var: Environment variable the getter reads (unused here).
+        cli_flag: CLI flag named in the getter's error message (unused here).
+    """
+
+    config = _config_with_environment({config_key: '/from/config'})
+    assert getter(argparse.Namespace(), config) == '/from/config'
+
+
+@pytest.mark.parametrize(('getter', 'arg_attr', 'config_key', 'env_var', 'cli_flag'), GETTER_CASES)
+def test_getter_env_var_used_when_argument_and_config_unset(
+    getter: RootGetter,
+    arg_attr: str,
+    config_key: str,
+    env_var: str,
+    cli_flag: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The env var is the last documented fallback before the error.
+
+    Parameters:
+        getter: The root getter under test.
+        arg_attr: Name of the argparse attribute the getter reads (unused here).
+        config_key: Key in ``config.environment`` the getter reads (unused here).
+        env_var: Environment variable the getter reads.
+        cli_flag: CLI flag named in the getter's error message (unused here).
+        monkeypatch: Pytest fixture for environment isolation.
+    """
+
+    monkeypatch.setenv(env_var, '/from/env')
+    config = _config_with_environment(None)
+    assert getter(argparse.Namespace(), config) == '/from/env'
+
+
+@pytest.mark.parametrize(('getter', 'arg_attr', 'config_key', 'env_var', 'cli_flag'), GETTER_CASES)
+def test_getter_config_key_none_falls_through_to_env(
+    getter: RootGetter,
+    arg_attr: str,
+    config_key: str,
+    env_var: str,
+    cli_flag: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A config key explicitly set to null is treated as unset.
+
+    Parameters:
+        getter: The root getter under test.
+        arg_attr: Name of the argparse attribute the getter reads (unused here).
+        config_key: Key in ``config.environment`` the getter reads.
+        env_var: Environment variable the getter reads.
+        cli_flag: CLI flag named in the getter's error message (unused here).
+        monkeypatch: Pytest fixture for environment isolation.
+    """
+
+    monkeypatch.setenv(env_var, '/from/env')
+    config = _config_with_environment({config_key: None})
+    assert getter(argparse.Namespace(), config) == '/from/env'
+
+
+@pytest.mark.parametrize(('getter', 'arg_attr', 'config_key', 'env_var', 'cli_flag'), GETTER_CASES)
+def test_getter_raises_when_nothing_is_set(
+    getter: RootGetter,
+    arg_attr: str,
+    config_key: str,
+    env_var: str,
+    cli_flag: str,
+) -> None:
+    """With no argument, config key, or env var the getter raises ValueError.
+
+    The error message names the CLI flag, the configuration variable, and the
+    environment variable so the operator knows every way to fix it.
+
+    Parameters:
+        getter: The root getter under test.
+        arg_attr: Name of the argparse attribute the getter reads (unused here).
+        config_key: Key in ``config.environment`` the getter reads (unused here).
+        env_var: Environment variable named in the error message.
+        cli_flag: CLI flag named in the error message.
+    """
+
+    config = _config_with_environment(None)
+    with pytest.raises(ValueError, match=f'{cli_flag}.*{env_var}.*must be set'):
+        getter(argparse.Namespace(**{arg_attr: None}), config)
+
+
+# ---------------------------------------------------------------------------
+# Root getters: corner cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(('getter', 'arg_attr', 'config_key', 'env_var', 'cli_flag'), GETTER_CASES)
+def test_getter_empty_string_env_var_counts_as_set(
+    getter: RootGetter,
+    arg_attr: str,
+    config_key: str,
+    env_var: str,
+    cli_flag: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty-string env var is returned verbatim, not treated as unset.
+
+    The docstrings only distinguish set from unset (None); an exported but
+    empty variable therefore satisfies the lookup and yields ''.
+
+    Parameters:
+        getter: The root getter under test.
+        arg_attr: Name of the argparse attribute the getter reads (unused here).
+        config_key: Key in ``config.environment`` the getter reads (unused here).
+        env_var: Environment variable the getter reads.
+        cli_flag: CLI flag named in the getter's error message (unused here).
+        monkeypatch: Pytest fixture for environment isolation.
+    """
+
+    monkeypatch.setenv(env_var, '')
+    config = _config_with_environment(None)
+    assert getter(argparse.Namespace(), config) == ''
+
+
+@pytest.mark.parametrize(('getter', 'arg_attr', 'config_key', 'env_var', 'cli_flag'), GETTER_CASES)
+def test_getter_empty_string_argument_wins(
+    getter: RootGetter,
+    arg_attr: str,
+    config_key: str,
+    env_var: str,
+    cli_flag: str,
+) -> None:
+    """An empty-string argument still outranks a configured value.
+
+    Parameters:
+        getter: The root getter under test.
+        arg_attr: Name of the argparse attribute the getter reads.
+        config_key: Key in ``config.environment`` the getter reads.
+        env_var: Environment variable the getter reads (unused here).
+        cli_flag: CLI flag named in the getter's error message (unused here).
+    """
+
+    config = _config_with_environment({config_key: '/from/config'})
+    arguments = argparse.Namespace(**{arg_attr: ''})
+    assert getter(arguments, config) == ''
+
+
+@pytest.mark.parametrize('root_value', ['relative/results/dir', 'gs://bucket/nav-results'])
+@pytest.mark.parametrize(('getter', 'arg_attr', 'config_key', 'env_var', 'cli_flag'), GETTER_CASES)
+def test_getter_returns_value_verbatim(
+    getter: RootGetter,
+    arg_attr: str,
+    config_key: str,
+    env_var: str,
+    cli_flag: str,
+    root_value: str,
+) -> None:
+    """Relative paths and cloud URLs pass through without normalization.
+
+    The getters promise only to return the string that was found; no
+    absolutization or URL handling is documented or performed.
+
+    Parameters:
+        getter: The root getter under test.
+        arg_attr: Name of the argparse attribute the getter reads.
+        config_key: Key in ``config.environment`` the getter reads (unused here).
+        env_var: Environment variable the getter reads (unused here).
+        cli_flag: CLI flag named in the getter's error message (unused here).
+        root_value: The relative-path or cloud-URL value to round-trip.
+    """
+
+    config = _config_with_environment(None)
+    arguments = argparse.Namespace(**{arg_attr: root_value})
+    assert getter(arguments, config) == root_value
+
+
+def test_bundle_getter_env_var_is_nav_prefixed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The bundle getter reads NAV_BUNDLE_RESULTS_ROOT, not BUNDLE_RESULTS_ROOT.
+
+    The fallback environment variable carries the same ``NAV_`` prefix as the
+    sibling getters; a value exported under the un-prefixed name is ignored.
+
+    Parameters:
+        monkeypatch: Pytest fixture for environment isolation.
+    """
+
+    monkeypatch.setenv('NAV_BUNDLE_RESULTS_ROOT', '/from/nav/env')
+    config = _config_with_environment(None)
+    result = get_pds4_bundle_results_root(argparse.Namespace(), config)
+    assert result == '/from/nav/env'
+
+
+def test_bundle_getter_ignores_unprefixed_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A value exported under the un-prefixed name does not resolve the root.
+
+    Parameters:
+        monkeypatch: Pytest fixture for environment isolation.
+    """
+
+    monkeypatch.setenv('BUNDLE_RESULTS_ROOT', '/from/documented/env')
+    config = _config_with_environment(None)
+    with pytest.raises(ValueError, match='NAV_BUNDLE_RESULTS_ROOT'):
+        get_pds4_bundle_results_root(argparse.Namespace(), config)
+
+
+# ---------------------------------------------------------------------------
+# load_default_and_user_config
+# ---------------------------------------------------------------------------
+
+
+def test_load_bundled_defaults_without_user_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing ./nav_default_config.yaml is tolerated and defaults load.
+
+    Parameters:
+        tmp_path: Empty directory used as the current working directory.
+        monkeypatch: Pytest fixture used to change the working directory.
+    """
+
+    monkeypatch.chdir(tmp_path)
+    config = Config()
+    load_default_and_user_config(argparse.Namespace(), config)
+    assert config.is_loaded is True
+    assert config.override_paths == ()
+
+
+def test_load_applies_user_default_config_from_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """nav_default_config.yaml in the current directory overrides defaults.
+
+    Parameters:
+        tmp_path: Directory holding the generated user config file.
+        monkeypatch: Pytest fixture used to change the working directory.
+    """
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / 'nav_default_config.yaml').write_text(
+        'environment:\n  nav_results_root: /user/results\n', encoding='utf-8'
+    )
+    config = Config()
+    load_default_and_user_config(argparse.Namespace(), config)
+    assert config.environment.nav_results_root == '/user/results'
+    assert config.override_paths == ('nav_default_config.yaml',)
+
+
+def test_load_user_default_preserves_bundled_siblings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """User overrides deep-merge: untouched bundled keys survive.
+
+    Parameters:
+        tmp_path: Directory holding the generated user config file.
+        monkeypatch: Pytest fixture used to change the working directory.
+    """
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / 'nav_default_config.yaml').write_text(
+        'general:\n  truetype_font_dir: /user/fonts\n', encoding='utf-8'
+    )
+    config = Config()
+    load_default_and_user_config(argparse.Namespace(), config)
+    assert config.general.truetype_font_dir == '/user/fonts'
+    assert config.general.log_level_annotate == 'ERROR'
+
+
+def test_load_explicit_config_files_apply_in_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every --config-file path is applied, later files winning on conflicts.
+
+    Parameters:
+        tmp_path: Directory holding the generated override files.
+        monkeypatch: Pytest fixture used to change the working directory.
+    """
+
+    monkeypatch.chdir(tmp_path)
+    first = tmp_path / 'first.yaml'
+    first.write_text('environment:\n  nav_results_root: /first\n', encoding='utf-8')
+    second = tmp_path / 'second.yaml'
+    second.write_text('environment:\n  nav_results_root: /second\n', encoding='utf-8')
+    config = Config()
+    arguments = argparse.Namespace(config_file=[str(first), str(second)])
+    load_default_and_user_config(arguments, config)
+    assert config.environment.nav_results_root == '/second'
+    assert config.override_paths == (str(first), str(second))
+
+
+def test_load_explicit_config_files_skip_user_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When --config-file is given, nav_default_config.yaml is not read.
+
+    Parameters:
+        tmp_path: Directory holding both the explicit override and the
+            user-default file that must be ignored.
+        monkeypatch: Pytest fixture used to change the working directory.
+    """
+
+    monkeypatch.chdir(tmp_path)
+    explicit = tmp_path / 'explicit.yaml'
+    explicit.write_text('environment:\n  nav_results_root: /explicit\n', encoding='utf-8')
+    (tmp_path / 'nav_default_config.yaml').write_text(
+        'environment:\n  nav_results_root: /user\n  backplane_results_root: /user-bp\n',
+        encoding='utf-8',
+    )
+    config = Config()
+    load_default_and_user_config(argparse.Namespace(config_file=[str(explicit)]), config)
+    assert config.environment.nav_results_root == '/explicit'
+    assert 'backplane_results_root' not in config.environment
+
+
+def test_load_missing_explicit_config_file_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only the implicit user default is optional; explicit paths must exist.
+
+    Parameters:
+        tmp_path: Empty directory used as the current working directory.
+        monkeypatch: Pytest fixture used to change the working directory.
+    """
+
+    monkeypatch.chdir(tmp_path)
+    config = Config()
+    missing = str(tmp_path / 'no_such_config.yaml')
+    arguments = argparse.Namespace(config_file=[missing])
+    with pytest.raises(FileNotFoundError, match=r'no_such_config\.yaml'):
+        load_default_and_user_config(arguments, config)
+
+
+def test_load_malformed_user_default_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A user config that is not a YAML mapping raises ValueError.
+
+    The docstring is silent on malformed files; only FileNotFoundError is
+    suppressed, so the non-mapping diagnostic from Config propagates.
+
+    Parameters:
+        tmp_path: Directory holding the malformed user config file.
+        monkeypatch: Pytest fixture used to change the working directory.
+    """
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / 'nav_default_config.yaml').write_text('- not\n- a\n- mapping\n', encoding='utf-8')
+    config = Config()
+    with pytest.raises(ValueError, match='did not parse to a dictionary mapping'):
+        load_default_and_user_config(argparse.Namespace(), config)
+
+
+def test_load_config_file_none_still_loads_user_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """config_file=None (flag defined but not passed) must load the user default.
+
+    Every sd_* CLI defines --config-file with default=None and documents 'If
+    not provided, attempts to load ./nav_default_config.yaml if present'
+    (CLAUDE.md agrees: user overrides come from nav_default_config.yaml). The
+    implementation's early return fires whenever the attribute exists, even
+    when it is None/empty, so real CLI runs never load the user file.
+
+    Parameters:
+        tmp_path: Directory holding the user config file that should load.
+        monkeypatch: Pytest fixture used to change the working directory.
+    """
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / 'nav_default_config.yaml').write_text(
+        'environment:\n  nav_results_root: /user/results\n', encoding='utf-8'
+    )
+    config = Config()
+    load_default_and_user_config(argparse.Namespace(config_file=None), config)
+    assert config.environment.nav_results_root == '/user/results'
+
+
+def test_loaded_user_config_feeds_getter_before_env_var(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End to end: a user-config root outranks the environment variable.
+
+    Parameters:
+        tmp_path: Directory holding the generated user config file.
+        monkeypatch: Pytest fixture for cwd and environment isolation.
+    """
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv('NAV_RESULTS_ROOT', '/from/env')
+    (tmp_path / 'nav_default_config.yaml').write_text(
+        'environment:\n  nav_results_root: /from/user/config\n', encoding='utf-8'
+    )
+    config = Config()
+    load_default_and_user_config(argparse.Namespace(), config)
+    result = get_nav_results_root(argparse.Namespace(nav_results_root=None), config)
+    assert result == '/from/user/config'

--- a/tests/spindoctor/nav_model/test_nav_model_body_render.py
+++ b/tests/spindoctor/nav_model/test_nav_model_body_render.py
@@ -1,0 +1,894 @@
+"""Spec-first tests for the ``NavModelBody`` rendering pipeline.
+
+Covers ``_render`` / ``_build_backplane_model`` plus the parts of
+``instances_for_obs`` / ``to_features`` / ``to_annotations`` that depend on the
+rendered state.  The contract asserted here comes from
+``docs/dev_guide/dev_guide_navigation_models_body.rst`` and the module / method
+docstrings, not from the current implementation:
+
+- The predicted brightness image is extfov-shaped, float64, zero off-body, and
+  is the Lambert cosine plus a small floor on lit silhouette pixels (or the
+  0.01 visibility floor when the body is entirely dark).
+- The limb mask is the set of *lit* silhouette pixels with at least one
+  off-body neighbour; the terminator mask is the set of lit pixels with at
+  least one dark neighbour.
+- ``visible_lit_fraction`` and ``overflow_fraction`` follow the documented
+  formulas over the discrete masks.
+- An empty silhouette collapses every downstream product (masks, samplers,
+  km/px) to its empty / zero form without special-case failures.
+- Feature emission gates (LIMB_ARC / BODY_DISC / BODY_BLOB / TERMINATOR_ARC)
+  fire exactly per the documented thresholds.
+
+The oops ``Meshgrid`` / ``Backplane`` names inside the module under test are
+monkeypatched with an analytic orthographic-sphere backplane so the tests are
+hermetic (no SPICE, no holdings).
+"""
+
+from __future__ import annotations
+
+import math
+import types
+from dataclasses import dataclass
+from typing import Any, cast
+
+import numpy as np
+import polymath
+import pytest
+from tests.shims import BodyBackplaneData, FakeBackplane, FakeMeshgrid, FakeObs, bare_nav_context
+
+import spindoctor.nav_model.nav_model_body as nav_model_body_module
+from spindoctor.annotation import Annotations
+from spindoctor.config.config import Config
+from spindoctor.feature.feature import NavFeature
+from spindoctor.feature.geometry import LimbPolyline
+from spindoctor.nav_model.nav_model_body import NavModelBody
+from spindoctor.nav_orchestrator.nav_context import NavContext
+from spindoctor.support.types import NDArrayBoolType, NDArrayFloatType
+
+_BODY = 'TESTBODY'
+
+
+@dataclass(frozen=True)
+class _SphereSpec:
+    """Analytic orthographic-sphere scene driving the fake backplane.
+
+    Parameters:
+        center_vu: Sphere centre in FOV pixel coordinates ``(v, u)``.
+        radius_px: Sphere radius in pixels.
+        sun_vuz: Sun direction in the ``(v, u, z)`` image frame where ``+z``
+            points toward the observer.  Normalised on use.
+        km_per_px: Constant km/px scale on the resolved body.
+    """
+
+    center_vu: tuple[float, float]
+    radius_px: float
+    sun_vuz: tuple[float, float, float] = (0.0, 0.0, 1.0)
+    km_per_px: float = 5.0
+
+
+def _sun_for_angle(alpha_deg: float) -> tuple[float, float, float]:
+    """Return a sun direction tilted ``alpha_deg`` from the observer axis.
+
+    Parameters:
+        alpha_deg: Tilt angle in degrees; the tilt is along the +u axis so the
+            terminator appears on the -u side of the disc.
+    """
+    alpha = math.radians(alpha_deg)
+    return (0.0, math.sin(alpha), math.cos(alpha))
+
+
+def _sphere_backplane_class(spec: _SphereSpec) -> type:
+    """Build a Backplane stand-in rendering ``spec`` over any meshgrid.
+
+    The class mirrors the three per-pixel products ``_build_backplane_model``
+    queries: ``incidence_angle`` (masked off the silhouette), ``lambert_law``
+    (cosine of incidence clipped at zero, masked off the silhouette), and
+    ``resolution`` (constant km/px, masked off the silhouette).
+
+    Parameters:
+        spec: Sphere geometry to render.
+    """
+    sun = np.asarray(spec.sun_vuz, dtype=np.float64)
+    sun = sun / np.linalg.norm(sun)
+
+    class _SphereBackplane:
+        """Backplane stand-in computing sphere geometry over a fake meshgrid.
+
+        Parameters:
+            obs: Observation (unused; accepted for signature parity).
+            meshgrid: ``FakeMeshgrid`` carrying origin / limit / oversample.
+        """
+
+        def __init__(self, obs: Any, meshgrid: FakeMeshgrid | None = None) -> None:
+            assert meshgrid is not None
+            self._mg = meshgrid
+
+        def _grid(self) -> tuple[NDArrayFloatType, NDArrayFloatType]:
+            """Return ``(vv, uu)`` sample-centre coordinate arrays."""
+            assert self._mg.origin is not None
+            assert self._mg.limit is not None
+            assert self._mg.oversample is not None
+            origin_u, origin_v = self._mg.origin
+            limit_u, limit_v = self._mg.limit
+            over_u, over_v = self._mg.oversample
+            n_u = round((limit_u - origin_u) * over_u) + 1
+            n_v = round((limit_v - origin_v) * over_v) + 1
+            u = origin_u + np.arange(n_u, dtype=np.float64) / over_u
+            v = origin_v + np.arange(n_v, dtype=np.float64) / over_v
+            vv, uu = np.meshgrid(v, u, indexing='ij')
+            return vv, uu
+
+        def _geometry(self) -> tuple[NDArrayBoolType, NDArrayFloatType, NDArrayFloatType]:
+            """Return ``(on_body, incidence_rad, cos_incidence)`` arrays."""
+            vv, uu = self._grid()
+            center_v, center_u = spec.center_vu
+            dv = vv - center_v
+            du = uu - center_u
+            dist = np.hypot(dv, du)
+            on_body = dist <= spec.radius_px
+            r = spec.radius_px
+            z = np.sqrt(np.clip(r * r - dist * dist, 0.0, None))
+            cos_inc = (dv * sun[0] + du * sun[1] + z * sun[2]) / r
+            incidence = np.arccos(np.clip(cos_inc, -1.0, 1.0))
+            return on_body, incidence, cos_inc
+
+        def incidence_angle(self, body_name: str) -> polymath.Scalar:
+            """Return per-sample incidence angle masked off the silhouette."""
+            del body_name
+            on_body, incidence, _ = self._geometry()
+            return polymath.Scalar(np.ma.array(incidence, mask=~on_body))
+
+        def lambert_law(self, body_name: str) -> polymath.Scalar:
+            """Return per-sample Lambert reflectance masked off the silhouette."""
+            del body_name
+            on_body, _, cos_inc = self._geometry()
+            lam = np.clip(cos_inc, 0.0, None)
+            return polymath.Scalar(np.ma.array(lam, mask=~on_body))
+
+        def resolution(self, body_name: str) -> polymath.Scalar:
+            """Return the constant km/px scale masked off the silhouette."""
+            del body_name
+            on_body, _, _ = self._geometry()
+            res = np.full(on_body.shape, spec.km_per_px, dtype=np.float64)
+            return polymath.Scalar(np.ma.array(res, mask=~on_body))
+
+    return _SphereBackplane
+
+
+def _make_obs(
+    spec: _SphereSpec,
+    *,
+    data_shape: tuple[int, int] = (100, 100),
+    margin: int = 10,
+    phase_deg: float = 30.0,
+    sub_solar_lonlat_deg: tuple[float, float] = (10.0, 20.0),
+    sub_observer_lonlat_deg: tuple[float, float] = (30.0, 40.0),
+) -> tuple[FakeObs, dict[str, Any]]:
+    """Build a ``FakeObs`` plus the sphere's inventory record.
+
+    Parameters:
+        spec: Sphere geometry (drives the inventory bounding box).
+        data_shape: Sensor-area ``(rows, cols)`` shape.
+        margin: Extfov margin applied to both axes.
+        phase_deg: Centre phase angle reported by the geometry backplane.
+        sub_solar_lonlat_deg: ``(lon, lat)`` reported for the sub-solar point.
+        sub_observer_lonlat_deg: ``(lon, lat)`` reported for the sub-observer
+            point.
+    """
+    center_v, center_u = spec.center_vu
+    r = spec.radius_px
+    inventory = {
+        'u_min_unclipped': int(np.floor(center_u - r)),
+        'u_max_unclipped': int(np.ceil(center_u + r)),
+        'v_min_unclipped': int(np.floor(center_v - r)),
+        'v_max_unclipped': int(np.ceil(center_v + r)),
+        'u_pixel_size': 2.0 * r,
+        'v_pixel_size': 2.0 * r,
+        'range': 1.0e6,
+    }
+    geometry_body = BodyBackplaneData(
+        body_mask=np.ones((1, 1), dtype=bool),
+        incidence_rad=np.zeros((1, 1), dtype=np.float64),
+        sub_solar_lon_rad=math.radians(sub_solar_lonlat_deg[0]),
+        sub_solar_lat_rad=math.radians(sub_solar_lonlat_deg[1]),
+        sub_observer_lon_rad=math.radians(sub_observer_lonlat_deg[0]),
+        sub_observer_lat_rad=math.radians(sub_observer_lonlat_deg[1]),
+        center_phase_rad=math.radians(phase_deg),
+    )
+    obs = FakeObs(
+        data=np.zeros(data_shape, dtype=np.float64),
+        extfov_margin_vu=(margin, margin),
+        closest_planet='SATURN',
+        ext_bp=FakeBackplane(per_body={_BODY: geometry_body}),
+        inventory_records={_BODY: inventory},
+    )
+    return obs, inventory
+
+
+def _make_model(
+    monkeypatch: pytest.MonkeyPatch,
+    spec: _SphereSpec,
+    *,
+    config: Config | None = None,
+    **obs_kwargs: Any,
+) -> tuple[NavModelBody, FakeObs]:
+    """Build a ``NavModelBody`` wired to the analytic sphere backplane.
+
+    Parameters:
+        monkeypatch: Pytest monkeypatch fixture (patches the module's oops
+            ``Meshgrid`` / ``Backplane`` names).
+        spec: Sphere geometry to render.
+        config: Optional ``Config`` override for the model.
+        **obs_kwargs: Forwarded to :func:`_make_obs`.
+    """
+    obs, inventory = _make_obs(spec, **obs_kwargs)
+    monkeypatch.setattr(nav_model_body_module, 'Meshgrid', FakeMeshgrid)
+    monkeypatch.setattr(nav_model_body_module, 'Backplane', _sphere_backplane_class(spec))
+    model = NavModelBody(f'body:{_BODY}', cast(Any, obs), _BODY, inventory=inventory, config=config)
+    return model, obs
+
+
+def _noise_context(obs: FakeObs, *, seed: int = 12345) -> NavContext:
+    """Return a NavContext over a deterministic unit-sigma noise frame.
+
+    Parameters:
+        obs: Observation whose extfov shape sizes the frame.
+        seed: RNG seed for reproducibility.
+    """
+    rng = np.random.default_rng(seed)
+    image = rng.standard_normal(obs.extdata_shape_vu)
+    return bare_nav_context(cast(Any, obs), image)
+
+
+def _bodies_config(**overrides: Any) -> Config:
+    """Return a ``Config`` with ``bodies`` keys overridden.
+
+    Parameters:
+        **overrides: Key / value pairs written into the ``bodies`` block.
+    """
+    config = Config()
+    config.read_config()
+    bodies = dict(config._config_dict['bodies'])
+    bodies.update(overrides)
+    config._config_dict['bodies'] = bodies
+    config._update_attrdicts()
+    return config
+
+
+def _feature_types(features: list[NavFeature]) -> set[str]:
+    """Return the set of feature-type names emitted.
+
+    Parameters:
+        features: Features returned by ``to_features``.
+    """
+    return {f.feature_type.name for f in features}
+
+
+def _analytic_disc(obs: FakeObs, spec: _SphereSpec) -> NDArrayBoolType:
+    """Return the analytic pixel-centre silhouette in extfov coordinates.
+
+    Pixel index ``i`` covers continuous coordinate ``[i, i + 1)``, so its
+    centre sits at ``i + 0.5`` in the FOV frame the sphere is defined in.
+
+    Parameters:
+        obs: Observation defining the extfov grid.
+        spec: Sphere geometry.
+    """
+    shape = obs.extdata_shape_vu
+    vv, uu = np.indices(shape, dtype=np.float64)
+    center_v = spec.center_vu[0] + obs.extfov_margin_v
+    center_u = spec.center_vu[1] + obs.extfov_margin_u
+    disc: NDArrayBoolType = np.hypot(vv + 0.5 - center_v, uu + 0.5 - center_u) <= spec.radius_px
+    return disc
+
+
+# ---------------------------------------------------------------------------
+# _render / _build_backplane_model: brightness image contract
+# ---------------------------------------------------------------------------
+
+
+def test_model_img_is_extfov_shaped_float64(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The rendered brightness image is float64 over the extended FOV grid."""
+    model, obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 20.0))
+    model.create_model()
+    assert model._model_img is not None
+    assert model._model_img.shape == obs.extdata_shape_vu
+    assert model._model_img.dtype == np.float64
+
+
+def test_model_img_zero_outside_bbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pixels outside the body bounding box carry exactly zero."""
+    model, _obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 20.0))
+    model.create_model()
+    assert model._model_img is not None
+    v_min, u_min, v_max, u_max = model._bbox_extfov_vu
+    outside = np.ones_like(model._model_img, dtype=bool)
+    outside[v_min:v_max, u_min:u_max] = False
+    assert float(np.abs(model._model_img[outside]).max()) == 0.0
+
+
+def test_model_img_zero_on_off_body_pixels_inside_bbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Off-body pixels inside the bounding box carry exactly zero."""
+    model, _obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 20.0))
+    model.create_model()
+    assert model._model_img is not None
+    assert model._body_mask is not None
+    v_min, u_min, v_max, u_max = model._bbox_extfov_vu
+    inside_bbox = np.zeros_like(model._body_mask)
+    inside_bbox[v_min:v_max, u_min:u_max] = True
+    off_body = inside_bbox & ~model._body_mask
+    assert bool(off_body.any())
+    assert float(np.abs(model._model_img[off_body]).max()) == 0.0
+
+
+def test_model_img_lambert_plus_floor_at_disc_center(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lit pixel's value is the Lambert cosine plus the 0.05 floor."""
+    # Centre the sphere on a pixel centre (pixel 50 spans [50, 51)) so the
+    # centre pixel's surface normal is +z and cos(incidence) = cos(60).
+    spec = _SphereSpec((50.5, 50.5), 20.0, sun_vuz=_sun_for_angle(60.0))
+    model, obs = _make_model(monkeypatch, spec)
+    model.create_model()
+    assert model._model_img is not None
+    center_v = 50 + obs.extfov_margin_v
+    center_u = 50 + obs.extfov_margin_u
+    expected = math.cos(math.radians(60.0)) + 0.05
+    assert model._model_img[center_v, center_u] == pytest.approx(expected, abs=0.02)
+
+
+def test_dark_body_renders_visibility_floor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An entirely-dark silhouette renders the 0.01 visibility floor on-body."""
+    model, _obs = _make_model(
+        monkeypatch, _SphereSpec((50.0, 50.0), 20.0, sun_vuz=(0.0, 0.0, -1.0))
+    )
+    model.create_model()
+    assert model._model_img is not None
+    assert model._body_mask is not None
+    on_body_values = np.unique(model._model_img[model._body_mask])
+    assert on_body_values.tolist() == [0.01]
+
+
+def test_binary_silhouette_when_lambert_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With ``use_lambert`` false the brightness image is the binary silhouette."""
+    config = _bodies_config(use_lambert=False)
+    model, _obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 20.0), config=config)
+    model.create_model()
+    assert model._model_img is not None
+    assert model._body_mask is not None
+    on_body_values = np.unique(model._model_img[model._body_mask])
+    assert on_body_values.tolist() == [1.0]
+
+
+def test_albedo_scales_brightness(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With ``use_albedo`` the brightness image is scaled by the body's albedo."""
+    albedo = 0.25
+    plain = _bodies_config(use_albedo=False)
+    scaled = _bodies_config(use_albedo=True, geometric_albedo={_BODY: albedo})
+    spec = _SphereSpec((50.0, 50.0), 20.0)
+    model_plain, _obs = _make_model(monkeypatch, spec, config=plain)
+    model_plain.create_model()
+    model_scaled, _obs2 = _make_model(monkeypatch, spec, config=scaled)
+    model_scaled.create_model()
+    assert model_plain._model_img is not None
+    assert model_scaled._model_img is not None
+    ratio = model_scaled._model_img.max() / model_plain._model_img.max()
+    assert ratio == pytest.approx(albedo, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# _render: mask contracts
+# ---------------------------------------------------------------------------
+
+
+def test_body_mask_matches_analytic_silhouette(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The rendered silhouette agrees with the analytic disc (IoU > 0.9)."""
+    spec = _SphereSpec((50.0, 50.0), 20.0)
+    model, obs = _make_model(monkeypatch, spec)
+    model.create_model()
+    assert model._body_mask is not None
+    analytic = _analytic_disc(obs, spec)
+    intersection = int((model._body_mask & analytic).sum())
+    union = int((model._body_mask | analytic).sum())
+    assert intersection / union > 0.9
+
+
+def test_limb_mask_is_boundary_subset_of_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every limb pixel is a silhouette pixel with an off-body 4-neighbour."""
+    model, _obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 20.0))
+    model.create_model()
+    assert model._limb_mask is not None
+    assert model._body_mask is not None
+    limb = model._limb_mask
+    body = model._body_mask
+    assert bool(limb.any())
+    assert bool((limb & ~body).sum() == 0)
+    off = ~body
+    has_space_neighbour = (
+        np.roll(off, 1, axis=0)
+        | np.roll(off, -1, axis=0)
+        | np.roll(off, 1, axis=1)
+        | np.roll(off, -1, axis=1)
+    )
+    assert bool((limb & ~has_space_neighbour).sum() == 0)
+
+
+def test_limb_mask_empty_for_fully_dark_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The limb mask keeps only lit-side vertices, so a dark body has none."""
+    model, _obs = _make_model(
+        monkeypatch, _SphereSpec((50.0, 50.0), 20.0, sun_vuz=(0.0, 0.0, -1.0))
+    )
+    model.create_model()
+    assert model._limb_mask is not None
+    assert int(model._limb_mask.sum()) == 0
+
+
+def test_terminator_location_matches_analytic_prediction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The terminator ridge sits at ``u = center_u - r*cos(alpha)`` mid-disc.
+
+    For an orthographic sphere lit from ``alpha`` degrees off the observer
+    axis (tilt along +u), the terminator's innermost column is at
+    ``center_u - radius * cos(alpha)``.
+    """
+    alpha_deg = 60.0
+    spec = _SphereSpec((50.0, 50.0), 20.0, sun_vuz=_sun_for_angle(alpha_deg))
+    model, obs = _make_model(monkeypatch, spec, phase_deg=alpha_deg)
+    model.create_model()
+    assert model._terminator_mask is not None
+    vs, us = np.where(model._terminator_mask)
+    assert vs.size > 0
+    expected_u = (
+        spec.center_vu[1] - spec.radius_px * math.cos(math.radians(alpha_deg)) + obs.extfov_margin_u
+    )
+    assert float(us.min()) == pytest.approx(expected_u, abs=2.0)
+
+
+def test_terminator_empty_when_fully_lit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A sub-solar-illuminated disc has no lit-to-dark boundary."""
+    model, _obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 20.0))
+    model.create_model()
+    assert model._terminator_mask is not None
+    assert int(model._terminator_mask.sum()) == 0
+
+
+def test_nonsquare_fov_places_body_correctly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On a non-square FOV the silhouette lands at the predicted extfov centre."""
+    spec = _SphereSpec((30.0, 90.0), 15.0)
+    model, obs = _make_model(monkeypatch, spec, data_shape=(60, 120))
+    model.create_model()
+    assert model._body_mask is not None
+    vs, us = np.where(model._body_mask)
+    assert vs.size > 0
+    assert float(vs.mean()) == pytest.approx(30.0 + obs.extfov_margin_v, abs=1.0)
+    assert float(us.mean()) == pytest.approx(90.0 + obs.extfov_margin_u, abs=1.0)
+
+
+# ---------------------------------------------------------------------------
+# _render: metadata and derived scalars
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_geometry_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The documented geometry metadata entries reflect the backplane values."""
+    model, _obs = _make_model(
+        monkeypatch,
+        _SphereSpec((50.0, 50.0), 20.0),
+        phase_deg=45.0,
+        sub_solar_lonlat_deg=(11.0, 22.0),
+        sub_observer_lonlat_deg=(33.0, 44.0),
+    )
+    model.create_model()
+    meta = model.metadata
+    assert meta['body_name'] == _BODY
+    assert meta['sub_solar_lon_deg'] == pytest.approx(11.0)
+    assert meta['sub_solar_lat_deg'] == pytest.approx(22.0)
+    assert meta['sub_observer_lon_deg'] == pytest.approx(33.0)
+    assert meta['sub_observer_lat_deg'] == pytest.approx(44.0)
+    assert meta['phase_angle_deg'] == pytest.approx(45.0)
+
+
+def test_metadata_bookkeeping_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Timing, bbox-area, and size entries are populated by ``create_model``."""
+    model, _obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 20.0))
+    model.create_model()
+    meta = model.metadata
+    assert meta['end_time'] is not None
+    assert meta['elapsed_time_sec'] is not None
+    assert meta['bbox_area_px'] == pytest.approx(1600.0)
+    assert meta['size_ok'] is True
+    assert meta['predicted_diameter_px'] == pytest.approx(40.0)
+
+
+def test_km_per_pixel_at_limb_positive_and_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The mean limb km/px is positive and at most the configured constant.
+
+    Anti-aliased limb pixels average the on-body scale with off-body zeros, so
+    the mean sits below the constant but must remain strictly positive.
+    """
+    spec = _SphereSpec((50.0, 50.0), 20.0, km_per_px=5.0)
+    model, _obs = _make_model(monkeypatch, spec)
+    model.create_model()
+    assert model._km_per_pixel_at_limb > 0.0
+    assert model._km_per_pixel_at_limb <= 5.0
+
+
+def test_visible_lit_fraction_matches_illuminated_area(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """For a fully-framed sphere the lit fraction is ``(1 + cos(alpha)) / 2``."""
+    alpha_deg = 60.0
+    spec = _SphereSpec((50.0, 50.0), 20.0, sun_vuz=_sun_for_angle(alpha_deg))
+    model, _obs = _make_model(monkeypatch, spec, phase_deg=alpha_deg)
+    model.create_model()
+    expected = (1.0 + math.cos(math.radians(alpha_deg))) / 2.0
+    assert model._visible_lit_fraction == pytest.approx(expected, abs=0.05)
+
+
+def test_overflow_zero_for_centered_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A body fully inside the sensor has zero overflow."""
+    model, _obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 20.0))
+    model.create_model()
+    assert model._overflow_fraction == pytest.approx(0.0)
+
+
+def test_overflow_fraction_matches_off_sensor_area(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Overflow equals the fraction of silhouette pixels outside the sensor.
+
+    Checked twice per the documented formula ``1 - |body & sensor| / |body|``:
+    exactly against the model's own discrete masks, and approximately against
+    an independent analytic pixel-centre count (the rendered mask is
+    anti-aliased, so the analytic count carries a small boundary tolerance).
+    """
+    spec = _SphereSpec((50.0, 95.0), 10.0)
+    model, obs = _make_model(monkeypatch, spec)
+    model.create_model()
+    assert model._body_mask is not None
+    sensor = obs.extfov_data_sensor_mask()
+    body = model._body_mask
+    from_masks = 1.0 - int((body & sensor).sum()) / int(body.sum())
+    assert model._overflow_fraction == pytest.approx(from_masks)
+    analytic = _analytic_disc(obs, spec)
+    independent = 1.0 - int((analytic & sensor).sum()) / int(analytic.sum())
+    assert model._overflow_fraction == pytest.approx(independent, abs=0.02)
+
+
+def test_body_entirely_in_margin_scores_zero_visible_lit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A body rendered wholly inside the extfov margin has vlf 0 / overflow 1."""
+    model, _obs = _make_model(monkeypatch, _SphereSpec((50.0, -5.0), 4.0))
+    model.create_model()
+    assert model._body_mask is not None
+    assert int(model._body_mask.sum()) > 0
+    assert model._visible_lit_fraction == pytest.approx(0.0)
+    assert model._overflow_fraction == pytest.approx(1.0)
+
+
+def test_body_overflowing_every_edge(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A frame-filling body clips against every extfov border and overflows."""
+    model, _obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 80.0))
+    model.create_model()
+    assert model._body_mask is not None
+    body = model._body_mask
+    assert bool(body[0, :].any())
+    assert bool(body[-1, :].any())
+    assert bool(body[:, 0].any())
+    assert bool(body[:, -1].any())
+    assert model._overflow_fraction > 0.0
+
+
+def test_guaranteed_visible_flag_true_for_inner_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bbox fully inside the sensor-minus-margin area sets the flag True."""
+    model, _obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 20.0))
+    model.create_model()
+    assert model.metadata['guaranteed_visible_in_fov'] is True
+
+
+def test_guaranteed_visible_flag_false_near_edge(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bbox crossing the sensor-minus-margin boundary sets the flag False."""
+    model, _obs = _make_model(monkeypatch, _SphereSpec((50.0, 95.0), 10.0))
+    model.create_model()
+    assert model.metadata['guaranteed_visible_in_fov'] is False
+
+
+# ---------------------------------------------------------------------------
+# _render: degenerate silhouettes
+# ---------------------------------------------------------------------------
+
+
+def test_empty_silhouette_produces_empty_products(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty silhouette collapses masks, image, and km/px without failing.
+
+    The sphere is placed between the oversampled sample centres so no sample
+    lands on the body; per the dev guide, an empty mask collapses the sampler
+    to zero-length arrays and the downstream gates skip every feature.
+    """
+    model, obs = _make_model(monkeypatch, _SphereSpec((50.5, 50.5), 0.1))
+    model.create_model()
+    assert model._body_mask is not None
+    assert int(model._body_mask.sum()) == 0
+    assert model._model_img is not None
+    assert float(np.abs(model._model_img).max()) == 0.0
+    assert model._km_per_pixel_at_limb == pytest.approx(0.0)
+    assert model._visible_lit_fraction == pytest.approx(0.0)
+    assert model._overflow_fraction == pytest.approx(1.0)
+    features = model.to_features(bare_nav_context(cast(Any, obs)))
+    assert features == []
+
+
+def test_body_beyond_extfov_renders_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A body whose bbox lies wholly beyond the extfov renders nothing.
+
+    The clipped bbox degenerates to the extfov edge (exercising the one-pixel
+    bump) and the silhouette query returns all-masked, so every mask is empty.
+    """
+    model, _obs = _make_model(monkeypatch, _SphereSpec((50.0, 200.0), 20.0))
+    model.create_model()
+    assert model._body_mask is not None
+    assert int(model._body_mask.sum()) == 0
+    assert model._model_img is not None
+    assert float(np.abs(model._model_img).max()) == 0.0
+    assert model._overflow_fraction == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# to_features: emission gates over rendered state
+# ---------------------------------------------------------------------------
+
+
+def test_limb_arc_emitted_for_resolved_lit_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A well-resolved lit body with low limb uncertainty emits LIMB_ARC."""
+    model, obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 20.0))
+    model.create_model()
+    features = model.to_features(bare_nav_context(cast(Any, obs)))
+    assert 'LIMB_ARC' in _feature_types(features)
+
+
+def test_body_disc_emitted_alongside_limb_arc(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BODY_DISC accompanies LIMB_ARC when visibility / overflow gates pass."""
+    model, obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 20.0))
+    model.create_model()
+    types_emitted = _feature_types(model.to_features(bare_nav_context(cast(Any, obs))))
+    assert 'LIMB_ARC' in types_emitted
+    assert 'BODY_DISC' in types_emitted
+
+
+def test_terminator_arc_emitted_when_gates_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TERMINATOR_ARC fires with enough vertices and sin(phase) above 0.05."""
+    spec = _SphereSpec((50.0, 50.0), 20.0, sun_vuz=_sun_for_angle(60.0))
+    model, obs = _make_model(monkeypatch, spec, phase_deg=60.0)
+    model.create_model()
+    types_emitted = _feature_types(model.to_features(bare_nav_context(cast(Any, obs))))
+    assert 'TERMINATOR_ARC' in types_emitted
+
+
+def test_no_terminator_below_phase_factor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TERMINATOR_ARC is suppressed when sin(phase) is below 0.05."""
+    spec = _SphereSpec((50.0, 50.0), 20.0, sun_vuz=_sun_for_angle(60.0))
+    model, obs = _make_model(monkeypatch, spec, phase_deg=2.0)
+    model.create_model()
+    types_emitted = _feature_types(model.to_features(bare_nav_context(cast(Any, obs))))
+    assert 'TERMINATOR_ARC' not in types_emitted
+
+
+def test_blob_emitted_when_limb_uncertainty_too_high(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BODY_BLOB replaces LIMB_ARC when the limb-uncertainty cap is exceeded.
+
+    A tiny km/px scale maps the ellipsoid residual to far more than the 3 px
+    cap, so the extractor must fall back to the centroid path.
+    """
+    spec = _SphereSpec((50.0, 50.0), 10.0, km_per_px=0.1)
+    model, obs = _make_model(monkeypatch, spec)
+    model.create_model()
+    types_emitted = _feature_types(model.to_features(_noise_context(obs)))
+    assert 'LIMB_ARC' not in types_emitted
+    assert 'BODY_BLOB' in types_emitted
+
+
+def test_no_disc_when_overflow_exceeds_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BODY_DISC is suppressed when the overflow fraction exceeds 0.3."""
+    spec = _SphereSpec((50.0, 101.0), 8.0)
+    model, obs = _make_model(monkeypatch, spec)
+    model.create_model()
+    assert model._overflow_fraction > 0.3
+    types_emitted = _feature_types(model.to_features(_noise_context(obs)))
+    assert 'BODY_DISC' not in types_emitted
+
+
+def test_no_features_for_subpixel_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A body below the blob-diameter floor emits nothing at all."""
+    model, obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 0.6))
+    model.create_model()
+    features = model.to_features(_noise_context(obs))
+    assert features == []
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        '#254: spec tension: dev_guide_navigation_models_body.rst says a fully-shadowed '
+        'silhouette emits only geometric features ("otherwise nothing"), but the '
+        'module docstring gates BODY_BLOB on diameter alone and the extractor emits '
+        'a BODY_BLOB for an all-dark disc'
+    ),
+)
+def test_fully_dark_body_emits_no_photometric_blob(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per the dev guide, an entirely-shadowed body emits no BODY_BLOB."""
+    model, obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 20.0, sun_vuz=(0.0, 0.0, -1.0)))
+    model.create_model()
+    types_emitted = _feature_types(model.to_features(_noise_context(obs)))
+    assert 'BODY_BLOB' not in types_emitted
+
+
+# ---------------------------------------------------------------------------
+# to_features: consistency between rendered silhouette and emitted polylines
+# ---------------------------------------------------------------------------
+
+
+def _limb_feature(model: NavModelBody, context: NavContext) -> NavFeature:
+    """Return the emitted LIMB_ARC feature.
+
+    Parameters:
+        model: Model whose ``create_model`` already ran.
+        context: NavContext for ``to_features``.
+    """
+    features = model.to_features(context)
+    return next(f for f in features if f.feature_type.name == 'LIMB_ARC')
+
+
+def test_limb_arc_vertices_lie_on_silhouette_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every LIMB_ARC vertex is a silhouette pixel adjacent to space."""
+    model, obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 20.0))
+    model.create_model()
+    limb = _limb_feature(model, bare_nav_context(cast(Any, obs)))
+    geometry = limb.geometry
+    assert isinstance(geometry, LimbPolyline)
+    assert model._body_mask is not None
+    body = model._body_mask
+    off = ~body
+    has_space_neighbour = (
+        np.roll(off, 1, axis=0)
+        | np.roll(off, -1, axis=0)
+        | np.roll(off, 1, axis=1)
+        | np.roll(off, -1, axis=1)
+    )
+    vs = geometry.vertices_vu[:, 0].astype(int)
+    us = geometry.vertices_vu[:, 1].astype(int)
+    assert bool(body[vs, us].all())
+    assert bool(has_space_neighbour[vs, us].all())
+
+
+def test_limb_arc_normals_point_outward(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LIMB_ARC normals point away from the body centre at >=95% of vertices."""
+    spec = _SphereSpec((50.0, 50.0), 20.0)
+    model, obs = _make_model(monkeypatch, spec)
+    model.create_model()
+    limb = _limb_feature(model, bare_nav_context(cast(Any, obs)))
+    geometry = limb.geometry
+    assert isinstance(geometry, LimbPolyline)
+    center = np.array(
+        [
+            spec.center_vu[0] + obs.extfov_margin_v,
+            spec.center_vu[1] + obs.extfov_margin_u,
+        ]
+    )
+    radial = geometry.vertices_vu - center
+    dots = np.sum(geometry.normals_vu * radial, axis=1)
+    outward_fraction = float(np.count_nonzero(dots > 0)) / dots.shape[0]
+    assert outward_fraction >= 0.95
+
+
+def test_limb_arc_sigmas_positive_and_finite(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The per-vertex sigma arrays are strictly positive and finite."""
+    model, obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 20.0))
+    model.create_model()
+    limb = _limb_feature(model, bare_nav_context(cast(Any, obs)))
+    geometry = limb.geometry
+    assert isinstance(geometry, LimbPolyline)
+    assert bool(np.all(geometry.sigma_normal_per_vertex_px > 0.0))
+    assert bool(np.all(np.isfinite(geometry.sigma_normal_per_vertex_px)))
+
+
+def test_disc_template_matches_model_crop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The BODY_DISC template is the brightness image cropped to the bbox."""
+    model, obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 20.0))
+    model.create_model()
+    features = model.to_features(bare_nav_context(cast(Any, obs)))
+    disc = next(f for f in features if f.feature_type.name == 'BODY_DISC')
+    assert model._model_img is not None
+    assert model._body_mask is not None
+    v_min, u_min, v_max, u_max = model._bbox_extfov_vu
+    assert disc.template_img is not None
+    assert disc.template_mask is not None
+    assert np.array_equal(disc.template_img, model._model_img[v_min:v_max, u_min:u_max])
+    assert np.array_equal(disc.template_mask, model._body_mask[v_min:v_max, u_min:u_max])
+
+
+# ---------------------------------------------------------------------------
+# instances_for_obs
+# ---------------------------------------------------------------------------
+
+
+def test_instances_for_obs_skips_simulated_obs() -> None:
+    """Simulated observations use the sim sibling, so no instances here."""
+    obs = types.SimpleNamespace(is_simulated=True)
+    assert NavModelBody.instances_for_obs(cast(Any, obs)) == []
+
+
+def test_instances_for_obs_requires_closest_planet() -> None:
+    """No closest planet means no candidate body list."""
+    obs = types.SimpleNamespace(closest_planet=None)
+    assert NavModelBody.instances_for_obs(cast(Any, obs)) == []
+
+
+def test_instances_for_obs_requires_callable_inventory() -> None:
+    """A non-callable inventory attribute yields no instances."""
+    obs = types.SimpleNamespace(closest_planet='SATURN', inventory=None)
+    assert NavModelBody.instances_for_obs(cast(Any, obs)) == []
+
+
+def test_instances_for_obs_tolerates_inventory_failure() -> None:
+    """An inventory query that raises ValueError yields no instances."""
+
+    def _raise(body_list: list[str], *, return_type: str = 'full') -> dict[str, Any]:
+        """Raise the error the SPICE-less inventory path produces."""
+        raise ValueError('no SPICE kernels')
+
+    obs = types.SimpleNamespace(closest_planet='SATURN', inventory=_raise)
+    assert NavModelBody.instances_for_obs(cast(Any, obs)) == []
+
+
+def test_instances_for_obs_returns_one_model_per_body_in_extfov() -> None:
+    """One instance per inventory entry whose bbox overlaps the extfov."""
+    in_fov = {
+        'u_min_unclipped': 30,
+        'u_max_unclipped': 70,
+        'v_min_unclipped': 30,
+        'v_max_unclipped': 70,
+        'u_pixel_size': 40.0,
+        'v_pixel_size': 40.0,
+        'range': 1.0e6,
+    }
+    out_of_fov = dict(in_fov)
+    out_of_fov.update(u_min_unclipped=500, u_max_unclipped=600)
+    obs = FakeObs(
+        data=np.zeros((100, 100), dtype=np.float64),
+        extfov_margin_vu=(10, 10),
+        closest_planet='SATURN',
+        inventory_records={'SATURN': in_fov, 'MIMAS': out_of_fov},
+    )
+    instances = NavModelBody.instances_for_obs(cast(Any, obs))
+    assert [inst.name for inst in instances] == ['body:SATURN']
+
+
+# ---------------------------------------------------------------------------
+# to_annotations
+# ---------------------------------------------------------------------------
+
+
+def test_to_annotations_empty_before_create_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without a rendered model the annotation collection is empty."""
+    model, obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 20.0))
+    annotations = model.to_annotations(bare_nav_context(cast(Any, obs)))
+    assert isinstance(annotations, Annotations)
+    assert annotations.annotations == []
+
+
+def test_to_annotations_emits_body_overlay(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After rendering, the model contributes one body annotation."""
+    model, obs = _make_model(monkeypatch, _SphereSpec((50.0, 50.0), 20.0))
+    model.create_model()
+    annotations = model.to_annotations(bare_nav_context(cast(Any, obs)))
+    assert len(annotations.annotations) == 1

--- a/tests/spindoctor/nav_model/test_nav_model_rings_render.py
+++ b/tests/spindoctor/nav_model/test_nav_model_rings_render.py
@@ -1,0 +1,825 @@
+"""Spec-first tests for the ``NavModelRings`` rendering pipeline.
+
+Covers ``_render`` (including the ``min_res_at_radius`` closure and the sparse
+visibility pre-check) plus the parts of ``instances_for_obs`` / ``to_features``
+/ ``to_annotations`` that depend on the rendered state.  The contract asserted
+here comes from ``docs/dev_guide/dev_guide_navigation_models_ring.rst`` and the
+module / method docstrings, not from the current implementation:
+
+- One RING_EDGE per surviving catalog edge on the "edges resolve" path; a
+  single composite RING_ANNULUS per planet on the "edges compress" path.
+- Per-vertex radial sigma is the feature's catalog RMS (max across edges)
+  divided by the radial km/px; the along-edge sigma is the 0.5 px constant.
+- Straight-line polylines are flagged ``is_straight_line`` and receive the
+  rank-1 reliability penalty.
+- ``min_res_at_radius`` maps a radius to the minimum positive finite radial
+  resolution along that radius's border pixels, or ``None`` when the radius
+  is not resolvable in the image (no border pixels, zero, or non-finite).
+- Skip paths: no ring-plane intersection, visible range beyond the catalog,
+  every feature filtered out, empty catalog.
+
+Backplane data is supplied by the table-driven ``tests.shims`` fakes; the
+sparse pre-check's oops ``Meshgrid`` / ``Backplane`` names are monkeypatched
+so the tests are hermetic (no SPICE, no holdings).
+"""
+
+from __future__ import annotations
+
+import types
+from collections.abc import Sequence
+from typing import Any, cast
+
+import numpy as np
+import polymath
+import pytest
+from tests.shims import FakeBackplane, FakeObs, RingBackplaneData, bare_nav_context
+
+import spindoctor.nav_model.nav_model_rings as nav_model_rings_module
+from spindoctor.annotation import Annotations
+from spindoctor.config.config import Config
+from spindoctor.feature.feature import NavFeature
+from spindoctor.feature.geometry import RingAnnulusGeometry, RingEdgePolyline
+from spindoctor.nav_model.nav_model_rings import NavModelRings
+from spindoctor.nav_model.rings import RingFeature, RingFeatureFilter
+from spindoctor.support.types import NDArrayBoolType
+
+_SHAPE = (100, 100)
+_TARGET = 'saturn:ring'
+_EPOCH = '2007-01-01 00:00:00'
+
+
+class _RingBackplane(FakeBackplane):
+    """FakeBackplane plus the ``radial_mode`` call the edge renderer chains.
+
+    The synthetic catalogs used here are circular (``ae = 0``) with no
+    perturbations, for which the multi-mode radius equals the base ring
+    radius, so the identity mapping is the spec-correct behaviour.
+    """
+
+    def radial_mode(
+        self, key: tuple[Any, ...], mode: int, epoch: float, *args: Any, **kwargs: Any
+    ) -> polymath.Scalar:
+        """Return the ring-radius Scalar unchanged (circular base orbit)."""
+        del mode, epoch, args, kwargs
+        return self.ring_radius(key[1])
+
+
+class _FakeSparseMeshgrid:
+    """Meshgrid stand-in accepting the sparse pre-check's ``undersample``.
+
+    Parameters:
+        origin: ``(u, v)`` grid origin.
+        limit: ``(u, v)`` grid limit.
+        undersample: Per-axis undersampling steps.
+        swap: Whether arrays are (v, u)-indexed.
+    """
+
+    def __init__(
+        self,
+        origin: tuple[float, float],
+        limit: tuple[float, float],
+        *,
+        undersample: tuple[int, int] = (1, 1),
+        swap: bool = False,
+    ) -> None:
+        self.origin = origin
+        self.limit = limit
+        self.undersample = undersample
+        self.swap = swap
+
+    @classmethod
+    def for_fov(
+        cls,
+        fov: Any,
+        *,
+        origin: tuple[float, float],
+        limit: tuple[float, float],
+        undersample: tuple[int, int] = (1, 1),
+        swap: bool = False,
+    ) -> _FakeSparseMeshgrid:
+        """Mirror the ``oops.Meshgrid.for_fov`` sparse-grid signature."""
+        del fov
+        return cls(origin, limit, undersample=undersample, swap=swap)
+
+
+class _DelegatingSparseBackplane:
+    """Backplane stand-in for the sparse pre-check.
+
+    Delegates ``ring_radius`` to the observation's dense ``ext_bp`` so the
+    sparse visibility verdict always matches the dense data the test wired.
+
+    Parameters:
+        obs: Observation carrying the fake ``ext_bp``.
+        meshgrid: Accepted for signature parity; unused.
+    """
+
+    def __init__(self, obs: Any, meshgrid: Any = None) -> None:
+        del meshgrid
+        self._obs = obs
+
+    def ring_radius(self, ring_target: str) -> Any:
+        """Return the dense fake backplane's ring radius Scalar."""
+        return self._obs.ext_bp.ring_radius(ring_target)
+
+
+def _ramp_ring(
+    *,
+    r0: float = 100_000.0,
+    slope: float = 100.0,
+    res: float = 100.0,
+    mask: NDArrayBoolType | None = None,
+    res_array: np.ndarray | None = None,
+) -> RingBackplaneData:
+    """Build ring backplane data with radius increasing linearly along u.
+
+    ``radius(v, u) = r0 + slope * u`` produces straight vertical ring edges.
+    The border for radius ``a`` is the pixel column within half a resolution
+    of ``a``.
+
+    Parameters:
+        r0: Ring radius at the leftmost column (km).
+        slope: Radius increase per pixel column (km/px).
+        res: Constant radial resolution (km/px).
+        mask: Optional ring-plane mask; defaults to all-True.
+        res_array: Optional explicit per-pixel resolution array overriding
+            the constant ``res``.
+    """
+    vv, uu = np.indices(_SHAPE, dtype=np.float64)
+    del vv
+    radius = r0 + slope * uu
+    ring_mask = np.ones(_SHAPE, dtype=bool) if mask is None else mask
+    resolutions = np.full(_SHAPE, res, dtype=np.float64) if res_array is None else res_array
+
+    def _border(key: tuple[Any, ...], a: float) -> NDArrayBoolType:
+        """Mark pixels whose ring radius is within half a resolution of ``a``."""
+        del key
+        border: NDArrayBoolType = (np.abs(radius - a) <= res / 2.0) & ring_mask
+        return border
+
+    return RingBackplaneData(
+        ring_radius_km=radius,
+        ring_mask=ring_mask,
+        radial_resolution_km_px=resolutions,
+        border_atop=_border,
+    )
+
+
+def _arc_ring(*, scale: float = 800.0) -> RingBackplaneData:
+    """Build ring backplane data whose iso-radius contours are curved arcs.
+
+    ``radius(v, u) = scale * hypot(v + 100, u - 50)`` centres the ring system
+    100 rows above the frame so edges arc visibly across the FOV.
+
+    Parameters:
+        scale: km per pixel of radial distance.
+    """
+    vv, uu = np.indices(_SHAPE, dtype=np.float64)
+    radius = scale * np.hypot(vv + 100.0, uu - 50.0)
+    ring_mask = np.ones(_SHAPE, dtype=bool)
+
+    def _border(key: tuple[Any, ...], a: float) -> NDArrayBoolType:
+        """Mark pixels whose ring radius is within half a resolution of ``a``."""
+        del key
+        border: NDArrayBoolType = np.abs(radius - a) <= scale / 2.0
+        return border
+
+    return RingBackplaneData(
+        ring_radius_km=radius,
+        ring_mask=ring_mask,
+        radial_resolution_km_px=np.full(_SHAPE, scale, dtype=np.float64),
+        border_atop=_border,
+    )
+
+
+def _ringlet(
+    inner_a: float,
+    outer_a: float,
+    *,
+    rms_inner: float = 10.0,
+    rms_outer: float = 20.0,
+    **extra: Any,
+) -> dict[str, Any]:
+    """Return a two-edge RINGLET catalog entry.
+
+    Parameters:
+        inner_a: Inner-edge semi-major axis (km).
+        outer_a: Outer-edge semi-major axis (km).
+        rms_inner: Inner-edge RMS (km).
+        rms_outer: Outer-edge RMS (km).
+        **extra: Additional per-feature keys (e.g. ``end_date``).
+    """
+    entry: dict[str, Any] = {
+        'feature_type': 'RINGLET',
+        'name': 'TESTR',
+        'inner_data': [
+            {
+                'mode': 1,
+                'a': inner_a,
+                'rms': rms_inner,
+                'ae': 0.0,
+                'long_peri': 0.0,
+                'rate_peri': 0.0,
+            }
+        ],
+        'outer_data': [
+            {
+                'mode': 1,
+                'a': outer_a,
+                'rms': rms_outer,
+                'ae': 0.0,
+                'long_peri': 0.0,
+                'rate_peri': 0.0,
+            }
+        ],
+    }
+    entry.update(extra)
+    return entry
+
+
+def _gap_inner(a: float, *, rms: float = 8.0) -> dict[str, Any]:
+    """Return a single-inner-edge GAP catalog entry.
+
+    Parameters:
+        a: Edge semi-major axis (km).
+        rms: Edge RMS (km).
+    """
+    return {
+        'feature_type': 'GAP',
+        'name': 'TESTG',
+        'inner_data': [
+            {'mode': 1, 'a': a, 'rms': rms, 'ae': 0.0, 'long_peri': 0.0, 'rate_peri': 0.0}
+        ],
+    }
+
+
+def _ring_config(features: dict[str, Any], *, planet_entry: dict[str, Any] | None = None) -> Config:
+    """Return a ``Config`` whose SATURN ring catalog is exactly ``features``.
+
+    The bundled defaults are loaded first (so every other section keeps its
+    normal values), then ``rings.ring_features`` is replaced wholesale with a
+    single synthetic SATURN entry.
+
+    Parameters:
+        features: Per-feature catalog entries keyed by feature name.
+        planet_entry: Optional full replacement for the SATURN planet block
+            (used by the config-validation tests); when given, ``features``
+            is ignored.
+    """
+    config = Config()
+    config.read_config()
+    entry: dict[str, Any]
+    if planet_entry is not None:
+        entry = planet_entry
+    else:
+        entry = {
+            'epoch': _EPOCH,
+            'fade_width_pix': 10.0,
+            'min_allowed_fade_width_pix': 2.0,
+            'min_feature_pixels': 2.0,
+            'features': features,
+        }
+    config._config_dict['rings'] = dict(config._config_dict['rings'])
+    config._config_dict['rings']['ring_features'] = {'SATURN': entry}
+    config._update_attrdicts()
+    return config
+
+
+def _make_obs(ring_data: RingBackplaneData) -> FakeObs:
+    """Return a zero-margin FakeObs over the fake ring backplane.
+
+    Parameters:
+        ring_data: Ring backplane tables for the ``saturn:ring`` target.
+    """
+    return FakeObs(
+        data=np.zeros(_SHAPE, dtype=np.float64),
+        extfov_margin_vu=(0, 0),
+        closest_planet='SATURN',
+        ext_bp=_RingBackplane(per_ring={_TARGET: ring_data}),
+        midtime=2.5e8,
+    )
+
+
+def _make_model(
+    monkeypatch: pytest.MonkeyPatch,
+    ring_data: RingBackplaneData,
+    config: Config,
+) -> tuple[NavModelRings, FakeObs]:
+    """Build a ``NavModelRings`` wired to the fake backplanes.
+
+    Parameters:
+        monkeypatch: Pytest monkeypatch fixture (patches the module's oops
+            ``Meshgrid`` / ``Backplane`` used by the sparse pre-check).
+        ring_data: Ring backplane tables.
+        config: Config carrying the synthetic catalog.
+    """
+    obs = _make_obs(ring_data)
+    monkeypatch.setattr(nav_model_rings_module, 'Meshgrid', _FakeSparseMeshgrid)
+    monkeypatch.setattr(nav_model_rings_module, 'Backplane', _DelegatingSparseBackplane)
+    model = NavModelRings('rings:SATURN', cast(Any, obs), config=config)
+    return model, obs
+
+
+def _features(model: NavModelRings, obs: FakeObs) -> list[NavFeature]:
+    """Run ``to_features`` with a bare context.
+
+    Parameters:
+        model: Model whose ``create_model`` already ran.
+        obs: Observation the model was built against.
+    """
+    return model.to_features(bare_nav_context(cast(Any, obs)))
+
+
+# ---------------------------------------------------------------------------
+# _render: metadata and the edges-resolve path
+# ---------------------------------------------------------------------------
+
+
+def test_create_model_populates_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The documented metadata entries are populated for a surviving catalog."""
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0)})
+    model, _obs = _make_model(monkeypatch, _ramp_ring(), config)
+    model.create_model()
+    meta = model.metadata
+    assert meta['planet'] == 'SATURN'
+    assert meta['epoch'] == _EPOCH
+    assert meta['feature_count'] == 1
+    assert meta['features'] == [{'name': 'TESTR', 'type': 'RINGLET'}]
+    assert meta['elapsed_time_sec'] is not None
+
+
+def test_km_per_pixel_radial_is_mean_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The per-planet radial scale is the mean of the resolution backplane."""
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0)})
+    model, _obs = _make_model(monkeypatch, _ramp_ring(res=100.0), config)
+    model.create_model()
+    assert model._km_per_pixel_radial == pytest.approx(100.0)
+
+
+def test_ring_edges_emitted_per_surviving_edge(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The edges-resolve path emits one RING_EDGE per catalog edge."""
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0)})
+    model, obs = _make_model(monkeypatch, _ramp_ring(), config)
+    model.create_model()
+    features = _features(model, obs)
+    ids = sorted(f.feature_id for f in features)
+    assert ids == ['ring_edge:SATURN:TESTR:IER', 'ring_edge:SATURN:TESTR:OER']
+    assert {f.feature_type.name for f in features} == {'RING_EDGE'}
+
+
+def test_edge_vertices_lie_on_catalog_radius(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each edge polyline sits on the pixel column of its catalog radius.
+
+    With ``radius = 100000 + 100 * u``, the 103000 km inner edge maps to the
+    u = 30 column and the 107000 km outer edge to u = 70.
+    """
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0)})
+    model, obs = _make_model(monkeypatch, _ramp_ring(), config)
+    model.create_model()
+    by_id = {f.feature_id: f for f in _features(model, obs)}
+    inner_geometry = by_id['ring_edge:SATURN:TESTR:IER'].geometry
+    outer_geometry = by_id['ring_edge:SATURN:TESTR:OER'].geometry
+    assert isinstance(inner_geometry, RingEdgePolyline)
+    assert isinstance(outer_geometry, RingEdgePolyline)
+    assert set(inner_geometry.vertices_vu[:, 1].tolist()) == {30.0}
+    assert set(outer_geometry.vertices_vu[:, 1].tolist()) == {70.0}
+
+
+def test_straight_edge_flag_and_rank1_penalty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A straight polyline is flagged and gets the 0.7 rank-1 multiplier."""
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0)})
+    model, obs = _make_model(monkeypatch, _ramp_ring(), config)
+    model.create_model()
+    features = _features(model, obs)
+    for feature in features:
+        geometry = feature.geometry
+        assert isinstance(geometry, RingEdgePolyline)
+        assert geometry.is_straight_line is True
+        # catalog_default (0.7) * visible_arc (1.0) * straight penalty (0.7)
+        assert feature.reliability == pytest.approx(0.7 * 0.7)
+
+
+def test_edge_sigma_radial_from_catalog_rms(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Radial sigma is the feature's max edge RMS over the radial km/px.
+
+    The dev guide specifies the conservative maximum of the two edge RMS
+    values (20 km here) divided by the per-image radial scale (100 km/px),
+    broadcast across every vertex of both edge polylines.
+    """
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0, rms_inner=10.0, rms_outer=20.0)})
+    model, obs = _make_model(monkeypatch, _ramp_ring(res=100.0), config)
+    model.create_model()
+    for feature in _features(model, obs):
+        geometry = feature.geometry
+        assert isinstance(geometry, RingEdgePolyline)
+        assert bool(np.all(geometry.sigma_radial_per_vertex_px == pytest.approx(0.2)))
+
+
+def test_edge_sigma_along_is_constant(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The along-edge sigma is the 0.5 px sampling-resolution constant."""
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0)})
+    model, obs = _make_model(monkeypatch, _ramp_ring(), config)
+    model.create_model()
+    for feature in _features(model, obs):
+        geometry = feature.geometry
+        assert isinstance(geometry, RingEdgePolyline)
+        assert bool(np.all(geometry.sigma_along_edge_per_vertex_px == pytest.approx(0.5)))
+
+
+def test_edge_normals_unit_length(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every per-vertex normal on an emitted edge polyline is unit length."""
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0)})
+    model, obs = _make_model(monkeypatch, _ramp_ring(), config)
+    model.create_model()
+    for feature in _features(model, obs):
+        geometry = feature.geometry
+        assert isinstance(geometry, RingEdgePolyline)
+        norms = np.hypot(geometry.normals_vu[:, 0], geometry.normals_vu[:, 1])
+        assert bool(np.allclose(norms, 1.0))
+
+
+def test_curved_edge_not_flagged_straight(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An edge arcing across the FOV escapes the straight-line rank-1 flag."""
+    config = _ring_config({'TESTG': _gap_inner(104_000.0)})
+    model, obs = _make_model(monkeypatch, _arc_ring(), config)
+    model.create_model()
+    features = _features(model, obs)
+    assert len(features) == 1
+    geometry = features[0].geometry
+    assert isinstance(geometry, RingEdgePolyline)
+    assert geometry.is_straight_line is False
+    assert features[0].reliability == pytest.approx(0.7)
+
+
+# ---------------------------------------------------------------------------
+# to_features: the edges-compress (annulus) path
+# ---------------------------------------------------------------------------
+
+
+def test_annulus_forced_at_low_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Above the per-planet km/px threshold a single RING_ANNULUS is emitted.
+
+    Saturn's ``feature_emission.ring_annulus`` threshold is 1000 km/px; a
+    1500 km/px scene must collapse every edge into one composite annulus.
+    """
+    config = _ring_config({'TESTR': _ringlet(80_000.0, 110_000.0)})
+    ring = _ramp_ring(r0=50_000.0, slope=1500.0, res=1500.0)
+    model, obs = _make_model(monkeypatch, ring, config)
+    model.create_model()
+    features = _features(model, obs)
+    assert len(features) == 1
+    assert features[0].feature_type.name == 'RING_ANNULUS'
+
+
+def test_annulus_template_cropped_to_bbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The annulus template is a postage stamp sized to its bounding box."""
+    config = _ring_config({'TESTR': _ringlet(80_000.0, 110_000.0)})
+    ring = _ramp_ring(r0=50_000.0, slope=1500.0, res=1500.0)
+    model, obs = _make_model(monkeypatch, ring, config)
+    model.create_model()
+    annulus = _features(model, obs)[0]
+    geometry = annulus.geometry
+    assert isinstance(geometry, RingAnnulusGeometry)
+    v_min, u_min, v_max, u_max = geometry.bbox_extfov_vu
+    assert annulus.template_img is not None
+    assert annulus.template_mask is not None
+    assert annulus.template_img.shape == (v_max - v_min, u_max - u_min)
+    assert annulus.template_mask.shape == (v_max - v_min, u_max - u_min)
+
+
+def test_annulus_carries_constituent_count_and_center(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The composite annulus reports its constituent edges and frame centre."""
+    config = _ring_config({'TESTR': _ringlet(80_000.0, 110_000.0)})
+    ring = _ramp_ring(r0=50_000.0, slope=1500.0, res=1500.0)
+    model, obs = _make_model(monkeypatch, ring, config)
+    model.create_model()
+    annulus = _features(model, obs)[0]
+    assert annulus.flags is not None
+    assert getattr(annulus.flags, 'constituent_edge_count', None) == 2
+    geometry = annulus.geometry
+    assert isinstance(geometry, RingAnnulusGeometry)
+    assert geometry.predicted_center_vu == (50.0, 50.0)
+
+
+# ---------------------------------------------------------------------------
+# _render: skip paths
+# ---------------------------------------------------------------------------
+
+
+def test_no_ring_plane_intersection_skips_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An all-masked ring radius yields an empty model and no features."""
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0)})
+    ring = _ramp_ring(mask=np.zeros(_SHAPE, dtype=bool))
+    model, obs = _make_model(monkeypatch, ring, config)
+    model.create_model()
+    assert 'feature_count' not in model.metadata
+    assert model._render_results == []
+    assert _features(model, obs) == []
+
+
+def test_visible_range_beyond_catalog_skips(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A FOV whose radii all exceed the catalog max extent renders nothing."""
+    config = _ring_config({'TESTR': _ringlet(50_000.0, 60_000.0)})
+    model, obs = _make_model(monkeypatch, _ramp_ring(), config)
+    model.create_model()
+    assert model._render_results == []
+    assert _features(model, obs) == []
+
+
+def test_all_features_date_filtered_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A catalog whose features expired before the image renders nothing."""
+    expired = _ringlet(103_000.0, 107_000.0, end_date='2000-01-01 00:00:00')
+    config = _ring_config({'TESTR': expired})
+    model, obs = _make_model(monkeypatch, _ramp_ring(), config)
+    model.create_model()
+    assert model._render_results == []
+    assert _features(model, obs) == []
+
+
+def test_empty_features_dict_yields_empty_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty per-planet feature dict is tolerated and renders nothing."""
+    config = _ring_config({})
+    model, obs = _make_model(monkeypatch, _ramp_ring(), config)
+    model.create_model()
+    assert model._render_results == []
+    assert _features(model, obs) == []
+
+
+def test_edge_on_single_row_ring_plane(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A one-row ring-plane projection still yields per-edge features.
+
+    Simulates an edge-on viewing geometry where the ring plane collapses to a
+    single pixel row; the surviving polylines are confined to that row.
+    """
+    row_mask = np.zeros(_SHAPE, dtype=bool)
+    row_mask[50, :] = True
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0)})
+    model, obs = _make_model(monkeypatch, _ramp_ring(mask=row_mask), config)
+    model.create_model()
+    features = _features(model, obs)
+    assert len(features) == 2
+    for feature in features:
+        geometry = feature.geometry
+        assert isinstance(geometry, RingEdgePolyline)
+        assert set(geometry.vertices_vu[:, 0].tolist()) == {50.0}
+
+
+# ---------------------------------------------------------------------------
+# _render: shadow handling
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_removal_zeroes_shadowed_pixels(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With ``remove_planet_shadow`` the rendered model is zero in shadow."""
+    ring = _ramp_ring()
+    shadow = np.zeros(_SHAPE, dtype=bool)
+    shadow[:, 60:] = True
+    ring.shadow_mask = shadow
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0)})
+    model, _obs = _make_model(monkeypatch, ring, config)
+    model.create_model()
+    assert len(model._render_results) == 1
+    _feat, model_img, model_mask, _unc, _edges = model._render_results[0]
+    assert float(model_img[:, 60:].max()) == 0.0
+    assert not bool(model_mask[:, 60:].any())
+    assert bool(model_mask[:, :60].any())
+
+
+# ---------------------------------------------------------------------------
+# min_res_at_radius: documented closure contract
+# ---------------------------------------------------------------------------
+
+
+def _capture_min_res(
+    monkeypatch: pytest.MonkeyPatch,
+    ring_data: RingBackplaneData,
+    config: Config,
+) -> Any:
+    """Run ``_render`` far enough to capture its ``min_res_at_radius`` closure.
+
+    The module's ``RingFeatureFilter`` is replaced with a capturing subclass
+    whose ``filter`` returns no survivors, so ``_render`` stops immediately
+    after the closure is built and none of the later validation runs.
+
+    Parameters:
+        monkeypatch: Pytest monkeypatch fixture.
+        ring_data: Ring backplane tables.
+        config: Config carrying the synthetic catalog.
+    """
+    captured: dict[str, Any] = {}
+
+    class _CapturingFilter(RingFeatureFilter):
+        """RingFeatureFilter that records the closure and survives nothing."""
+
+        def __init__(self, **kwargs: Any) -> None:
+            captured['fn'] = kwargs['min_res_at_radius']
+            super().__init__(**kwargs)
+
+        def filter(self, features: Sequence[RingFeature]) -> list[RingFeature]:
+            """Return no survivors so ``_render`` stops after the capture."""
+            del features
+            return []
+
+    monkeypatch.setattr(nav_model_rings_module, 'RingFeatureFilter', _CapturingFilter)
+    model, _obs = _make_model(monkeypatch, ring_data, config)
+    model.create_model()
+    return captured['fn']
+
+
+def test_min_res_at_radius_returns_min_resolution_when_covered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A radius with border pixels maps to the minimum radial resolution."""
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0)})
+    fn = _capture_min_res(monkeypatch, _ramp_ring(res=100.0), config)
+    assert fn(103_000.0) == pytest.approx(100.0)
+
+
+def test_min_res_at_radius_at_exact_coverage_edges(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Radii exactly at the visible minimum and maximum are still resolvable.
+
+    The ramp covers [100000, 109900] km; queries at both extremes hit the
+    first / last pixel columns and must return the resolution, not ``None``.
+    """
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0)})
+    fn = _capture_min_res(monkeypatch, _ramp_ring(res=100.0), config)
+    assert fn(100_000.0) == pytest.approx(100.0)
+    assert fn(109_900.0) == pytest.approx(100.0)
+
+
+def test_min_res_at_radius_none_outside_coverage(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Radii with no border pixels in the image map to ``None``."""
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0)})
+    fn = _capture_min_res(monkeypatch, _ramp_ring(res=100.0), config)
+    assert fn(150_000.0) is None
+    assert fn(90_000.0) is None
+
+
+def test_min_res_at_radius_none_for_zero_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A radius whose border pixels all have zero resolution maps to ``None``."""
+    res_array = np.full(_SHAPE, 100.0, dtype=np.float64)
+    res_array[:, 30] = 0.0  # the u = 30 column carries radius 103000 km
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0)})
+    fn = _capture_min_res(monkeypatch, _ramp_ring(res=100.0, res_array=res_array), config)
+    assert fn(103_000.0) is None
+
+
+def test_min_res_at_radius_none_for_nonfinite_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A radius whose border resolutions are all non-finite maps to ``None``."""
+    res_array = np.full(_SHAPE, 100.0, dtype=np.float64)
+    res_array[:, 30] = np.inf
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0)})
+    fn = _capture_min_res(monkeypatch, _ramp_ring(res=100.0, res_array=res_array), config)
+    assert fn(103_000.0) is None
+
+
+# ---------------------------------------------------------------------------
+# _render: config validation
+# ---------------------------------------------------------------------------
+
+
+def _entry_without(*keys: str, **overrides: Any) -> dict[str, Any]:
+    """Return a SATURN planet block with keys removed / overridden.
+
+    Parameters:
+        *keys: Keys deleted from the baseline block.
+        **overrides: Key / value pairs written over the baseline block.
+    """
+    entry: dict[str, Any] = {
+        'epoch': _EPOCH,
+        'fade_width_pix': 10.0,
+        'min_allowed_fade_width_pix': 2.0,
+        'min_feature_pixels': 2.0,
+        'features': {'TESTR': _ringlet(103_000.0, 107_000.0)},
+    }
+    for key in keys:
+        del entry[key]
+    entry.update(overrides)
+    return entry
+
+
+def test_missing_epoch_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A planet block without an epoch fails fast."""
+    config = _ring_config({}, planet_entry=_entry_without('epoch'))
+    model, _obs = _make_model(monkeypatch, _ramp_ring(), config)
+    with pytest.raises(ValueError, match='No epoch configured for planet SATURN'):
+        model.create_model()
+
+
+def test_non_string_epoch_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-string epoch fails fast with a type-naming message."""
+    config = _ring_config({}, planet_entry=_entry_without(epoch=12345))
+    model, _obs = _make_model(monkeypatch, _ramp_ring(), config)
+    with pytest.raises(ValueError, match=r'epoch for planet .SATURN. must be a string'):
+        model.create_model()
+
+
+def test_invalid_epoch_string_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unparseable epoch string fails fast naming the bad value."""
+    config = _ring_config({}, planet_entry=_entry_without(epoch='not a date'))
+    model, _obs = _make_model(monkeypatch, _ramp_ring(), config)
+    with pytest.raises(ValueError, match='is not a valid UTC'):
+        model.create_model()
+
+
+def test_missing_features_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A planet block without a features mapping fails fast."""
+    config = _ring_config({}, planet_entry=_entry_without('features'))
+    model, _obs = _make_model(monkeypatch, _ramp_ring(), config)
+    with pytest.raises(ValueError, match='Missing required ring configuration key "features"'):
+        model.create_model()
+
+
+def test_non_dict_features_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A features value that is not a mapping fails fast."""
+    config = _ring_config({}, planet_entry=_entry_without(features=['not', 'a', 'dict']))
+    model, _obs = _make_model(monkeypatch, _ramp_ring(), config)
+    with pytest.raises(ValueError, match=r'"features" for planet .SATURN. must be a dict'):
+        model.create_model()
+
+
+def test_non_dict_feature_entry_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A per-feature entry that is not a mapping fails fast naming the key."""
+    config = _ring_config({'BAD': 'not a dict'})
+    model, _obs = _make_model(monkeypatch, _ramp_ring(), config)
+    with pytest.raises(ValueError, match=r"features.'BAD' must be a dict"):
+        model.create_model()
+
+
+def test_non_dict_planet_entry_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A planet block that is not a mapping fails fast."""
+    config = Config()
+    config.read_config()
+    config._config_dict['rings'] = dict(config._config_dict['rings'])
+    config._config_dict['rings']['ring_features'] = {'SATURN': 'not a dict'}
+    config._update_attrdicts()
+    model, _obs = _make_model(monkeypatch, _ramp_ring(), config)
+    with pytest.raises(ValueError, match=r'entry for planet .SATURN. must be'):
+        model.create_model()
+
+
+# ---------------------------------------------------------------------------
+# instances_for_obs
+# ---------------------------------------------------------------------------
+
+
+def test_instances_for_obs_returns_model_for_cataloged_planet() -> None:
+    """A planet with a bundled ring catalog gets exactly one model."""
+    obs = _make_obs(_ramp_ring())
+    instances = NavModelRings.instances_for_obs(cast(Any, obs))
+    assert [inst.name for inst in instances] == ['rings:SATURN']
+
+
+def test_instances_for_obs_skips_simulated_obs() -> None:
+    """Simulated observations use the sim sibling, so no instances here."""
+    obs = types.SimpleNamespace(is_simulated=True)
+    assert NavModelRings.instances_for_obs(cast(Any, obs)) == []
+
+
+def test_instances_for_obs_requires_closest_planet() -> None:
+    """No closest planet means no ring model."""
+    obs = types.SimpleNamespace(closest_planet=None)
+    assert NavModelRings.instances_for_obs(cast(Any, obs)) == []
+
+
+def test_instances_for_obs_requires_extfov_surface() -> None:
+    """An obs without the extfov / backplane surface gets no ring model."""
+    obs = types.SimpleNamespace(closest_planet='SATURN')
+    assert NavModelRings.instances_for_obs(cast(Any, obs)) == []
+
+
+def test_instances_for_obs_requires_cataloged_planet() -> None:
+    """A planet absent from the ring catalog gets no ring model."""
+    obs = FakeObs(
+        data=np.zeros(_SHAPE, dtype=np.float64),
+        extfov_margin_vu=(0, 0),
+        closest_planet='PLUTO',
+        ext_bp=_RingBackplane(per_ring={}),
+    )
+    assert NavModelRings.instances_for_obs(cast(Any, obs)) == []
+
+
+# ---------------------------------------------------------------------------
+# to_annotations
+# ---------------------------------------------------------------------------
+
+
+def test_to_annotations_empty_before_create_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without a rendered model the annotation collection is empty."""
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0)})
+    model, obs = _make_model(monkeypatch, _ramp_ring(), config)
+    annotations = model.to_annotations(bare_nav_context(cast(Any, obs)))
+    assert isinstance(annotations, Annotations)
+    assert annotations.annotations == []
+
+
+def test_to_annotations_emits_edge_overlays(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After rendering, each surviving edge contributes an annotation."""
+    config = _ring_config({'TESTR': _ringlet(103_000.0, 107_000.0)})
+    model, obs = _make_model(monkeypatch, _ramp_ring(), config)
+    model.create_model()
+    annotations = model.to_annotations(bare_nav_context(cast(Any, obs)))
+    assert len(annotations.annotations) == 2

--- a/tests/spindoctor/reproj/test_bodies_reproject.py
+++ b/tests/spindoctor/reproj/test_bodies_reproject.py
@@ -1,0 +1,1105 @@
+"""Spec-first unit tests for the ``BodyMosaic.reproject()`` pipeline.
+
+These tests exercise the full ``reproject()`` inner loop hermetically (no SPICE,
+no holdings) by combining a synthetic observation whose ``uv_from_coords`` is an
+exact linear map with an ``override_backplane`` fake whose latitude/longitude
+backplanes are the inverse of that map.  Each detector pixel ``(v, u)`` is placed
+at the CENTER of latitude bin ``lat0 + v`` and longitude bin ``lon0 + u``, so the
+expected reprojection grid follows directly from the documented floor/ceil bin
+arithmetic: ``lat_idx_range == (lat0, lat0 + nv)`` and the extra ceil row/column
+is masked.
+
+Contract sources: the ``reproject()`` / ``BodyMosaic`` docstrings in
+``src/spindoctor/reproj/bodies.py`` and ``docs/dev_guide/dev_guide_reprojection.rst``
+(grid semantics, dtype propagation, photometric correction, masking rules).
+"""
+
+import math
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import numpy as np
+import numpy.ma as ma
+import numpy.typing as npt
+import polymath
+import pytest
+from tests.spindoctor.reproj.test_bodies import _make_repro
+
+from spindoctor.reproj.bodies import BodyMosaic, BodyReprojResult
+from spindoctor.reproj.cartographic_model import create_cartographic_model
+from spindoctor.reproj.photometric_model import LambertModel
+
+_LAT_RES = 0.1  # rad/pixel
+_LON_RES = 0.1  # rad/pixel
+_LAT0 = 10  # full-grid latitude bin of detector row 0
+_LON0 = 20  # full-grid longitude bin of detector column 0
+_HALF_PI = math.pi / 2.0
+_DEF_INCIDENCE = 0.3  # rad
+_DEF_EMISSION = 0.2  # rad
+_DEF_PHASE = 0.7  # rad
+_DEF_CENTER_RES = 5.0  # km/pixel
+_N_FULL_LAT = math.floor(math.pi / _LAT_RES) + 1  # 32
+_N_FULL_LON = math.floor(2.0 * math.pi / _LON_RES) + 1  # 63
+
+
+class FakeBackplane:
+    """Backplane stand-in mapping detector pixel (v, u) to bin centers.
+
+    Latitude of pixel ``(v, u)`` is ``(lat0 + v_offset + v + 0.5) * _LAT_RES - pi/2``
+    and longitude is ``(lon0 + u_offset + u + 0.5) * _LON_RES``, i.e. each pixel
+    sits exactly at the center of one full-grid bin.
+    """
+
+    def __init__(
+        self,
+        shape: tuple[int, int],
+        *,
+        lat0: int = _LAT0,
+        lon0: int = _LON0,
+        v_offset: int = 0,
+        u_offset: int = 0,
+        lat_mask: npt.NDArray[np.bool_] | bool = False,
+        lon_mask: npt.NDArray[np.bool_] | bool = False,
+        incidence: npt.NDArray[np.float64] | None = None,
+        emission: npt.NDArray[np.float64] | None = None,
+        phase: npt.NDArray[np.float64] | None = None,
+        center_res: float = _DEF_CENTER_RES,
+        sub_solar: tuple[float, float] = (0.1, 0.2),
+        sub_observer: tuple[float, float] = (0.3, 0.4),
+    ) -> None:
+        """Build the fake backplane arrays.
+
+        Parameters:
+            shape: (n_v, n_u) shape of the backplane arrays (detector or subimage).
+            lat0: Full-grid latitude bin of detector row 0.
+            lon0: Full-grid longitude bin of detector column 0.
+            v_offset: Detector row of this backplane's row 0 (for subimage backplanes).
+            u_offset: Detector column of this backplane's column 0.
+            lat_mask: Mask for the latitude backplane (True = no surface point).
+            lon_mask: Mask for the longitude backplane.
+            incidence: Per-pixel incidence angle (rad); scalar default 0.3.
+            emission: Per-pixel emission angle (rad); scalar default 0.2.
+            phase: Per-pixel phase angle (rad); scalar default 0.7.
+            center_res: Scalar center resolution (km/pixel).
+            sub_solar: (longitude, latitude) sub-solar point (rad).
+            sub_observer: (longitude, latitude) sub-observer point (rad).
+        """
+        nv, nu = shape
+        v_idx, u_idx = np.meshgrid(np.arange(nv), np.arange(nu), indexing='ij')
+        lat = (lat0 + v_offset + v_idx + 0.5) * _LAT_RES - _HALF_PI
+        lon = (lon0 + u_offset + u_idx + 0.5) * _LON_RES
+        self._lat = ma.MaskedArray(lat, mask=lat_mask)
+        self._lon = ma.MaskedArray(lon, mask=lon_mask)
+        inc = incidence if incidence is not None else np.full(shape, _DEF_INCIDENCE)
+        emi = emission if emission is not None else np.full(shape, _DEF_EMISSION)
+        pha = phase if phase is not None else np.full(shape, _DEF_PHASE)
+        self._incidence = ma.MaskedArray(inc)
+        self._emission = ma.MaskedArray(emi)
+        self._phase = ma.MaskedArray(pha)
+        self._center_res = center_res
+        self._sub_solar = sub_solar
+        self._sub_observer = sub_observer
+
+    def latitude(self, name: str, lat_type: str = 'centric') -> SimpleNamespace:
+        """Return the latitude backplane wrapper.
+
+        Parameters:
+            name: Body name (ignored).
+            lat_type: Latitude type (ignored).
+        """
+        return SimpleNamespace(mvals=self._lat)
+
+    def longitude(
+        self, name: str, direction: str = 'east', lon_type: str = 'centric'
+    ) -> SimpleNamespace:
+        """Return the longitude backplane wrapper.
+
+        Parameters:
+            name: Body name (ignored).
+            direction: Longitude direction (ignored).
+            lon_type: Longitude type (ignored).
+        """
+        return SimpleNamespace(mvals=self._lon)
+
+    def incidence_angle(self, name: str) -> SimpleNamespace:
+        """Return the incidence backplane wrapper.
+
+        Parameters:
+            name: Body name (ignored).
+        """
+        return SimpleNamespace(mvals=self._incidence)
+
+    def emission_angle(self, name: str) -> SimpleNamespace:
+        """Return the emission backplane wrapper.
+
+        Parameters:
+            name: Body name (ignored).
+        """
+        return SimpleNamespace(mvals=self._emission)
+
+    def phase_angle(self, name: str) -> SimpleNamespace:
+        """Return the phase backplane wrapper.
+
+        Parameters:
+            name: Body name (ignored).
+        """
+        return SimpleNamespace(mvals=self._phase)
+
+    def center_resolution(self, name: str) -> SimpleNamespace:
+        """Return the scalar center-resolution wrapper.
+
+        Parameters:
+            name: Body name (ignored).
+        """
+        return SimpleNamespace(vals=self._center_res)
+
+    def sub_solar_longitude(self, name: str) -> SimpleNamespace:
+        """Return the sub-solar longitude wrapper.
+
+        Parameters:
+            name: Body name (ignored).
+        """
+        return SimpleNamespace(vals=self._sub_solar[0])
+
+    def sub_solar_latitude(self, name: str) -> SimpleNamespace:
+        """Return the sub-solar latitude wrapper.
+
+        Parameters:
+            name: Body name (ignored).
+        """
+        return SimpleNamespace(vals=self._sub_solar[1])
+
+    def sub_observer_longitude(self, name: str) -> SimpleNamespace:
+        """Return the sub-observer longitude wrapper.
+
+        Parameters:
+            name: Body name (ignored).
+        """
+        return SimpleNamespace(vals=self._sub_observer[0])
+
+    def sub_observer_latitude(self, name: str) -> SimpleNamespace:
+        """Return the sub-observer latitude wrapper.
+
+        Parameters:
+            name: Body name (ignored).
+        """
+        return SimpleNamespace(vals=self._sub_observer[1])
+
+
+class FakeObs:
+    """Observation stand-in with an exact linear lat/lon -> (u, v) mapping.
+
+    Inverts the :class:`FakeBackplane` geometry: bin edge ``lat = bin * _LAT_RES - pi/2``
+    maps to full-frame pixel coordinate ``v = bin - lat0`` (and similarly for u), with
+    rounding to defeat float jitter and optional fractional offsets and per-bin masking.
+    """
+
+    def __init__(
+        self,
+        data: npt.NDArray[np.float64],
+        *,
+        lat0: int = _LAT0,
+        lon0: int = _LON0,
+        midtime: float = 1000.0,
+        frac_u: float = 0.0,
+        frac_v: float = 0.0,
+        masked_lon_bin: int | None = None,
+    ) -> None:
+        """Build the fake observation.
+
+        Parameters:
+            data: Full-frame detector image, shape (n_v, n_u).
+            lat0: Full-grid latitude bin of detector row 0 (must match the backplane).
+            lon0: Full-grid longitude bin of detector column 0.
+            midtime: Observation midtime (TDB seconds).
+            frac_u: Fractional pixel offset added to every u coordinate.
+            frac_v: Fractional pixel offset added to every v coordinate.
+            masked_lon_bin: If set, the returned UV pair is masked for samples at
+                this full-grid longitude bin (simulates an invalid surface point).
+        """
+        self.data = data
+        self.midtime = midtime
+        self._lat0 = lat0
+        self._lon0 = lon0
+        self._frac_u = frac_u
+        self._frac_v = frac_v
+        self._masked_lon_bin = masked_lon_bin
+
+    def uv_from_coords(self, surface: Any, coords: Any) -> Any:
+        """Map (longitude, latitude) arrays to a polymath UV Pair.
+
+        Parameters:
+            surface: Body surface object (ignored).
+            coords: (longitude, latitude) polymath Scalars in radians.
+        """
+        lon, lat = coords
+        lon_v = np.asarray(polymath.Scalar.as_scalar(lon).vals, dtype=np.float64)
+        lat_v = np.asarray(polymath.Scalar.as_scalar(lat).vals, dtype=np.float64)
+        lon_bins = np.round(lon_v / _LON_RES)
+        u = lon_bins - self._lon0 + self._frac_u
+        v = np.round((lat_v + _HALF_PI) / _LAT_RES) - self._lat0 + self._frac_v
+        vals = np.stack([u, v], axis=-1)
+        if self._masked_lon_bin is not None:
+            return polymath.Pair(vals, lon_bins.astype(int) == self._masked_lon_bin)
+        return polymath.Pair(vals)
+
+
+def _make_mosaic(**overrides: Any) -> BodyMosaic:
+    """Return a BodyMosaic wired for the fake linear geometry.
+
+    Parameters:
+        overrides: Keyword arguments overriding the defaults (squashed latlon type,
+            zero edge margin, 0.1 rad resolutions, body MIMAS).
+    """
+    kwargs: dict[str, Any] = {
+        'body_name': 'MIMAS',
+        'lat_resolution': _LAT_RES,
+        'lon_resolution': _LON_RES,
+        'latlon_type': 'squashed',
+        'edge_margin': 0,
+    }
+    kwargs.update(overrides)
+    return BodyMosaic(**kwargs)
+
+
+def _reproject(mosaic: BodyMosaic, obs: FakeObs, bp: FakeBackplane, **kwargs: Any) -> Any:
+    """Run mosaic.reproject with oops.Body.lookup stubbed out.
+
+    Parameters:
+        mosaic: The BodyMosaic under test.
+        obs: Fake observation.
+        bp: Fake backplane passed as ``override_backplane``.
+        kwargs: Extra keyword arguments forwarded to ``reproject``.
+    """
+    with patch('oops.Body.lookup', return_value=SimpleNamespace(surface=object())):
+        return mosaic.reproject(obs, override_backplane=bp, **kwargs)
+
+
+def _scene(nv: int = 6, nu: int = 8) -> tuple[npt.NDArray[np.float64], FakeObs, FakeBackplane]:
+    """Return a standard non-square scene (data, obs, backplane).
+
+    Parameters:
+        nv: Number of detector rows.
+        nu: Number of detector columns.
+    """
+    data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+    return data, FakeObs(data), FakeBackplane((nv, nu))
+
+
+# =========================================================================
+# latitude_longitude_to_pixels
+# =========================================================================
+
+
+class TestLatitudeLongitudeToPixels:
+    """Contract tests for BodyMosaic.latitude_longitude_to_pixels."""
+
+    def test_empty_input_returns_empty_pair(self) -> None:
+        """Zero-length inputs return a UV Pair with shape (0, 2)."""
+        mosaic = _make_mosaic()
+        uv = mosaic.latitude_longitude_to_pixels(object(), [], [])
+        assert uv.vals.shape == (0, 2)
+
+    def test_squashed_east_passes_coords_unchanged(self) -> None:
+        """With latlon_type='squashed' and east longitudes, coords reach uv unchanged."""
+        received: list[tuple[Any, Any]] = []
+
+        class _Obs:
+            """Observation recording the coordinates given to uv_from_coords."""
+
+            def uv_from_coords(self, surface: Any, coords: Any) -> Any:
+                """Record coords and return a zero UV Pair.
+
+                Parameters:
+                    surface: Body surface object (ignored).
+                    coords: (longitude, latitude) polymath Scalars.
+                """
+                lon, lat = coords
+                received.append((np.asarray(lon.vals), np.asarray(lat.vals)))
+                return polymath.Pair(np.zeros((2, 2)))
+
+        mosaic = _make_mosaic()
+        with patch('oops.Body.lookup', return_value=SimpleNamespace(surface=object())):
+            mosaic.latitude_longitude_to_pixels(_Obs(), [0.1, -0.4], [1.0, 2.0])
+        np.testing.assert_allclose(received[0][0], [1.0, 2.0])
+        np.testing.assert_allclose(received[0][1], [0.1, -0.4])
+
+    def test_west_direction_negates_longitude_mod_2pi(self) -> None:
+        """lon_direction='west' converts longitudes to (-lon) mod 2*pi before uv."""
+        received: list[Any] = []
+
+        class _Obs:
+            """Observation recording the longitude given to uv_from_coords."""
+
+            def uv_from_coords(self, surface: Any, coords: Any) -> Any:
+                """Record the longitude and return a zero UV Pair.
+
+                Parameters:
+                    surface: Body surface object (ignored).
+                    coords: (longitude, latitude) polymath Scalars.
+                """
+                received.append(np.asarray(coords[0].vals))
+                return polymath.Pair(np.zeros((2, 2)))
+
+        mosaic = _make_mosaic(lon_direction='west')
+        with patch('oops.Body.lookup', return_value=SimpleNamespace(surface=object())):
+            mosaic.latitude_longitude_to_pixels(_Obs(), [0.0, 0.0], [1.0, 2.0])
+        np.testing.assert_allclose(received[0], [2.0 * math.pi - 1.0, 2.0 * math.pi - 2.0])
+
+    def test_centric_converts_via_surface_and_feeds_converted_lon(self) -> None:
+        """latlon_type='centric' converts lon first, then lat using the converted lon."""
+
+        class _Surface:
+            """Surface stub converting centric coords with recordable arguments."""
+
+            def __init__(self) -> None:
+                """Initialize the lat-conversion argument recorder."""
+                self.lat_call_lon: npt.NDArray[np.float64] | None = None
+
+            def lon_from_centric(self, lon: Any) -> Any:
+                """Return lon + 0.5 as the 'squashed' longitude.
+
+                Parameters:
+                    lon: Centric longitude Scalar.
+                """
+                return polymath.Scalar.as_scalar(np.asarray(lon.vals) + 0.5)
+
+            def lat_from_centric(self, lat: Any, lon: Any) -> Any:
+                """Record lon and return lat + 0.25 as the 'squashed' latitude.
+
+                Parameters:
+                    lat: Centric latitude Scalar.
+                    lon: Longitude Scalar (should be the converted one).
+                """
+                self.lat_call_lon = np.asarray(lon.vals).copy()
+                return polymath.Scalar.as_scalar(np.asarray(lat.vals) + 0.25)
+
+        received: list[tuple[Any, Any]] = []
+
+        class _Obs:
+            """Observation recording the coordinates given to uv_from_coords."""
+
+            def uv_from_coords(self, surface: Any, coords: Any) -> Any:
+                """Record coords and return a zero UV Pair.
+
+                Parameters:
+                    surface: Body surface object (ignored).
+                    coords: (longitude, latitude) polymath Scalars.
+                """
+                received.append((np.asarray(coords[0].vals), np.asarray(coords[1].vals)))
+                return polymath.Pair(np.zeros((2, 2)))
+
+        surface = _Surface()
+        mosaic = _make_mosaic(latlon_type='centric')
+        with patch('oops.Body.lookup', return_value=SimpleNamespace(surface=surface)):
+            mosaic.latitude_longitude_to_pixels(_Obs(), [0.1, 0.2], [1.0, 2.0])
+        np.testing.assert_allclose(received[0][0], [1.5, 2.5])
+        np.testing.assert_allclose(received[0][1], [0.35, 0.45])
+        assert surface.lat_call_lon is not None
+        np.testing.assert_allclose(surface.lat_call_lon, [1.5, 2.5])
+
+
+# =========================================================================
+# navigation_uncertainty validation
+# =========================================================================
+
+
+class TestNavigationUncertaintyValidation:
+    """reproject() rejects invalid navigation_uncertainty per its docstring."""
+
+    def test_bool_raises_type_error(self) -> None:
+        """A bool is not accepted as navigation_uncertainty."""
+        _data, obs, bp = _scene()
+        mosaic = _make_mosaic()
+        with pytest.raises(TypeError, match='navigation_uncertainty must be a real number'):
+            _reproject(mosaic, obs, bp, navigation_uncertainty=True)
+
+    def test_negative_raises_value_error(self) -> None:
+        """A negative value raises ValueError."""
+        _data, obs, bp = _scene()
+        mosaic = _make_mosaic()
+        with pytest.raises(ValueError, match='must be finite and >= 0'):
+            _reproject(mosaic, obs, bp, navigation_uncertainty=-0.1)
+
+    def test_infinite_raises_value_error(self) -> None:
+        """An infinite value raises ValueError."""
+        _data, obs, bp = _scene()
+        mosaic = _make_mosaic()
+        with pytest.raises(ValueError, match='must be finite and >= 0'):
+            _reproject(mosaic, obs, bp, navigation_uncertainty=math.inf)
+
+    def test_nan_raises_value_error(self) -> None:
+        """A NaN value raises ValueError."""
+        _data, obs, bp = _scene()
+        mosaic = _make_mosaic()
+        with pytest.raises(ValueError, match='must be finite and >= 0'):
+            _reproject(mosaic, obs, bp, navigation_uncertainty=math.nan)
+
+
+# =========================================================================
+# Grid construction and pixel sampling
+# =========================================================================
+
+
+class TestReprojectGrid:
+    """Grid semantics: bin index ranges, shapes, and value placement."""
+
+    def test_lat_idx_range_follows_floor_ceil_of_coverage(self) -> None:
+        """lat_idx_range spans floor(min lat bin) to ceil(max lat bin) of valid pixels."""
+        _data, obs, bp = _scene(nv=6, nu=8)
+        result = _reproject(_make_mosaic(), obs, bp)
+        assert result.lat_idx_range == (_LAT0, _LAT0 + 6)
+
+    def test_lon_idx_range_follows_floor_ceil_of_coverage(self) -> None:
+        """lon_idx_range spans floor(min lon bin) to ceil(max lon bin) of valid pixels."""
+        _data, obs, bp = _scene(nv=6, nu=8)
+        result = _reproject(_make_mosaic(), obs, bp)
+        assert result.lon_idx_range == (_LON0, _LON0 + 8)
+
+    def test_img_shape_matches_idx_ranges(self) -> None:
+        """img covers exactly the inclusive lat/lon index ranges (non-square)."""
+        _data, obs, bp = _scene(nv=6, nu=8)
+        result = _reproject(_make_mosaic(), obs, bp)
+        assert result.img.shape == (7, 9)
+
+    def test_img_values_sampled_from_mapped_detector_pixels(self) -> None:
+        """Cell (r, c) holds data[v, u] of the detector pixel its bin maps to."""
+        data, obs, bp = _scene(nv=6, nu=8)
+        result = _reproject(_make_mosaic(), obs, bp)
+        np.testing.assert_allclose(result.img.data[:6, :8], data)
+
+    def test_bins_with_no_detector_pixel_are_masked(self) -> None:
+        """The extra ceil row and column (mapping off-detector) are masked."""
+        _data, obs, bp = _scene(nv=6, nu=8)
+        result = _reproject(_make_mosaic(), obs, bp)
+        mask = ma.getmaskarray(result.img)
+        assert bool(mask[6, :].all())
+        assert bool(mask[:, 8].all())
+        assert not mask[:6, :8].any()
+
+    def test_metadata_arrays_share_img_window(self) -> None:
+        """resolution/eff_resolution/phase/emission/incidence match the img window."""
+        _data, obs, bp = _scene(nv=6, nu=8)
+        result = _reproject(_make_mosaic(), obs, bp)
+        assert result.resolution.shape == result.img.shape
+        assert result.eff_resolution.shape == result.img.shape
+        assert result.phase.shape == result.img.shape
+        assert result.emission.shape == result.img.shape
+        assert result.incidence.shape == result.img.shape
+
+    def test_data_defaults_to_obs_data(self) -> None:
+        """When data is not given, obs.data is reprojected."""
+        data, obs, bp = _scene()
+        explicit = _reproject(_make_mosaic(), obs, bp, data=data)
+        default = _reproject(_make_mosaic(), obs, bp)
+        np.testing.assert_allclose(default.img.filled(-1.0), explicit.img.filled(-1.0))
+
+    def test_explicit_data_overrides_obs_data(self) -> None:
+        """An explicit data array is used instead of obs.data."""
+        data, obs, bp = _scene()
+        other = data + 100.0
+        result = _reproject(_make_mosaic(), obs, bp, data=other)
+        np.testing.assert_allclose(result.img.data[:6, :8], other)
+
+    def test_scalar_metadata_on_result(self) -> None:
+        """time, image_name, and sub-solar/sub-observer scalars come from obs and bp."""
+        _data, obs, bp = _scene()
+        result = _reproject(_make_mosaic(), obs, bp, image_name='img_stem')
+        assert result.time == pytest.approx(1000.0)
+        assert result.image_name == 'img_stem'
+        assert result.sub_solar_lon == pytest.approx(0.1)
+        assert result.sub_solar_lat == pytest.approx(0.2)
+        assert result.sub_observer_lon == pytest.approx(0.3)
+        assert result.sub_observer_lat == pytest.approx(0.4)
+
+    def test_grid_configuration_echoed_on_result(self) -> None:
+        """Resolutions, latlon_type, lon_direction, and body_name echo the mosaic."""
+        _data, obs, bp = _scene()
+        result = _reproject(_make_mosaic(), obs, bp)
+        assert result.body_name == 'MIMAS'
+        assert result.lat_resolution == pytest.approx(_LAT_RES)
+        assert result.lon_resolution == pytest.approx(_LON_RES)
+        assert result.latlon_type == 'squashed'
+        assert result.lon_direction == 'east'
+
+    def test_pole_adjacent_coverage_clips_to_grid(self) -> None:
+        """Latitude bins beyond the top of the full grid are clipped to n_full_lat - 1."""
+        nv, nu = 4, 4
+        lat0 = _N_FULL_LAT - 4  # ceil of the max bin would exceed the grid
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        obs = FakeObs(data, lat0=lat0)
+        bp = FakeBackplane((nv, nu), lat0=lat0)
+        result = _reproject(_make_mosaic(), obs, bp)
+        assert result.lat_idx_range == (lat0, _N_FULL_LAT - 1)
+        assert not ma.getmaskarray(result.img)[3, 0]
+
+    def test_longitude_edge_coverage_clips_to_grid(self) -> None:
+        """Longitude bins beyond the top of the full grid are clipped to n_full_lon - 1."""
+        nv, nu = 4, 4
+        lon0 = _N_FULL_LON - 3
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        obs = FakeObs(data, lon0=lon0)
+        bp = FakeBackplane((nv, nu), lon0=lon0)
+        result = _reproject(_make_mosaic(), obs, bp)
+        assert result.lon_idx_range == (lon0, _N_FULL_LON - 1)
+
+
+# =========================================================================
+# Masking rules and limits
+# =========================================================================
+
+
+class TestReprojectMasking:
+    """Zero data, backplane masks, uv masks, edge margins, and angle limits."""
+
+    def test_zero_data_pixel_is_masked(self) -> None:
+        """Pixels with data == 0 are treated as invalid and their bins are masked."""
+        data, obs, bp = _scene()
+        data[2, 3] = 0.0
+        result = _reproject(_make_mosaic(), obs, bp)
+        assert bool(ma.getmaskarray(result.img)[2, 3])
+        assert not ma.getmaskarray(result.img)[2, 2]
+
+    def test_mask_bad_areas_expands_zero_regions(self) -> None:
+        """mask_bad_areas=True grows each zero-pixel region by one pixel in all directions."""
+        data, obs, bp = _scene()
+        data[2, 3] = 0.0
+        result = _reproject(_make_mosaic(), obs, bp, mask_bad_areas=True)
+        mask = ma.getmaskarray(result.img)
+        assert bool(mask[1, 2])
+        assert bool(mask[3, 4])
+        assert not mask[0, 3]
+
+    def test_backplane_masked_pixel_is_masked(self) -> None:
+        """A masked latitude backplane sample invalidates the corresponding bin."""
+        nv, nu = 6, 8
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        lat_mask = np.zeros((nv, nu), dtype=bool)
+        lat_mask[1, 1] = True
+        obs = FakeObs(data)
+        bp = FakeBackplane((nv, nu), lat_mask=lat_mask)
+        result = _reproject(_make_mosaic(), obs, bp)
+        assert bool(ma.getmaskarray(result.img)[1, 1])
+        assert not ma.getmaskarray(result.img)[1, 2]
+
+    def test_masked_uv_sample_is_masked(self) -> None:
+        """Bins whose lat/lon do not map onto the detector (masked UV) are masked."""
+        nv, nu = 6, 8
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        obs = FakeObs(data, masked_lon_bin=_LON0 + 2)
+        bp = FakeBackplane((nv, nu))
+        result = _reproject(_make_mosaic(), obs, bp)
+        mask = ma.getmaskarray(result.img)
+        assert bool(mask[:, 2].all())
+        assert not mask[:6, 3].any()
+
+    def test_edge_margin_discards_border_pixels(self) -> None:
+        """edge_margin masks that many detector border pixels before binning."""
+        data, obs, bp = _scene(nv=6, nu=8)
+        result = _reproject(_make_mosaic(edge_margin=1), obs, bp)
+        assert result.lat_idx_range == (_LAT0 + 1, _LAT0 + 5)
+        assert result.lon_idx_range == (_LON0 + 1, _LON0 + 7)
+        assert result.img.data[0, 0] == pytest.approx(data[1, 1])
+
+    def test_max_incidence_masks_over_limit_pixels(self) -> None:
+        """Pixels with incidence beyond the mosaic max_incidence are excluded."""
+        nv, nu = 6, 8
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        incidence = np.full((nv, nu), _DEF_INCIDENCE)
+        incidence[2, 2] = 1.0
+        obs = FakeObs(data)
+        bp = FakeBackplane((nv, nu), incidence=incidence)
+        result = _reproject(_make_mosaic(max_incidence=0.5), obs, bp)
+        assert bool(ma.getmaskarray(result.img)[2, 2])
+        assert not ma.getmaskarray(result.img)[2, 3]
+
+    def test_max_emission_masks_over_limit_pixels(self) -> None:
+        """Pixels with emission beyond the mosaic max_emission are excluded."""
+        nv, nu = 6, 8
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        emission = np.full((nv, nu), _DEF_EMISSION)
+        emission[3, 1] = 1.2
+        obs = FakeObs(data)
+        bp = FakeBackplane((nv, nu), emission=emission)
+        result = _reproject(_make_mosaic(max_emission=0.5), obs, bp)
+        assert bool(ma.getmaskarray(result.img)[3, 1])
+        assert not ma.getmaskarray(result.img)[3, 2]
+
+    def test_max_resolution_masks_coarse_pixels(self) -> None:
+        """Pixels whose center_res / cos(emission) exceeds max_resolution are excluded."""
+        nv, nu = 6, 8
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        emission = np.full((nv, nu), _DEF_EMISSION)
+        emission[3, 3] = 1.2  # resolution 5 / cos(1.2) ~ 13.8 km/pixel
+        obs = FakeObs(data)
+        bp = FakeBackplane((nv, nu), emission=emission)
+        result = _reproject(_make_mosaic(max_resolution=10.0), obs, bp)
+        assert bool(ma.getmaskarray(result.img)[3, 3])
+        assert not ma.getmaskarray(result.img)[3, 4]
+
+    def test_fully_masked_backplane_returns_empty_placeholder(self) -> None:
+        """A body entirely off the detector yields the minimal fully-masked result."""
+        nv, nu = 6, 8
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        obs = FakeObs(data)
+        bp = FakeBackplane((nv, nu), lat_mask=np.ones((nv, nu), dtype=bool))
+        result = _reproject(_make_mosaic(), obs, bp, image_name='off_fov')
+        assert result.lat_idx_range == (0, 1)
+        assert result.lon_idx_range == (0, 1)
+        assert result.img.shape == (2, 2)
+        assert bool(ma.getmaskarray(result.img).all())
+        assert result.time == pytest.approx(1000.0)
+        assert result.image_name == 'off_fov'
+        assert result.sub_solar_lon == pytest.approx(0.1)
+
+    def test_all_zero_data_returns_fully_masked_result(self) -> None:
+        """An observation with no nonzero pixels produces a fully masked 2x2 result."""
+        nv, nu = 6, 8
+        data = np.zeros((nv, nu))
+        obs = FakeObs(data)
+        bp = FakeBackplane((nv, nu))
+        result = _reproject(_make_mosaic(), obs, bp)
+        assert result.lat_idx_range == (0, 1)
+        assert result.lon_idx_range == (0, 1)
+        assert bool(ma.getmaskarray(result.img).all())
+
+    def test_single_valid_pixel(self) -> None:
+        """A single nonzero pixel yields exactly one valid cell with its value."""
+        nv, nu = 6, 8
+        data = np.zeros((nv, nu))
+        data[2, 3] = 7.5
+        obs = FakeObs(data)
+        bp = FakeBackplane((nv, nu))
+        result = _reproject(_make_mosaic(), obs, bp)
+        mask = ma.getmaskarray(result.img)
+        assert int((~mask).sum()) == 1
+        assert result.img.data[0, 0] == pytest.approx(7.5)
+        assert result.lat_idx_range == (_LAT0 + 2, _LAT0 + 3)
+        assert result.lon_idx_range == (_LON0 + 3, _LON0 + 4)
+
+    def test_single_valid_pixel_at_frame_corner(self) -> None:
+        """A body reduced to the (0, 0) detector corner still reprojects correctly."""
+        nv, nu = 6, 8
+        data = np.zeros((nv, nu))
+        data[0, 0] = 3.25
+        obs = FakeObs(data)
+        bp = FakeBackplane((nv, nu))
+        result = _reproject(_make_mosaic(), obs, bp)
+        assert result.img.data[0, 0] == pytest.approx(3.25)
+        assert int((~ma.getmaskarray(result.img)).sum()) == 1
+
+
+# =========================================================================
+# Resolution, effective resolution, photometry, dtypes
+# =========================================================================
+
+
+class TestReprojectResolutionAndPhotometry:
+    """Resolution formulas, navigation uncertainty scaling, and photometric models."""
+
+    def test_resolution_is_center_resolution_over_cos_emission(self) -> None:
+        """resolution == center_resolution / cos(emission) at each mapped pixel."""
+        _data, obs, bp = _scene()
+        result = _reproject(_make_mosaic(), obs, bp)
+        expected = _DEF_CENTER_RES / math.cos(_DEF_EMISSION)
+        np.testing.assert_allclose(result.resolution.data[:6, :8], expected, rtol=1e-6)
+
+    def test_eff_resolution_equals_resolution_at_zero_uncertainty(self) -> None:
+        """With navigation_uncertainty=0 the effective resolution equals resolution."""
+        _data, obs, bp = _scene()
+        result = _reproject(_make_mosaic(), obs, bp, navigation_uncertainty=0.0)
+        np.testing.assert_allclose(
+            result.eff_resolution.data[:6, :8], result.resolution.data[:6, :8]
+        )
+
+    def test_eff_resolution_scales_with_uncertainty(self) -> None:
+        """eff_resolution == resolution * (1 + navigation_uncertainty)."""
+        _data, obs, bp = _scene()
+        result = _reproject(_make_mosaic(), obs, bp, navigation_uncertainty=0.5)
+        np.testing.assert_allclose(
+            result.eff_resolution.data[:6, :8], result.resolution.data[:6, :8] * 1.5, rtol=1e-6
+        )
+
+    def test_geometry_angles_copied_to_grid(self) -> None:
+        """phase/emission/incidence carry the detector backplane values per cell."""
+        nv, nu = 6, 8
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        incidence = np.linspace(0.1, 0.6, nv * nu).reshape(nv, nu)
+        obs = FakeObs(data)
+        bp = FakeBackplane((nv, nu), incidence=incidence)
+        result = _reproject(_make_mosaic(), obs, bp)
+        np.testing.assert_allclose(result.incidence.data[:6, :8], incidence, rtol=1e-6)
+        np.testing.assert_allclose(result.phase.data[:6, :8], _DEF_PHASE, rtol=1e-6)
+        np.testing.assert_allclose(result.emission.data[:6, :8], _DEF_EMISSION, rtol=1e-6)
+
+    def test_photometric_model_divides_by_cos_incidence(self) -> None:
+        """A Lambert model corrects sampled data by max(cos(incidence), clamp)."""
+        nv, nu = 6, 8
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        incidence = np.linspace(0.1, 1.4, nv * nu).reshape(nv, nu)
+        obs = FakeObs(data)
+        bp = FakeBackplane((nv, nu), incidence=incidence)
+        mosaic = _make_mosaic(photometric_model=LambertModel())
+        result = _reproject(mosaic, obs, bp)
+        expected = data / np.maximum(np.cos(incidence.astype(np.float32)), 0.01)
+        np.testing.assert_allclose(result.img.data[:6, :8], expected, rtol=1e-5)
+
+    def test_photometric_model_name_recorded(self) -> None:
+        """photometric_model_name is the model's name when a model is configured."""
+        _data, obs, bp = _scene()
+        result = _reproject(_make_mosaic(photometric_model=LambertModel()), obs, bp)
+        assert result.photometric_model_name == 'lambert'
+
+    def test_photometric_model_name_none_without_model(self) -> None:
+        """photometric_model_name is None when no model is configured."""
+        _data, obs, bp = _scene()
+        result = _reproject(_make_mosaic(), obs, bp)
+        assert result.photometric_model_name is None
+
+    def test_dtype_propagation(self) -> None:
+        """img uses image_dtype; geometry arrays use metadata_dtype; time is a float."""
+        _data, obs, bp = _scene()
+        mosaic = _make_mosaic(image_dtype=np.float32, metadata_dtype=np.float64)
+        result = _reproject(mosaic, obs, bp)
+        assert result.img.dtype == np.dtype(np.float32)
+        assert result.resolution.dtype == np.dtype(np.float64)
+        assert result.eff_resolution.dtype == np.dtype(np.float64)
+        assert result.phase.dtype == np.dtype(np.float64)
+        assert result.image_dtype == np.dtype(np.float32)
+        assert result.metadata_dtype == np.dtype(np.float64)
+        assert isinstance(result.time, float)
+
+
+# =========================================================================
+# mask_only mode
+# =========================================================================
+
+
+class TestReprojectMaskOnly:
+    """mask_only=True returns the valid-pixel coverage mask only."""
+
+    def test_mask_only_img_is_unmasked_coverage(self) -> None:
+        """img holds 1.0 at covered bins and 0.0 elsewhere, with no mask bits set."""
+        _data, obs, bp = _scene(nv=6, nu=8)
+        result = _reproject(_make_mosaic(), obs, bp, mask_only=True)
+        assert not ma.getmaskarray(result.img).any()
+        np.testing.assert_allclose(result.img.data[:6, :8], 1.0)
+        np.testing.assert_allclose(result.img.data[6, :], 0.0)
+        np.testing.assert_allclose(result.img.data[:, 8], 0.0)
+
+    def test_mask_only_metadata_fully_masked(self) -> None:
+        """All geometry fields are fully masked in mask_only mode."""
+        _data, obs, bp = _scene()
+        result = _reproject(_make_mosaic(), obs, bp, mask_only=True)
+        assert bool(ma.getmaskarray(result.resolution).all())
+        assert bool(ma.getmaskarray(result.eff_resolution).all())
+        assert bool(ma.getmaskarray(result.phase).all())
+        assert bool(ma.getmaskarray(result.emission).all())
+        assert bool(ma.getmaskarray(result.incidence).all())
+
+    def test_mask_only_ignores_data_values(self) -> None:
+        """Coverage is based on geometry only; zero data still counts as covered."""
+        nv, nu = 6, 8
+        data = np.zeros((nv, nu))
+        obs = FakeObs(data)
+        bp = FakeBackplane((nv, nu))
+        result = _reproject(_make_mosaic(), obs, bp, mask_only=True)
+        np.testing.assert_allclose(result.img.data[:6, :8], 1.0)
+
+    def test_mask_only_photometric_model_name_is_none(self) -> None:
+        """mask_only results carry photometric_model_name=None even with a model set."""
+        _data, obs, bp = _scene()
+        mosaic = _make_mosaic(photometric_model=LambertModel())
+        result = _reproject(mosaic, obs, bp, mask_only=True)
+        assert result.photometric_model_name is None
+
+    def test_mask_only_outside_fov_placeholder(self) -> None:
+        """mask_only with the body off the detector returns a 2x2 all-zero coverage."""
+        nv, nu = 6, 8
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        obs = FakeObs(data)
+        bp = FakeBackplane((nv, nu), lat_mask=np.ones((nv, nu), dtype=bool))
+        result = _reproject(_make_mosaic(), obs, bp, mask_only=True)
+        assert result.img.shape == (2, 2)
+        np.testing.assert_allclose(result.img.data, 0.0)
+        assert bool(ma.getmaskarray(result.resolution).all())
+
+
+# =========================================================================
+# Subimage handling
+# =========================================================================
+
+
+class TestReprojectSubimage:
+    """subimage_edges with a backplane covering only the subimage."""
+
+    def test_subimage_backplane_samples_subimage_pixels(self) -> None:
+        """A subimage-shaped backplane maps bins to subimage-relative data samples."""
+        nv, nu = 8, 8
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        obs = FakeObs(data)
+        bp = FakeBackplane((4, 4), v_offset=2, u_offset=2)
+        result = _reproject(_make_mosaic(), obs, bp, subimage_edges=(2, 5, 2, 5))
+        assert result.lat_idx_range == (_LAT0 + 2, _LAT0 + 6)
+        assert result.lon_idx_range == (_LON0 + 2, _LON0 + 6)
+        np.testing.assert_allclose(result.img.data[:4, :4], data[2:6, 2:6])
+
+    def test_mask_only_full_frame_backplane_with_subimage(self) -> None:
+        """mask_only supports subimage_edges with a full-frame backplane."""
+        nv, nu = 8, 8
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        obs = FakeObs(data)
+        bp = FakeBackplane((nv, nu))
+        result = _reproject(_make_mosaic(), obs, bp, subimage_edges=(2, 5, 2, 5), mask_only=True)
+        np.testing.assert_allclose(result.img.data[2:6, 2:6], 1.0)
+
+    def test_full_frame_backplane_with_subimage_edges(self) -> None:
+        """A full-frame backplane plus subimage_edges reprojects the subimage."""
+        nv, nu = 8, 8
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        obs = FakeObs(data)
+        bp = FakeBackplane((nv, nu))
+        result = _reproject(_make_mosaic(), obs, bp, subimage_edges=(2, 5, 2, 5))
+        assert result.img.data[0, 0] == pytest.approx(data[2, 2])
+
+
+# =========================================================================
+# zoom
+# =========================================================================
+
+
+class TestReprojectZoom:
+    """The zoom parameter's documented sub-pixel interpolation."""
+
+    def test_zoom_one_matches_direct_sampling(self) -> None:
+        """zoom=1 samples the original image directly."""
+        data, obs, bp = _scene()
+        result = _reproject(_make_mosaic(zoom=1), obs, bp)
+        np.testing.assert_allclose(result.img.data[:6, :8], data)
+
+    def test_zoom_enables_sub_pixel_sampling(self) -> None:
+        """zoom > 1 must change sampling when bins map to fractional pixel positions."""
+        nv, nu = 6, 8
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        obs = FakeObs(data, frac_u=0.75, frac_v=0.75)
+        bp = FakeBackplane((nv, nu))
+        r1 = _reproject(_make_mosaic(zoom=1), obs, bp)
+        r4 = _reproject(_make_mosaic(zoom=4), obs, bp)
+        assert not np.array_equal(r1.img.filled(-1.0), r4.img.filled(-1.0))
+
+
+# =========================================================================
+# add() fed by reproject() results
+# =========================================================================
+
+
+class TestAddWithReprojectResults:
+    """Accumulation semantics of add() using real reproject() outputs."""
+
+    def test_reproject_add_round_trip(self) -> None:
+        """Adding a reprojection and reading it back preserves values and coverage."""
+        data, obs, bp = _scene(nv=6, nu=8)
+        mosaic = _make_mosaic()
+        mosaic.add(_reproject(mosaic, obs, bp))
+        out = mosaic.to_bounded()
+        np.testing.assert_allclose(out.img.data[:6, :8], data)
+
+    def test_overlapping_add_better_resolution_wins(self) -> None:
+        """When coverage overlaps, the image with finer effective resolution wins."""
+        nv, nu = 6, 8
+        coarse = np.full((nv, nu), 1.0)
+        fine = np.full((nv, nu), 9.0)
+        mosaic = _make_mosaic()
+        mosaic.add(_reproject(mosaic, FakeObs(coarse), FakeBackplane((nv, nu), center_res=5.0)))
+        mosaic.add(_reproject(mosaic, FakeObs(fine), FakeBackplane((nv, nu), center_res=2.0)))
+        out = mosaic.to_bounded()
+        np.testing.assert_allclose(out.img.data[:6, :8], 9.0)
+
+    def test_overlapping_add_worse_resolution_loses(self) -> None:
+        """A later image with coarser effective resolution does not overwrite."""
+        nv, nu = 6, 8
+        fine = np.full((nv, nu), 9.0)
+        coarse = np.full((nv, nu), 1.0)
+        mosaic = _make_mosaic()
+        mosaic.add(_reproject(mosaic, FakeObs(fine), FakeBackplane((nv, nu), center_res=2.0)))
+        mosaic.add(_reproject(mosaic, FakeObs(coarse), FakeBackplane((nv, nu), center_res=5.0)))
+        out = mosaic.to_bounded()
+        np.testing.assert_allclose(out.img.data[:6, :8], 9.0)
+
+    def test_disjoint_adds_union_coverage(self) -> None:
+        """Two disjoint reprojections both appear in the mosaic at their own bins."""
+        nv, nu = 3, 3
+        d1 = np.full((nv, nu), 4.0)
+        d2 = np.full((nv, nu), 6.0)
+        mosaic = _make_mosaic()
+        mosaic.add(_reproject(mosaic, FakeObs(d1), FakeBackplane((nv, nu))))
+        obs2 = FakeObs(d2, lat0=_LAT0, lon0=_LON0 + 10)
+        mosaic.add(_reproject(mosaic, obs2, FakeBackplane((nv, nu), lon0=_LON0 + 10)))
+        out = mosaic.to_full()
+        assert out.img.data[_LAT0, _LON0] == pytest.approx(4.0)
+        assert out.img.data[_LAT0, _LON0 + 10] == pytest.approx(6.0)
+
+    def test_no_valid_pixel_result_still_counts_image(self) -> None:
+        """An empty (off-detector) reprojection still records its image name."""
+        nv, nu = 6, 8
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        obs = FakeObs(data)
+        bp_off = FakeBackplane((nv, nu), lat_mask=np.ones((nv, nu), dtype=bool))
+        mosaic = _make_mosaic()
+        mosaic.add(_reproject(mosaic, obs, bp_off, image_name='empty_one'))
+        mosaic.add(_reproject(mosaic, obs, FakeBackplane((nv, nu)), image_name='real_one'))
+        out = mosaic.to_full()
+        assert out.contributing_image_names == ('empty_one', 'real_one')
+        assert int(out.image_number.data[_LAT0, _LON0]) == 1
+
+    def test_bounds_reflect_valid_data_only(self) -> None:
+        """bounds covers only bins that actually hold valid data."""
+        nv, nu = 6, 8
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        obs = FakeObs(data)
+        bp_off = FakeBackplane((nv, nu), lat_mask=np.ones((nv, nu), dtype=bool))
+        mosaic = _make_mosaic()
+        mosaic.add(_reproject(mosaic, obs, bp_off))  # fully masked (0..1, 0..1) window
+        mosaic.add(_reproject(mosaic, obs, FakeBackplane((nv, nu))))
+        bounds = mosaic.bounds
+        assert bounds is not None
+        (lat_min, _), (lon_min, _) = bounds
+        assert lat_min == pytest.approx(_LAT0 * _LAT_RES - _HALF_PI)
+        assert lon_min == pytest.approx(_LON0 * _LON_RES)
+
+    def test_add_mismatched_grid_shape_raises(self) -> None:
+        """A repro whose img shape disagrees with its idx ranges fails to add."""
+        good = _make_repro(lat_range=(5, 6), lon_range=(10, 11))
+        bad = BodyReprojResult(
+            body_name=good.body_name,
+            img=good.img,
+            lat_resolution=good.lat_resolution,
+            lon_resolution=good.lon_resolution,
+            lat_idx_range=(5, 7),  # claims 3 rows but img has 2
+            lon_idx_range=(10, 11),
+            latlon_type=good.latlon_type,
+            lon_direction=good.lon_direction,
+            resolution=good.resolution,
+            eff_resolution=good.eff_resolution,
+            phase=good.phase,
+            emission=good.emission,
+            incidence=good.incidence,
+            time=good.time,
+            photometric_model_name=None,
+            image_dtype=good.image_dtype,
+            metadata_dtype=good.metadata_dtype,
+        )
+        mosaic = BodyMosaic(body_name='MIMAS', lat_resolution=_LAT_RES, lon_resolution=_LON_RES)
+        with pytest.raises(IndexError, match='boolean index'):
+            mosaic.add(bad)
+
+    def test_add_photometric_model_mismatch_raises(self) -> None:
+        """Adding a photometrically corrected repro to a plain mosaic raises ValueError."""
+        _data, obs, bp = _scene()
+        phot_mosaic = _make_mosaic(photometric_model=LambertModel())
+        repro = _reproject(phot_mosaic, obs, bp)
+        plain_mosaic = _make_mosaic()
+        with pytest.raises(ValueError, match='photometric_model_name mismatch'):
+            plain_mosaic.add(repro)
+
+    def test_add_at_uint16_capacity_succeeds(self) -> None:
+        """The 65,536th image (number 65535) is still accepted."""
+        mosaic = BodyMosaic(body_name='MIMAS', lat_resolution=_LAT_RES, lon_resolution=_LON_RES)
+        mosaic._image_count = np.iinfo(np.uint16).max
+        mosaic.add(_make_repro(lat_range=(5, 5), lon_range=(10, 10)))
+        out = mosaic.to_bounded()
+        assert int(out.image_number.data[0, 0]) == np.iinfo(np.uint16).max
+
+    def test_add_beyond_uint16_capacity_raises_overflow(self) -> None:
+        """Exceeding the uint16 image-number capacity raises OverflowError."""
+        mosaic = BodyMosaic(body_name='MIMAS', lat_resolution=_LAT_RES, lon_resolution=_LON_RES)
+        mosaic._image_count = np.iinfo(np.uint16).max + 1
+        with pytest.raises(OverflowError, match='exceeds uint16 max'):
+            mosaic.add(_make_repro(lat_range=(5, 5), lon_range=(10, 10)))
+
+    def test_copy_slop_copies_neighbors_of_replaced_pixels(self) -> None:
+        """copy_slop=1 also copies pixels adjacent to each replaced pixel."""
+        mosaic = BodyMosaic(body_name='MIMAS', lat_resolution=_LAT_RES, lon_resolution=_LON_RES)
+        first = _make_repro(
+            lat_range=(5, 7), lon_range=(10, 12), img_values=1.0, eff_res_values=1.0
+        )
+        mosaic.add(first)
+        eff2 = np.full((3, 3), 5.0, dtype=np.float32)
+        eff2[1, 1] = 0.1  # only the center wins on resolution
+        second = _make_repro(
+            lat_range=(5, 7), lon_range=(10, 12), img_values=9.0, eff_res_values=eff2
+        )
+        mosaic.add(second, copy_slop=1)
+        out = mosaic.to_bounded()
+        assert out.img.data[1, 1] == pytest.approx(9.0)
+        assert out.img.data[0, 1] == pytest.approx(9.0)
+
+
+# =========================================================================
+# Inverse-mapping consistency (reproject -> mosaic -> cartographic model)
+# =========================================================================
+
+
+class TestInverseMappingConsistency:
+    """Projecting a reprojected mosaic back onto the image recovers the data."""
+
+    def test_reproject_then_project_back_recovers_image(self) -> None:
+        """create_cartographic_model on the mosaic reproduces the observed image.
+
+        Detector pixels sit at bin CENTERS, so projecting back samples the mosaic
+        halfway between grid rows/columns; the expected model is the bilinear
+        average of the four surrounding mosaic cells (zero-filled at the masked
+        ceil row/column).
+        """
+        nv, nu = 6, 8
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        obs = FakeObs(data)
+        bp = FakeBackplane((nv, nu))
+        mosaic = _make_mosaic()
+        repro = _reproject(mosaic, obs, bp)
+        mosaic.add(repro)
+        # Window the bounded view to the full reprojection extent (including
+        # the masked ceil row/column) so the bilinear expectation below sees
+        # zero-filled cells there; the default window is the valid-data bounds,
+        # which exclude the masked edge bins.
+        bounded = mosaic.to_bounded(
+            lat_range=(
+                repro.lat_idx_range[0] * _LAT_RES - math.pi / 2.0,
+                repro.lat_idx_range[1] * _LAT_RES - math.pi / 2.0,
+            ),
+            lon_range=(
+                repro.lon_idx_range[0] * _LON_RES,
+                repro.lon_idx_range[1] * _LON_RES,
+            ),
+        )
+
+        with patch('oops.backplane.Backplane', new=lambda o: bp):
+            carto = create_cartographic_model(
+                bounded, obs, body_name='MIMAS', latlon_type='squashed'
+            )
+
+        assert carto is not None
+        padded = np.zeros((nv + 1, nu + 1))
+        padded[:nv, :nu] = data
+        expected = 0.25 * (padded[:-1, :-1] + padded[:-1, 1:] + padded[1:, :-1] + padded[1:, 1:])
+        np.testing.assert_allclose(carto.model_img, expected, rtol=1e-4, atol=1e-4)
+
+    def test_round_trip_resolution_ratio(self) -> None:
+        """The resolution ratio is median mosaic eff_resolution over center resolution."""
+        nv, nu = 6, 8
+        data = np.arange(1.0, nv * nu + 1.0).reshape(nv, nu)
+        obs = FakeObs(data)
+        bp = FakeBackplane((nv, nu))
+        mosaic = _make_mosaic()
+        mosaic.add(_reproject(mosaic, obs, bp))
+        bounded = mosaic.to_bounded()
+
+        with patch('oops.backplane.Backplane', new=lambda o: bp):
+            carto = create_cartographic_model(
+                bounded, obs, body_name='MIMAS', latlon_type='squashed'
+            )
+
+        assert carto is not None
+        expected_ratio = (_DEF_CENTER_RES / math.cos(_DEF_EMISSION)) / _DEF_CENTER_RES
+        assert carto.resolution_ratio == pytest.approx(expected_ratio, rel=1e-5)

--- a/tests/spindoctor/reproj/test_cartographic_model_contract.py
+++ b/tests/spindoctor/reproj/test_cartographic_model_contract.py
@@ -1,0 +1,361 @@
+"""Spec-first contract tests for create_cartographic_model.
+
+Contracts under test come from the docstrings in
+``src/spindoctor/reproj/cartographic_model.py`` and the "Cartographic model
+projection" section of ``docs/dev_guide/dev_guide_reprojection.rst``: for each
+image pixel the mosaic is sampled at the pixel's lat/lon via bilinear
+interpolation, ``col = ((bp_longitude - lon_min) % (2 * pi)) / lon_resolution``
+handles longitude wraparound, pixels off the body or outside the mosaic are 0.0,
+and ``resolution_ratio`` is the median mosaic effective resolution over the
+image-center resolution (falling back to 1.0 on degenerate inputs).
+
+All geometry is supplied through a fake ``oops.backplane.Backplane`` so the
+tests run hermetically (no SPICE kernels, no holdings).
+"""
+
+import math
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import numpy.ma as ma
+import numpy.typing as npt
+import pytest
+
+from spindoctor.reproj.bodies import BodyMosaicData
+from spindoctor.reproj.cartographic_model import create_cartographic_model
+
+_LAT_RES = 0.1  # rad/pixel
+_LON_RES = 0.1  # rad/pixel
+_TWO_PI = 2.0 * math.pi
+
+
+def _make_mosaic_data(
+    img: npt.NDArray[np.float64],
+    *,
+    img_mask: npt.NDArray[np.bool_] | bool = False,
+    lat_min: float = -0.2,
+    lon_min: float = 0.5,
+    eff_res: npt.NDArray[np.float64] | float = 2.0,
+    eff_res_mask: npt.NDArray[np.bool_] | bool = False,
+) -> BodyMosaicData:
+    """Build a synthetic BodyMosaicData around a given image array.
+
+    Parameters:
+        img: Mosaic image array of shape (n_lat, n_lon).
+        img_mask: Mask for the mosaic image (True = no data).
+        lat_min: Latitude of mosaic row 0 (rad).
+        lon_min: Longitude of mosaic column 0 (rad); the grid may extend past 2*pi.
+        eff_res: Scalar or per-cell effective resolution (km/pixel).
+        eff_res_mask: Mask for the effective-resolution array.
+    """
+    n_lat, n_lon = img.shape
+    shape = (n_lat, n_lon)
+    zeros = np.zeros(shape, dtype=np.float32)
+    eff = np.broadcast_to(np.asarray(eff_res, dtype=np.float32), shape)
+    return BodyMosaicData(
+        body_name='MIMAS',
+        img=ma.MaskedArray(np.asarray(img, dtype=np.float64), mask=img_mask),
+        lat_resolution=_LAT_RES,
+        lon_resolution=_LON_RES,
+        lat_range=(lat_min, lat_min + (n_lat - 1) * _LAT_RES),
+        lon_range=(lon_min, lon_min + (n_lon - 1) * _LON_RES),
+        latlon_type='centric',
+        lon_direction='east',
+        resolution=ma.MaskedArray(np.ones(shape, dtype=np.float32)),
+        eff_resolution=ma.MaskedArray(eff.copy(), mask=eff_res_mask),
+        phase=ma.MaskedArray(zeros.copy()),
+        emission=ma.MaskedArray(zeros.copy()),
+        incidence=ma.MaskedArray(zeros.copy()),
+        time=ma.MaskedArray(np.zeros(shape, dtype=np.float64)),
+        image_number=ma.MaskedArray(np.zeros(shape, dtype=np.uint16)),
+        photometric_model_name=None,
+        image_dtype=np.dtype(np.float64),
+        metadata_dtype=np.dtype(np.float32),
+    )
+
+
+class _CartoBackplane:
+    """Backplane stand-in returning explicit lat/lon arrays for the image."""
+
+    def __init__(
+        self,
+        latitude: npt.NDArray[np.float64],
+        longitude: npt.NDArray[np.float64],
+        *,
+        lat_mask: npt.NDArray[np.bool_] | bool = False,
+        lon_mask: npt.NDArray[np.bool_] | bool = False,
+        center_res: float = 2.0,
+    ) -> None:
+        """Store the fake backplane arrays.
+
+        Parameters:
+            latitude: Per-pixel body latitude (rad), image shaped.
+            longitude: Per-pixel body longitude (rad), image shaped.
+            lat_mask: Mask for the latitude backplane (True = off body).
+            lon_mask: Mask for the longitude backplane.
+            center_res: Scalar image-center resolution (km/pixel).
+        """
+        self._lat = ma.MaskedArray(np.asarray(latitude, dtype=np.float64), mask=lat_mask)
+        self._lon = ma.MaskedArray(np.asarray(longitude, dtype=np.float64), mask=lon_mask)
+        self._center_res = center_res
+
+    def latitude(self, name: str, lat_type: str = 'centric') -> SimpleNamespace:
+        """Return the latitude backplane wrapper.
+
+        Parameters:
+            name: Body name (ignored).
+            lat_type: Latitude type (ignored).
+        """
+        return SimpleNamespace(mvals=self._lat)
+
+    def longitude(
+        self, name: str, direction: str = 'east', lon_type: str = 'centric'
+    ) -> SimpleNamespace:
+        """Return the longitude backplane wrapper.
+
+        Parameters:
+            name: Body name (ignored).
+            direction: Longitude direction (ignored).
+            lon_type: Longitude type (ignored).
+        """
+        return SimpleNamespace(mvals=self._lon)
+
+    def center_resolution(self, name: str) -> SimpleNamespace:
+        """Return the scalar center-resolution wrapper.
+
+        Parameters:
+            name: Body name (ignored).
+        """
+        return SimpleNamespace(vals=self._center_res)
+
+
+def _run(
+    mosaic: BodyMosaicData,
+    bp: _CartoBackplane,
+) -> tuple[npt.NDArray[np.float32], float]:
+    """Run create_cartographic_model against a fake backplane.
+
+    Parameters:
+        mosaic: Mosaic data to project.
+        bp: Fake backplane supplying the image geometry.
+    """
+    with patch('oops.backplane.Backplane', new=lambda obs: bp):
+        result = create_cartographic_model(mosaic, object(), body_name='MIMAS')
+    assert result is not None
+    return result.model_img, result.resolution_ratio
+
+
+def _cell_coords(
+    mosaic: BodyMosaicData,
+    row: float,
+    col: float,
+    shape: tuple[int, int],
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Return constant lat/lon image arrays targeting a fractional mosaic cell.
+
+    Parameters:
+        mosaic: Mosaic whose grid defines the coordinate mapping.
+        row: Fractional mosaic row to target.
+        col: Fractional mosaic column to target.
+        shape: Image shape for the returned arrays.
+    """
+    lat = np.full(shape, mosaic.lat_range[0] + row * _LAT_RES)
+    lon = np.full(shape, mosaic.lon_range[0] + col * _LON_RES)
+    return lat, lon
+
+
+# =========================================================================
+# Input validation
+# =========================================================================
+
+
+class TestValidation:
+    """Argument validation happens before any backplane is created."""
+
+    def test_non_string_body_name_raises_type_error(self) -> None:
+        """A non-str body_name raises TypeError."""
+        mosaic = _make_mosaic_data(np.ones((2, 2)))
+        with pytest.raises(TypeError, match='body_name must be str'):
+            create_cartographic_model(mosaic, object(), body_name=123)  # type: ignore[arg-type]
+
+    def test_empty_body_name_raises_value_error(self) -> None:
+        """A blank body_name raises ValueError."""
+        mosaic = _make_mosaic_data(np.ones((2, 2)))
+        with pytest.raises(ValueError, match='body_name must be a non-empty string'):
+            create_cartographic_model(mosaic, object(), body_name='   ')
+
+    def test_bad_latlon_type_raises_value_error(self) -> None:
+        """An unknown latlon_type raises ValueError."""
+        mosaic = _make_mosaic_data(np.ones((2, 2)))
+        with pytest.raises(ValueError, match="latlon_type must be 'centric'"):
+            create_cartographic_model(
+                mosaic,
+                object(),
+                body_name='MIMAS',
+                latlon_type='polar',  # type: ignore[arg-type]
+            )
+
+    def test_bad_lon_direction_raises_value_error(self) -> None:
+        """An unknown lon_direction raises ValueError."""
+        mosaic = _make_mosaic_data(np.ones((2, 2)))
+        with pytest.raises(ValueError, match="lon_direction must be 'east' or 'west'"):
+            create_cartographic_model(
+                mosaic,
+                object(),
+                body_name='MIMAS',
+                lon_direction='up',  # type: ignore[arg-type]
+            )
+
+
+# =========================================================================
+# Sampling and interpolation
+# =========================================================================
+
+
+class TestSampling:
+    """Bilinear sampling of the mosaic at each image pixel's lat/lon."""
+
+    def test_exact_cell_returns_cell_value(self) -> None:
+        """A pixel mapping exactly onto a mosaic cell receives that cell's value."""
+        img = np.zeros((4, 6))
+        img[2, 3] = 0.8
+        mosaic = _make_mosaic_data(img)
+        lat, lon = _cell_coords(mosaic, 2.0, 3.0, (3, 5))
+        model, _ = _run(mosaic, _CartoBackplane(lat, lon))
+        np.testing.assert_allclose(model, 0.8, rtol=1e-6)
+
+    def test_midpoint_between_rows_is_average(self) -> None:
+        """A pixel halfway between two rows receives the average of both values."""
+        img = np.zeros((4, 6))
+        img[1, 3] = 2.0
+        img[2, 3] = 4.0
+        mosaic = _make_mosaic_data(img)
+        lat, lon = _cell_coords(mosaic, 1.5, 3.0, (2, 2))
+        model, _ = _run(mosaic, _CartoBackplane(lat, lon))
+        np.testing.assert_allclose(model, 3.0, rtol=1e-6)
+
+    def test_midpoint_between_columns_is_average(self) -> None:
+        """A pixel halfway between two columns receives the average of both values."""
+        img = np.zeros((4, 6))
+        img[2, 3] = 2.0
+        img[2, 4] = 6.0
+        mosaic = _make_mosaic_data(img)
+        lat, lon = _cell_coords(mosaic, 2.0, 3.5, (2, 2))
+        model, _ = _run(mosaic, _CartoBackplane(lat, lon))
+        np.testing.assert_allclose(model, 4.0, rtol=1e-6)
+
+    def test_masked_mosaic_cell_contributes_zero(self) -> None:
+        """Masked mosaic cells enter the interpolation as 0.0."""
+        img = np.full((4, 6), 2.0)
+        img_mask = np.zeros((4, 6), dtype=bool)
+        img_mask[2, 3] = True
+        mosaic = _make_mosaic_data(img, img_mask=img_mask)
+        lat, lon = _cell_coords(mosaic, 2.0, 2.5, (2, 2))  # between valid col 2 and masked col 3
+        model, _ = _run(mosaic, _CartoBackplane(lat, lon))
+        np.testing.assert_allclose(model, 1.0, rtol=1e-6)
+
+    def test_longitude_wraparound_samples_across_two_pi(self) -> None:
+        """Longitudes expressed modulo 2*pi map onto a mosaic extending past 2*pi."""
+        img = np.zeros((4, 6))
+        img[1, 4] = 5.0
+        mosaic = _make_mosaic_data(img, lon_min=6.0)  # columns span 6.0..6.5 rad, past 2*pi
+        lat = np.full((2, 2), mosaic.lat_range[0] + 1.0 * _LAT_RES)
+        lon = np.full((2, 2), (6.0 + 4.0 * _LON_RES) - _TWO_PI)  # same angle, wrapped into [0, 2pi)
+        model, _ = _run(mosaic, _CartoBackplane(lat, lon))
+        np.testing.assert_allclose(model, 5.0, rtol=1e-5)
+
+    def test_single_cell_mosaic(self) -> None:
+        """A 1x1 mosaic is sampled only by pixels mapping exactly onto its cell."""
+        mosaic = _make_mosaic_data(np.array([[7.0]]))
+        lat = np.array([[mosaic.lat_range[0], mosaic.lat_range[0] + _LAT_RES]])
+        lon = np.full((1, 2), mosaic.lon_range[0])
+        model, _ = _run(mosaic, _CartoBackplane(lat, lon))
+        assert model[0, 0] == pytest.approx(7.0)
+        assert model[0, 1] == pytest.approx(0.0)
+
+
+class TestOutOfBoundsAndMasks:
+    """Pixels off the body or outside the mosaic coverage are 0.0."""
+
+    def test_latitude_outside_mosaic_is_zero(self) -> None:
+        """Pixels whose latitude is beyond the mosaic extent get 0.0."""
+        mosaic = _make_mosaic_data(np.full((4, 6), 3.0))
+        lat, lon = _cell_coords(mosaic, 4.5, 2.0, (2, 3))  # rows run 0..3 only
+        model, _ = _run(mosaic, _CartoBackplane(lat, lon))
+        np.testing.assert_allclose(model, 0.0)
+
+    def test_body_masked_pixel_is_zero(self) -> None:
+        """Pixels masked in the latitude backplane get 0.0 even with in-range coords."""
+        mosaic = _make_mosaic_data(np.full((4, 6), 3.0))
+        lat, lon = _cell_coords(mosaic, 2.0, 3.0, (2, 3))
+        lat_mask = np.zeros((2, 3), dtype=bool)
+        lat_mask[0, 1] = True
+        model, _ = _run(mosaic, _CartoBackplane(lat, lon, lat_mask=lat_mask))
+        assert model[0, 1] == pytest.approx(0.0)
+        assert model[0, 0] == pytest.approx(3.0)
+
+    def test_last_row_boundary_is_inclusive(self) -> None:
+        """A pixel on the last mosaic row (row n_lat - 1) is in bounds.
+
+        The target latitude is nudged a few ULPs below the exact boundary so that
+        float round-off in the row-coordinate division cannot push the sample past
+        the inclusive ``row_coords <= n_lat - 1`` bound being tested.
+        """
+        img = np.zeros((4, 6))
+        img[3, :] = 1.5
+        mosaic = _make_mosaic_data(img)
+        boundary_lat = mosaic.lat_range[0] + 3.0 * _LAT_RES
+        lat_val = boundary_lat - 4.0 * float(np.spacing(boundary_lat))
+        lat = np.full((2, 2), lat_val)
+        lon = np.full((2, 2), mosaic.lon_range[0] + 2.0 * _LON_RES)
+        model, _ = _run(mosaic, _CartoBackplane(lat, lon))
+        np.testing.assert_allclose(model, 1.5, rtol=1e-6)
+
+    def test_just_beyond_last_row_is_zero(self) -> None:
+        """A pixel slightly past the last mosaic row is out of bounds."""
+        mosaic = _make_mosaic_data(np.full((4, 6), 1.5))
+        lat, lon = _cell_coords(mosaic, 3.01, 2.0, (2, 2))
+        model, _ = _run(mosaic, _CartoBackplane(lat, lon))
+        np.testing.assert_allclose(model, 0.0)
+
+
+# =========================================================================
+# Output format and resolution ratio
+# =========================================================================
+
+
+class TestOutputFormat:
+    """Model image shape/dtype and the resolution_ratio field."""
+
+    def test_model_shape_matches_image_and_dtype_float32(self) -> None:
+        """The model image matches the backplane shape and is float32."""
+        mosaic = _make_mosaic_data(np.ones((4, 6)))
+        lat, lon = _cell_coords(mosaic, 2.0, 3.0, (5, 7))
+        model, _ = _run(mosaic, _CartoBackplane(lat, lon))
+        assert model.shape == (5, 7)
+        assert model.dtype == np.dtype(np.float32)
+
+    def test_resolution_ratio_is_median_over_center(self) -> None:
+        """resolution_ratio == median(unmasked eff_resolution) / center_resolution."""
+        eff = np.arange(1.0, 25.0).reshape(4, 6)
+        eff_mask = eff > 12.0  # unmasked values 1..12, median 6.5
+        mosaic = _make_mosaic_data(np.ones((4, 6)), eff_res=eff, eff_res_mask=eff_mask)
+        lat, lon = _cell_coords(mosaic, 2.0, 3.0, (2, 2))
+        _, ratio = _run(mosaic, _CartoBackplane(lat, lon, center_res=2.0))
+        assert ratio == pytest.approx(6.5 / 2.0)
+
+    def test_zero_center_resolution_falls_back_to_one(self) -> None:
+        """A non-positive image-center resolution yields resolution_ratio == 1.0."""
+        mosaic = _make_mosaic_data(np.ones((4, 6)), eff_res=3.0)
+        lat, lon = _cell_coords(mosaic, 2.0, 3.0, (2, 2))
+        _, ratio = _run(mosaic, _CartoBackplane(lat, lon, center_res=0.0))
+        assert ratio == pytest.approx(1.0)
+
+    def test_fully_masked_mosaic_returns_none_without_backplane(self) -> None:
+        """An all-masked mosaic returns None before any backplane is constructed."""
+        mosaic = _make_mosaic_data(np.ones((4, 6)), img_mask=True)
+        with patch('oops.backplane.Backplane') as bp_cls:
+            result = create_cartographic_model(mosaic, object(), body_name='MIMAS')
+        assert result is None
+        bp_cls.assert_not_called()

--- a/tests/spindoctor/reproj/test_context_managers.py
+++ b/tests/spindoctor/reproj/test_context_managers.py
@@ -1,0 +1,111 @@
+"""Spec tests for ``spindoctor.reproj._context_managers._reduced_oops_precision``.
+
+The documented contract (module docstring, function docstring, and the dev guide's
+"Context managers" section) is: the manager sets ``oops.config.PATH_PHOTONS.dlt_precision``
+and ``oops.config.SURFACE_PHOTONS.dlt_precision`` to ``dlt`` (default 1) for the
+duration of the block and restores both original values on exit, even when the
+wrapped code raises.
+"""
+
+from collections.abc import Iterator
+
+import oops
+import pytest
+
+from spindoctor.reproj._context_managers import _reduced_oops_precision
+
+
+@pytest.fixture(autouse=True)
+def _oops_precision_guard() -> Iterator[None]:
+    """Snapshot and restore the oops global precision attributes around each test.
+
+    Yields:
+        None; the pre-test values are restored afterwards even if a test fails.
+    """
+    old_path = oops.config.PATH_PHOTONS.dlt_precision
+    old_surf = oops.config.SURFACE_PHOTONS.dlt_precision
+    yield
+    oops.config.PATH_PHOTONS.dlt_precision = old_path
+    oops.config.SURFACE_PHOTONS.dlt_precision = old_surf
+
+
+class TestReducedOopsPrecision:
+    """Set-and-restore contract of ``_reduced_oops_precision``."""
+
+    def test_default_sets_path_photons_to_one(self) -> None:
+        """Inside the block, PATH_PHOTONS.dlt_precision is the documented default of 1."""
+        with _reduced_oops_precision():
+            assert oops.config.PATH_PHOTONS.dlt_precision == 1
+
+    def test_default_sets_surface_photons_to_one(self) -> None:
+        """Inside the block, SURFACE_PHOTONS.dlt_precision is the documented default of 1."""
+        with _reduced_oops_precision():
+            assert oops.config.SURFACE_PHOTONS.dlt_precision == 1
+
+    def test_restores_path_photons_on_normal_exit(self) -> None:
+        """PATH_PHOTONS.dlt_precision is restored to its prior value after the block."""
+        before = oops.config.PATH_PHOTONS.dlt_precision
+        with _reduced_oops_precision():
+            pass
+        assert oops.config.PATH_PHOTONS.dlt_precision == before
+
+    def test_restores_surface_photons_on_normal_exit(self) -> None:
+        """SURFACE_PHOTONS.dlt_precision is restored to its prior value after the block."""
+        before = oops.config.SURFACE_PHOTONS.dlt_precision
+        with _reduced_oops_precision():
+            pass
+        assert oops.config.SURFACE_PHOTONS.dlt_precision == before
+
+    def test_custom_dlt_applied_to_path_photons(self) -> None:
+        """An explicit dlt value is applied to PATH_PHOTONS."""
+        with _reduced_oops_precision(dlt=7):
+            assert oops.config.PATH_PHOTONS.dlt_precision == 7
+
+    def test_custom_dlt_applied_to_surface_photons(self) -> None:
+        """An explicit dlt value is applied to SURFACE_PHOTONS."""
+        with _reduced_oops_precision(dlt=7):
+            assert oops.config.SURFACE_PHOTONS.dlt_precision == 7
+
+    def test_restores_path_photons_on_exception(self) -> None:
+        """PATH_PHOTONS.dlt_precision is restored even when the block raises."""
+        before = oops.config.PATH_PHOTONS.dlt_precision
+        with pytest.raises(RuntimeError, match='boom'), _reduced_oops_precision():
+            raise RuntimeError('boom')
+        assert oops.config.PATH_PHOTONS.dlt_precision == before
+
+    def test_restores_surface_photons_on_exception(self) -> None:
+        """SURFACE_PHOTONS.dlt_precision is restored even when the block raises."""
+        before = oops.config.SURFACE_PHOTONS.dlt_precision
+        with pytest.raises(RuntimeError, match='boom'), _reduced_oops_precision():
+            raise RuntimeError('boom')
+        assert oops.config.SURFACE_PHOTONS.dlt_precision == before
+
+    def test_restores_non_default_prior_values(self) -> None:
+        """Restoration returns to whatever values were in effect, not to library defaults."""
+        oops.config.PATH_PHOTONS.dlt_precision = 0.125
+        oops.config.SURFACE_PHOTONS.dlt_precision = 0.25
+        with _reduced_oops_precision():
+            assert oops.config.PATH_PHOTONS.dlt_precision == 1
+        assert oops.config.PATH_PHOTONS.dlt_precision == 0.125
+        assert oops.config.SURFACE_PHOTONS.dlt_precision == 0.25
+
+    def test_nested_blocks_restore_in_lifo_order(self) -> None:
+        """Exiting an inner block restores the outer block's value, then the original."""
+        original = oops.config.PATH_PHOTONS.dlt_precision
+        with _reduced_oops_precision(dlt=1):
+            with _reduced_oops_precision(dlt=5):
+                assert oops.config.PATH_PHOTONS.dlt_precision == 5
+                assert oops.config.SURFACE_PHOTONS.dlt_precision == 5
+            assert oops.config.PATH_PHOTONS.dlt_precision == 1
+            assert oops.config.SURFACE_PHOTONS.dlt_precision == 1
+        assert oops.config.PATH_PHOTONS.dlt_precision == original
+
+    def test_yields_none(self) -> None:
+        """The context manager yields None (no handle is exposed)."""
+        with _reduced_oops_precision() as handle:
+            assert handle is None
+
+    def test_dlt_is_keyword_only(self) -> None:
+        """The dlt parameter cannot be passed positionally."""
+        with pytest.raises(TypeError, match='positional'), _reduced_oops_precision(2):  # type: ignore[misc]
+            pass

--- a/tests/spindoctor/reproj/test_context_managers.py
+++ b/tests/spindoctor/reproj/test_context_managers.py
@@ -7,7 +7,9 @@ duration of the block and restores both original values on exit, even when the
 wrapped code raises.
 """
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
+from contextlib import AbstractContextManager
+from typing import cast
 
 import oops
 import pytest
@@ -107,5 +109,8 @@ class TestReducedOopsPrecision:
 
     def test_dlt_is_keyword_only(self) -> None:
         """The dlt parameter cannot be passed positionally."""
-        with pytest.raises(TypeError, match='positional'), _reduced_oops_precision(2):  # type: ignore[misc]
+        # cast() makes the deliberately wrong positional call opaque to mypy;
+        # a type-ignore here is release-dependent (misc vs call-arg).
+        bad_call = cast('Callable[[int], AbstractContextManager[None]]', _reduced_oops_precision)
+        with pytest.raises(TypeError, match='positional'), bad_call(2):
             pass

--- a/tests/spindoctor/reproj/test_photometric_model.py
+++ b/tests/spindoctor/reproj/test_photometric_model.py
@@ -1,0 +1,365 @@
+"""Spec-first unit tests for spindoctor.reproj.photometric_model.
+
+Contracts under test come from the class and method docstrings in
+``src/spindoctor/reproj/photometric_model.py`` and the "Photometric models"
+section of ``docs/dev_guide/dev_guide_reprojection.rst``: all angles are in
+radians, Lambert divides by a clamped cos(incidence), Lommel-Seeliger applies
+``(mu0 + mu) / (2 * mu0)`` with a signed denominator floor, Minnaert divides by
+``cos(incidence)^k * cos(emission)^(k-1)``, every ``uncorrect`` inverts its
+``correct`` with identical clamping, and ``photometric_model_from_name``
+resolves case/space/hyphen-insensitive aliases.
+"""
+
+import math
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from spindoctor.reproj.photometric_model import (
+    LambertModel,
+    LommelSeeligerModel,
+    MinnaertModel,
+    photometric_model_from_name,
+)
+
+_DATA = np.array([[1.0, 2.0], [3.0, 4.0]])
+
+
+def _angles(value: float) -> npt.NDArray[np.float64]:
+    """Return a 2x2 constant angle array matching ``_DATA``.
+
+    Parameters:
+        value: Angle in radians to fill the array with.
+    """
+    return np.full((2, 2), value)
+
+
+# =========================================================================
+# Lambert
+# =========================================================================
+
+
+class TestLambertModel:
+    """LambertModel divides by max(cos(incidence), min_cos_incidence)."""
+
+    def test_name(self) -> None:
+        """The model name is 'lambert'."""
+        assert LambertModel().name == 'lambert'
+
+    def test_zero_incidence_is_identity(self) -> None:
+        """cos(0) == 1, so normal illumination leaves the data unchanged."""
+        out = LambertModel().correct(
+            _DATA, incidence=_angles(0.0), emission=_angles(0.3), phase=_angles(0.5)
+        )
+        np.testing.assert_allclose(out, _DATA)
+
+    def test_divides_by_cos_incidence(self) -> None:
+        """Moderate incidence divides the data by cos(incidence)."""
+        inc = 1.0
+        out = LambertModel().correct(
+            _DATA, incidence=_angles(inc), emission=_angles(0.3), phase=_angles(0.5)
+        )
+        np.testing.assert_allclose(out, _DATA / math.cos(inc))
+
+    def test_emission_and_phase_are_ignored(self) -> None:
+        """Changing emission and phase does not change the Lambert correction."""
+        a = LambertModel().correct(
+            _DATA, incidence=_angles(0.4), emission=_angles(0.1), phase=_angles(0.1)
+        )
+        b = LambertModel().correct(
+            _DATA, incidence=_angles(0.4), emission=_angles(1.4), phase=_angles(2.8)
+        )
+        np.testing.assert_allclose(a, b)
+
+    def test_grazing_incidence_uses_clamp(self) -> None:
+        """Near-grazing incidence divides by min_cos_incidence, not by ~0."""
+        out = LambertModel(min_cos_incidence=0.01).correct(
+            _DATA, incidence=_angles(math.pi / 2.0), emission=_angles(0.3), phase=_angles(0.5)
+        )
+        np.testing.assert_allclose(out, _DATA / 0.01)
+
+    def test_uncorrect_inverts_correct(self) -> None:
+        """uncorrect(correct(x)) == x at moderate angles."""
+        model = LambertModel()
+        inc = _angles(0.7)
+        emi = _angles(0.3)
+        pha = _angles(0.5)
+        corrected = model.correct(_DATA, incidence=inc, emission=emi, phase=pha)
+        out = model.uncorrect(corrected, incidence=inc, emission=emi, phase=pha)
+        np.testing.assert_allclose(out, _DATA)
+
+    def test_uncorrect_uses_same_clamp(self) -> None:
+        """uncorrect at grazing incidence multiplies by the clamp value."""
+        out = LambertModel(min_cos_incidence=0.01).uncorrect(
+            _DATA, incidence=_angles(math.pi / 2.0), emission=_angles(0.3), phase=_angles(0.5)
+        )
+        np.testing.assert_allclose(out, _DATA * 0.01)
+
+    def test_bool_clamp_raises_type_error(self) -> None:
+        """A bool min_cos_incidence is rejected."""
+        with pytest.raises(TypeError, match='min_cos_incidence must be a real number'):
+            LambertModel(min_cos_incidence=True)
+
+    def test_zero_clamp_raises_value_error(self) -> None:
+        """min_cos_incidence == 0 is outside the valid cosine clamp range."""
+        with pytest.raises(ValueError, match='min_cos_incidence must be finite with'):
+            LambertModel(min_cos_incidence=0.0)
+
+    def test_clamp_above_one_raises_value_error(self) -> None:
+        """min_cos_incidence > 1 is outside the valid cosine clamp range."""
+        with pytest.raises(ValueError, match='min_cos_incidence must be finite with'):
+            LambertModel(min_cos_incidence=1.5)
+
+    def test_nan_clamp_raises_value_error(self) -> None:
+        """A NaN min_cos_incidence is rejected as non-finite."""
+        with pytest.raises(ValueError, match='min_cos_incidence must be finite'):
+            LambertModel(min_cos_incidence=math.nan)
+
+
+# =========================================================================
+# Lommel-Seeliger
+# =========================================================================
+
+
+class TestLommelSeeligerModel:
+    """LommelSeeligerModel multiplies by (mu0 + mu) / (2 * mu0)."""
+
+    def test_name(self) -> None:
+        """The model name is 'lommel_seeliger'."""
+        assert LommelSeeligerModel().name == 'lommel_seeliger'
+
+    def test_normal_geometry_is_identity(self) -> None:
+        """At incidence == emission == 0 the factor is (1 + 1) / 2 == 1."""
+        out = LommelSeeligerModel().correct(
+            _DATA, incidence=_angles(0.0), emission=_angles(0.0), phase=_angles(0.5)
+        )
+        np.testing.assert_allclose(out, _DATA)
+
+    def test_general_angles_follow_documented_formula(self) -> None:
+        """correct() multiplies by (cos i + cos e) / (2 cos i) at moderate angles."""
+        inc, emi = 0.4, 0.9
+        out = LommelSeeligerModel().correct(
+            _DATA, incidence=_angles(inc), emission=_angles(emi), phase=_angles(0.5)
+        )
+        factor = (math.cos(inc) + math.cos(emi)) / (2.0 * math.cos(inc))
+        np.testing.assert_allclose(out, _DATA * factor)
+
+    def test_phase_is_ignored(self) -> None:
+        """Changing phase does not change the correction."""
+        a = LommelSeeligerModel().correct(
+            _DATA, incidence=_angles(0.4), emission=_angles(0.9), phase=_angles(0.1)
+        )
+        b = LommelSeeligerModel().correct(
+            _DATA, incidence=_angles(0.4), emission=_angles(0.9), phase=_angles(2.9)
+        )
+        np.testing.assert_allclose(a, b)
+
+    def test_grazing_incidence_uses_clamp(self) -> None:
+        """cos(incidence) is clamped to min_cos_incidence at grazing incidence."""
+        emi = 0.3
+        out = LommelSeeligerModel(min_cos_incidence=0.01).correct(
+            _DATA, incidence=_angles(math.pi / 2.0), emission=_angles(emi), phase=_angles(0.5)
+        )
+        factor = (0.01 + math.cos(emi)) / 0.02
+        np.testing.assert_allclose(out, _DATA * factor, rtol=1e-12)
+
+    def test_near_zero_denominator_stays_finite(self) -> None:
+        """The signed denominator floor keeps the output finite when mu0 + mu ~ 0."""
+        # Clamped cos(incidence) == 0.01 and cos(emission) == -0.01 cancel.
+        out = LommelSeeligerModel().correct(
+            _DATA,
+            incidence=_angles(math.pi / 2.0),
+            emission=_angles(math.acos(-0.01)),
+            phase=_angles(0.5),
+        )
+        assert bool(np.isfinite(out).all())
+
+    def test_uncorrect_inverts_correct(self) -> None:
+        """uncorrect(correct(x)) == x at moderate angles."""
+        model = LommelSeeligerModel()
+        inc = _angles(0.6)
+        emi = _angles(1.1)
+        pha = _angles(0.5)
+        corrected = model.correct(_DATA, incidence=inc, emission=emi, phase=pha)
+        out = model.uncorrect(corrected, incidence=inc, emission=emi, phase=pha)
+        np.testing.assert_allclose(out, _DATA)
+
+    def test_min_denom_below_floor_raises_value_error(self) -> None:
+        """min_denom below the smallest allowed positive value is rejected."""
+        with pytest.raises(ValueError, match='min_denom must be finite and >='):
+            LommelSeeligerModel(min_denom=0.0)
+
+    def test_bool_min_denom_raises_type_error(self) -> None:
+        """A bool min_denom is rejected."""
+        with pytest.raises(TypeError, match='min_denom must be a real number'):
+            LommelSeeligerModel(min_denom=False)
+
+
+# =========================================================================
+# Minnaert
+# =========================================================================
+
+
+class TestMinnaertModel:
+    """MinnaertModel divides by cos(i)^k * cos(e)^(k-1)."""
+
+    def test_name(self) -> None:
+        """The model name is 'minnaert'."""
+        assert MinnaertModel().name == 'minnaert'
+
+    def test_k_one_reduces_to_lambert(self) -> None:
+        """With k == 1 the Minnaert correction equals the Lambert correction."""
+        inc = _angles(0.8)
+        emi = _angles(0.4)
+        pha = _angles(0.5)
+        minnaert = MinnaertModel(k=1.0).correct(_DATA, incidence=inc, emission=emi, phase=pha)
+        lambert = LambertModel().correct(_DATA, incidence=inc, emission=emi, phase=pha)
+        np.testing.assert_allclose(minnaert, lambert)
+
+    def test_default_k_half_follows_documented_formula(self) -> None:
+        """With k == 0.5 the correction multiplies by sqrt(cos e / cos i)."""
+        inc, emi = 0.7, 0.4
+        out = MinnaertModel().correct(
+            _DATA, incidence=_angles(inc), emission=_angles(emi), phase=_angles(0.5)
+        )
+        expected = _DATA / (math.cos(inc) ** 0.5 * math.cos(emi) ** (-0.5))
+        np.testing.assert_allclose(out, expected)
+
+    def test_both_cosines_clamped(self) -> None:
+        """Grazing incidence and emission both use their configured clamps."""
+        out = MinnaertModel(k=0.5, min_cos_incidence=0.02, min_cos_emission=0.04).correct(
+            _DATA,
+            incidence=_angles(math.pi / 2.0),
+            emission=_angles(math.pi / 2.0),
+            phase=_angles(0.5),
+        )
+        expected = _DATA / (0.02**0.5 * 0.04**-0.5)
+        np.testing.assert_allclose(out, expected, rtol=1e-12)
+
+    def test_uncorrect_inverts_correct(self) -> None:
+        """uncorrect(correct(x)) == x at moderate angles."""
+        model = MinnaertModel(k=0.7)
+        inc = _angles(0.5)
+        emi = _angles(0.9)
+        pha = _angles(0.5)
+        corrected = model.correct(_DATA, incidence=inc, emission=emi, phase=pha)
+        out = model.uncorrect(corrected, incidence=inc, emission=emi, phase=pha)
+        np.testing.assert_allclose(out, _DATA)
+
+    def test_non_finite_k_raises_value_error(self) -> None:
+        """An infinite k is rejected."""
+        with pytest.raises(ValueError, match='k must be finite'):
+            MinnaertModel(k=math.inf)
+
+    def test_bool_k_raises_type_error(self) -> None:
+        """A bool k is rejected."""
+        with pytest.raises(TypeError, match='k must be a real number'):
+            MinnaertModel(k=True)
+
+    def test_bad_emission_clamp_raises_value_error(self) -> None:
+        """min_cos_emission outside (0, 1] is rejected."""
+        with pytest.raises(ValueError, match='min_cos_emission must be finite with'):
+            MinnaertModel(min_cos_emission=-0.5)
+
+
+# =========================================================================
+# Protocol conformance
+# =========================================================================
+
+
+class TestProtocolConformance:
+    """All implementations satisfy the PhotometricModel protocol shape."""
+
+    @pytest.mark.parametrize(
+        'model',
+        [LambertModel(), LommelSeeligerModel(), MinnaertModel()],
+        ids=['lambert', 'lommel_seeliger', 'minnaert'],
+    )
+    def test_correct_preserves_shape(
+        self, model: LambertModel | LommelSeeligerModel | MinnaertModel
+    ) -> None:
+        """correct() returns an array of the same shape as its input data.
+
+        Parameters:
+            model: Photometric model instance under test.
+        """
+        data = np.linspace(0.5, 2.0, 12).reshape(3, 4)
+        out = model.correct(
+            data,
+            incidence=np.full((3, 4), 0.4),
+            emission=np.full((3, 4), 0.3),
+            phase=np.full((3, 4), 0.5),
+        )
+        assert out.shape == (3, 4)
+
+    @pytest.mark.parametrize(
+        'model',
+        [LambertModel(), LommelSeeligerModel(), MinnaertModel()],
+        ids=['lambert', 'lommel_seeliger', 'minnaert'],
+    )
+    def test_name_is_nonempty_string(
+        self, model: LambertModel | LommelSeeligerModel | MinnaertModel
+    ) -> None:
+        """Every model exposes a non-empty string name.
+
+        Parameters:
+            model: Photometric model instance under test.
+        """
+        assert isinstance(model.name, str)
+        assert len(model.name) > 0
+
+
+# =========================================================================
+# photometric_model_from_name
+# =========================================================================
+
+
+class TestPhotometricModelFromName:
+    """Alias resolution and error behavior of photometric_model_from_name."""
+
+    @pytest.mark.parametrize('name', [None, '', '  ', 'none', 'NULL', ' None '])
+    def test_none_like_names_return_none(self, name: str | None) -> None:
+        """None and none-like labels resolve to no model.
+
+        Parameters:
+            name: Stored model label to resolve.
+        """
+        assert photometric_model_from_name(name) is None
+
+    def test_lambert_alias(self) -> None:
+        """'lambert' (any case) resolves to LambertModel."""
+        model = photometric_model_from_name('Lambert')
+        assert isinstance(model, LambertModel)
+
+    @pytest.mark.parametrize('name', ['lommel_seeliger', 'Lommel-Seeliger', 'lommelseeliger'])
+    def test_lommel_seeliger_aliases(self, name: str) -> None:
+        """Hyphen, underscore, and fused spellings all resolve to LommelSeeligerModel.
+
+        Parameters:
+            name: Stored model label to resolve.
+        """
+        model = photometric_model_from_name(name)
+        assert isinstance(model, LommelSeeligerModel)
+
+    def test_lommel_seeliger_space_alias(self) -> None:
+        """A space-separated spelling resolves to LommelSeeligerModel."""
+        model = photometric_model_from_name('lommel seeliger')
+        assert isinstance(model, LommelSeeligerModel)
+
+    def test_minnaert_alias(self) -> None:
+        """'MINNAERT' with surrounding spaces resolves to MinnaertModel."""
+        model = photometric_model_from_name('  MINNAERT ')
+        assert isinstance(model, MinnaertModel)
+
+    def test_unknown_name_raises_value_error(self) -> None:
+        """An unrecognized label raises ValueError naming the input."""
+        with pytest.raises(ValueError, match="Unknown photometric model name 'hapke'"):
+            photometric_model_from_name('hapke')
+
+    def test_returned_model_name_round_trips(self) -> None:
+        """The name of a resolved model resolves back to the same model type."""
+        model = photometric_model_from_name('lambert')
+        assert model is not None
+        again = photometric_model_from_name(model.name)
+        assert type(again) is type(model)

--- a/tests/spindoctor/reproj/test_ring_orbit_model.py
+++ b/tests/spindoctor/reproj/test_ring_orbit_model.py
@@ -1,0 +1,292 @@
+"""Spec tests for ``spindoctor.reproj.ring_orbit_model``.
+
+Contracts under test (from the module and method docstrings):
+
+- All angles are radians; rates (``dw``, ``mean_motion``) are radians/day; times are
+  ephemeris time (TDB seconds).
+- ``radius_at_longitude`` implements ``a (1 - e^2) / (1 + e cos(lon - curly_w))`` with a
+  precessing pericenter ``curly_w = w0 + dw * et / 86400`` referenced to J2000.
+- ``inertial_to_corotating`` / ``corotating_to_inertial`` are mutual inverses; the
+  co-rotating frame is anchored at ``epoch_utc`` and rotates at ``mean_motion``; results
+  are wrapped to ``[0, 2*pi)``.
+- Constructor validation raises the documented ``ValueError`` / ``TypeError``.
+- ``get_orbit_model_by_name`` returns registered instances or ``None``.
+"""
+
+import dataclasses
+import math
+
+import julian
+import numpy as np
+import pytest
+
+from spindoctor.reproj.ring_orbit_model import (
+    BRING_OUTER_EDGE,
+    FRING_CORE,
+    RingOrbitModel,
+    get_orbit_model_by_name,
+)
+
+_SECONDS_PER_DAY = 86400.0
+_EPOCH_UTC = '2005-06-01T00:00:00'
+
+
+def _epoch_et(epoch_utc: str = _EPOCH_UTC) -> float:
+    """Convert an ISO UTC string to ephemeris time (TDB seconds) as the module does.
+
+    Parameters:
+        epoch_utc: ISO UTC time string.
+
+    Returns:
+        Ephemeris time in TDB seconds.
+    """
+    return float(julian.tdb_from_tai(julian.tai_from_iso(epoch_utc)))
+
+
+def _model(
+    *,
+    a: float = 140000.0,
+    e: float = 0.1,
+    w0: float = 0.5,
+    dw: float = 0.0,
+    mean_motion: float = 0.0,
+    epoch_utc: str = _EPOCH_UTC,
+) -> RingOrbitModel:
+    """Build a RingOrbitModel with convenient defaults for tests.
+
+    Parameters:
+        a: Semi-major axis (km).
+        e: Eccentricity.
+        w0: Longitude of pericenter at J2000 (rad).
+        dw: Apsidal precession rate (rad/day).
+        mean_motion: Co-rotating frame mean motion (rad/day).
+        epoch_utc: ISO UTC epoch anchoring the co-rotating frame.
+
+    Returns:
+        A RingOrbitModel built from the given parameters.
+    """
+    return RingOrbitModel(
+        name='unit-test-model',
+        a=a,
+        e=e,
+        w0=w0,
+        dw=dw,
+        mean_motion=mean_motion,
+        epoch_utc=epoch_utc,
+    )
+
+
+class TestConstructorValidation:
+    """Documented constructor errors and frozen-dataclass behavior."""
+
+    def test_zero_semi_major_axis_rejected(self) -> None:
+        """a == 0 raises ValueError naming the semi-major axis."""
+        with pytest.raises(ValueError, match='semi-major axis must be positive'):
+            _model(a=0.0)
+
+    def test_negative_semi_major_axis_rejected(self) -> None:
+        """a < 0 raises ValueError naming the semi-major axis."""
+        with pytest.raises(ValueError, match='semi-major axis must be positive'):
+            _model(a=-140000.0)
+
+    def test_eccentricity_of_one_rejected(self) -> None:
+        """e == 1 is outside the documented half-open interval [0, 1)."""
+        with pytest.raises(ValueError, match=r'eccentricity must be in \[0, 1\)'):
+            _model(e=1.0)
+
+    def test_negative_eccentricity_rejected(self) -> None:
+        """e < 0 is outside the documented half-open interval [0, 1)."""
+        with pytest.raises(ValueError, match=r'eccentricity must be in \[0, 1\)'):
+            _model(e=-0.001)
+
+    def test_zero_eccentricity_accepted(self) -> None:
+        """e == 0 (circular orbit) is inside the documented interval."""
+        assert _model(e=0.0).e == 0.0
+
+    def test_nan_semi_major_axis_rejected(self) -> None:
+        """A non-finite a raises ValueError naming the field."""
+        with pytest.raises(ValueError, match='a must be finite'):
+            _model(a=math.nan)
+
+    def test_infinite_pericenter_rejected(self) -> None:
+        """A non-finite w0 raises ValueError naming the field."""
+        with pytest.raises(ValueError, match='w0 must be finite'):
+            _model(w0=math.inf)
+
+    def test_nan_mean_motion_rejected(self) -> None:
+        """A non-finite mean_motion raises ValueError naming the field."""
+        with pytest.raises(ValueError, match='mean_motion must be finite'):
+            _model(mean_motion=math.nan)
+
+    def test_non_string_epoch_rejected(self) -> None:
+        """A non-str epoch_utc raises TypeError."""
+        with pytest.raises(TypeError, match='epoch_utc must be str'):
+            _model(epoch_utc=12345)  # type: ignore[arg-type]
+
+    def test_instances_are_frozen(self) -> None:
+        """Field assignment on the frozen dataclass raises FrozenInstanceError."""
+        m = _model()
+        with pytest.raises(dataclasses.FrozenInstanceError, match='cannot assign'):
+            m.a = 1.0  # type: ignore[misc]
+
+    def test_value_equality_for_distinct_instances(self) -> None:
+        """Two separately constructed models with equal fields compare equal."""
+        assert _model() == _model()
+
+    def test_inequality_when_a_field_differs(self) -> None:
+        """Models differing in any field (here ``a``) compare unequal."""
+        assert _model() != _model(a=140001.0)
+
+
+class TestRadiusAtLongitude:
+    """Keplerian radius formula with precessing pericenter."""
+
+    def test_circular_orbit_radius_is_constant_a(self) -> None:
+        """With e == 0, radius equals the semi-major axis at every longitude."""
+        m = _model(e=0.0, a=123456.0)
+        lons = np.linspace(0.0, 2.0 * math.pi, 17)
+        radii = m.radius_at_longitude(lons, 0.0)
+        np.testing.assert_array_equal(radii, np.full(17, 123456.0))
+
+    def test_radius_at_pericenter_is_a_times_one_minus_e(self) -> None:
+        """At longitude == pericenter direction, r == a (1 - e)."""
+        m = _model(e=0.1, w0=0.7, dw=0.0)
+        radii = m.radius_at_longitude(np.array([0.7]), 0.0)
+        assert radii[0] == pytest.approx(140000.0 * 0.9, rel=1e-12)
+
+    def test_radius_at_apocenter_is_a_times_one_plus_e(self) -> None:
+        """At longitude == pericenter + pi, r == a (1 + e)."""
+        m = _model(e=0.1, w0=0.7, dw=0.0)
+        radii = m.radius_at_longitude(np.array([0.7 + math.pi]), 0.0)
+        assert radii[0] == pytest.approx(140000.0 * 1.1, rel=1e-12)
+
+    def test_radius_at_quadrature_is_semi_latus_rectum(self) -> None:
+        """At longitude == pericenter + pi/2, r == a (1 - e^2)."""
+        m = _model(e=0.1, w0=0.7, dw=0.0)
+        radii = m.radius_at_longitude(np.array([0.7 + math.pi / 2.0]), 0.0)
+        assert radii[0] == pytest.approx(140000.0 * (1.0 - 0.01), rel=1e-12)
+
+    def test_pericenter_precesses_at_dw_radians_per_day(self) -> None:
+        """After one day with dw == pi/3, the pericenter has advanced by pi/3 from w0."""
+        m = _model(e=0.1, w0=0.7, dw=math.pi / 3.0)
+        radii = m.radius_at_longitude(np.array([0.7 + math.pi / 3.0]), _SECONDS_PER_DAY)
+        assert radii[0] == pytest.approx(140000.0 * 0.9, rel=1e-12)
+
+    def test_array_shape_is_preserved(self) -> None:
+        """The output radius array has the same shape as the input longitude array."""
+        m = _model()
+        lons = np.zeros((3, 4))
+        assert m.radius_at_longitude(lons, 0.0).shape == (3, 4)
+
+
+class TestLongitudeFrameConversions:
+    """Inertial <-> co-rotating longitude conversions."""
+
+    def test_conversions_are_identity_at_epoch(self) -> None:
+        """At et == epoch, the co-rotating frame coincides with the inertial frame."""
+        m = _model(mean_motion=100.0)
+        lons = np.array([0.0, 1.0, 3.0, 6.0])
+        np.testing.assert_array_equal(m.inertial_to_corotating(lons, _epoch_et()), lons)
+
+    def test_roundtrip_recovers_inertial_longitudes(self) -> None:
+        """corotating_to_inertial inverts inertial_to_corotating (mod 2 pi)."""
+        m = _model(mean_motion=37.5)
+        et = _epoch_et() + 3.75 * _SECONDS_PER_DAY
+        lons = np.array([0.0, 0.5, 2.0, 4.5, 6.2])
+        back = m.corotating_to_inertial(m.inertial_to_corotating(lons, et), et)
+        np.testing.assert_allclose(back, lons, rtol=0.0, atol=1e-12)
+
+    def test_shift_after_one_day_equals_minus_mean_motion(self) -> None:
+        """One day past epoch, corotating == (inertial - mean_motion) mod 2 pi."""
+        mm = 0.75
+        m = _model(mean_motion=mm)
+        et = _epoch_et() + _SECONDS_PER_DAY
+        lons = np.array([1.0, 2.0, 3.0])
+        expected = (lons - mm) % (2.0 * math.pi)
+        np.testing.assert_allclose(m.inertial_to_corotating(lons, et), expected, atol=1e-12)
+
+    def test_inertial_to_corotating_wraps_into_zero_two_pi(self) -> None:
+        """Converted longitudes are wrapped into [0, 2 pi)."""
+        m = _model(mean_motion=1000.0)
+        et = _epoch_et() + 12.3 * _SECONDS_PER_DAY
+        out = m.inertial_to_corotating(np.linspace(0.0, 6.28, 20), et)
+        assert bool(np.all(out >= 0.0))
+        assert bool(np.all(out < 2.0 * math.pi))
+
+    def test_corotating_to_inertial_wraps_into_zero_two_pi(self) -> None:
+        """Inverse-converted longitudes are wrapped into [0, 2 pi)."""
+        m = _model(mean_motion=1000.0)
+        et = _epoch_et() + 12.3 * _SECONDS_PER_DAY
+        out = m.corotating_to_inertial(np.linspace(0.0, 6.28, 20), et)
+        assert bool(np.all(out >= 0.0))
+        assert bool(np.all(out < 2.0 * math.pi))
+
+
+class TestLongitudeRadius:
+    """Full-circle (longitude, radius) sampling."""
+
+    def test_length_is_two_pi_over_step(self) -> None:
+        """Arrays have length int(2 pi / step) as documented."""
+        m = _model(e=0.0)
+        step = math.pi / 180.0
+        lons, radii = m.longitude_radius(0.0, step=step)
+        assert len(lons) == int(2.0 * math.pi / step)
+        assert len(radii) == len(lons)
+
+    def test_longitudes_start_at_zero_with_uniform_step(self) -> None:
+        """Longitudes are 0, step, 2 step, ..."""
+        m = _model(e=0.0)
+        step = 0.1
+        lons, _ = m.longitude_radius(0.0, step=step)
+        assert lons[0] == 0.0
+        np.testing.assert_allclose(np.diff(lons), step, rtol=0.0, atol=1e-15)
+
+    def test_radii_match_radius_at_longitude(self) -> None:
+        """For a circular orbit every sampled radius equals a."""
+        m = _model(e=0.0, a=99000.0)
+        _, radii = m.longitude_radius(0.0, step=0.5)
+        np.testing.assert_array_equal(radii, np.full(len(radii), 99000.0))
+
+    @pytest.mark.parametrize('step', [0.0, -0.01, math.inf, math.nan])
+    def test_invalid_step_rejected(self, step: float) -> None:
+        """Non-positive or non-finite steps raise the documented ValueError."""
+        m = _model()
+        with pytest.raises(ValueError, match='step must be a finite positive number'):
+            m.longitude_radius(0.0, step=step)
+
+
+class TestPredefinedModelsAndRegistry:
+    """Pre-defined instances and get_orbit_model_by_name lookups."""
+
+    def test_fring_core_lookup_by_name(self) -> None:
+        """The F ring core model is registered under its own name."""
+        assert get_orbit_model_by_name('F-RING-CORE-ALBERS-2007') is FRING_CORE
+
+    def test_bring_outer_edge_lookup_by_name(self) -> None:
+        """The B ring outer edge model is registered under its own name."""
+        assert get_orbit_model_by_name('BRING-OUTER-EDGE') is BRING_OUTER_EDGE
+
+    def test_fring_core_published_parameters(self) -> None:
+        """FRING_CORE carries the Albers et al. 2012 Table 3 Fit #2 values."""
+        assert FRING_CORE.a == 140221.3
+        assert FRING_CORE.e == 0.00235
+        assert FRING_CORE.epoch_utc == '2007-01-01'
+
+    def test_unknown_name_returns_none(self) -> None:
+        """An unregistered name returns None rather than raising."""
+        assert get_orbit_model_by_name('NOT-A-REAL-MODEL') is None
+
+    def test_non_string_name_rejected(self) -> None:
+        """A non-str name raises TypeError."""
+        with pytest.raises(TypeError, match='expects str'):
+            get_orbit_model_by_name(42)  # type: ignore[arg-type]
+
+    def test_empty_name_rejected(self) -> None:
+        """An empty name raises ValueError."""
+        with pytest.raises(ValueError, match='non-empty string'):
+            get_orbit_model_by_name('')
+
+    def test_whitespace_only_name_rejected(self) -> None:
+        """A whitespace-only name raises ValueError."""
+        with pytest.raises(ValueError, match='non-empty string'):
+            get_orbit_model_by_name('   ')

--- a/tests/spindoctor/reproj/test_rings_reproject.py
+++ b/tests/spindoctor/reproj/test_rings_reproject.py
@@ -1,0 +1,1103 @@
+"""Spec tests for ``RingMosaic.reproject`` and its argument validators.
+
+``reproject()`` is exercised hermetically (CI has no SPICE kernels or holdings) by
+installing a synthetic pinhole geometry: a fake ``oops.backplane.Backplane`` whose
+ring radius/longitude backplanes are exact linear functions of the pixel indices,
+plus a matching fake ``RingMosaic.longitude_radius_to_pixels`` implementing the
+analytic inverse. Every expected value below is derived from that closed-form
+geometry and from the documented contracts:
+
+- ``reproject()`` always returns a *sparse* result: only longitude columns holding
+  at least one valid pixel are stored, ``longitude_antimask`` marks the full-circle
+  bins present, and ``count_nonzero(longitude_antimask) == img.shape[1]``
+  (dev guide, "Ring sparse storage").
+- Longitude bin ``b`` corresponds to longitude ``b * longitude_resolution`` (rad);
+  radius row ``r`` corresponds to ``radius_inner + r * radius_resolution`` (km).
+- With an ``orbit_model``, longitudes are co-rotating and radii are signed offsets
+  (km) from the orbital radius at each (longitude, time), so an eccentric ring
+  reprojects to a straight line (dev guide, "Ring radius and longitude semantics").
+- Validators raise the documented ``TypeError`` / ``ValueError`` with the documented
+  message content.
+
+The synthetic image is 20x20 with ``data[v, u] = 100 v + u`` so any indexing error
+changes the observed values. Geometry: pixel ``(v, u)`` sees longitude
+``LON0 + (u - 0.5) * LON_RES / 2`` and (absolute mode) radius
+``990 + (v - 0.5) * 2.5`` km. With the default mosaic grid (radii 1000..1020 km at
+5 km, longitude pi/16 rad) the reprojection covers bins 8..14 sampling pixels
+``u = 4 + 2 c``, ``v = 4 + 2 r``.
+"""
+
+import dataclasses
+import math
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any, ClassVar
+
+import julian
+import numpy as np
+import numpy.ma as ma
+import oops.fov
+import pytest
+from polymath import Scalar
+
+from spindoctor.reproj.ring_orbit_model import RingOrbitModel
+from spindoctor.reproj.rings import (
+    _MAX_LONGITUDE,
+    RingMosaic,
+    _validate_reproject_longitude_range,
+    _validate_reproject_radius_range,
+    _validate_reproject_zoom_amt,
+)
+from spindoctor.support.types import NDArrayFloatType
+
+# ---------------------------------------------------------------------------
+# Synthetic geometry constants (see module docstring)
+# ---------------------------------------------------------------------------
+
+_N = 20  # image size (pixels per side)
+_LON_RES = math.pi / 16  # mosaic longitude resolution (rad/bin)
+_RAD_RES = 5.0  # mosaic radius resolution (km/bin)
+_N_FULL_LON = math.floor(_MAX_LONGITUDE / _LON_RES) + 1  # 32 bins in 0..2pi
+_LON0 = 6 * _LON_RES  # longitude seen by pixel u = 0.5
+_LON_PIX = _LON_RES / 2.0  # rad per pixel (2 pixels per longitude bin)
+_RAD0 = 990.0  # radius seen by pixel v = 0.5 (absolute mode)
+_RAD_PIX = 2.5  # km per pixel (2 pixels per radius bin)
+_EPOCH_UTC = '2000-01-01T12:00:00'
+_EPOCH_ET = float(julian.tdb_from_tai(julian.tai_from_iso(_EPOCH_UTC)))
+
+
+def _lon_of_u(u: NDArrayFloatType) -> NDArrayFloatType:
+    """Longitude (rad) seen at fractional pixel column u.
+
+    Parameters:
+        u: Fractional pixel column array.
+
+    Returns:
+        Longitude array in radians.
+    """
+    return _LON0 + (u - 0.5) * _LON_PIX
+
+
+def _u_of_lon(lon: NDArrayFloatType) -> NDArrayFloatType:
+    """Fractional pixel column at which longitude lon (rad) is seen.
+
+    Parameters:
+        lon: Longitude array in radians.
+
+    Returns:
+        Fractional pixel column array.
+    """
+    return (lon - _LON0) / _LON_PIX + 0.5
+
+
+def _rad_of_v(v: NDArrayFloatType) -> NDArrayFloatType:
+    """Absolute ring radius (km) seen at fractional pixel row v.
+
+    Parameters:
+        v: Fractional pixel row array.
+
+    Returns:
+        Radius array in km.
+    """
+    return _RAD0 + (v - 0.5) * _RAD_PIX
+
+
+def _v_of_rad(rad: NDArrayFloatType) -> NDArrayFloatType:
+    """Fractional pixel row at which absolute radius rad (km) is seen.
+
+    Parameters:
+        rad: Radius array in km.
+
+    Returns:
+        Fractional pixel row array.
+    """
+    return (rad - _RAD0) / _RAD_PIX + 0.5
+
+
+class _FakeObs:
+    """Minimal Observation stand-in exposing what reproject() touches.
+
+    Parameters:
+        data: Optional image array; defaults to the ``100 v + u`` pattern.
+        midtime: Observation mid-time (ET seconds).
+    """
+
+    def __init__(self, *, data: Any = None, midtime: float = 0.0) -> None:
+        """Initialize with the default synthetic image unless data is given."""
+        self.midtime = midtime
+        if data is None:
+            vv, uu = np.meshgrid(np.arange(_N), np.arange(_N), indexing='ij')
+            data = (vv * 100 + uu).astype(np.float64)
+        self.data = data
+        self.data_shape_uv = (_N, _N)
+        self.fov = oops.fov.FlatFOV((0.001, 0.001), (_N, _N))
+
+
+def _make_backplane_class(
+    *,
+    model: RingOrbitModel | None,
+    shadow_u_columns: tuple[int, ...],
+) -> type[Any]:
+    """Build a fake oops Backplane class implementing the synthetic geometry.
+
+    In absolute mode (``model is None``) the radius backplane is
+    ``_rad_of_v(v)``. In offset mode the radius backplane is
+    ``model.radius_at_longitude(lon, obs.midtime) + (v - 7.5) * _RAD_PIX`` so pixel
+    rows hold constant *offsets* from the orbit while absolute radii vary with
+    longitude. When a meshgrid is supplied (uv_range), the arrays cover only the
+    restricted region, exactly as a real Backplane would.
+
+    Parameters:
+        model: Orbit model for offset-mode radii, or None for absolute radii.
+        shadow_u_columns: Pixel columns reported as inside the planet shadow.
+
+    Returns:
+        A class with the Backplane methods reproject() calls.
+    """
+
+    class _FakeRingBackplane:
+        """Fake Backplane producing analytic ring backplanes over the pixel grid."""
+
+        shadow_calls: ClassVar[int] = 0
+
+        def __init__(self, obs: Any, meshgrid: Any = None) -> None:
+            """Build backplane arrays for the full frame or the meshgrid region."""
+            if meshgrid is None:
+                u0, v0, nv, nu = 0, 0, _N, _N
+            else:
+                uv = meshgrid.uv.vals
+                u0 = int(uv[0, 0, 0] - 0.5)
+                v0 = int(uv[0, 0, 1] - 0.5)
+                nv, nu = uv.shape[0], uv.shape[1]
+            vv, uu = np.meshgrid(np.arange(v0, v0 + nv), np.arange(u0, u0 + nu), indexing='ij')
+            lons = _lon_of_u(uu.astype(np.float64))
+            if model is None:
+                radius = _rad_of_v(vv.astype(np.float64))
+            else:
+                radius = (
+                    model.radius_at_longitude(lons, obs.midtime)
+                    + (vv.astype(np.float64) - 7.5) * _RAD_PIX
+                )
+            self._radius = Scalar(radius)
+            self._longitude = Scalar(lons)
+            self._radial_res = Scalar(vv.astype(np.float64) + 2.0)
+            self._shape = (nv, nu)
+            self._shadow = np.isin(uu, np.asarray(shadow_u_columns, dtype=np.int64))
+
+        def ring_radius(self, name: str) -> Scalar:
+            """Ring radius backplane."""
+            return self._radius
+
+        def ring_longitude(self, name: str) -> Scalar:
+            """Inertial ring longitude backplane."""
+            return self._longitude
+
+        def ring_radial_resolution(self, name: str) -> Scalar:
+            """Radial resolution backplane (2 + v, so per-column means are testable)."""
+            return self._radial_res
+
+        def ring_angular_resolution(self, name: str) -> Scalar:
+            """Constant angular resolution backplane."""
+            return Scalar(np.full(self._shape, 0.001))
+
+        def phase_angle(self, name: str) -> Scalar:
+            """Constant phase angle backplane."""
+            return Scalar(np.full(self._shape, 0.5))
+
+        def emission_angle(self, name: str) -> Scalar:
+            """Constant emission angle backplane."""
+            return Scalar(np.full(self._shape, 0.3))
+
+        def incidence_angle(self, name: str) -> Scalar:
+            """Constant incidence angle backplane."""
+            return Scalar(np.full(self._shape, 0.4))
+
+        def where_inside_shadow(self, name: str, shadow_name: str) -> Scalar:
+            """Shadow mask backplane; counts calls for omit_shadow assertions."""
+            type(self).shadow_calls += 1
+            return Scalar(self._shadow)
+
+    return _FakeRingBackplane
+
+
+def _make_lr2p(
+    model: RingOrbitModel | None,
+) -> Callable[..., tuple[NDArrayFloatType, NDArrayFloatType]]:
+    """Build the analytic inverse mapping used in place of longitude_radius_to_pixels.
+
+    Parameters:
+        model: Orbit model matching the fake backplane's mode, or None.
+
+    Returns:
+        A function with the longitude_radius_to_pixels signature returning (u, v).
+    """
+
+    def _fake_lr2p(
+        obs: Any,
+        longitude: Any,
+        radius: Any,
+        *,
+        orbit_model: RingOrbitModel | None = None,
+        ring_body_name: str = 'saturn:ring',
+    ) -> tuple[NDArrayFloatType, NDArrayFloatType]:
+        """Convert (longitude, radius) to fractional (u, v) via the synthetic geometry."""
+        lon = np.atleast_1d(np.asarray(Scalar(longitude).vals, dtype=np.float64))
+        rad = np.atleast_1d(np.asarray(Scalar(radius).vals, dtype=np.float64))
+        if orbit_model is not None:
+            lon = orbit_model.corotating_to_inertial(lon, obs.midtime)
+        u = _u_of_lon(lon)
+        if model is None:
+            v = _v_of_rad(rad)
+        else:
+            v = (rad - model.radius_at_longitude(lon, obs.midtime)) / _RAD_PIX + 7.5
+        return u, v
+
+    return _fake_lr2p
+
+
+def _install_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    model: RingOrbitModel | None = None,
+    shadow_u_columns: tuple[int, ...] = (),
+) -> type[Any]:
+    """Install the fake Backplane and inverse mapping for one test.
+
+    Parameters:
+        monkeypatch: The pytest monkeypatch fixture (restores on teardown).
+        model: Orbit model for offset-mode geometry, or None for absolute mode.
+        shadow_u_columns: Pixel columns reported as shadowed.
+
+    Returns:
+        The fake Backplane class (exposes ``shadow_calls``).
+    """
+    bp_cls = _make_backplane_class(model=model, shadow_u_columns=shadow_u_columns)
+    monkeypatch.setattr('oops.backplane.Backplane', bp_cls)
+    monkeypatch.setattr(RingMosaic, 'longitude_radius_to_pixels', staticmethod(_make_lr2p(model)))
+    return bp_cls
+
+
+def _make_mosaic(**kwargs: Any) -> RingMosaic:
+    """Return the standard absolute-radius test mosaic (1000..1020 km, pi/16 rad).
+
+    Parameters:
+        kwargs: Extra keyword arguments forwarded to the RingMosaic constructor.
+
+    Returns:
+        A RingMosaic for SATURN on the shared synthetic grid.
+    """
+    return RingMosaic(
+        body_name='SATURN',
+        radius_inner=1000.0,
+        radius_outer=1020.0,
+        longitude_resolution=_LON_RES,
+        radius_resolution=_RAD_RES,
+        **kwargs,
+    )
+
+
+def _make_offset_mosaic(model: RingOrbitModel) -> RingMosaic:
+    """Return the offset-radius test mosaic (-10..+10 km about the orbit).
+
+    Parameters:
+        model: The orbit model defining the co-rotating frame.
+
+    Returns:
+        A RingMosaic for SATURN with offset radius semantics.
+    """
+    return RingMosaic(
+        body_name='SATURN',
+        radius_inner=-10.0,
+        radius_outer=10.0,
+        longitude_resolution=_LON_RES,
+        radius_resolution=_RAD_RES,
+        orbit_model=model,
+    )
+
+
+def _make_model(*, e: float = 0.0, w0: float = 0.0, mean_motion: float = 0.0) -> RingOrbitModel:
+    """Return an orbit model with a = 1010 km centred on the synthetic ring.
+
+    Parameters:
+        e: Eccentricity.
+        w0: Longitude of pericenter at J2000 (rad).
+        mean_motion: Mean motion (rad/day) of the co-rotating frame.
+
+    Returns:
+        A RingOrbitModel anchored at the shared test epoch.
+    """
+    return RingOrbitModel(
+        name='reproject-test-model',
+        a=1010.0,
+        e=e,
+        w0=w0,
+        dw=0.0,
+        mean_motion=mean_motion,
+        epoch_utc=_EPOCH_UTC,
+    )
+
+
+def _expected_absolute_img() -> NDArrayFloatType:
+    """Expected 5x7 image for absolute mode: rows sample v = 4 + 2 r, bins 8..14."""
+    out = np.empty((5, 7), dtype=np.float64)
+    for r in range(5):
+        for c in range(7):
+            out[r, c] = (4 + 2 * r) * 100 + (4 + 2 * c)
+    return out
+
+
+def _expected_offset_img() -> NDArrayFloatType:
+    """Expected 5x7 image for offset mode: rows sample v = 3 + 2 r, bins 8..14."""
+    out = np.empty((5, 7), dtype=np.float64)
+    for r in range(5):
+        for c in range(7):
+            out[r, c] = (3 + 2 * r) * 100 + (4 + 2 * c)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Validator contracts
+# ---------------------------------------------------------------------------
+
+
+class TestValidateLongitudeRange:
+    """Documented error contract of _validate_reproject_longitude_range."""
+
+    @pytest.mark.parametrize('bad', ['abc', {'a': 1}, 1.5, None])
+    def test_non_sequence_rejected(self, bad: object) -> None:
+        """Anything but a tuple/list raises TypeError naming the expected type."""
+        with pytest.raises(TypeError, match='must be a tuple or list of two numbers'):
+            _validate_reproject_longitude_range(bad)
+
+    @pytest.mark.parametrize('bad', [(1.0,), (1.0, 2.0, 3.0), ()])
+    def test_wrong_length_rejected(self, bad: tuple[float, ...]) -> None:
+        """Sequences without exactly two elements raise ValueError."""
+        with pytest.raises(ValueError, match='exactly two elements'):
+            _validate_reproject_longitude_range(bad)
+
+    def test_bool_endpoint_rejected(self) -> None:
+        """bool endpoints are rejected even though bool subclasses int."""
+        with pytest.raises(TypeError, match='start must be int or float'):
+            _validate_reproject_longitude_range((True, 1.0))
+
+    def test_string_endpoint_rejected(self) -> None:
+        """String endpoints raise TypeError naming the offending element."""
+        with pytest.raises(TypeError, match='end must be int or float'):
+            _validate_reproject_longitude_range((0.5, '1.0'))
+
+    @pytest.mark.parametrize('bad', [(math.nan, 1.0), (0.5, math.inf)])
+    def test_non_finite_rejected(self, bad: tuple[float, float]) -> None:
+        """NaN or infinite endpoints raise ValueError."""
+        with pytest.raises(ValueError, match='must be finite'):
+            _validate_reproject_longitude_range(bad)
+
+    def test_negative_start_rejected(self) -> None:
+        """Longitudes below 0 raise ValueError."""
+        with pytest.raises(ValueError, match='start must satisfy'):
+            _validate_reproject_longitude_range((-0.1, 1.0))
+
+    def test_end_beyond_max_longitude_rejected(self) -> None:
+        """An end of exactly 2 pi exceeds _MAX_LONGITUDE and raises ValueError."""
+        with pytest.raises(ValueError, match='end must satisfy'):
+            _validate_reproject_longitude_range((0.0, 2.0 * math.pi))
+
+    def test_start_greater_than_end_rejected(self) -> None:
+        """start > end raises ValueError (ranges do not wrap through 0)."""
+        with pytest.raises(ValueError, match='start <= end'):
+            _validate_reproject_longitude_range((2.0, 1.0))
+
+    def test_seam_crossing_range_rejected(self) -> None:
+        """A range crossing the 2 pi -> 0 seam is rejected, not wrapped."""
+        with pytest.raises(ValueError, match='start <= end'):
+            _validate_reproject_longitude_range((6.0, 0.5))
+
+    def test_valid_list_returns_floats(self) -> None:
+        """A valid list is returned as a (start, end) float tuple."""
+        assert _validate_reproject_longitude_range([0.25, 0.5]) == (0.25, 0.5)
+
+    def test_numpy_endpoints_accepted(self) -> None:
+        """NumPy floating endpoints are accepted and converted to Python floats."""
+        out = _validate_reproject_longitude_range((np.float32(0.25), np.float64(0.5)))
+        assert out == (float(np.float32(0.25)), 0.5)
+
+    def test_equal_endpoints_accepted(self) -> None:
+        """A zero-width range (start == end) is allowed."""
+        assert _validate_reproject_longitude_range((1.0, 1.0)) == (1.0, 1.0)
+
+
+class TestValidateRadiusRange:
+    """Documented error contract of _validate_reproject_radius_range."""
+
+    def test_non_sequence_rejected(self) -> None:
+        """Anything but a tuple/list raises TypeError."""
+        with pytest.raises(TypeError, match='must be a tuple or list of two numbers'):
+            _validate_reproject_radius_range('abc')
+
+    def test_wrong_length_rejected(self) -> None:
+        """Sequences without exactly two elements raise ValueError."""
+        with pytest.raises(ValueError, match='exactly two elements'):
+            _validate_reproject_radius_range((1.0, 2.0, 3.0))
+
+    def test_bool_endpoint_rejected(self) -> None:
+        """bool endpoints raise TypeError naming the offending element."""
+        with pytest.raises(TypeError, match='inner must be int or float'):
+            _validate_reproject_radius_range((True, 5.0))
+
+    def test_non_finite_rejected(self) -> None:
+        """NaN endpoints raise ValueError."""
+        with pytest.raises(ValueError, match='must be finite'):
+            _validate_reproject_radius_range((math.nan, 5.0))
+
+    def test_zero_width_range_rejected(self) -> None:
+        """inner == outer violates the strict inner < outer requirement."""
+        with pytest.raises(ValueError, match='inner < outer'):
+            _validate_reproject_radius_range((5.0, 5.0))
+
+    def test_inverted_range_rejected(self) -> None:
+        """inner > outer raises ValueError explaining both radius conventions."""
+        with pytest.raises(ValueError, match='inner < outer'):
+            _validate_reproject_radius_range((7.0, 3.0))
+
+    def test_signed_offsets_accepted(self) -> None:
+        """Negative inner values are valid (offset semantics with an orbit model)."""
+        assert _validate_reproject_radius_range((-1000.0, 1000.0)) == (-1000.0, 1000.0)
+
+    def test_integer_endpoints_accepted(self) -> None:
+        """Plain ints are accepted and converted to floats."""
+        assert _validate_reproject_radius_range((1000, 1020)) == (1000.0, 1020.0)
+
+
+class TestValidateZoomAmt:
+    """Documented error contract of _validate_reproject_zoom_amt."""
+
+    def test_scalar_int_duplicated(self) -> None:
+        """A single int applies to both axes."""
+        assert _validate_reproject_zoom_amt(3) == (3, 3)
+
+    def test_numpy_integer_accepted(self) -> None:
+        """NumPy integers are accepted as int-like."""
+        assert _validate_reproject_zoom_amt(np.int32(4)) == (4, 4)
+
+    @pytest.mark.parametrize('pair', [(2, 3), [2, 3]])
+    def test_two_element_sequence_accepted(self, pair: object) -> None:
+        """A (radial, longitude) pair is returned in order."""
+        assert _validate_reproject_zoom_amt(pair) == (2, 3)
+
+    @pytest.mark.parametrize('bad', [(2,), (1, 2, 3), []])
+    def test_wrong_length_sequence_rejected(self, bad: object) -> None:
+        """Sequences without exactly two elements raise ValueError."""
+        with pytest.raises(ValueError, match='exactly two elements'):
+            _validate_reproject_zoom_amt(bad)
+
+    @pytest.mark.parametrize('bad', [True, np.bool_(True)])
+    def test_bool_scalar_rejected(self, bad: object) -> None:
+        """bool scalars raise TypeError despite bool subclassing int."""
+        with pytest.raises(TypeError, match='not bool'):
+            _validate_reproject_zoom_amt(bad)
+
+    def test_bool_element_rejected(self) -> None:
+        """A bool inside the pair raises TypeError naming the element."""
+        with pytest.raises(TypeError, match='element 2 must be int-like'):
+            _validate_reproject_zoom_amt((2, True))
+
+    def test_float_scalar_rejected(self) -> None:
+        """Fractional zoom factors raise TypeError."""
+        with pytest.raises(TypeError, match='must be int'):
+            _validate_reproject_zoom_amt(2.5)
+
+    def test_float_element_rejected(self) -> None:
+        """A float inside the pair raises TypeError naming the element."""
+        with pytest.raises(TypeError, match='element 2 must be int or numpy integer'):
+            _validate_reproject_zoom_amt((2, 2.5))
+
+    def test_zero_accepted_by_validator(self) -> None:
+        """Zero passes validation; downstream treats it as zoom 1 with spline order 0.
+
+        The reproject() docstring only defines positive (zoom) and negative (spline
+        order) values, so zero falls into an undocumented gap; this test pins the
+        validator's current behavior.
+        """
+        assert _validate_reproject_zoom_amt(0) == (0, 0)
+
+    def test_negative_passes_validator_for_downstream_spline_check(self) -> None:
+        """Negative values pass validation; reproject() raises NotImplementedError later."""
+        assert _validate_reproject_zoom_amt(-2) == (-2, -2)
+
+
+# ---------------------------------------------------------------------------
+# reproject() argument errors that need no geometry
+# ---------------------------------------------------------------------------
+
+
+class TestReprojectArgumentErrors:
+    """Errors raised before any oops geometry is touched."""
+
+    def test_margin_below_one_rejected(self) -> None:
+        """margin < 1 raises ValueError before the observation is accessed."""
+        mosaic = _make_mosaic()
+        with pytest.raises(ValueError, match='margin must be >= 1'):
+            mosaic.reproject(object(), margin=0)
+
+    def test_per_call_orbit_model_mismatch_rejected(self) -> None:
+        """A per-call orbit model differing from the constructor's raises ValueError."""
+        mosaic = _make_mosaic()
+        with pytest.raises(ValueError, match='must match the orbit_model passed to'):
+            mosaic.reproject(object(), orbit_model=_make_model())
+
+    def test_negative_zoom_spline_order_not_implemented(self) -> None:
+        """Negative zoom_amt (spline order) raises the documented NotImplementedError."""
+        mosaic = _make_mosaic()
+        data = ma.MaskedArray(np.zeros((4, 4)))
+        with pytest.raises(NotImplementedError, match='Spline interpolation'):
+            mosaic.reproject(object(), data, zoom_amt=-1)
+
+    def test_invalid_longitude_range_rejected_through_reproject(self) -> None:
+        """reproject() surfaces the longitude_range validator error unchanged."""
+        mosaic = _make_mosaic()
+        data = ma.MaskedArray(np.zeros((4, 4)))
+        with pytest.raises(ValueError, match='start <= end'):
+            mosaic.reproject(object(), data, longitude_range=(2.0, 1.0))
+
+    def test_invalid_radius_range_rejected_through_reproject(self) -> None:
+        """reproject() surfaces the radius_range validator error unchanged."""
+        mosaic = _make_mosaic()
+        data = ma.MaskedArray(np.zeros((4, 4)))
+        with pytest.raises(ValueError, match='inner < outer'):
+            mosaic.reproject(object(), data, radius_range=(1020.0, 1000.0))
+
+
+# ---------------------------------------------------------------------------
+# Constructor and static grid utilities
+# ---------------------------------------------------------------------------
+
+
+class TestConstructorAndGridValidation:
+    """RingMosaic constructor and generate_* error contracts."""
+
+    def test_inverted_radius_bounds_rejected(self) -> None:
+        """radius_inner >= radius_outer raises ValueError."""
+        with pytest.raises(ValueError, match='must be less than radius_outer'):
+            RingMosaic(body_name='SATURN', radius_inner=1020.0, radius_outer=1000.0)
+
+    def test_zero_longitude_resolution_rejected(self) -> None:
+        """longitude_resolution == 0 raises ValueError."""
+        with pytest.raises(ValueError, match='longitude_resolution must be positive'):
+            RingMosaic(
+                body_name='SATURN',
+                radius_inner=1000.0,
+                radius_outer=1020.0,
+                longitude_resolution=0.0,
+            )
+
+    def test_full_circle_longitude_resolution_rejected(self) -> None:
+        """longitude_resolution >= 2 pi raises ValueError."""
+        with pytest.raises(ValueError, match='longitude_resolution must be positive'):
+            RingMosaic(
+                body_name='SATURN',
+                radius_inner=1000.0,
+                radius_outer=1020.0,
+                longitude_resolution=7.0,
+            )
+
+    def test_zero_radius_resolution_rejected(self) -> None:
+        """radius_resolution <= 0 raises ValueError."""
+        with pytest.raises(ValueError, match='radius_resolution must be positive'):
+            RingMosaic(
+                body_name='SATURN',
+                radius_inner=1000.0,
+                radius_outer=1020.0,
+                radius_resolution=0.0,
+            )
+
+    def test_generate_longitudes_rejects_non_positive_resolution(self) -> None:
+        """generate_longitudes raises ValueError for resolution <= 0."""
+        with pytest.raises(ValueError, match='longitude_resolution must be positive'):
+            RingMosaic.generate_longitudes(longitude_resolution=0.0)
+
+    def test_generate_radii_rejects_non_positive_resolution(self) -> None:
+        """generate_radii raises ValueError for resolution <= 0."""
+        with pytest.raises(ValueError, match='radius_resolution must be positive'):
+            RingMosaic.generate_radii(1000.0, 1020.0, radius_resolution=-1.0)
+
+    def test_generate_radii_rejects_inverted_bounds(self) -> None:
+        """generate_radii raises ValueError when outer < inner."""
+        with pytest.raises(ValueError, match='must be >= radius_inner'):
+            RingMosaic.generate_radii(1020.0, 1000.0)
+
+    def test_to_bounded_reuses_longitude_validator(self) -> None:
+        """to_bounded rejects inverted ranges with the reproject() validator message."""
+        with pytest.raises(ValueError, match='start <= end'):
+            _make_mosaic().to_bounded(longitude_range=(2.0, 1.0))
+
+
+# ---------------------------------------------------------------------------
+# Full reprojection through the synthetic geometry
+# ---------------------------------------------------------------------------
+
+
+class TestReprojectAbsoluteGeometry:
+    """reproject() against the absolute-radius (no orbit model) geometry."""
+
+    def test_antimask_marks_expected_bins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The sparse antimask marks exactly bins 8..14 of the full-circle grid."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs())
+        np.testing.assert_array_equal(np.where(res.longitude_antimask)[0], np.arange(8, 15))
+
+    def test_antimask_length_is_full_circle_bin_count(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The antimask always spans all full-circle longitude bins."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs())
+        assert res.longitude_antimask.shape == (_N_FULL_LON,)
+
+    def test_sparsity_invariant_columns_match_antimask(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """count_nonzero(longitude_antimask) equals the sparse column count."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs())
+        assert int(np.count_nonzero(res.longitude_antimask)) == res.img.shape[1]
+
+    def test_image_values_match_analytic_geometry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Each cell holds data[4 + 2 r, 4 + 2 c]: bin/radius edges map to those pixels."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs())
+        np.testing.assert_array_equal(ma.getdata(res.img), _expected_absolute_img())
+
+    def test_image_fully_valid_for_unmasked_input(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No cell is masked when every sampled pixel is valid."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs())
+        assert not ma.getmaskarray(res.img).any()
+
+    def test_result_grid_fields_echo_mosaic(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Resolutions and default radius bounds are copied from the mosaic."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs())
+        assert res.body_name == 'SATURN'
+        assert res.longitude_resolution == _LON_RES
+        assert res.radius_resolution == _RAD_RES
+        assert res.radius_inner == 1000.0
+        assert res.radius_outer == 1020.0
+        assert res.orbit_model is None
+        assert res.photometric_model_name is None
+
+    def test_time_is_observation_midtime(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The result records obs.midtime."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs(midtime=777.5))
+        assert res.time == 777.5
+
+    def test_image_name_is_recorded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The image_name label is stored on the result."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs(), image_name='N12345')
+        assert res.image_name == 'N12345'
+
+    def test_mean_radial_resolution_averages_over_radius_rows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Per-column mean radial resolution is mean(v + 2) over sampled rows = 10."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs())
+        np.testing.assert_allclose(res.mean_radial_resolution, 10.0)
+
+    def test_constant_geometry_means_pass_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Constant phase/emission/angular-resolution backplanes yield constant means."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs())
+        np.testing.assert_allclose(res.mean_phase, 0.5, rtol=1e-6)
+        np.testing.assert_allclose(res.mean_emission, 0.3, rtol=1e-6)
+        np.testing.assert_allclose(res.mean_angular_resolution, 0.001, rtol=1e-6)
+
+    def test_incidence_is_mean_of_sampled_pixels(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The scalar incidence is the mean of the constant incidence backplane."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs())
+        assert res.incidence == pytest.approx(0.4)
+
+    def test_default_dtypes_follow_mosaic(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """img is float64 and metadata arrays are float32 by default."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs())
+        assert ma.getdata(res.img).dtype == np.dtype(np.float64)
+        assert res.mean_radial_resolution.dtype == np.dtype(np.float32)
+
+    def test_custom_dtypes_follow_mosaic(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Mosaic-level image/metadata dtypes propagate to the result arrays."""
+        _install_geometry(monkeypatch)
+        mosaic = _make_mosaic(image_dtype=np.float32, metadata_dtype=np.float64)
+        res = mosaic.reproject(_FakeObs())
+        assert ma.getdata(res.img).dtype == np.dtype(np.float32)
+        assert res.mean_phase.dtype == np.dtype(np.float64)
+        assert res.image_dtype == np.dtype(np.float32)
+        assert res.metadata_dtype == np.dtype(np.float64)
+
+    def test_explicit_data_matches_obs_data_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Passing data=obs.data explicitly reproduces the data=None result."""
+        _install_geometry(monkeypatch)
+        mosaic = _make_mosaic()
+        obs = _FakeObs()
+        res_default = mosaic.reproject(obs)
+        res_explicit = mosaic.reproject(obs, ma.MaskedArray(obs.data))
+        np.testing.assert_array_equal(ma.getdata(res_default.img), ma.getdata(res_explicit.img))
+
+    def test_longitude_range_restricts_bins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A [9, 12] bin-edge range keeps only bins whose pixels fall inside it."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs(), longitude_range=(9 * _LON_RES, 12 * _LON_RES))
+        np.testing.assert_array_equal(np.where(res.longitude_antimask)[0], np.array([9, 10, 11]))
+
+    def test_non_grid_aligned_start_keeps_columns_grid_aligned(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A sub-bin longitude_range start does not shift columns off the global grid.
+
+        The binning origin is the floor of the start snapped to the global grid, so
+        the surviving bins are identical to the grid-aligned request and column k
+        still means longitude bin_index * longitude_resolution.
+        """
+        _install_geometry(monkeypatch)
+        mosaic = _make_mosaic()
+        aligned = mosaic.reproject(_FakeObs(), longitude_range=(9 * _LON_RES, 12 * _LON_RES))
+        offset = mosaic.reproject(_FakeObs(), longitude_range=(9.3 * _LON_RES, 12 * _LON_RES))
+        np.testing.assert_array_equal(offset.longitude_antimask, aligned.longitude_antimask)
+        np.testing.assert_array_equal(ma.getdata(offset.img), ma.getdata(aligned.img))
+
+    def test_single_column_result(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A narrow longitude range produces a valid single-column sparse result."""
+        _install_geometry(monkeypatch)
+        mosaic = _make_mosaic()
+        res = mosaic.reproject(_FakeObs(), longitude_range=(9 * _LON_RES, 9.9 * _LON_RES))
+        assert res.img.shape == (5, 1)
+        np.testing.assert_array_equal(np.where(res.longitude_antimask)[0], np.array([9]))
+        mosaic.add(res)
+        assert mosaic.to_sparse().img.shape == (5, 1)
+
+    def test_custom_radius_range_echoed_and_resized(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """radius_range overrides the mosaic bounds and sizes the radius axis."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs(), radius_range=(1000.0, 1010.0))
+        assert res.radius_inner == 1000.0
+        assert res.radius_outer == 1010.0
+        assert res.img.shape[0] == 3
+        np.testing.assert_array_equal(ma.getdata(res.img), _expected_absolute_img()[:3, :])
+
+    def test_custom_radius_range_result_rejected_by_add(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A result on different radius bounds cannot be accumulated into the mosaic."""
+        _install_geometry(monkeypatch)
+        mosaic = _make_mosaic()
+        res = mosaic.reproject(_FakeObs(), radius_range=(1000.0, 1010.0))
+        with pytest.raises(ValueError, match='radius bounds mismatch'):
+            mosaic.add(res)
+
+    def test_margin_excludes_edge_pixels(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A large margin removes bins whose sample pixels fall within it."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs(), margin=8)
+        np.testing.assert_array_equal(np.where(res.longitude_antimask)[0], np.array([10, 11]))
+
+    def test_result_accumulates_into_mosaic_at_correct_bins(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """add() places the sparse columns at their global longitude bins."""
+        _install_geometry(monkeypatch)
+        mosaic = _make_mosaic()
+        res = mosaic.reproject(_FakeObs(), image_name='img_a')
+        mosaic.add(res)
+        full = mosaic.to_full()
+        np.testing.assert_array_equal(ma.getdata(full.img)[:, 8:15], _expected_absolute_img())
+        assert full.contributing_image_names == ('img_a',)
+
+    def test_masked_input_column_drops_longitude_bin(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Masking every pixel a bin samples removes that bin from the result."""
+        _install_geometry(monkeypatch)
+        obs = _FakeObs()
+        data = ma.MaskedArray(obs.data.copy())
+        data[:, 4:6] = ma.masked  # u = 4 is bin 8's only sampled column
+        res = _make_mosaic().reproject(obs, data)
+        np.testing.assert_array_equal(np.where(res.longitude_antimask)[0], np.arange(9, 15))
+        np.testing.assert_array_equal(ma.getdata(res.img), _expected_absolute_img()[:, 1:])
+
+    def test_single_masked_pixel_masks_single_cell(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """One masked pixel masks exactly the cell that samples it; the column stays."""
+        _install_geometry(monkeypatch)
+        obs = _FakeObs()
+        data = ma.MaskedArray(obs.data.copy())
+        data[4, 6] = ma.masked  # sampled by radius row 0 of bin 9 (column 1)
+        res = _make_mosaic().reproject(obs, data)
+        mask = ma.getmaskarray(res.img)
+        assert mask[0, 1]
+        assert int(mask.sum()) == 1
+        assert res.img.shape == (5, 7)
+
+    def test_shadowed_bin_dropped_when_omit_shadow(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Pixels inside the shadow are masked, dropping fully shadowed bins."""
+        _install_geometry(monkeypatch, shadow_u_columns=(8,))  # bin 10 samples u = 8
+        res = _make_mosaic().reproject(_FakeObs(), omit_shadow=True)
+        np.testing.assert_array_equal(
+            np.where(res.longitude_antimask)[0], np.array([8, 9, 11, 12, 13, 14])
+        )
+
+    def test_shadow_ignored_when_omit_shadow_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """omit_shadow=False keeps shadowed pixels and never computes the shadow."""
+        bp_cls = _install_geometry(monkeypatch, shadow_u_columns=(8,))
+        res = _make_mosaic().reproject(_FakeObs(), omit_shadow=False)
+        np.testing.assert_array_equal(np.where(res.longitude_antimask)[0], np.arange(8, 15))
+        assert bp_cls.shadow_calls == 0
+
+    @pytest.mark.filterwarnings('ignore::RuntimeWarning')
+    def test_empty_intersection_returns_empty_sparse_result(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A radius window missing the visible ring yields zero sparse columns."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs(), radius_range=(5000.0, 5100.0))
+        assert res.img.shape[1] == 0
+        assert not res.longitude_antimask.any()
+        assert res.mean_phase.shape == (0,)
+        assert math.isnan(res.incidence)
+
+    @pytest.mark.filterwarnings('ignore::RuntimeWarning')
+    def test_zero_width_longitude_range_returns_empty_result(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """start == end selects no pixels and yields an empty sparse result."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs(), longitude_range=(9 * _LON_RES, 9 * _LON_RES))
+        assert res.img.shape == (5, 0)
+        assert not res.longitude_antimask.any()
+
+    @pytest.mark.filterwarnings('ignore::RuntimeWarning')
+    def test_adding_empty_result_is_a_no_op(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """add() of a zero-column result records no image and stores no columns."""
+        _install_geometry(monkeypatch)
+        mosaic = _make_mosaic()
+        res = mosaic.reproject(_FakeObs(), longitude_range=(9 * _LON_RES, 9 * _LON_RES))
+        mosaic.add(res)
+        data = mosaic.to_sparse()
+        assert not data.longitude_antimask.any()
+        assert data.contributing_image_names == ()
+
+    def test_zoom_without_orbit_model_not_implemented(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Zoom in inertial (absolute-radius) mode raises NotImplementedError."""
+        _install_geometry(monkeypatch)
+        with pytest.raises(NotImplementedError, match='non-corotating inertial radius'):
+            _make_mosaic().reproject(_FakeObs(), zoom_amt=2)
+
+    def test_add_overflow_after_uint16_images(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """add() raises OverflowError once the uint16 image counter is exhausted."""
+        _install_geometry(monkeypatch)
+        mosaic = _make_mosaic()
+        res = mosaic.reproject(_FakeObs())
+        mosaic._image_count = np.iinfo(np.uint16).max + 1
+        with pytest.raises(OverflowError, match='exceeds uint16 max'):
+            mosaic.add(res)
+
+    def test_add_rejects_antimask_column_count_mismatch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """add() rejects results whose antimask true-count disagrees with img columns."""
+        _install_geometry(monkeypatch)
+        mosaic = _make_mosaic()
+        res = mosaic.reproject(_FakeObs())
+        corrupt_antimask = res.longitude_antimask.copy()
+        corrupt_antimask[0] = True  # one more True than sparse columns
+        corrupt = dataclasses.replace(res, longitude_antimask=corrupt_antimask)
+        with pytest.raises(ValueError, match='one True entry per sparse column'):
+            mosaic.add(corrupt)
+
+    def test_uv_range_with_shadow_masking_succeeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """uv_range with the default omit_shadow=True must not crash."""
+        _install_geometry(monkeypatch)
+        res = _make_mosaic().reproject(_FakeObs(), uv_range=(2, 17, 2, 17))
+        assert res.img.shape[0] == 5
+
+    def test_uv_range_preserves_reprojected_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Restricting uv_range must not change the values of surviving cells."""
+        _install_geometry(monkeypatch)
+        mosaic = _make_mosaic()
+        res = mosaic.reproject(_FakeObs(), uv_range=(2, 17, 2, 17), omit_shadow=False)
+        bins = np.where(res.longitude_antimask)[0]
+        np.testing.assert_array_equal(bins, np.arange(9, 14))
+        # Analytic expectation: cell (r, bin b) samples data[4 + 2 r, (b - 6) * 2].
+        expected = np.empty(res.img.shape, dtype=np.float64)
+        for r in range(expected.shape[0]):
+            for c, b in enumerate(bins):
+                expected[r, c] = (4 + 2 * r) * 100 + (b - 6) * 2
+        valid = ~ma.getmaskarray(res.img)
+        assert valid.any()
+        np.testing.assert_array_equal(ma.getdata(res.img)[valid], expected[valid])
+
+
+class TestReprojectWithOrbitModel:
+    """Offset-radius and co-rotating longitude semantics."""
+
+    def test_offset_rows_straighten_circular_orbit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With a circular orbit model, offset rows sample constant-offset pixels."""
+        model = _make_model()
+        _install_geometry(monkeypatch, model=model)
+        res = _make_offset_mosaic(model).reproject(_FakeObs())
+        np.testing.assert_array_equal(np.where(res.longitude_antimask)[0], np.arange(8, 15))
+        np.testing.assert_array_equal(ma.getdata(res.img), _expected_offset_img())
+
+    def test_offset_rows_straighten_eccentric_orbit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An eccentric ring reprojects to the same straight rows as a circular one.
+
+        The absolute radius sampled varies with longitude, but each output row holds
+        a constant signed offset from the orbit, per the documented offset semantics.
+        """
+        model = _make_model(e=0.05, w0=0.3)
+        _install_geometry(monkeypatch, model=model)
+        res = _make_offset_mosaic(model).reproject(_FakeObs())
+        np.testing.assert_array_equal(ma.getdata(res.img), _expected_offset_img())
+
+    def test_result_radius_bounds_are_offsets(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The result echoes the signed offset bounds, not absolute radii."""
+        model = _make_model()
+        _install_geometry(monkeypatch, model=model)
+        res = _make_offset_mosaic(model).reproject(_FakeObs())
+        assert res.radius_inner == -10.0
+        assert res.radius_outer == 10.0
+        assert res.orbit_model == model
+
+    def test_corotating_longitudes_shift_antimask_bins(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One day past epoch with mean_motion -2 bins/day, bins shift by +2."""
+        model = _make_model(mean_motion=-2 * _LON_RES)
+        _install_geometry(monkeypatch, model=model)
+        obs = _FakeObs(midtime=_EPOCH_ET + 86400.0)
+        res = _make_offset_mosaic(model).reproject(obs)
+        np.testing.assert_array_equal(np.where(res.longitude_antimask)[0], np.arange(10, 17))
+        np.testing.assert_array_equal(ma.getdata(res.img), _expected_offset_img())
+
+    def test_corotating_bins_wrap_across_longitude_seam(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A co-rotating shift of 20 bins wraps the result across the 2 pi -> 0 seam."""
+        model = _make_model(mean_motion=-20 * _LON_RES)
+        _install_geometry(monkeypatch, model=model)
+        obs = _FakeObs(midtime=_EPOCH_ET + 86400.0)
+        res = _make_offset_mosaic(model).reproject(obs)
+        corot_bins = np.where(res.longitude_antimask)[0]
+        np.testing.assert_array_equal(corot_bins, np.array([0, 1, 2, 28, 29, 30, 31]))
+        # Columns are sorted by co-rotating bin; recover each column's inertial bin.
+        expected = np.empty(res.img.shape, dtype=np.float64)
+        for c, b in enumerate(corot_bins):
+            inertial_bin = (b - 20) % _N_FULL_LON
+            for r in range(expected.shape[0]):
+                expected[r, c] = (3 + 2 * r) * 100 + (4 + 2 * (inertial_bin - 8))
+        np.testing.assert_array_equal(ma.getdata(res.img), expected)
+
+    def test_per_call_value_equal_orbit_model_accepted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A distinct but value-equal per-call orbit model is accepted."""
+        model = _make_model()
+        _install_geometry(monkeypatch, model=model)
+        twin = _make_model()
+        assert twin is not model
+        res = _make_offset_mosaic(model).reproject(_FakeObs(), orbit_model=twin)
+        assert res.orbit_model == model
+
+    def test_zoom_preserves_constant_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """(2, 2) sub-pixel zoom returns the unzoomed grid shape and exact values.
+
+        With a constant input image the zoomed samples all read the same value, so
+        the unzoom averaging must return it exactly.
+        """
+        model = _make_model()
+        _install_geometry(monkeypatch, model=model)
+        obs = _FakeObs(data=np.full((_N, _N), 7.0))
+        res = _make_offset_mosaic(model).reproject(obs, zoom_amt=(2, 2))
+        assert res.img.shape == (5, 7)
+        np.testing.assert_array_equal(np.where(res.longitude_antimask)[0], np.arange(8, 15))
+        valid = ~ma.getmaskarray(res.img)
+        assert valid.any()
+        np.testing.assert_array_equal(ma.getdata(res.img)[valid], 7.0)
+
+
+# ---------------------------------------------------------------------------
+# orbit_pixels and the coordinate-conversion empty path
+# ---------------------------------------------------------------------------
+
+
+class _FakeExtBpObs:
+    """Observation stand-in for orbit_pixels: exposes ext_bp and extdata shape."""
+
+    def __init__(self) -> None:
+        """Build the analytic full-frame backplane as the extended backplane."""
+        bp_cls = _make_backplane_class(model=None, shadow_u_columns=())
+        self.ext_bp = bp_cls(self)
+        self.extdata_shape_uv = (_N, _N)
+        self.midtime = 0.0
+
+
+class TestOrbitPixels:
+    """orbit_pixels filtering against the synthetic geometry."""
+
+    def test_orbit_inside_image_yields_constant_row(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A circular orbit at 1010 km maps to the constant fractional row 8.5."""
+        monkeypatch.setattr(
+            RingMosaic, 'longitude_radius_to_pixels', staticmethod(_make_lr2p(None))
+        )
+        u_pix, v_pix = RingMosaic.orbit_pixels(_FakeExtBpObs(), _make_model())
+        assert len(u_pix) > 0
+        np.testing.assert_allclose(v_pix, 8.5)
+
+    def test_returned_pixels_are_inside_the_fov(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """All returned (u, v) pairs lie within the extended data bounds."""
+        monkeypatch.setattr(
+            RingMosaic, 'longitude_radius_to_pixels', staticmethod(_make_lr2p(None))
+        )
+        u_pix, v_pix = RingMosaic.orbit_pixels(_FakeExtBpObs(), _make_model())
+        assert bool(np.all(u_pix >= 0))
+        assert bool(np.all(u_pix <= _N - 1))
+        assert bool(np.all(v_pix >= 0))
+        assert bool(np.all(v_pix <= _N - 1))
+
+    def test_orbit_outside_radius_range_yields_no_pixels(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An orbit whose radius never intersects the backplane returns empty arrays."""
+        monkeypatch.setattr(
+            RingMosaic, 'longitude_radius_to_pixels', staticmethod(_make_lr2p(None))
+        )
+        far_model = RingOrbitModel(
+            name='far',
+            a=5000.0,
+            e=0.0,
+            w0=0.0,
+            dw=0.0,
+            mean_motion=0.0,
+            epoch_utc=_EPOCH_UTC,
+        )
+        u_pix, v_pix = RingMosaic.orbit_pixels(_FakeExtBpObs(), far_model)
+        assert len(u_pix) == 0
+        assert len(v_pix) == 0
+
+
+class TestLongitudeRadiusToPixelsEmptyPath:
+    """The real longitude_radius_to_pixels short-circuits on empty input."""
+
+    def test_empty_input_returns_empty_pixels(self) -> None:
+        """Empty longitude/radius arrays return empty pixel arrays without oops calls."""
+        u, v = RingMosaic.longitude_radius_to_pixels(None, np.zeros(0), np.zeros(0))
+        assert u.shape == (0,)
+        assert v.shape == (0,)
+
+    def test_empty_input_with_orbit_model(self) -> None:
+        """The empty path also works after the co-rotating conversion."""
+        obs = SimpleNamespace(midtime=0.0)
+        u, v = RingMosaic.longitude_radius_to_pixels(
+            obs, np.zeros(0), np.zeros(0), orbit_model=_make_model()
+        )
+        assert u.shape == (0,)
+        assert v.shape == (0,)

--- a/tests/spindoctor/reproj/test_serialization_roundtrip.py
+++ b/tests/spindoctor/reproj/test_serialization_roundtrip.py
@@ -1,0 +1,561 @@
+"""Spec tests for FITS/npz round-trip completeness in ``spindoctor.reproj._serialization``.
+
+Contracts under test (module docstring of ``_serialization``, the dev guide
+"Serialization" section, and the ``save`` / ``load`` docstrings on
+``RingReprojResult`` / ``RingMosaicData``):
+
+- Every documented dataclass field survives a save/load cycle bit-exact (arrays) or
+  exactly (scalars/strings); FITS may flip array byte order but not kind or width.
+- ``__kind__`` / ``__version__`` sentinels are written and checked; mismatched or
+  missing sentinels raise ``ValueError``.
+- Load-time dtype verification raises ``ValueError`` naming the offending field.
+- ``RingOrbitModel`` round-trips through flattened ``orbit_model__*`` entries;
+  ``None`` round-trips through the ``is_none`` sentinel.
+- Format inference follows the documented extension rules.
+
+Synthetic reprojection results reuse the ``_make_ring_repro`` builder from
+``tests.spindoctor.reproj.test_rings``.
+"""
+
+import dataclasses
+import math
+from pathlib import Path
+
+import numpy as np
+import numpy.ma as ma
+import pytest
+from astropy.io import fits as astropy_fits
+from tests.spindoctor.reproj.test_rings import (
+    _LON_RES,
+    _RAD_RES,
+    _RADIUS_INNER,
+    _RADIUS_OUTER,
+    _make_ring_repro,
+)
+
+from spindoctor.reproj._serialization import (
+    infer_format,
+    load_npz,
+    orbit_model_from_dict,
+    orbit_model_to_dict,
+    save_npz,
+    tuple_of_strings_field,
+    verify_dtype,
+)
+from spindoctor.reproj.ring_orbit_model import RingOrbitModel
+from spindoctor.reproj.rings import RingMosaic, RingMosaicData, RingReprojResult
+
+_ORBIT_MODEL = RingOrbitModel(
+    name='roundtrip-model',
+    a=140221.3,
+    e=0.00235,
+    w0=0.4224,
+    dw=0.0471,
+    mean_motion=10.157,
+    epoch_utc='2007-01-01',
+)
+
+
+def _make_mosaic() -> RingMosaic:
+    """Return a small SATURN RingMosaic matching the shared test grid constants."""
+    return RingMosaic(
+        body_name='SATURN',
+        radius_inner=_RADIUS_INNER,
+        radius_outer=_RADIUS_OUTER,
+        longitude_resolution=_LON_RES,
+        radius_resolution=_RAD_RES,
+    )
+
+
+def _make_mosaic_data() -> RingMosaicData:
+    """Return sparse RingMosaicData built from two synthetic reprojections."""
+    mosaic = _make_mosaic()
+    img_a = ma.MaskedArray(np.arange(10, dtype=np.float64).reshape(5, 2))
+    img_a[0, 0] = ma.masked
+    mosaic.add(
+        _make_ring_repro(
+            valid_lon_bins=[3, 4],
+            img_values=img_a,
+            mean_radial_resolution=7.5,
+            incidence=0.2,
+            time=1000.5,
+            image_name='img_a',
+        )
+    )
+    mosaic.add(
+        _make_ring_repro(
+            valid_lon_bins=[10],
+            img_values=42.0,
+            mean_radial_resolution=3.25,
+            incidence=0.6,
+            time=2000.25,
+            image_name='img_b',
+        )
+    )
+    return mosaic.to_sparse()
+
+
+def _assert_repro_equal(loaded: RingReprojResult, original: RingReprojResult) -> None:
+    """Assert that every documented RingReprojResult field round-tripped exactly.
+
+    Parameters:
+        loaded: The result reconstructed by ``RingReprojResult.load``.
+        original: The result that was saved.
+    """
+    assert loaded.body_name == original.body_name
+    assert loaded.longitude_resolution == original.longitude_resolution
+    assert loaded.radius_resolution == original.radius_resolution
+    assert loaded.radius_inner == original.radius_inner
+    assert loaded.radius_outer == original.radius_outer
+    np.testing.assert_array_equal(loaded.longitude_antimask, original.longitude_antimask)
+    assert loaded.longitude_antimask.dtype == np.dtype(np.bool_)
+    np.testing.assert_array_equal(ma.getdata(loaded.img), ma.getdata(original.img))
+    np.testing.assert_array_equal(ma.getmaskarray(loaded.img), ma.getmaskarray(original.img))
+    np.testing.assert_array_equal(loaded.mean_radial_resolution, original.mean_radial_resolution)
+    np.testing.assert_array_equal(loaded.mean_angular_resolution, original.mean_angular_resolution)
+    np.testing.assert_array_equal(loaded.mean_phase, original.mean_phase)
+    np.testing.assert_array_equal(loaded.mean_emission, original.mean_emission)
+    assert loaded.incidence == original.incidence
+    assert loaded.time == original.time
+    assert loaded.orbit_model == original.orbit_model
+    assert loaded.image_dtype == original.image_dtype
+    assert loaded.metadata_dtype == original.metadata_dtype
+    assert loaded.photometric_model_name == original.photometric_model_name
+    assert loaded.image_name == original.image_name
+
+
+def _assert_mosaic_data_equal(loaded: RingMosaicData, original: RingMosaicData) -> None:
+    """Assert that every documented RingMosaicData field round-tripped exactly.
+
+    Parameters:
+        loaded: The data reconstructed by ``RingMosaicData.load``.
+        original: The data that was saved.
+    """
+    assert loaded.body_name == original.body_name
+    assert loaded.ring_body_name == original.ring_body_name
+    assert loaded.shadow_body_name == original.shadow_body_name
+    assert loaded.longitude_resolution == original.longitude_resolution
+    assert loaded.radius_resolution == original.radius_resolution
+    assert loaded.radius_inner == original.radius_inner
+    assert loaded.radius_outer == original.radius_outer
+    np.testing.assert_array_equal(loaded.longitude_antimask, original.longitude_antimask)
+    np.testing.assert_array_equal(ma.getdata(loaded.img), ma.getdata(original.img))
+    np.testing.assert_array_equal(ma.getmaskarray(loaded.img), ma.getmaskarray(original.img))
+    assert loaded.longitude_range == original.longitude_range
+    for field in (
+        'mean_radial_resolution',
+        'mean_angular_resolution',
+        'mean_phase',
+        'mean_emission',
+        'image_number',
+        'time',
+    ):
+        got = getattr(loaded, field)
+        want = getattr(original, field)
+        np.testing.assert_array_equal(ma.getdata(got), ma.getdata(want))
+        np.testing.assert_array_equal(ma.getmaskarray(got), ma.getmaskarray(want))
+    assert loaded.mean_incidence == original.mean_incidence
+    # FITS may flip byte order; the documented contract is width and kind.
+    assert loaded.image_number.dtype.kind == 'u'
+    assert loaded.image_number.dtype.itemsize == 2
+    assert loaded.time.dtype.kind == 'f'
+    assert loaded.time.dtype.itemsize == 8
+    assert loaded.image_dtype == original.image_dtype
+    assert loaded.metadata_dtype == original.metadata_dtype
+    assert loaded.contributing_image_names == original.contributing_image_names
+    assert loaded.orbit_model_name == original.orbit_model_name
+    assert loaded.photometric_model_name == original.photometric_model_name
+
+
+class TestRingReprojResultRoundTrip:
+    """Field-complete save/load round trips for RingReprojResult."""
+
+    @pytest.mark.parametrize('compress', [True, False])
+    def test_npz_round_trip_all_fields(self, tmp_path: Path, compress: bool) -> None:
+        """All fields survive an npz round trip, compressed or not."""
+        img = ma.MaskedArray(np.arange(15, dtype=np.float64).reshape(5, 3))
+        img[2, 1] = ma.masked
+        original = _make_ring_repro(
+            valid_lon_bins=[2, 7, 8],
+            img_values=img,
+            mean_radial_resolution=np.array([1.5, 2.5, 3.5]),
+            incidence=0.775,
+            time=987654.125,
+            photometric_model_name='lambert',
+            image_name='N171',
+        )
+        path = tmp_path / 'repro.npz'
+        original.save(path, compress=compress)
+        _assert_repro_equal(RingReprojResult.load(path), original)
+
+    def test_fits_round_trip_all_fields(self, tmp_path: Path) -> None:
+        """All fields survive a FITS round trip."""
+        img = ma.MaskedArray(np.arange(15, dtype=np.float64).reshape(5, 3))
+        img[0, 0] = ma.masked
+        original = _make_ring_repro(
+            valid_lon_bins=[2, 7, 8],
+            img_values=img,
+            mean_phase=np.array([0.25, 0.5, 0.75]),
+            incidence=0.775,
+            time=987654.125,
+            photometric_model_name='lambert',
+            image_name='N171',
+        )
+        path = tmp_path / 'repro.fits'
+        original.save(path, format_='fits')
+        _assert_repro_equal(RingReprojResult.load(path, format_='fits'), original)
+
+    @pytest.mark.parametrize('fmt', ['npz', 'fits'])
+    def test_orbit_model_round_trips_by_value(self, tmp_path: Path, fmt: str) -> None:
+        """A non-None orbit model is rebuilt equal to the original in both formats."""
+        original = _make_ring_repro(
+            valid_lon_bins=[5],
+            radius_inner=-10.0,
+            radius_outer=10.0,
+            orbit_model=_ORBIT_MODEL,
+        )
+        path = tmp_path / f'om.{fmt}'
+        original.save(path, format_=fmt)
+        loaded = RingReprojResult.load(path, format_=fmt)
+        assert loaded.orbit_model == _ORBIT_MODEL
+        assert loaded.orbit_model is not None
+        assert loaded.orbit_model.a == _ORBIT_MODEL.a
+        assert loaded.orbit_model.epoch_utc == _ORBIT_MODEL.epoch_utc
+
+    def test_npz_round_trip_nan_incidence(self, tmp_path: Path) -> None:
+        """A NaN incidence (produced by an all-masked reprojection) survives npz."""
+        original = _make_ring_repro(valid_lon_bins=[3, 4], incidence=float('nan'))
+        path = tmp_path / 'nan_inc.npz'
+        original.save(path)
+        assert math.isnan(RingReprojResult.load(path).incidence)
+
+    def test_fits_round_trip_nan_incidence(self, tmp_path: Path) -> None:
+        """A NaN incidence should survive a FITS round trip like it does for npz."""
+        original = _make_ring_repro(valid_lon_bins=[3, 4], incidence=float('nan'))
+        path = tmp_path / 'nan_inc.fits'
+        original.save(path, format_='fits')
+        assert math.isnan(RingReprojResult.load(path, format_='fits').incidence)
+
+    @pytest.mark.parametrize('fmt', ['npz', 'fits'])
+    def test_non_finite_image_values_survive(self, tmp_path: Path, fmt: str) -> None:
+        """Unmasked NaN and inf pixels in img round trip bit-exact in both formats."""
+        img = ma.MaskedArray(np.ones((5, 2), dtype=np.float64))
+        img[0, 0] = np.nan
+        img[1, 1] = np.inf
+        original = _make_ring_repro(valid_lon_bins=[1, 2], img_values=img)
+        path = tmp_path / f'nonfinite.{fmt}'
+        original.save(path, format_=fmt)
+        loaded = RingReprojResult.load(path, format_=fmt)
+        assert math.isnan(ma.getdata(loaded.img)[0, 0])
+        assert math.isinf(ma.getdata(loaded.img)[1, 1])
+
+    @pytest.mark.parametrize('fmt', ['npz', 'fits'])
+    def test_empty_reprojection_round_trips(self, tmp_path: Path, fmt: str) -> None:
+        """A reprojection with zero valid longitude columns round trips in both formats."""
+        original = _make_ring_repro(valid_lon_bins=[])
+        path = tmp_path / f'empty.{fmt}'
+        original.save(path, format_=fmt)
+        loaded = RingReprojResult.load(path, format_=fmt)
+        assert loaded.img.shape == (5, 0)
+        assert loaded.mean_phase.shape == (0,)
+        assert not loaded.longitude_antimask.any()
+
+    def test_fits_preserves_metadata_dtype_width_and_kind(self, tmp_path: Path) -> None:
+        """FITS may flip byte order but metadata arrays stay 4-byte floats."""
+        original = _make_ring_repro(valid_lon_bins=[2, 3])
+        path = tmp_path / 'dtypes.fits'
+        original.save(path, format_='fits')
+        loaded = RingReprojResult.load(path, format_='fits')
+        assert loaded.mean_radial_resolution.dtype.kind == 'f'
+        assert loaded.mean_radial_resolution.dtype.itemsize == 4
+        assert ma.getdata(loaded.img).dtype.kind == 'f'
+        assert ma.getdata(loaded.img).dtype.itemsize == 8
+
+
+class TestRingMosaicDataRoundTrip:
+    """Field-complete save/load round trips for RingMosaicData."""
+
+    @pytest.mark.parametrize('fmt', ['npz', 'fits'])
+    def test_round_trip_all_fields(self, tmp_path: Path, fmt: str) -> None:
+        """Every field of a two-image sparse mosaic survives both formats."""
+        original = _make_mosaic_data()
+        path = tmp_path / f'mosaic.{fmt}'
+        original.save(path, format_=fmt)
+        _assert_mosaic_data_equal(RingMosaicData.load(path, format_=fmt), original)
+
+    @pytest.mark.parametrize('fmt', ['npz', 'fits'])
+    def test_bounded_longitude_range_round_trips(self, tmp_path: Path, fmt: str) -> None:
+        """The (start, end) longitude_range tuple from to_bounded survives exactly."""
+        mosaic = _make_mosaic()
+        mosaic.add(_make_ring_repro(valid_lon_bins=[3, 4], image_name='img_a'))
+        original = mosaic.to_bounded(longitude_range=(3 * _LON_RES, 5 * _LON_RES))
+        path = tmp_path / f'bounded.{fmt}'
+        original.save(path, format_=fmt)
+        loaded = RingMosaicData.load(path, format_=fmt)
+        assert loaded.longitude_range == original.longitude_range
+
+    @pytest.mark.parametrize('fmt', ['npz', 'fits'])
+    def test_empty_mosaic_round_trips(self, tmp_path: Path, fmt: str) -> None:
+        """A mosaic with no images saves and reloads with zero-width sparse arrays."""
+        original = _make_mosaic().to_sparse()
+        path = tmp_path / f'empty_mosaic.{fmt}'
+        original.save(path, format_=fmt)
+        loaded = RingMosaicData.load(path, format_=fmt)
+        assert loaded.img.shape == original.img.shape
+        assert not loaded.longitude_antimask.any()
+        assert loaded.contributing_image_names == ()
+        assert loaded.image_number.dtype.kind == 'u'
+        assert loaded.image_number.dtype.itemsize == 2
+        assert loaded.time.dtype.kind == 'f'
+        assert loaded.time.dtype.itemsize == 8
+
+    def test_fits_single_empty_image_name_round_trips(self, tmp_path: Path) -> None:
+        """contributing_image_names == ('',) must survive a FITS round trip."""
+        mosaic = _make_mosaic()
+        mosaic.add(_make_ring_repro(valid_lon_bins=[3], image_name=''))
+        original = mosaic.to_sparse()
+        assert original.contributing_image_names == ('',)
+        path = tmp_path / 'empty_name.fits'
+        original.save(path, format_='fits')
+        loaded = RingMosaicData.load(path, format_='fits')
+        assert loaded.contributing_image_names == ('',)
+
+    def test_npz_single_empty_image_name_round_trips(self, tmp_path: Path) -> None:
+        """contributing_image_names == ('',) survives an npz round trip."""
+        mosaic = _make_mosaic()
+        mosaic.add(_make_ring_repro(valid_lon_bins=[3], image_name=''))
+        original = mosaic.to_sparse()
+        path = tmp_path / 'empty_name.npz'
+        original.save(path)
+        assert RingMosaicData.load(path).contributing_image_names == ('',)
+
+    def test_fits_mixed_empty_names_round_trip(self, tmp_path: Path) -> None:
+        """Empty names between non-empty ones survive the NUL-separated FITS encoding."""
+        original = dataclasses.replace(
+            _make_mosaic_data(), contributing_image_names=('img_a', '', 'img_b')
+        )
+        path = tmp_path / 'mixed_names.fits'
+        original.save(path, format_='fits')
+        loaded = RingMosaicData.load(path, format_='fits')
+        assert loaded.contributing_image_names == ('img_a', '', 'img_b')
+
+
+class TestCorruptAndMismatchedInputs:
+    """Documented rejection of wrong-kind, truncated, and dtype-corrupted files."""
+
+    def test_npz_kind_mismatch_rejected(self, tmp_path: Path) -> None:
+        """Loading a RingMosaicData npz as RingReprojResult raises ValueError."""
+        path = tmp_path / 'mosaic.npz'
+        _make_mosaic_data().save(path)
+        with pytest.raises(ValueError, match='Kind mismatch'):
+            RingReprojResult.load(path)
+
+    def test_fits_kind_mismatch_rejected(self, tmp_path: Path) -> None:
+        """Loading a RingReprojResult FITS file as RingMosaicData raises ValueError."""
+        path = tmp_path / 'repro.fits'
+        _make_ring_repro(valid_lon_bins=[1]).save(path, format_='fits')
+        with pytest.raises(ValueError, match='Kind mismatch'):
+            RingMosaicData.load(path, format_='fits')
+
+    def test_npz_missing_kind_sentinel_rejected(self, tmp_path: Path) -> None:
+        """An npz without __kind__ is rejected as truncated or wrong format."""
+        path = tmp_path / 'no_kind.npz'
+        np.savez(path, foo=np.array([1]))
+        with pytest.raises(ValueError, match='Missing file sentinel __kind__'):
+            load_npz(path, 'RingReprojResult')
+
+    def test_npz_missing_version_sentinel_rejected(self, tmp_path: Path) -> None:
+        """An npz without __version__ is rejected as truncated or wrong format."""
+        path = tmp_path / 'no_version.npz'
+        np.savez(path, __kind__=np.array('RingReprojResult'))
+        with pytest.raises(ValueError, match='Missing file sentinel __version__'):
+            load_npz(path, 'RingReprojResult')
+
+    def test_missing_required_keys_rejected(self, tmp_path: Path) -> None:
+        """A well-formed npz lacking required RingReprojResult keys raises ValueError."""
+        path = tmp_path / 'partial.npz'
+        save_npz(path, 'RingReprojResult', 1, {'body_name': 'SATURN'}, compress=False)
+        with pytest.raises(ValueError, match='missing required keys'):
+            RingReprojResult.load(path)
+
+    def test_npz_orphaned_data_entry_rejected(self, tmp_path: Path) -> None:
+        """A __data entry without its __mask twin raises ValueError."""
+        path = tmp_path / 'orphan.npz'
+        np.savez(
+            path,
+            __kind__=np.array('K'),
+            __version__=np.array(1),
+            img__data=np.zeros(3),
+        )
+        with pytest.raises(ValueError, match='Unmatched "__data"/"__mask"'):
+            load_npz(path, 'K')
+
+    def test_fits_duplicate_extname_rejected(self, tmp_path: Path) -> None:
+        """Two HDUs sharing an EXTNAME raise ValueError instead of silently clobbering."""
+        path = tmp_path / 'dup.fits'
+        primary = astropy_fits.PrimaryHDU()
+        primary.header['KIND'] = 'K'
+        primary.header['VERSION'] = 1
+        hdus = astropy_fits.HDUList(
+            [
+                primary,
+                astropy_fits.ImageHDU(data=np.zeros(3), name='IMG'),
+                astropy_fits.ImageHDU(data=np.zeros(3), name='IMG'),
+            ]
+        )
+        hdus.writeto(path, overwrite=True)
+        from spindoctor.reproj._serialization import load_fits
+
+        with pytest.raises(ValueError, match="Duplicate FITS EXTNAME 'IMG'"):
+            load_fits(path, 'K')
+
+    def test_fits_orphaned_mask_hdu_rejected(self, tmp_path: Path) -> None:
+        """A _MASK HDU without its base HDU raises ValueError."""
+        path = tmp_path / 'orphan_mask.fits'
+        primary = astropy_fits.PrimaryHDU()
+        primary.header['KIND'] = 'K'
+        primary.header['VERSION'] = 1
+        hdus = astropy_fits.HDUList(
+            [primary, astropy_fits.ImageHDU(data=np.zeros(3, np.uint8), name='FOO_MASK')]
+        )
+        hdus.writeto(path, overwrite=True)
+        from spindoctor.reproj._serialization import load_fits
+
+        with pytest.raises(ValueError, match='Orphaned "_MASK" HDUs'):
+            load_fits(path, 'K')
+
+    def test_image_dtype_mismatch_rejected_on_load(self, tmp_path: Path) -> None:
+        """A file whose img dtype disagrees with its declared image_dtype is rejected."""
+        bad = dataclasses.replace(
+            _make_ring_repro(valid_lon_bins=[1, 2]), image_dtype=np.dtype(np.float32)
+        )
+        path = tmp_path / 'bad_dtype.npz'
+        bad.save(path)
+        with pytest.raises(ValueError, match="image_dtype mismatch for field 'img'"):
+            RingReprojResult.load(path)
+
+    def test_image_number_dtype_mismatch_rejected_on_load(self, tmp_path: Path) -> None:
+        """A file whose image_number is not uint16 is rejected."""
+        data = _make_mosaic_data()
+        n = data.image_number.shape[0]
+        bad = dataclasses.replace(data, image_number=ma.MaskedArray(np.zeros(n, dtype=np.uint32)))
+        path = tmp_path / 'bad_imgnum.npz'
+        bad.save(path)
+        with pytest.raises(ValueError, match='image_number must be uint16'):
+            RingMosaicData.load(path)
+
+
+class TestInferFormat:
+    """Documented extension-based format inference."""
+
+    @pytest.mark.parametrize(
+        ('name', 'expected'),
+        [
+            ('data.npz', 'npz'),
+            ('data.fits', 'fits'),
+            ('data.fit', 'fits'),
+            ('data.fz', 'fits'),
+            ('data.fits.gz', 'fits'),
+        ],
+    )
+    def test_extension_mapping(self, name: str, expected: str) -> None:
+        """Each documented extension maps to its format (files need not exist)."""
+        assert infer_format(name, None) == expected
+
+    def test_unknown_extension_rejected(self) -> None:
+        """An unrecognized extension raises ValueError telling the user to pass format_."""
+        with pytest.raises(ValueError, match='Cannot infer format'):
+            infer_format('data.dat', None)
+
+    def test_invalid_explicit_format_rejected(self) -> None:
+        """An unsupported explicit format_ raises ValueError."""
+        with pytest.raises(ValueError, match="format must be 'npz' or 'fits'"):
+            infer_format('data.npz', 'hdf5')
+
+    def test_explicit_format_overrides_extension(self) -> None:
+        """An explicit format_ wins over the file extension."""
+        assert infer_format('data.fits', 'npz') == 'npz'
+
+
+class TestSerializationHelpers:
+    """tuple_of_strings_field, orbit_model dict helpers, and verify_dtype."""
+
+    def test_tuple_of_strings_none_becomes_empty(self) -> None:
+        """None normalizes to the empty tuple."""
+        assert tuple_of_strings_field(None) == ()
+
+    def test_tuple_of_strings_from_unicode_array(self) -> None:
+        """A 1-D unicode array (npz encoding) becomes a tuple of str."""
+        assert tuple_of_strings_field(np.array(['a', 'bb'])) == ('a', 'bb')
+
+    def test_tuple_of_strings_from_utf8_bytes(self) -> None:
+        """A uint8 array of NUL-terminated UTF-8 (FITS encoding) decodes correctly."""
+        raw = np.frombuffer(b'x\0y\0', dtype=np.uint8).copy()
+        assert tuple_of_strings_field(raw) == ('x', 'y')
+
+    def test_tuple_of_strings_missing_terminator_rejected(self) -> None:
+        """A payload without the per-entry NUL terminator raises ValueError."""
+        raw = np.frombuffer(b'x\0y', dtype=np.uint8).copy()
+        with pytest.raises(ValueError, match='missing entry terminator'):
+            tuple_of_strings_field(raw)
+
+    def test_tuple_of_strings_invalid_utf8_rejected(self) -> None:
+        """Invalid UTF-8 bytes raise the documented ValueError."""
+        raw = np.array([0xFF, 0xFE, 0x00], dtype=np.uint8)
+        with pytest.raises(ValueError, match='Invalid UTF-8'):
+            tuple_of_strings_field(raw)
+
+    def test_tuple_of_strings_from_list(self) -> None:
+        """A plain list normalizes to a tuple of str."""
+        assert tuple_of_strings_field(['a', 'b']) == ('a', 'b')
+
+    def test_orbit_model_none_round_trips_through_sentinel(self) -> None:
+        """None serializes to the is_none sentinel and deserializes back to None."""
+        d = orbit_model_to_dict(None)
+        assert d == {'is_none': True}
+        assert orbit_model_from_dict(d) is None
+
+    def test_orbit_model_dict_round_trip(self) -> None:
+        """A model round-trips through to_dict/from_dict by value."""
+        assert orbit_model_from_dict(orbit_model_to_dict(_ORBIT_MODEL)) == _ORBIT_MODEL
+
+    def test_orbit_model_missing_keys_rejected(self) -> None:
+        """A non-None dict lacking required keys raises ValueError."""
+        with pytest.raises(ValueError, match='missing required key'):
+            orbit_model_from_dict({'is_none': False, 'name': 'x'})
+
+    def test_verify_dtype_allows_endian_swap(self) -> None:
+        """Big-endian arrays (as FITS produces) match a little-endian declaration."""
+        arrays = {'img': np.zeros(3, dtype='>f8')}
+        verify_dtype(
+            arrays,
+            image_dtype=np.dtype('<f8'),
+            metadata_dtype=np.dtype(np.float32),
+            image_fields=['img'],
+            metadata_fields=[],
+        )
+
+    def test_verify_dtype_rejects_kind_mismatch(self) -> None:
+        """Same-width but different-kind arrays (int64 vs float64) are rejected."""
+        arrays = {'img': np.zeros(3, dtype=np.int64)}
+        with pytest.raises(ValueError, match="image_dtype mismatch for field 'img'"):
+            verify_dtype(
+                arrays,
+                image_dtype=np.dtype(np.float64),
+                metadata_dtype=np.dtype(np.float32),
+                image_fields=['img'],
+                metadata_fields=[],
+            )
+
+    def test_verify_dtype_enforces_float64_fields(self) -> None:
+        """Fields listed in float64_fields must be 8-byte floats regardless of dtypes."""
+        arrays = {'time': np.zeros(3, dtype=np.float32)}
+        with pytest.raises(ValueError, match='must be float64'):
+            verify_dtype(
+                arrays,
+                image_dtype=np.dtype(np.float64),
+                metadata_dtype=np.dtype(np.float32),
+                image_fields=[],
+                metadata_fields=[],
+                float64_fields=['time'],
+            )


### PR DESCRIPTION
## Summary

Comprehensive spec-first unit-test suites for the reprojection backend, the backplane backend (the non-CLI half of #241), `config_helper`, annotation text rendering, and the nav-model render paths — written from the dev guides and docstrings rather than current behavior — plus fixes for the 16 defects the suites uncovered.

**596 new tests** (1,926 → 2,522, all green, +7 xfails pinning open findings), all hermetic (no SPICE/holdings/network; verified under `env -i`). Package coverage 57% → 64%; the targeted modules go from 0–63% to **92–100%**:

| Module | Before | After |
|---|---|---|
| `cli/backplanes/*` (5 modules) | 0% | 97–100% |
| `config/config_helper.py` | 8% | 100% |
| `annotation/annotation_text_info.py` | 20% | 98% |
| `reproj/rings.py` | 51% | 93% |
| `reproj/bodies.py` | 63% | 92% |
| `reproj/_serialization.py` | 79% | 93% |
| `reproj/photometric_model.py`, `cartographic_model.py`, `_context_managers.py` | 38–89% | 100% |
| `nav_model/nav_model_body.py` | 58% | 97% |
| `nav_model/nav_model_rings.py` | 63% | 94% |

## Fixes (each was pinned by a strict xfail, now a live regression test)

**reproj/bodies.py** — `zoom` was a complete no-op (coords truncated before scaling; repetition-only zoom); `copy_slop` was a no-op (mask ANDed with its own dilation); `subimage_edges` + default full-frame backplane crashed on a mask broadcast; `bounds` returned the buffer extent instead of the valid-data bounding box.

**reproj/rings.py** — `uv_range` crashed under `omit_shadow` and sampled pixels shifted by the region origin (zero in-repo callers, hence latent); `orbit_pixels` crashed on any real backplane (polymath `Boolean` used as a numpy index).

**reproj/_serialization.py** — FITS save crashed on NaN scalar metadata (which empty reprojections legitimately produce); `('',)` in `contributing_image_names` (the default `image_name`) silently decoded to `()`, breaking the documented image-number indexing. Non-finite header scalars now use `_NONF` string cards; tuple-of-strings payloads carry one NUL terminator per entry.

**cli/backplanes** — merge filled unclaimed pixels with NaN where the dev guide says zero (which also defeated the writer's all-zero plane omission); fake NAIF IDs came from the salted `hash()` and changed across interpreter runs (new deterministic `fake_naif_id()` hashlib helper; same fix for the simulated value seed); the ring `distance` merge-ordering array leaked into products as an HDU; the writer's omission filter now treats non-finite as invalid.

**config/config_helper.py** — a misplaced `return` meant `nav_default_config.yaml` was **never loaded on any real `sd_*` run** (every driver defines `--config-file`, and the mere presence of the attribute skipped the user-default branch); the bundle-root docstring named a nonexistent env var.

**annotation/annotation_text_info.py** — `_draw_text` reported success when `show_all_positions` placed nothing.

**docs** — Lommel-Seeliger correction factor was missing its factor 2; `image_number` capacity wording (65,536 entries, numbers 0–65535).

## ⚠️ Operator note: behavior change on merge

With the `config_helper` fix, local `sd_offset` runs will load the repo-root `nav_default_config.yaml` for the first time. That file currently sets `nav_results_root: /data/nav-offset-results/nav` (which by documented precedence beats the `NAV_RESULTS_ROOT` env var) and DEBUG log levels. **Review/trim that file before or at merge.** Until this merges, `main` behavior is unchanged, so the in-flight Phase D frame evaluations are unaffected.

## Held findings (pinned as xfails, tracked as issues)

- #251 — ring-won pixels carry no BODY_ID_MAP entry (needs an ID-source decision; the dev guide's `bodn2c('SATURN_RINGS')` suggestion raises).
- #252 — occluding ring does not take ownership of body planes/ID map (plausibly intentional; code-or-doc decision).
- #253 — backplane sidecar lacks dev-guide-promised content (stats mean/count, per-body NAIF IDs, observation block).
- #254 — fully dark body emits a `BODY_BLOB` where the dev guide says "otherwise nothing" (navigation-affecting; deliberately NOT touched while the Phase D evaluation of current main is in flight).

## Residual gap (recorded for #241)

Real `oops.Backplane` *evaluation* (actual geometric values per plane) needs SPICE and stays integration-test scope; everything around it (dispatch, masking, embedding, merge, writer, driver) is covered hermetically.

## Test plan

- `pytest -n auto --dist=loadfile`: 2,522 passed, 7 xfailed
- `ruff check src tests`, `ruff format --check src tests`, `mypy src tests` (strict): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KW6fkURsA2zgrWFKjbR5JY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reprojection/mosaicing accuracy, including tighter bounds based on actual valid data and more reliable masking/cropping.
  * Fixed annotation text placement status reporting when no placement is possible.
  * Made simulated backplane values and generated identifiers deterministic across runs.
  * Refined FITS output emission rules and improved handling of non-finite header/scalar values during read/write.
* **Documentation**
  * Updated reprojection guide limits and the Lommel–Seeliger correction formula.
* **Tests**
  * Added extensive coverage for reprojection, mosaicing, backplanes, rendering, configuration, and FITS/serialization round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->