### PR TITLE
fix: correct PDS4 LID transform for bundle indexes

### DIFF
--- a/docs/dev_guide/dev_guide_pds4.rst
+++ b/docs/dev_guide/dev_guide_pds4.rst
@@ -93,6 +93,13 @@ The full extension-point set:
   including the image name (e.g.
   ``1234xxxxxx/123456xxxx/1234567890w``). Builds the per-file paths under
   ``data/`` and ``browse/``.
+- :meth:`~spindoctor.dataset.dataset.DataSet.pds4_lid_part_to_image_name` —
+  inverse of the image-name transform baked into ``pds4_path_stub`` and the
+  ``pds4_image_name_to_*`` builders. Each product is stored on disk under a
+  filename whose stem is the LID part (e.g. ``1234567890w``); this hook lets
+  the collection and global-index scanners recover the original image name from
+  that stem and round-trip it back through the canonical LID builders instead
+  of re-applying the transform.
 - :meth:`~spindoctor.dataset.dataset.DataSet.pds4_image_name_to_browse_lid` /
   :meth:`~spindoctor.dataset.dataset.DataSet.pds4_image_name_to_browse_lidvid`
   — emit the browse-product Logical Identifier (LID) and LID + version
@@ -240,7 +247,9 @@ The end-to-end checklist:
    are :meth:`~spindoctor.dataset.dataset.DataSet.pds4_bundle_template_dir`,
    :meth:`~spindoctor.dataset.dataset.DataSet.pds4_bundle_name`,
    :meth:`~spindoctor.dataset.dataset.DataSet.pds4_path_stub`, the four
