### PR TITLE
feat: results-file selection filters and uniform random sampling

### DIFF
--- a/docs/api_reference/api_dataset.rst
+++ b/docs/api_reference/api_dataset.rst
@@ -14,6 +14,11 @@ spindoctor.dataset
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: spindoctor.dataset.results_filter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: spindoctor.dataset.dataset_pds4
    :members:
    :undoc-members:

--- a/docs/user_guide/user_guide_navigation.rst
+++ b/docs/user_guide/user_guide_navigation.rst
@@ -160,7 +160,24 @@ For PDS3 datasets (``coiss``, ``coiss_pds3``, ``coiss_cruise``, ``coiss_cruise_p
 * ``--last-volume NAME``: ending PDS3 volume; only that volume and chronologically earlier ones are processed.
 * ``--image-filespec-csv FILE`` (repeatable): CSV file(s) containing PDS3 file specifications; files must include a header column named ``Primary File Spec`` or ``primaryfilespec``.
 * ``--image-file-list FILE`` (repeatable): file(s) containing file specifications or names, one per line; lines beginning with ``#`` are ignored.
-* ``--choose-random-images N``: choose a random subset of N images that meet the other criteria.
+* ``--choose-random-images N``: choose a random subset of N images, uniformly
+  distributed across all images (in every selected volume) that meet the other
+  criteria; the selected images are yielded in random order.
+* ``--has-offset-file`` / ``--has-no-offset-file``: only images whose offset
+  metadata file (``*_metadata.json`` under the navigation results root) already
+  exists / does not exist.
+* ``--has-png-file`` / ``--has-no-png-file``: only images whose summary PNG file
+  (``*_summary.png`` under the navigation results root) already exists / does
+  not exist.
+* ``--has-offset-error``: only images whose offset metadata file exists and
+  records a fatal error (``status`` of ``error``).
+* ``--has-offset-spice-error`` / ``--has-offset-nonspice-error``: like
+  ``--has-offset-error``, but restricted to fatal errors caused by / not caused
+  by missing SPICE data.
+
+The results-file filters answer "file exists" questions by walking the results
+tree once per selected volume, and read metadata contents in batches, so they
+are efficient even when the results root is a cloud location.
 
 Miscellaneous
 ^^^^^^^^^^^^^

--- a/src/spindoctor/cli/sd_backplanes.py
+++ b/src/spindoctor/cli/sd_backplanes.py
@@ -159,6 +159,7 @@ def main() -> None:
     obs_class = inst_name_to_obs_class(inst_name)
 
     if arguments.output_cloud_tasks_file:
+        MAIN_LOGGER.info('Writing cloud_tasks file to %s', arguments.output_cloud_tasks_file)
         tasks_json = []
         for imagefile_idx, imagefiles in enumerate(
             DATASET.yield_image_files_from_arguments(arguments)

--- a/src/spindoctor/cli/sd_mosaic.py
+++ b/src/spindoctor/cli/sd_mosaic.py
@@ -562,6 +562,7 @@ def main() -> None:
     log_run_environment(MAIN_LOGGER, sys.argv[1:])
 
     if args.output_cloud_tasks_file:
+        MAIN_LOGGER.info('Writing cloud_tasks file to %s', args.output_cloud_tasks_file)
         _write_cloud_tasks_file(mode, args)
         MAIN_LOGGER.info('Wrote cloud_tasks file to %s', args.output_cloud_tasks_file)
         if args.profile:

--- a/src/spindoctor/cli/sd_offset.py
+++ b/src/spindoctor/cli/sd_offset.py
@@ -407,6 +407,7 @@ def main() -> None:
         sys.exit(0)
 
     if arguments.output_cloud_tasks_file:
+        MAIN_LOGGER.info('Writing cloud_tasks file to %s', arguments.output_cloud_tasks_file)
         task_arguments = {
             'nav_models': nav_models,
             'nav_techniques': nav_techniques,
@@ -440,6 +441,7 @@ def main() -> None:
         with cloud_tasks_path.open('w') as f:
             json_string = json_as_string(tasks_json)
             f.write(json_string)
+        MAIN_LOGGER.info('Wrote cloud_tasks file to %s', arguments.output_cloud_tasks_file)
         sys.exit(0)
 
     for imagefiles in DATASET.yield_image_files_from_arguments(arguments):

--- a/src/spindoctor/dataset/dataset_pds3.py
+++ b/src/spindoctor/dataset/dataset_pds3.py
@@ -12,10 +12,11 @@ from typing import Any, cast
 from filecache import FCPath, FileCache
 from pdstable import PdsTable
 
-from spindoctor.config import Config
+from spindoctor.config import Config, get_nav_results_root
 from spindoctor.support.misc import flatten_list
 
 from .dataset import DataSet, ImageFile, ImageFiles
+from .results_filter import RESULTS_FILTER_BATCH_SIZE, ResultsFilter
 
 # A PDS3 ^IMAGE pointer naming the data file that holds the image object, e.g.
 #   ^IMAGE = ("N1454725799_1.IMG",4)
@@ -235,11 +236,6 @@ class DataSetPDS3(DataSet):
             type=str,
             help='Specific image name(s) to process',
         )
-        # group.add_argument(
-        #     '--planet', default='saturn',
-        #     type=_validate_planet,
-        #     help=f"""Which planet to process: jupiter, saturn, uranus, neptune
-        #              (saturn is the default)""")
         group.add_argument(
             '--first-image-num',
             type=int,
@@ -292,30 +288,51 @@ class DataSetPDS3(DataSet):
             help="""A file that contains filespecs or names of images to process;
             the list is still subject to other selection criteria.""",
         )
-        # group.add_argument(
-        #     '--has-offset-file', action='store_true', default=False,
-        #     help='Only process images that already have an offset file')
-        # group.add_argument(
-        #     '--has-no-offset-file', action='store_true', default=False,
-        #     help='Only process images that don\'t already have an offset file')
-        # group.add_argument(
-        #     '--has-png-file', action='store_true', default=False,
-        #     help='Only process images that already have a PNG file')
-        # group.add_argument(
-        #     '--has-no-png-file', action='store_true', default=False,
-        #     help='Only process images that don\'t already have a PNGfile')
-        # group.add_argument(
-        #     '--has-offset-error', action='store_true', default=False,
-        #     help="""Only process images if the offset file exists and
-        #             indicates a fatal error""")
-        # group.add_argument(
-        #     '--has-offset-nonspice-error', action='store_true', default=False,
-        #     help="""Only process images if the offset file exists and
-        #             indicates a fatal error other than missing SPICE data""")
-        # group.add_argument(
-        #     '--has-offset-spice-error', action='store_true', default=False,
-        #     help="""Only process images if the offset file exists and
-        #             indicates a fatal error from missing SPICE data""")
+        group.add_argument(
+            '--has-offset-file',
+            action='store_true',
+            default=False,
+            help='Only process images that already have an offset metadata file',
+        )
+        group.add_argument(
+            '--has-no-offset-file',
+            action='store_true',
+            default=False,
+            help="Only process images that don't already have an offset metadata file",
+        )
+        group.add_argument(
+            '--has-png-file',
+            action='store_true',
+            default=False,
+            help='Only process images that already have a summary PNG file',
+        )
+        group.add_argument(
+            '--has-no-png-file',
+            action='store_true',
+            default=False,
+            help="Only process images that don't already have a summary PNG file",
+        )
+        group.add_argument(
+            '--has-offset-error',
+            action='store_true',
+            default=False,
+            help="""Only process images if the offset metadata file exists and
+            indicates a fatal error""",
+        )
+        group.add_argument(
+            '--has-offset-spice-error',
+            action='store_true',
+            default=False,
+            help="""Only process images if the offset metadata file exists and
+            indicates a fatal error from missing SPICE data""",
+        )
+        group.add_argument(
+            '--has-offset-nonspice-error',
+            action='store_true',
+            default=False,
+            help="""Only process images if the offset metadata file exists and
+            indicates a fatal error other than missing SPICE data""",
+        )
         # group.add_argument(
         #     '--selection-expr', type=str, metavar='EXPR',
         #     help='Expression to evaluate to decide whether to reprocess an offset')
@@ -427,14 +444,6 @@ class DataSetPDS3(DataSet):
         if arguments.volumes:
             volumes = [x for y in arguments.volumes for x in y.split(',')]
 
-        # if use_index_files:
-        #     yield_function = yield_image_filenames_index
-        # else:
-        #     yield_function = yield_image_filenames
-
-        # last_image_name = None
-        # last_image_path = None
-
         yield from self.yield_image_files_index(
             img_start_num=first_image_number,
             img_end_num=last_image_number,
@@ -443,45 +452,17 @@ class DataSetPDS3(DataSet):
             volumes=volumes,
             img_name_list=img_name_list,
             img_filespec_list=img_filespec_list,
-            # TODO
-            # force_has_offset_file=arguments.has_offset_file,
-            # force_has_no_offset_file=arguments.has_no_offset_file,
-            # force_has_png_file=arguments.has_png_file,
-            # force_has_no_png_file=arguments.has_no_png_file,
-            # force_has_offset_error=arguments.has_offset_error,
-            # force_has_offset_spice_error=arguments.has_offset_spice_error,
-            # force_has_offset_nonspice_error=arguments.has_offset_nonspice_error,
-            # selection_expr=arguments.selection_expr,
+            has_offset_file=arguments.has_offset_file,
+            has_no_offset_file=arguments.has_no_offset_file,
+            has_png_file=arguments.has_png_file,
+            has_no_png_file=arguments.has_no_png_file,
+            has_offset_error=arguments.has_offset_error,
+            has_offset_spice_error=arguments.has_offset_spice_error,
+            has_offset_nonspice_error=arguments.has_offset_nonspice_error,
+            # TODO selection_expr=arguments.selection_expr,
             choose_random_images=arguments.choose_random_images,
             arguments=arguments,
         )
-        #     # Before returning a matching image, see if we need to combine BOTSIM
-        #     # images. We do this by looking at adjacent pairs of returned images to
-        #     # see if they match.
-        #     _, image_name = os.path.split(image_path)
-        #     image_name = image_name[img_lim_start:img_lim_end]
-        #     if (combine_botsim and
-        #         last_image_name is not None and
-        #         last_image_name[0] == 'N' and
-        #         image_name[0] == 'W' and
-        #         image_name[1:] == last_image_name[1:]):
-        #         yield (last_image_path, image_path)
-        #         last_image_path = None
-        #         last_image_name = None
-        #     else:
-        #         if last_image_path is not None:
-        #             if combine_botsim:
-        #                 yield (last_image_path, None)
-        #             else:
-        #                 yield last_image_path
-        #         last_image_path = image_path
-        #         last_image_name = image_name
-
-        # if last_image_path is not None:
-        #     if combine_botsim:
-        #         yield (last_image_path, None)
-        #     else:
-        #         yield last_image_path
 
     @staticmethod
     def _image_filename_from_label(label_path: Path) -> str | None:
@@ -584,14 +565,18 @@ class DataSetPDS3(DataSet):
             img_filespec_list: Optional[list[str]] = None,
                 Label filespecs; each is resolved to an image base name into local
                 ``img_name_filter_list`` (unresolvable entries skipped).
-            force_has_offset_file: bool = False,
-            force_has_no_offset_file: bool = False,
-            force_has_png_file: bool = False,
-            force_has_no_png_file: bool = False,
-            force_has_offset_error: bool = False,
-            force_has_offset_spice_error: bool = False,
-            force_has_offset_nonspice_error: bool = False,
-            selection_expr: Optional[str] = None,
+            has_offset_file: bool = False,
+            has_no_offset_file: bool = False,
+            has_png_file: bool = False,
+            has_no_png_file: bool = False,
+            has_offset_error: bool = False,
+            has_offset_spice_error: bool = False,
+            has_offset_nonspice_error: bool = False,
+                Results-based filters matching the same-named command-line options;
+                see :class:`spindoctor.dataset.results_filter.ResultsFilter`.
+            nav_results_root: str | Path | FCPath | None = None,
+                Results root for the filters above.  None resolves via the
+                arguments, configuration, or NAV_RESULTS_ROOT environment variable.
             choose_random_images: int | None = False,
             max_filenames: Optional[int] = None,
             suffix: Optional[str] = None,
@@ -610,6 +595,14 @@ class DataSetPDS3(DataSet):
         camera: str | None = kwargs.pop('camera', None)
         img_name_list: list[str] | None = kwargs.pop('img_name_list', None)
         img_name_filter_list: list[str] | None = kwargs.pop('img_filespec_list', None)
+        has_offset_file: bool = kwargs.pop('has_offset_file', False)
+        has_no_offset_file: bool = kwargs.pop('has_no_offset_file', False)
+        has_png_file: bool = kwargs.pop('has_png_file', False)
+        has_no_png_file: bool = kwargs.pop('has_no_png_file', False)
+        has_offset_error: bool = kwargs.pop('has_offset_error', False)
+        has_offset_spice_error: bool = kwargs.pop('has_offset_spice_error', False)
+        has_offset_nonspice_error: bool = kwargs.pop('has_offset_nonspice_error', False)
+        nav_results_root: str | Path | FCPath | None = kwargs.pop('nav_results_root', None)
         choose_random_images: int | None = kwargs.pop('choose_random_images', None)
         max_filenames: int | None = kwargs.pop('max_filenames', None)
         arguments: argparse.Namespace | None = kwargs.pop('arguments', None)
@@ -623,16 +616,18 @@ class DataSetPDS3(DataSet):
         logger.info(f'*** Image number range: {img_start_num} - {img_end_num}')
         logger.info(f'*** Volume range:       {vol_start} - {vol_end}')
         logger.info(f'*** Camera:             {camera}')
-        # logger.info('*** Results root directory:  %s', CB_RESULTS_ROOT)
-        # logger.info('*** Instrument host:         %s', arguments.instrument_host)
-        # if arguments.image_full_path:
-        #     log('*** Images explicitly from full paths:')
-        #     for image_path in arguments.image_full_path:
-        #         log('        %s', image_path)
-        # log('*** Already has offset file: %s', arguments.has_offset_file)
-        # log('*** Has no offset file:      %s', arguments.has_no_offset_file)
-        # log('*** Already has PNG file:    %s', arguments.has_png_file)
-        # log('*** Has no PNG file:         %s', arguments.has_no_png_file)
+        results_filter_flags = {
+            'has_offset_file': has_offset_file,
+            'has_no_offset_file': has_no_offset_file,
+            'has_png_file': has_png_file,
+            'has_no_png_file': has_no_png_file,
+            'has_offset_error': has_offset_error,
+            'has_offset_spice_error': has_offset_spice_error,
+            'has_offset_nonspice_error': has_offset_nonspice_error,
+        }
+        active_filter_flags = [name for name, value in results_filter_flags.items() if value]
+        if active_filter_flags:
+            logger.info(f'*** Results filters:    {", ".join(active_filter_flags)}')
         if img_name_list:
             logger.info('*** Explicit image names:')
             for explicit_img_name in img_name_list:
@@ -684,6 +679,25 @@ class DataSetPDS3(DataSet):
             )
         ]
 
+        # Build the results-based filter, if any of its flags is active. Presence
+        # filters walk the results tree once per selected volume (at construction);
+        # absence and error filters are applied in batches as images are accepted.
+        results_filter: ResultsFilter | None = None
+        if any(results_filter_flags.values()):
+            if nav_results_root is None:
+                nav_results_root = get_nav_results_root(
+                    arguments if arguments is not None else argparse.Namespace(), self.config
+                )
+            if isinstance(nav_results_root, FCPath):
+                results_root = nav_results_root
+            else:
+                # Results are not shared with other processes and may change between
+                # runs, so use a private temporary cache like the writers do.
+                results_root = FileCache(None).new_path(nav_results_root)
+            results_filter = ResultsFilter(
+                valid_volumes, results_root, logger=logger, **results_filter_flags
+            )
+
         # URLs to the volume raw directory and index directory
         volume_raw_dir_url = self.pds3_holdings_root / volumes_dir_name
         index_dir_url = self.pds3_holdings_root / 'metadata'
@@ -731,47 +745,6 @@ class DataSetPDS3(DataSet):
                 999999999999 if img_end_num is None else img_end_num,
                 max([self._extract_img_number(x) for x in img_name_filter_list]),
             )
-
-        # TODO When yielding via an index, we don't get to optimize searching for
-        # offset/png files. We just always look through the index files, and then check
-        # out the offset/png files later. This could definitely be improved.
-
-        # search_volume_path = None
-        # search_suffix = None
-
-        # if (force_has_offset_error or force_has_offset_nonspice_error or
-        #     force_has_offset_spice_error):
-        #     force_has_offset_file = True
-
-        # assert not (force_has_offset_file and force_has_png_file)
-        # if force_has_offset_file:
-        #     # If we need an offset file, then we're actually looking for files in
-        #     # the offsets directories, not the image directories. This is much faster
-        #     # than going through the image directories and checking each one when there
-        #     # aren't a lot of offset files.
-        #     search_volume_path = clean_join(CB_RESULTS_ROOT, 'offsets')
-        #     search_suffix = '-OFFSET.dat'
-        # if force_has_png_file:
-        #     # If we need an offset file, then we're actually looking for files in
-        #     # the png directories, not the image directories. This is much faster
-        #     # than going through the image directories and checking each one when there
-        #     # aren't a lot of png files.
-        #     search_volume_path = clean_join(CB_RESULTS_ROOT, 'png')
-        #     search_suffix = '.png'
-        # # The directory format if searching_offset or searching_png is:
-        # #       <search_volume_path>/<VOLUME>/<RANGE>/<IMGNAME><search_suffix>
-        # # The directory format if NOT searching_offset or searching_png is:
-        # #       <search_volume_path>/<VOLUME>/[data]/<RANGE>/IMGNAME_<SUFFIX>
-
-        # What part of the filename do we look at to get the image number?
-
-        # index_volume_path = clean_join(CB_HOLDINGS_ROOT,
-        #                             instrument_host_config['index_volume_path'][planet])
-        # index_path = instrument_host_config['index_path']
-        # volume_prefix = instrument_host_config['volume_prefix']
-
-        # logger.debug('Index files exist in: %s', index_volume_path)
-        # logger.debug('Data exists in: %s', data_volume_path)
 
         # Limit the number of returned yields from this method if necessary
         limit_yields = choose_random_images if choose_random_images else None