-   ``pds4_image_name_to_*_lid[vid]`` methods, and
+   ``pds4_image_name_to_*_lid[vid]`` methods,
+   :meth:`~spindoctor.dataset.dataset.DataSet.pds4_lid_part_to_image_name`
+   (the inverse of ``pds4_path_stub``'s image-name transform), and
    :meth:`~spindoctor.dataset.dataset.DataSet.pds4_template_variables`.
 2. Drop a per-dataset template directory under
    ``src/spindoctor/cli/pds4/templates/<dataset>_<version>/`` containing the ``.lblx``

--- a/plans/ENGINEERING_PLAN.md
+++ b/plans/ENGINEERING_PLAN.md
@@ -322,12 +322,12 @@ Work items, in dependency order:
    from each on-disk product stem before calling the canonical LID
    builders. The strict-xfail label-round-trip tests in
    `tests/spindoctor/cli/pds4/test_collections.py` are flipped. Two
-   characterized defects recorded on #256 remain open in the same area
-   (they need a home once #264 closes #256): every `template.write`
-   ignores pdstemplate's error/warning counts (an unresolved variable
-   silently drops the label while the run reports success), and the
-   dev-guide "Output layout" section describes a layout neither the code
-   nor the user guide matches.
+   characterized defects recorded on #256 are tracked by **#265** for
+   the same area: every `template.write` ignores pdstemplate's
+   error/warning counts (an unresolved variable silently drops the label
+   while the run reports success), and the dev-guide "Output layout"
+   section describes a layout neither the code nor the user guide
+   matches.
 2. **Template finalization acceptance list** — the ten items recorded
    on #53 (2026-07-13 comment): schema validation, the unreferenced
    `cassini:*` variables and hardcoded placeholders, TITLE/DESCRIPTION

--- a/plans/ENGINEERING_PLAN.md
+++ b/plans/ENGINEERING_PLAN.md
@@ -311,21 +311,23 @@ plus hook implementations, mechanical but voluminous.
 
 Work items, in dependency order:
 
-1. **#139 and #256** (Essential, interacting — fix together) — the
-   global-index LID is malformed (missing `urn:nasa:pds:` prefix, wrong
-   image part), and the collection inventory LIDVIDs double-transform
-   the image name (the on-disk name is already LID-part form, then the
-   LID builder re-applies the Cassini rotate-first-char transform):
-   `src/spindoctor/cli/pds4/collections.py`. The #139 fix direction
-   (route through the dataset LID builder) hits the #256 double
-   transform, so land them as one change. Label-round-trip regression
-   tests already exist as strict xfails in
-   `tests/spindoctor/cli/pds4/test_collections.py` — flip them.
-   #256 also records two characterized defects to resolve in the same
-   area: every `template.write` ignores pdstemplate's error/warning
-   counts (an unresolved variable silently drops the label while the
-   run reports success), and the dev-guide "Output layout" section
-   describes a layout neither the code nor the user guide matches.
+1. **#139 and #256 — LID cross-referencing (fixed in PR #264)** — the
+   global-index LID was malformed (missing `urn:nasa:pds:` prefix, wrong
+   image part) and the collection inventory LIDVIDs double-transformed
+   the image name (the on-disk name is already LID-part form, so the LID
+   builder re-applied the Cassini rotate-first-char transform):
+   `src/spindoctor/cli/pds4/collections.py`. Both are resolved together
+   by a `DataSet.pds4_lid_part_to_image_name` inverse hook — the
+   collection and global-index scanners recover the original image name
+   from each on-disk product stem before calling the canonical LID
+   builders. The strict-xfail label-round-trip tests in
+   `tests/spindoctor/cli/pds4/test_collections.py` are flipped. Two
+   characterized defects recorded on #256 remain open in the same area
+   (they need a home once #264 closes #256): every `template.write`
+   ignores pdstemplate's error/warning counts (an unresolved variable
+   silently drops the label while the run reports success), and the
+   dev-guide "Output layout" section describes a layout neither the code
+   nor the user guide matches.
 2. **Template finalization acceptance list** — the ten items recorded
    on #53 (2026-07-13 comment): schema validation, the unreferenced
    `cassini:*` variables and hardcoded placeholders, TITLE/DESCRIPTION
@@ -421,7 +423,8 @@ asserts the generated half matches the registries.
   remaining scope is the `sd_backplanes.py` / `sd_create_bundle.py`
   driver arg-parsing layer, which should fold into the broader
   sd_*-driver test effort. The suites found and pinned #251, #252,
-  #253, #256 (strict xfails ready to flip when each fix lands).
+  #253, #256; the #256 LID xfails are flipped by PR #264, and #251,
+  #252, #253 remain (strict xfails ready to flip when each fix lands).
 - **#243** — direct tests for `nav_model/stars/conflicts.py`
   (`_check_one_star`, `mark_body_and_ring_conflicts`) with synthetic
   geometry; the existing per-pixel occlusion tests cover only the

--- a/plans/PROGRAM_PLAN.md
+++ b/plans/PROGRAM_PLAN.md
@@ -250,7 +250,9 @@ partially implemented machinery with no final templates, no tests, and
 no validation; Voyager, Galileo, and New Horizons additionally hit
 not-implemented walls. The work is: finish and validate the Cassini
 path (final templates — acceptance list recorded on #53; schema
-validation; the interacting LID defects #139/#256), then generalize —
+validation; the interacting LID defects #139/#256 fixed in PR #264,
+leaving two characterized #256 defects — swallowed `template.write`
+errors and the dev-guide output-layout mismatch), then generalize —
 per-mission label templates, LID builders, and collection machinery
 (#53 with #66, #67, #69, #71-#76, #79, #47, #30, #63). Distinct from this, **PDS4 *input***
 (#34) — reading PDS4-archived data instead of PDS3 — is treated like any

--- a/plans/PROGRAM_PLAN.md
+++ b/plans/PROGRAM_PLAN.md
@@ -251,8 +251,9 @@ no validation; Voyager, Galileo, and New Horizons additionally hit
 not-implemented walls. The work is: finish and validate the Cassini
 path (final templates — acceptance list recorded on #53; schema
 validation; the interacting LID defects #139/#256 fixed in PR #264,
-leaving two characterized #256 defects — swallowed `template.write`
-errors and the dev-guide output-layout mismatch), then generalize —
+with two characterized #256 defects — swallowed `template.write`
+errors and the dev-guide output-layout mismatch — tracked by #265),
+then generalize —
 per-mission label templates, LID builders, and collection machinery
 (#53 with #66, #67, #69, #71-#76, #79, #47, #30, #63). Distinct from this, **PDS4 *input***
 (#34) — reading PDS4-archived data instead of PDS3 — is treated like any
@@ -355,14 +356,15 @@ and the five decision gates, not by any implementation.
 Every open issue, by track. **Bold** = created after the 2026-07-11
 review (the 2026-07-12 reconciliation; #251-#254 and #256 by the
 2026-07-13 backend test suites, PRs #255/#257; #258/#259/#261/#263 by the
-2026-07-13 Phase D operator review).
+2026-07-13 Phase D operator review; #265 split from #256 alongside the
+PR #264 LID fix).
 
 | Track | Issues |
 |---|---|
 | A — validation & calibration | #84, #150, #153, #172, #174, #176, #223, **#224**, **#225**, **#226**, **#227**, **#228**, **#229**, **#230**, **#232**, **#233**, **#234**, **#235** |
 | B — navigation correctness | #24, #25, #128, #130, #132, #133, #179, #180, #210, #221, #222, **#237**, **#238**, **#239**, **#254**, **#258**, **#259**, **#261**, **#263** |
 | C — statistics & QA | **#240** (plus the standing cross-check and campaign-report practice) |
-| D — capability completion | #28, #30, #47, #50, #53, #54, #55, #57, #60, #63, #66, #67, #69, #70, #71, #72, #73, #74, #75, #76, #77, #79, #93, #108, #118, #126, #139, #141, #142, #188, **#231**, **#236**, **#251**, **#252**, **#253**, **#256** |
+| D — capability completion | #28, #30, #47, #50, #53, #54, #55, #57, #60, #63, #66, #67, #69, #70, #71, #72, #73, #74, #75, #76, #77, #79, #93, #108, #118, #126, #139, #141, #142, #188, **#231**, **#236**, **#251**, **#252**, **#253**, **#256**, **#265** |
 | E — test & docs debt | #122, #129, #177, #178, **#241**, **#242**, **#243**, **#244**, **#245** |
 | F — instruments, features, hardening | #2, #13, #15, #17, #18, #19, #21, #22, #23, #27, #33, #34, #38, #39, #43, #65, #78, #82, #81, #83, #92, #96, #97, #98, #99, #100, #101, #102, #103, #104, #105, #107, #109, #110, #119, #134, #135, #137, #138, #140, #143, #144, #147, #151, #152, #155, #157, #158, #181, #182, #183, #184, #185, #186, #187, #212 |
 

--- a/src/spindoctor/cli/pds4/collections.py
+++ b/src/spindoctor/cli/pds4/collections.py
@@ -59,7 +59,8 @@ def generate_collection_files(
         writer = csv.writer(f)
         writer.writerow(['Member Status', 'LIDVID_LID'])
         for label_file in label_files:
-            image_name = label_file.stem.replace('_backplanes', '')
+            lid_part = label_file.stem.replace('_backplanes', '')
+            image_name = dataset.pds4_lid_part_to_image_name(lid_part)
             lidvid = dataset.pds4_image_name_to_data_lidvid(image_name)
             writer.writerow(['P', lidvid])
     collection_data_csv.upload()
@@ -91,7 +92,8 @@ def generate_collection_files(
         writer = csv.writer(f)
         writer.writerow(['Member Status', 'LIDVID_LID'])
         for label_file in label_files:
-            image_name = label_file.stem.replace('_backplanes', '')
+            lid_part = label_file.stem.replace('_backplanes', '')
+            image_name = dataset.pds4_lid_part_to_image_name(lid_part)
             lidvid = dataset.pds4_image_name_to_browse_lidvid(image_name)
             writer.writerow(['P', lidvid])
     collection_browse_csv.upload()
@@ -157,8 +159,6 @@ def generate_global_index_files(
     body_index_rows: list[dict[str, Any]] = []
     ring_index_rows: list[dict[str, Any]] = []
 
-    pds4_bundle_name = dataset.pds4_bundle_name()
-
     for suppl_file in supplemental_files:
         try:
             suppl_text = suppl_file.read_text()
@@ -178,8 +178,9 @@ def generate_global_index_files(
         pds4_path_stub = str(suppl_relative).replace('_supplemental.txt', '')
         pds4_path_stub = pds4_path_stub.replace('\\', '/')
 
-        image_name = suppl_file.stem.replace('_supplemental', '')
-        lid = f'{pds4_bundle_name}:data:{image_name}'
+        lid_part = suppl_file.stem.replace('_supplemental', '')
+        image_name = dataset.pds4_lid_part_to_image_name(lid_part)
+        lid = dataset.pds4_image_name_to_data_lid(image_name)
         # pds4_path_stub includes path and filename prefix
         # Path relative to data directory
         path_to_image = f'data/{pds4_path_stub}_backplanes.lblx'

--- a/src/spindoctor/dataset/dataset.py
+++ b/src/spindoctor/dataset/dataset.py
@@ -256,6 +256,26 @@ class DataSet(ABC, NavBase):
         # a DataSet that doesn't support PDS4 bundle generation
         raise NotImplementedError
 
+    def pds4_lid_part_to_image_name(self, lid_part: str) -> str:
+        """Returns the image name for the given LID part.
+
+        Inverse of the image-name transformation baked into
+        :meth:`pds4_path_stub` and the ``pds4_image_name_to_*`` builders. The
+        bundle stores each product under a filename whose stem is the LID part
+        (e.g. ``1234567890w``); recovering the original image name lets bundle
+        scanners round-trip that stem back through the canonical LID builders
+        instead of re-applying the transform.
+
+        Parameters:
+            lid_part: The LID part (an on-disk product filename stem).
+
+        Returns:
+            The image name that produced the given LID part.
+        """
+        # We don't make PDS4 methods as @abstractmethod because it's possible to make
+        # a DataSet that doesn't support PDS4 bundle generation
+        raise NotImplementedError
+
     def pds4_image_name_to_browse_lid(self, image_name: str) -> str:
         """Returns the browse LID for the given image name.
 

--- a/src/spindoctor/dataset/dataset_pds3_cassini_iss.py
+++ b/src/spindoctor/dataset/dataset_pds3_cassini_iss.py
@@ -469,6 +469,25 @@ class DataSetPDS3CassiniISS(DataSetPDS3):
         bundle_path = self.pds4_bundle_path_for_image(image_name)
         return f'{bundle_path.rstrip("/")}/{image_lid_part}'
 
+    def pds4_lid_part_to_image_name(self, lid_part: str) -> str:
+        """Returns the image name for the given LID part.
+
+        Inverts the transform applied by :meth:`pds4_path_stub` and the
+        ``pds4_image_name_to_*`` builders, which move the leading camera letter
+        (``N``/``W``) to a lowercase suffix (``N1454725799`` ->
+        ``1454725799n``). The inverse moves the trailing lowercase letter back
+        to the front as an uppercase prefix (``1454725799n`` -> ``N1454725799``).
+
+        Parameters:
+            lid_part: The LID part (an on-disk product filename stem).
+
+        Returns:
+            The image name that produced the given LID part.
+        """
+        if len(lid_part) < 2:
+            raise ValueError(f'invalid Cassini LID part {lid_part!r}: expected >= 2 characters')
+        return lid_part[-1].upper() + lid_part[:-1]
+
     def pds4_image_name_to_browse_lid(self, image_name: str) -> str:
         """Returns the browse LID for the given image name.
 

--- a/src/spindoctor/dataset/dataset_pds3_galileo_ssi.py
+++ b/src/spindoctor/dataset/dataset_pds3_galileo_ssi.py
@@ -269,6 +269,17 @@ class DataSetPDS3GalileoSSI(DataSetPDS3):
         """Returns PDS4 path stub for bundle directory structure."""
         raise NotImplementedError
 
+    def pds4_lid_part_to_image_name(self, lid_part: str) -> str:
+        """Returns the image name for the given LID part.
+
+        Parameters:
+            lid_part: The LID part (an on-disk product filename stem).
+
+        Returns:
+            The image name that produced the given LID part.
+        """
+        raise NotImplementedError
+
     def pds4_image_name_to_browse_lid(self, image_name: str) -> str:
         """Returns the browse LID for the given image name.
 

--- a/src/spindoctor/dataset/dataset_pds3_newhorizons_lorri.py
+++ b/src/spindoctor/dataset/dataset_pds3_newhorizons_lorri.py
@@ -225,6 +225,17 @@ class DataSetPDS3NewHorizonsLORRI(DataSetPDS3):
         """Returns PDS4 path stub for bundle directory structure."""
         raise NotImplementedError
 
+    def pds4_lid_part_to_image_name(self, lid_part: str) -> str:
+        """Returns the image name for the given LID part.
+
+        Parameters:
+            lid_part: The LID part (an on-disk product filename stem).
+
+        Returns:
+            The image name that produced the given LID part.
+        """
+        raise NotImplementedError
+
     def pds4_image_name_to_browse_lid(self, image_name: str) -> str:
         """Returns the browse LID for the given image name.
 

--- a/src/spindoctor/dataset/dataset_pds3_voyager_iss.py
+++ b/src/spindoctor/dataset/dataset_pds3_voyager_iss.py
@@ -234,6 +234,17 @@ class DataSetPDS3VoyagerISS(DataSetPDS3):
         """Returns PDS4 path stub for bundle directory structure."""
         raise NotImplementedError
 
+    def pds4_lid_part_to_image_name(self, lid_part: str) -> str:
+        """Returns the image name for the given LID part.
+
+        Parameters:
+            lid_part: The LID part (an on-disk product filename stem).
+
+        Returns:
+            The image name that produced the given LID part.
+        """
+        raise NotImplementedError
+
     def pds4_image_name_to_browse_lid(self, image_name: str) -> str:
         """Returns the browse LID for the given image name.
 

--- a/tests/spindoctor/cli/pds4/conftest.py
+++ b/tests/spindoctor/cli/pds4/conftest.py
@@ -121,6 +121,17 @@ class FakePds4DataSet:
         """
         return f'{self._shard}/{image_file.image_file_url.stem}'
 
+    def pds4_lid_part_to_image_name(self, lid_part: str) -> str:
+        """Return the image name for the given LID part (identity round trip).
+
+        The builders here use the image name verbatim as the LID part, so the
+        inverse is the identity.
+
+        Parameters:
+            lid_part: The LID part (an on-disk product filename stem).
+        """
+        return lid_part
+
     def pds4_image_name_to_data_lid(self, image_name: str) -> str:
         """Return the canonical data LID for the given image name.
 

--- a/tests/spindoctor/cli/pds4/test_collections.py
+++ b/tests/spindoctor/cli/pds4/test_collections.py
@@ -14,10 +14,11 @@ scans ``data/`` for ``*_supplemental.txt`` files and writes
 min/max columns for each configured backplane type formatted to 5 decimal
 places, plus their labels when templates exist.
 
-Known bug pinned here as strict xfail: #139 (the global-index LID is hand-built
-without the ``urn:nasa:pds:`` prefix and without the dataset's image-name
-transformation, so it cannot cross-reference the product LIDVIDs in the
-collection inventories).
+Both generators recover the original image name from each on-disk product stem
+via ``DataSet.pds4_lid_part_to_image_name`` before building LIDs, so the stem
+(which is already in LID-part form) is not fed back through the image-name
+transform.  This is what keeps the inventory LIDVIDs and global-index LIDs
+matching the product labels' DATA_LID (regression coverage for #139 and #256).
 """
 
 from pathlib import Path
@@ -366,12 +367,6 @@ def _cross_reference_env(tmp_path: Path) -> BundleEnv:
     return env
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason='#139: the global-index LID is hand-built as <bundle>:data:<image> without '
-    'the urn:nasa:pds: prefix and without the dataset LID builder, so it does not '
-    'match the product LIDVIDs in collection_data.tab',
-)
 def test_global_index_bodies_lid_matches_collection_inventory(tmp_path: Path) -> None:
     """#139 round trip: the bodies-index LID equals the collection inventory LID."""
     env = _cross_reference_env(tmp_path)
@@ -383,12 +378,6 @@ def test_global_index_bodies_lid_matches_collection_inventory(tmp_path: Path) ->
     assert bodies_rows[1][0] == inventory_lid
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason='#139: the global-index LID is hand-built as <bundle>:data:<image> without '
-    'the urn:nasa:pds: prefix and without the dataset LID builder, so it does not '
-    'match the product LIDVIDs in collection_data.tab',
-)
 def test_global_index_rings_lid_matches_collection_inventory(tmp_path: Path) -> None:
     """#139 round trip: the rings-index LID equals the collection inventory LID."""
     env = _cross_reference_env(tmp_path)
@@ -445,6 +434,27 @@ def test_cassini_browse_lid_uses_browse_collection(tmp_path: Path) -> None:
     assert lid == 'urn:nasa:pds:cassini_iss_saturn_backplanes_rsfrench2027:browse:1454725799n'
 
 
+def test_cassini_lid_part_to_image_name_inverts_rotation(tmp_path: Path) -> None:
+    """The LID-part inverse moves the trailing letter back to an uppercase prefix."""
+    dataset = _cassini_dataset(tmp_path)
+    assert dataset.pds4_lid_part_to_image_name('1454725799n') == 'N1454725799'
+
+
+def test_cassini_lid_part_round_trips_through_data_lid(tmp_path: Path) -> None:
+    """An on-disk LID part recovers the image name whose data LID embeds it."""
+    dataset = _cassini_dataset(tmp_path)
+    image_name = dataset.pds4_lid_part_to_image_name('1454725799n')
+    lid = dataset.pds4_image_name_to_data_lid(image_name)
+    assert lid.endswith(':data:1454725799n')
+
+
+def test_cassini_lid_part_to_image_name_rejects_too_short(tmp_path: Path) -> None:
+    """A LID part shorter than two characters is a programming error."""
+    dataset = _cassini_dataset(tmp_path)
+    with pytest.raises(ValueError, match='invalid Cassini LID part'):
+        dataset.pds4_lid_part_to_image_name('n')
+
+
 def test_cassini_lid_strips_version_suffix_and_extension(tmp_path: Path) -> None:
     """Image-name version suffixes and extensions do not leak into the LID."""
     dataset = _cassini_dataset(tmp_path)
@@ -453,14 +463,6 @@ def test_cassini_lid_strips_version_suffix_and_extension(tmp_path: Path) -> None
     assert suffixed == plain
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason='#256: generate_collection_files feeds the '
-    'on-disk image name (already LID-part form, e.g. 1454725799n) back into '
-    'pds4_image_name_to_data_lidvid, which re-applies the N1454725799 -> 1454725799n '
-    'rotation, yielding 454725799n1 - the inventory LIDVID cannot match the DATA_LID '
-    'rendered inside the product label',
-)
 def test_cassini_inventory_lidvid_matches_label_lid(tmp_path: Path) -> None:
     """The Cassini collection inventory LIDVID matches the label's DATA_LID."""
     dataset = _cassini_dataset(tmp_path)


### PR DESCRIPTION
## Problem

The bundle stores each product under a filename whose stem is the **LID-part** form (`pds4_path_stub` turns Cassini `N1454725799` into `1454725799n`). Both `generate_collection_files` and `generate_global_index_files` scanned those files, took the stem, and fed it back through `pds4_image_name_to_*`, which re-applies the image-name rotate — yielding `454725799n1` (**#256**). The global index additionally hand-built its LID with no `urn:nasa:pds:` prefix and no dataset builder at all (**#139**). Both are the same root cause: passing a LID-part where an image name is expected.

## Fix (invert-then-reuse)

- New `DataSet.pds4_lid_part_to_image_name` hook inverts the `pds4_path_stub` transform. Base + the non-Cassini PDS4 datasets raise `NotImplementedError` (matching every other PDS4 hook); Cassini implements the inverse rotate (`1454725799n` -> `N1454725799`, with a length guard).
- `collections.py` recovers the image name from each on-disk stem before calling the existing canonical builders, at all three sites (data inventory, browse inventory, global index). The global index now routes through `pds4_image_name_to_data_lid`, which supplies the missing prefix. Removed a now-dead local.

## Tests

- Flipped the three strict xfails that pinned #139 (x2) and #256 to passing.
- Added round-trip coverage for the new hook (inverse, data-LID round trip, short-input guard).
- Rewrote the suite docstring's "pinned bug" note as regression coverage.

`ruff check` / `ruff format` / `mypy` clean; `tests/spindoctor/cli/pds4/` and `tests/spindoctor/dataset/` green.

## Out of scope

The two related findings noted at the bottom of #256 remain open: `template.write` swallowing pdstemplate errors, and the dev-guide "Output layout" mismatch.

Closes #139
Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected PDS4 collection and global index links to preserve accurate image names and LID/LIDVID references.
  * Fixed Cassini collection inventory cross-references and global index body/ring entries.

* **Tests**
  * Added regression coverage for LID round trips and image-name conversion.
  * Added validation for invalid image identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->