@@ -875,37 +848,53 @@ class DataSetPDS3(DataSet):
             ):
                 return None, False
 
+            # Check the filters answerable from the walked results sets (set
+            # lookups, no round trips)
+            results_path_stub = self._results_path_stub(search_vol, label_filespec)
+            if results_filter is not None and not results_filter.passes_presence(results_path_stub):
+                return None, False
+
             imagefile = ImageFile(
                 image_file_url=img_url,
                 label_file_url=label_url,
                 index_file_row=row,
-                results_path_stub=self._results_path_stub(search_vol, label_filespec),
+                results_path_stub=results_path_stub,
                 image_url_resolver=self._image_url_from_label,
             )
             return imagefile, False
 
         if choose_random_images:
-            # Random sampling: for each volume we visit, read its index ONCE, collect
-            # every row passing all active filters into a pool, then sample without
-            # replacement from that pool. Volumes whose pool is exhausted (or empty) are
-            # never revisited, so the loop is bounded by the set of volumes and cannot
-            # livelock even when filters reject most rows.
-            num_yields = 0
-            remaining_volumes = list(valid_volumes)
-            while remaining_volumes and (limit_yields is None or num_yields < limit_yields):
-                search_vol = remaining_volumes.pop(random.randint(0, len(remaining_volumes) - 1))
+            # Uniform random sampling across every selected volume: collect every row
+            # passing the cheap filters (index-derived criteria plus the walked
+            # results-presence sets) into one pool, shuffle it, then rejection-sample
+            # through the batched absence/error filters until the requested count is
+            # reached. Reading every volume's index is required for cross-volume
+            # uniformity (the indexes are cached locally, so repeat runs are cheap);
+            # the pool holds one ImageFile per qualifying image, so an unconstrained
+            # sample costs memory proportional to the archive's image count.
+            pool: list[ImageFile] = []
+            for search_vol in valid_volumes:
                 rows, index_tab_url = _read_index_rows(search_vol)
-                pool: list[ImageFile] = []
+                all_rows_past_end = bool(rows)
                 for row in rows:
-                    imagefile, _past_end = _row_to_imagefile(row, search_vol, index_tab_url)
+                    imagefile, past_end = _row_to_imagefile(row, search_vol, index_tab_url)
+                    if not past_end:
+                        all_rows_past_end = False
                     if imagefile is not None:
                         pool.append(imagefile)
-                if not pool:
-                    continue
-                needed = len(pool) if limit_yields is None else limit_yields - num_yields
-                for imagefile in random.sample(pool, min(needed, len(pool))):
+                if all_rows_past_end and self._IMG_NUM_MONOTONIC_ACROSS_VOLUMES:
+                    break
+            random.shuffle(pool)
+            num_yields = 0
+            for batch_start in range(0, len(pool), RESULTS_FILTER_BATCH_SIZE):
+                batch = pool[batch_start : batch_start + RESULTS_FILTER_BATCH_SIZE]
+                if results_filter is not None:
+                    batch = results_filter.filter_batch(batch)
+                for imagefile in batch:
                     yield imagefile
                     num_yields += 1
+                    if limit_yields is not None and num_yields >= limit_yields:
+                        return
             return
 
         # Sequential scanning over the requested volumes in order. Index rows are
@@ -918,8 +907,26 @@ class DataSetPDS3(DataSet):
         # every row is past the end of the requested range; otherwise (Voyager,
         # whose FDS counts roll over between encounter volume sets) no
         # image-number-based stop applies and every requested volume is scanned,
-        # though a requested result limit can still end the scan early.
+        # though a requested result limit can still end the scan early. Accepted
+        # images pass through the batched absence/error filters in buffered chunks
+        # (amortizing the per-batch cloud round trips) while preserving enumeration
+        # order; with no batch filtering active the buffer flushes immediately.
         num_yields = 0
+        pending: list[ImageFile] = []
+        pending_flush_size = (
+            RESULTS_FILTER_BATCH_SIZE
+            if results_filter is not None and results_filter.needs_batch_filtering
+            else 1
+        )
+
+        def _flush_pending() -> list[ImageFile]:
+            """Run the pending buffer through the batched results filters."""
+            nonlocal pending
+            batch, pending = pending, []
+            if results_filter is not None:
+                batch = results_filter.filter_batch(batch)
+            return batch
+
         for search_vol in valid_volumes:
             rows, index_tab_url = _read_index_rows(search_vol)
             all_rows_past_end = bool(rows)
@@ -929,11 +936,20 @@ class DataSetPDS3(DataSet):
                     all_rows_past_end = False
                 if imagefile is None:
                     continue
-                yield imagefile
-                num_yields += 1
-                if limit_yields is not None and num_yields >= limit_yields:
-                    return
+                pending.append(imagefile)
+                if len(pending) < pending_flush_size:
+                    continue
+                for filtered in _flush_pending():
+                    yield filtered
+                    num_yields += 1
+                    if limit_yields is not None and num_yields >= limit_yields:
+                        return
             if all_rows_past_end and self._IMG_NUM_MONOTONIC_ACROSS_VOLUMES:
+                break
+        for filtered in _flush_pending():
+            yield filtered
+            num_yields += 1
+            if limit_yields is not None and num_yields >= limit_yields:
                 return
 
     def _check_additional_image_selection_criteria(

--- a/src/spindoctor/dataset/results_filter.py
+++ b/src/spindoctor/dataset/results_filter.py
@@ -1,0 +1,282 @@
+"""Filter image selections against existing navigation result files.
+
+Implements the ``--has-offset-file`` / ``--has-no-offset-file`` /
+``--has-png-file`` / ``--has-no-png-file`` / ``--has-offset-error`` /
+``--has-offset-spice-error`` / ``--has-offset-nonspice-error`` image
+selection options shared by the PDS3 datasets.
+
+The navigation pipeline writes ``{nav_results_root}/{results_path_stub}_metadata.json``
+and ``{results_path_stub}_summary.png`` (see
+:func:`spindoctor.navigate_image_files.navigate_image_files`).  Presence
+filters are answered by walking the results tree once per selected volume and
+collecting the existing result files into sets, so each candidate image costs
+no additional cloud round trip.  Absence filters are answered with batched
+``FCPath.exists()`` calls (or from the walked sets when a walk already
+happened), and the error filters retrieve the metadata JSON files in batches
+and inspect their ``status`` / ``status_error`` fields.
+"""
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, cast
+
+from filecache import FCPath
+from pdslogger import PdsLogger
+
+from .dataset import ImageFile
+
+METADATA_SUFFIX = '_metadata.json'
+"""Suffix of the per-image offset metadata file under the results root."""
+
+SUMMARY_PNG_SUFFIX = '_summary.png'
+"""Suffix of the per-image summary PNG file under the results root."""
+
+RESULTS_FILTER_BATCH_SIZE = 64
+"""Number of images checked per batched ``exists()`` / ``retrieve()`` call."""
+
+_SPICE_STATUS_ERROR = 'missing_spice_data'
+
+
+class ResultsFilter:
+    """Filters candidate images against their navigation result files.
+
+    Constructed once per enumeration when any of the results-based selection
+    flags is active.  Construction validates the flag combination (the flags
+    AND together; directly contradictory pairs raise) and, when a presence or
+    error filter is active, walks the results tree under each selected volume
+    to collect the existing result files.
+
+    The filter is applied in two stages:
+
+    - :meth:`passes_presence` is a cheap per-row set-membership test used
+      while scanning index rows.
+    - :meth:`filter_batch` applies the absence and metadata-content filters
+      to a batch of already-accepted images with one batched ``exists()``
+      and/or ``retrieve()`` call, preserving input order.
+    """
+
+    def __init__(
+        self,
+        volumes: Iterable[str],
+        nav_results_root: FCPath,
+        *,
+        has_offset_file: bool = False,
+        has_no_offset_file: bool = False,
+        has_png_file: bool = False,
+        has_no_png_file: bool = False,
+        has_offset_error: bool = False,
+        has_offset_spice_error: bool = False,
+        has_offset_nonspice_error: bool = False,
+        logger: PdsLogger,
+    ) -> None:
+        """Validates the flag combination and scans the results tree if needed.
+
+        Parameters:
+            volumes: Volume names selected by the other constraints; only these
+                subdirectories of the results root are walked.
+            nav_results_root: Root of the navigation results tree; may be a
+                cloud URL.
+            has_offset_file: Only keep images whose offset metadata file exists.
+            has_no_offset_file: Only keep images whose offset metadata file does
+                not exist.
+            has_png_file: Only keep images whose summary PNG file exists.
+            has_no_png_file: Only keep images whose summary PNG file does not
+                exist.
+            has_offset_error: Only keep images whose offset metadata file
+                indicates a fatal error (``status == 'error'``).
+            has_offset_spice_error: Only keep images whose offset metadata file
+                indicates a fatal error from missing SPICE data.
+            has_offset_nonspice_error: Only keep images whose offset metadata
+                file indicates a fatal error other than missing SPICE data.
+            logger: Logger for scan statistics and unreadable-metadata warnings.
+
+        Raises:
+            ValueError: If the flag combination is contradictory.
+        """
+        if has_offset_file and has_no_offset_file:
+            raise ValueError('has_offset_file and has_no_offset_file are mutually exclusive')
+        if has_png_file and has_no_png_file:
+            raise ValueError('has_png_file and has_no_png_file are mutually exclusive')
+        if has_offset_spice_error and has_offset_nonspice_error:
+            raise ValueError(
+                'has_offset_spice_error and has_offset_nonspice_error are mutually exclusive'
+            )
+        needs_metadata_read = (
+            has_offset_error or has_offset_spice_error or has_offset_nonspice_error
+        )
+        if needs_metadata_read and has_no_offset_file:
+            raise ValueError(
+                'has_no_offset_file contradicts the offset-error filters, which '
+                'require the offset metadata file to exist'
+            )
+
+        self._has_no_offset_file = has_no_offset_file
+        self._has_no_png_file = has_no_png_file
+        self._has_offset_spice_error = has_offset_spice_error
+        self._has_offset_nonspice_error = has_offset_nonspice_error
+        # The error filters read the metadata file, so it must exist; fold them
+        # into the presence filter so the walked set prunes candidates first.
+        self._needs_offset_presence = has_offset_file or needs_metadata_read
+        self._needs_png_presence = has_png_file
+        self._needs_metadata_read = needs_metadata_read
+        self._nav_results_root = nav_results_root
+        self._logger = logger
+        self._offset_rel_paths: set[str] = set()
+        self._png_rel_paths: set[str] = set()
+        self._walked = self._needs_offset_presence or self._needs_png_presence
+        if self._walked:
+            self._scan_volumes(volumes)
+
+    @property
+    def needs_batch_filtering(self) -> bool:
+        """True when :meth:`filter_batch` performs any work.
+
+        The caller uses this to decide whether to buffer accepted images into
+        batches (amortizing the batched ``exists()`` / ``retrieve()`` round
+        trips) or to yield them immediately.  When the results tree was walked,
+        the absence filters are answered from the walked sets in
+        :meth:`passes_presence` instead and cost nothing here.
+        """
+        if self._needs_metadata_read:
+            return True
+        return not self._walked and (self._has_no_offset_file or self._has_no_png_file)
+
+    def _scan_volumes(self, volumes: Iterable[str]) -> None:
+        """Walks the results tree under each volume, collecting result files.
+
+        One directory walk per volume, restricted to the selected volumes so
+        unrelated results are never listed.  Both result-file suffixes are
+        collected in the single walk.  A volume with no results directory is
+        treated as having no result files.
+
+        Parameters:
+            volumes: Volume names to walk under the results root.
+        """
+        root_prefix = self._nav_results_root.as_posix().rstrip('/') + '/'
+        for volume in volumes:
+            volume_dir = self._nav_results_root / volume
+            try:
+                for dir_path, _dir_names, file_names in volume_dir.walk():
+                    dir_posix = dir_path.as_posix()
+                    if not dir_posix.startswith(root_prefix):
+                        continue
+                    rel_dir = dir_posix[len(root_prefix) :]
+                    for file_name in file_names:
+                        rel_path = f'{rel_dir}/{file_name}'
+                        if file_name.endswith(METADATA_SUFFIX):
+                            self._offset_rel_paths.add(rel_path)
+                        elif file_name.endswith(SUMMARY_PNG_SUFFIX):
+                            self._png_rel_paths.add(rel_path)
+            except OSError:
+                continue
+        self._logger.info(
+            f'*** Results scan found {len(self._offset_rel_paths)} offset metadata and '
+            f'{len(self._png_rel_paths)} summary PNG files under {self._nav_results_root}'
+        )
+
+    def passes_presence(self, results_path_stub: str) -> bool:
+        """True if the image passes the filters answerable from the walked sets.
+
+        Covers the presence filters and, when the results tree was walked
+        anyway, the absence filters too (a set lookup instead of a per-file
+        ``exists()`` round trip).
+
+        Parameters:
+            results_path_stub: The image's results path stub (relative to the
+                results root, no suffix).
+
+        Returns:
+            True if every active filter answerable from the walked sets is
+            satisfied.
+        """
+        if not self._walked:
+            return True
+        metadata_rel_path = results_path_stub + METADATA_SUFFIX
+        png_rel_path = results_path_stub + SUMMARY_PNG_SUFFIX
+        if self._needs_offset_presence and metadata_rel_path not in self._offset_rel_paths:
+            return False
+        if self._needs_png_presence and png_rel_path not in self._png_rel_paths:
+            return False
+        if self._has_no_offset_file and metadata_rel_path in self._offset_rel_paths:
+            return False
+        return not (self._has_no_png_file and png_rel_path in self._png_rel_paths)
+
+    def filter_batch(self, image_files: list[ImageFile]) -> list[ImageFile]:
+        """Applies the absence and metadata-content filters to a batch.
+
+        Input order is preserved.  Absence filters (when the results tree was
+        not walked) are answered with one batched ``exists()`` call covering
+        every active absence suffix.  The error filters retrieve all metadata
+        files in one batched call and inspect their ``status`` /
+        ``status_error`` fields.
+
+        Parameters:
+            image_files: Batch of images that already passed the cheap filters.
+
+        Returns:
+            The images that also pass the absence and error filters, in input
+            order.
+        """
+        keep = image_files
+        if not keep or not self.needs_batch_filtering:
+            return keep
+
+        absence_suffixes: list[str] = []
+        if not self._walked:
+            if self._has_no_offset_file:
+                absence_suffixes.append(METADATA_SUFFIX)
+            if self._has_no_png_file:
+                absence_suffixes.append(SUMMARY_PNG_SUFFIX)
+        if absence_suffixes:
+            sub_paths: list[str | Path] = [
+                f.results_path_stub + suffix for f in keep for suffix in absence_suffixes
+            ]
+            found = cast(list[bool], self._nav_results_root.exists(sub_paths))
+            n_suffixes = len(absence_suffixes)
+            keep = [
+                f
+                for i, f in enumerate(keep)
+                if not any(found[i * n_suffixes : (i + 1) * n_suffixes])
+            ]
+
+        if self._needs_metadata_read and keep:
+            metadata_sub_paths: list[str | Path] = [
+                f.results_path_stub + METADATA_SUFFIX for f in keep
+            ]
+            local_paths = cast(
+                list[Path | Exception],
+                self._nav_results_root.retrieve(metadata_sub_paths, exception_on_fail=False),
+            )
+            keep = [
+                f
+                for f, local_path in zip(keep, local_paths, strict=True)
+                if not isinstance(local_path, BaseException)
+                and self._metadata_matches(f, local_path)
+            ]
+
+        return keep
+
+    def _metadata_matches(self, image_file: ImageFile, local_path: Path) -> bool:
+        """True if the image's metadata file satisfies the error filters.
+
+        A metadata file that cannot be read or parsed excludes its image with
+        a logged warning rather than aborting the enumeration.
+
+        Parameters:
+            image_file: The candidate image (for the warning message only).
+            local_path: Local path of the retrieved metadata JSON file.
+        """
+        try:
+            metadata: dict[str, Any] = json.loads(local_path.read_text(encoding='utf-8'))
+        except (OSError, json.JSONDecodeError) as exc:
+            self._logger.warning(
+                f'Excluding {image_file.results_path_stub}: unreadable metadata file: {exc}'
+            )
+            return False
+        if metadata.get('status') != 'error':
+            return False
+        status_error = metadata.get('status_error')
+        if self._has_offset_spice_error and status_error != _SPICE_STATUS_ERROR:
+            return False
+        return not (self._has_offset_nonspice_error and status_error == _SPICE_STATUS_ERROR)

--- a/tests/spindoctor/dataset/test_dataset_pds3.py
+++ b/tests/spindoctor/dataset/test_dataset_pds3.py
@@ -1,3 +1,6 @@
+import argparse
+import json
+import random
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -141,6 +144,285 @@ def test_img_name_list_range_clamp_still_stops_scan(
 
     assert _yielded_names(groups) == ['N1000000101']
     assert volumes_read == ['COISS_2001', 'COISS_2002']
+
+
+# --- Results-based filters (--has-offset-file and friends) ---
+
+
+_FILTER_NUMS = [1000000100, 1000000101, 1000000102]
+
+
+def _install_two_camera_index(ds: DataSetPDS3CassiniISS, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install a COISS_2001 index with three NAC and three WAC frames."""
+    _install_fake_index(
+        ds,
+        monkeypatch,
+        {'COISS_2001': _coiss_filespecs('N', _FILTER_NUMS) + _coiss_filespecs('W', _FILTER_NUMS)},
+    )
+
+
+def _write_result_file(
+    results_root: Path,
+    volume: str,
+    numbers: list[int],
+    camera: str,
+    num: int,
+    suffix: str,
+    content: str = 'x',
+) -> None:
+    """Write one synthetic result file where the pipeline would put it.
+
+    The Cassini results path stub comes from the label filespec, so the
+    filename carries the ``_CALIB`` label suffix.
+    """
+    range_dir = f'{numbers[0]:010d}_{numbers[-1]:010d}'
+    path = results_root / volume / 'data' / range_dir / f'{camera}{num:010d}_1_CALIB{suffix}'
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def test_has_offset_file_keeps_only_navigated_in_order(
+    ds: DataSetPDS3CassiniISS, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Only the frames with an existing metadata file are yielded, in normal
+    # enumeration order (NAC rows before WAC rows within the volume). A summary
+    # PNG alone must not satisfy the offset-file filter.
+    _install_two_camera_index(ds, monkeypatch)
+    _write_result_file(tmp_path, 'COISS_2001', _FILTER_NUMS, 'N', 1000000101, '_metadata.json')
+    _write_result_file(tmp_path, 'COISS_2001', _FILTER_NUMS, 'W', 1000000100, '_metadata.json')
+    _write_result_file(tmp_path, 'COISS_2001', _FILTER_NUMS, 'N', 1000000100, '_summary.png')
+
+    groups = list(
+        ds.yield_image_files_index(
+            volumes=['COISS_2001'], has_offset_file=True, nav_results_root=str(tmp_path)
+        )
+    )
+
+    assert _yielded_names(groups) == ['N1000000101', 'W1000000100']
+
+
+def test_has_no_offset_file_excludes_navigated(
+    ds: DataSetPDS3CassiniISS, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _install_two_camera_index(ds, monkeypatch)
+    _write_result_file(tmp_path, 'COISS_2001', _FILTER_NUMS, 'N', 1000000101, '_metadata.json')
+    _write_result_file(tmp_path, 'COISS_2001', _FILTER_NUMS, 'W', 1000000100, '_metadata.json')
+
+    groups = list(
+        ds.yield_image_files_index(
+            volumes=['COISS_2001'], has_no_offset_file=True, nav_results_root=str(tmp_path)
+        )
+    )
+
+    assert _yielded_names(groups) == [
+        'N1000000100',
+        'N1000000102',
+        'W1000000101',
+        'W1000000102',
+    ]
+
+
+def test_has_png_file_ands_with_has_no_offset_file(
+    ds: DataSetPDS3CassiniISS, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The flags AND together: PNG must exist and the metadata file must not.
+    _install_two_camera_index(ds, monkeypatch)
+    _write_result_file(tmp_path, 'COISS_2001', _FILTER_NUMS, 'N', 1000000100, '_summary.png')
+    _write_result_file(tmp_path, 'COISS_2001', _FILTER_NUMS, 'N', 1000000101, '_summary.png')
+    _write_result_file(tmp_path, 'COISS_2001', _FILTER_NUMS, 'N', 1000000101, '_metadata.json')
+
+    groups = list(
+        ds.yield_image_files_index(
+            volumes=['COISS_2001'],
+            has_png_file=True,
+            has_no_offset_file=True,
+            nav_results_root=str(tmp_path),
+        )
+    )
+
+    assert _yielded_names(groups) == ['N1000000100']
+
+
+def _write_error_metadata(tmp_path: Path) -> None:
+    """Write metadata files: one success, one SPICE error, one non-SPICE error."""
+    contents = {
+        1000000100: {'status': 'success'},
+        1000000101: {'status': 'error', 'status_error': 'missing_spice_data'},
+        1000000102: {'status': 'error', 'status_error': 'image_read_error'},
+    }
+    for num, metadata in contents.items():
+        _write_result_file(
+            tmp_path,
+            'COISS_2001',
+            _FILTER_NUMS,
+            'N',
+            num,
+            '_metadata.json',
+            json.dumps(metadata),
+        )
+
+
+def test_has_offset_error_matches_any_fatal_error(
+    ds: DataSetPDS3CassiniISS, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # WAC frames have no metadata file at all and are excluded by the implied
+    # presence filter; the success metadata is excluded by its status.
+    _install_two_camera_index(ds, monkeypatch)
+    _write_error_metadata(tmp_path)
+
+    groups = list(
+        ds.yield_image_files_index(
+            volumes=['COISS_2001'], has_offset_error=True, nav_results_root=str(tmp_path)
+        )
+    )
+
+    assert _yielded_names(groups) == ['N1000000101', 'N1000000102']
+
+
+def test_has_offset_spice_error_matches_only_spice(
+    ds: DataSetPDS3CassiniISS, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _install_two_camera_index(ds, monkeypatch)
+    _write_error_metadata(tmp_path)
+
+    groups = list(
+        ds.yield_image_files_index(
+            volumes=['COISS_2001'], has_offset_spice_error=True, nav_results_root=str(tmp_path)
+        )
+    )
+
+    assert _yielded_names(groups) == ['N1000000101']
+
+
+def test_has_offset_nonspice_error_matches_only_nonspice(
+    ds: DataSetPDS3CassiniISS, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _install_two_camera_index(ds, monkeypatch)
+    _write_error_metadata(tmp_path)
+
+    groups = list(
+        ds.yield_image_files_index(
+            volumes=['COISS_2001'],
+            has_offset_nonspice_error=True,
+            nav_results_root=str(tmp_path),
+        )
+    )
+
+    assert _yielded_names(groups) == ['N1000000102']
+
+
+@pytest.mark.parametrize(
+    'flags',
+    [
+        {'has_offset_file': True, 'has_no_offset_file': True},
+        {'has_png_file': True, 'has_no_png_file': True},
+        {'has_offset_spice_error': True, 'has_offset_nonspice_error': True},
+        {'has_offset_error': True, 'has_no_offset_file': True},
+    ],
+)
+def test_contradictory_results_flags_raise(
+    ds: DataSetPDS3CassiniISS,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    flags: dict[str, bool],
+) -> None:
+    _install_two_camera_index(ds, monkeypatch)
+
+    with pytest.raises(ValueError, match=r'mutually exclusive|contradicts'):
+        list(
+            ds.yield_image_files_index(
+                volumes=['COISS_2001'], nav_results_root=str(tmp_path), **flags
+            )
+        )
+
+
+# --- Uniform random sampling (--choose-random-images) ---
+
+
+def test_choose_random_images_pool_spans_all_volumes(
+    ds: DataSetPDS3CassiniISS, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The pool is built from every selected volume before sampling. With
+    # shuffle replaced by reverse, the yields are deterministic and cross the
+    # volume boundary, in shuffled (not enumeration) order.
+    nums1 = [1000000100, 1000000101, 1000000102]
+    nums2 = [1000000200, 1000000201, 1000000202]
+    volumes_read = _install_fake_index(
+        ds,
+        monkeypatch,
+        {
+            'COISS_2001': _coiss_filespecs('N', nums1),
+            'COISS_2002': _coiss_filespecs('N', nums2),
+        },
+    )
+    monkeypatch.setattr(random, 'shuffle', lambda pool: pool.reverse())
+
+    groups = list(
+        ds.yield_image_files_index(volumes=['COISS_2001', 'COISS_2002'], choose_random_images=4)
+    )
+
+    assert _yielded_names(groups) == [
+        'N1000000202',
+        'N1000000201',
+        'N1000000200',
+        'N1000000102',
+    ]
+    assert volumes_read == ['COISS_2001', 'COISS_2002']
+
+
+def test_choose_random_images_returns_requested_count(
+    ds: DataSetPDS3CassiniISS, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_two_camera_index(ds, monkeypatch)
+
+    groups = list(ds.yield_image_files_index(volumes=['COISS_2001'], choose_random_images=2))
+
+    names = _yielded_names(groups)
+    assert len(names) == 2
+    assert len(set(names)) == 2
+    all_names = {f'{camera}{num}' for camera in 'NW' for num in _FILTER_NUMS}
+    assert set(names) <= all_names
+
+
+def test_choose_random_images_with_offset_filter(
+    ds: DataSetPDS3CassiniISS, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Random sampling combined with a results filter: only navigated images are
+    # candidates, and asking for more than exist returns exactly the candidates.
+    nums1 = [1000000100, 1000000101, 1000000102]
+    nums2 = [1000000200, 1000000201, 1000000202]
+    _install_fake_index(
+        ds,
+        monkeypatch,
+        {
+            'COISS_2001': _coiss_filespecs('N', nums1),
+            'COISS_2002': _coiss_filespecs('N', nums2),
+        },
+    )
+    _write_result_file(tmp_path, 'COISS_2001', nums1, 'N', 1000000101, '_metadata.json')
+    _write_result_file(tmp_path, 'COISS_2002', nums2, 'N', 1000000201, '_metadata.json')
+
+    groups = list(
+        ds.yield_image_files_index(
+            volumes=['COISS_2001', 'COISS_2002'],
+            choose_random_images=10,
+            has_offset_file=True,
+            nav_results_root=str(tmp_path),
+        )
+    )
+
+    assert sorted(_yielded_names(groups)) == ['N1000000101', 'N1000000201']
+
+
+def test_selection_arguments_include_results_filters() -> None:
+    parser = argparse.ArgumentParser()
+    DataSetPDS3CassiniISS.add_selection_arguments(parser)
+
+    arguments = parser.parse_args(['--has-offset-file', '--has-no-png-file'])
+
+    assert arguments.has_offset_file is True
+    assert arguments.has_no_png_file is True
+    assert arguments.has_offset_spice_error is False
 
 
 def test_yielded_imagefile_carries_label_resolver(


### PR DESCRIPTION
## Summary

- Implements the seven previously commented-out results-based image selection options for PDS3 datasets: `--has-offset-file`, `--has-no-offset-file`, `--has-png-file`, `--has-no-png-file`, `--has-offset-error`, `--has-offset-spice-error`, `--has-offset-nonspice-error` (new `spindoctor.dataset.results_filter` module).
- Makes `--choose-random-images N` sample uniformly across **all** selected volumes instead of drawing from one randomly chosen volume at a time; sampled images are yielded in random order.
- Adds start/finish INFO log messages (with the destination path) to the cloud_tasks file dumps in `sd_offset`, `sd_backplanes`, and `sd_mosaic`.

## Design

- **Presence filters** (`--has-offset-file`, `--has-png-file`, and the error flags, which imply the metadata file exists) are answered by walking the results tree once per selected volume with `FCPath.walk()` and collecting existing `*_metadata.json` / `*_summary.png` paths into sets, so per-image checks cost no cloud round trips.
- **Absence filters** use batched `FCPath.exists([...])` calls (64 images per call, threaded inside filecache); when a walk already happened for another flag, absence is answered from the walked sets for free.
- **Error filters** batch-retrieve metadata JSONs (`exception_on_fail=False`) and match `status == 'error'`; the spice/nonspice variants key off `status_error == 'missing_spice_data'`. Unreadable JSONs exclude the image with a logged warning.
- Flags AND together; contradictory combinations (`--has-offset-file` + `--has-no-offset-file`, spice + nonspice, error flags + `--has-no-offset-file`) raise `ValueError`.
- Filtered sequential enumeration preserves normal index order (image numbers with cameras intermixed). Random sampling pools all qualifying rows, shuffles, and rejection-samples through the batched filters until N accepted.
- The results root resolves like `sd_offset`: `--nav-results-root` -> config -> `NAV_RESULTS_ROOT`, with a `nav_results_root` kwarg override on the API path.
- Removes obsolete commented-out code (legacy BOTSIM pairing, force_has search-path strategy, stale `--planet` stub); documents the new options in the user guide and API reference.

Note: unconstrained uniform sampling must read every selected volume's index before yielding (required for cross-volume uniformity); indexes are cached locally by the shared index FileCache so repeat runs are cheap.

## Testing

- 12 new unit tests (fake index + tmp_path results tree) covering each flag, AND combinations, conflict errors, enumeration-order preservation, cross-volume pooling, and random+filter interaction.
- Full unit suite passes (2624 passed); ruff, mypy strict, sphinx-build -W, and pymarkdown all clean.
- Integration tests (real holdings) not run locally; CI should exercise them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNJS38p5zE26jUnGMqCiEb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PDS3 image-selection filters based on navigation-result files, summary images, and offset error status.
  * Improved random image selection for uniform sampling across eligible volumes.
  * Added documentation for new filtering options and random-selection behavior.
  * Added API reference documentation for results filtering.

* **Improvements**
  * Added progress logging when cloud-task files are written.
  * Optimized results-file checks through batching, including cloud-hosted results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->