### PR TITLE
feat: group nav stats by instrument and camera

### DIFF
--- a/docs/dev_guide/dev_guide_extending.rst
+++ b/docs/dev_guide/dev_guide_extending.rst
@@ -45,6 +45,17 @@ skeleton, using the Cassini ISS implementation
    class DataSetPDS3NewInstrument(DataSetPDS3):
        _ALL_VOLUME_NAMES = tuple(f'NEWI_{n:04d}' for n in range(1, 12))
        _INDEX_COLUMNS = ('FILE_SPECIFICATION_NAME',)
+       # Index columns naming the image's epoch and camera, in preference
+       # order.  Both are read for every enumerated image and land on
+       # ImageFile.image_et / ImageFile.camera.  Neither needs SPICE nor
+       # opens the image, so an image whose load fails for want of a kernel
+       # is still placed in time and attributed to its camera.
+       _INDEX_TIME_COLUMNS = ('IMAGE_MID_TIME', 'IMAGE_TIME')
+       _INDEX_CAMERA_COLUMNS = ('INSTRUMENT_ID',)
+       # Raw index value (upper-cased, stripped) -> the camera name the rest
+       # of the system uses, i.e. the same name ObsInst.camera returns.  An
+       # unmapped value is reported as unknown rather than passed through.
+       _INDEX_CAMERA_MAP = {'NEWICAM': 'NEWICAM'}
        _VOLUMES_DIR_NAME = 'volumes'
 
        @staticmethod
@@ -156,6 +167,15 @@ any instrument-specific helpers. Update the instrument registry in
    class ObsNewInstrument(ObsSnapshotInst):
        def __init__(self, obs, *, config=None, **kwargs):
            super().__init__(obs, config=config, **kwargs)
+
+       @property
+       def camera(self) -> str:
+           # The camera that took this observation.  Return the oops
+           # detector when the instrument has more than one camera; a
+           # single-camera instrument returns its one name.  ObsInst
+           # declares this abstract, so a subclass without it cannot be
+           # instantiated.
+           return 'NEWICAM'
 
        @classmethod
        def from_file(

--- a/docs/dev_guide/dev_guide_observations.rst
+++ b/docs/dev_guide/dev_guide_observations.rst
@@ -120,9 +120,19 @@ must implement:
 - :meth:`~spindoctor.obs.obs_inst.ObsInst.star_min_usable_vmag` /
   :meth:`~spindoctor.obs.obs_inst.ObsInst.star_max_usable_vmag` — the per-instrument
   photometric window. Stars outside this window do not contribute predicted detections.
+- :attr:`~spindoctor.obs.obs_inst.ObsInst.camera` — the camera that took the
+  observation. Instruments with more than one camera distinguish them
+  (Cassini ISS and Voyager ISS return ``'NAC'`` or ``'WAC'``, from the
+  ``oops`` detector); single-camera instruments return their one camera's
+  name (``'SSI'``, ``'LORRI'``). Pointing error is a property of the camera
+  rather than the spacecraft — one Cassini WAC pixel is ten NAC pixels — so
+  this is what ``navigate_image_files`` records as ``observation.camera``
+  and what the statistics report groups offset distributions by.
 - :meth:`~spindoctor.obs.obs_inst.ObsInst.get_public_metadata` — returns a JSON-friendly dict
   of per-image metadata fields (mission, instrument, exposure, filter wheel positions,
-  etc.) for the per-image sidecar.
+  etc.) for the per-image sidecar. Read the camera from
+  :attr:`~spindoctor.obs.obs_inst.ObsInst.camera` rather than repeating a
+  literal, so the name has one source.
 
 The :attr:`~spindoctor.obs.obs_inst.ObsInst.inst_config` property exposes the per-instrument YAML block
 loaded from ``src/spindoctor/config_files/config_4N0_inst_*.yaml`` so subclass

--- a/docs/user_guide/user_guide_navigation.rst
+++ b/docs/user_guide/user_guide_navigation.rst
@@ -492,6 +492,14 @@ Metadata Files (``*_metadata.json``)
 
 These JSON files contain the navigation results, including:
 
+* ``observation`` — the image's identity: name, path, instrument, and
+  ``camera`` (the camera that took it, e.g. ``NAC``). An image that fails to
+  load has no observation to ask, so the navigator falls back to what the
+  PDS3 index told it when the image was enumerated, recording ``camera``
+  and ``image_et`` there; that needs no SPICE and never opens the image, so
+  a frame whose navigation dies for want of a kernel is still placed in
+  time and attributed to its camera. An image navigated by explicit path
+  rather than enumerated from an index has neither.
 * The calculated pointing offset (dv, du)
 * Uncertainty estimates (sigma_v, sigma_u)
 * Confidence scores

--- a/docs/user_guide/user_guide_statistics.rst
+++ b/docs/user_guide/user_guide_statistics.rst
@@ -75,12 +75,24 @@ its row and children.
      - ``coiss`` / ``vgiss`` / ``gossi`` / ``nhlorri`` / ``sim``, from the
        metadata document's ``observation.instrument`` field (required; a
        document without it is skipped as an ingest error).
+   * - ``camera``
+     - TEXT
+     - The camera that took the image (``NAC`` / ``WAC`` / ``SSI`` /
+       ``LORRI``), from the metadata document's ``observation.camera``
+       field. Offset statistics group by this: pointing error belongs to
+       the camera, not the spacecraft. NULL when the document carries no
+       camera (results navigated before the field existed); it is never
+       inferred from the image name.
    * - ``image_path``
      - TEXT
      - Absolute path of the source image at navigate time.
    * - ``image_et``
      - REAL
-     - Observation midtime, TDB seconds past J2000.
+     - Observation midtime, TDB seconds past J2000. Taken from the
+       navigation provenance, or — for an image that never loaded, which
+       has no provenance — from the ``observation.image_et`` the navigator
+       read out of the PDS3 index. An image whose navigation died for want
+       of a SPICE kernel is therefore still placed in time.
    * - ``image_date``
      - TEXT
      - UTC calendar date ``YYYY-MM-DD`` derived from ``image_et``; drives
@@ -287,33 +299,61 @@ Three options control drill-down output:
 
 - ``--top-n N`` makes each categorical section (failure reasons, failure
   taxonomy, ensemble exclusions, suspect offsets) list up to N example
-  image names per category, caps the suspect-offset and worst-BOTSIM-pair
-  tables at N rows, and lists the N slowest images.
-- ``--filelists`` writes one plain-text file per category (one image name
-  per line, the full list rather than the top N) into the ``filelists/``
-  subdirectory of the output directory, ready to feed back into re-runs
-  and triage scripts.
+  image names per category and instrument, caps the suspect-offset and
+  worst-BOTSIM-pair tables at N rows, and lists the N slowest images.
+- ``--filelists`` writes one plain-text file per category and instrument
+  (one image name per line, the full list rather than the top N) into the
+  ``filelists/`` subdirectory of the output directory, ready to feed back
+  into re-runs and triage scripts.
 - ``--csv`` writes ``images.csv`` next to ``report.md``: one row per image
   with every ``images`` column plus per-image technique and feature-source
   counts, for pandas or spreadsheet analysis.
 
+The first two write *image names* rather than file names — ``N1454725799``
+rather than ``N1454725799_1_CALIB.IMG`` — because that is the token the
+datasets' ``--image-filelist`` option selects on. The filelists are
+directly consumable by it: one name per line, with a leading ``#`` comment
+naming the category.
+
+Every image count in the report carries its percentage — ``5 (3.2%)``.
+Counts are broken down by instrument: a table of counts gets one column per
+instrument plus a total column, where an instrument column's percentage is
+of that instrument's images and the total column's is of all selected
+images, so each column sums to 100% on its own. Tables of *statistics*
+rather than counts (offsets, run time, per-body shares, cross-technique
+agreement) carry an instrument column instead, a total being meaningless
+for a mean or a standard deviation. Bar charts are stacked, one segment per
+instrument, with a fixed color per instrument across every chart.
+
 The report contains:
 
-- **Success / failure counts** with a breakdown of failure reasons.
+- **Images selected** — per instrument: how many images, the first and last
+  image, and the first and last available date. Image numbers only compare
+  within one instrument, so the bounds are never pooled across instruments.
+  The date bounds are found independently of the image ordering, so a
+  single image with no recorded epoch at either end of the number range
+  cannot hide the instrument's real time span.
+- **Success / failure counts** with a breakdown of failure reasons. The
+  reason table carries each reason's status, so errors (SPICE-related or
+  not) are visible alongside outright navigation failures.
 - **Failure taxonomy by image content** — failed images classified from
   their recorded feature inventory (``stars-only``, ``single-body``,
   ``multi-body``, ``rings-only``, ``body+rings``, ``no-features``), with a
   per-category failure-reason breakdown and a per-body table of how often
   each named body appears in failed versus successful images (a body with
   a high failure share points at a modeling problem for that body).
-- **Technique usage** — runs, non-spurious runs, and mean confidence per
-  technique.
+- **Technique usage** — the images each technique ran on, plus a per-
+  technique, per-instrument detail table of non-spurious runs and mean
+  confidence.
 - **Model and source usage** — which bodies, rings, and star catalogs
   appeared, in how many images, and how many of their features survived the
   reliability gate.
 - **Offset statistics** — mean, median, standard deviation, minimum, and
-  maximum of the fused V and U offsets over successful images, with
-  histograms, plus the same statistics grouped by (instrument, image size).
+  maximum of the fused V and U offsets over successful images, grouped by
+  camera, with one histogram per camera, plus the same statistics grouped
+  by (instrument, camera, image size). Distributions are never pooled
+  across cameras: one Cassini WAC pixel is ten NAC pixels, so a pooled
+  distribution would describe neither camera.
 - **Suspect offsets** — successful images whose fused offset reaches at
   least ``--suspect-fraction`` (default 0.9) of the instrument's per-axis
   maximum expected pointing offset (the configured ``extfov_margin_vu``
@@ -334,7 +374,10 @@ The report contains:
   95th-percentile Euclidean distance between their offsets on images where
   both produced non-spurious results.
 - **Confidence calibration** — per confidence tier, the distribution of each
-  image's maximum cross-technique disagreement. Without ground truth,
+  image's maximum cross-technique disagreement. The tiers always read
+  ``high`` / ``medium`` / ``low`` / ``failed`` / ``conflicted``, so a tier
+  with no images reads as an explicit zero rather than a missing row.
+  Without ground truth,
   agreement between independent techniques is the production proxy for
   accuracy (the calibrated anchor is the simulation campaign; see
   :doc:`/dev_guide/dev_guide_techniques_confidence`): a healthy pipeline shows
@@ -342,7 +385,8 @@ The report contains:
   tier.
 - **Ensemble outlier exclusions** — how often the ensemble excluded a
   technique from the consensus, and which techniques.
-- **Run-time statistics** — minimum, maximum, mean, median, standard
+- **Run-time statistics** — per instrument (and pooled, when more than one
+  instrument is selected): minimum, maximum, mean, median, standard
   deviation, and total of the per-image wall-clock run times, a run-time
   histogram, and (with ``--top-n``) the slowest images. The section is
   omitted when no ingested document carries timing data.

--- a/src/spindoctor/cli/sd_offset.py
+++ b/src/spindoctor/cli/sd_offset.py
@@ -325,6 +325,7 @@ def _run_manual_pass(
                     image_path,
                     image_name,
                     instrument=obs_class_to_inst_name(obs_class),
+                    camera=obs.camera,
                     image_shape=(int(obs.data.shape[0]), int(obs.data.shape[1])),
                     timing=build_timing_section(run_start, datetime.now(UTC)),
                 )

--- a/src/spindoctor/cli/stats/classify.py
+++ b/src/spindoctor/cli/stats/classify.py
@@ -2,7 +2,7 @@
 
 import julian
 
-__all__ = ['date_from_image_et']
+__all__ = ['date_from_image_et', 'datetime_from_image_et']
 
 
 def date_from_image_et(image_et: float | None) -> str | None:
@@ -19,3 +19,24 @@ def date_from_image_et(image_et: float | None) -> str | None:
         return None
     iso = str(julian.iso_from_tai(julian.tai_from_tdb(image_et), digits=0))
     return iso[:10]
+
+
+def datetime_from_image_et(image_et: float | None) -> str | None:
+    """UTC calendar date and time (``YYYY-MM-DDTHH:MM:SS``) for a SPICE ET epoch.
+
+    The same instant as :func:`date_from_image_et`, to the second.  The
+    report shows this where a bare date would collapse many images taken
+    the same day into one indistinguishable bound.
+
+    Parameters:
+        image_et: TDB seconds past J2000 (the ``provenance.image_et``
+            metadata field), or None.
+
+    Returns:
+        The UTC timestamp string, or None when ``image_et`` is None.
+    """
+    if image_et is None:
+        return None
+    # digits=None truncates to whole seconds; digits=0 would leave a
+    # trailing '.' with no fractional part behind it.
+    return str(julian.iso_from_tai(julian.tai_from_tdb(image_et), digits=None))

--- a/src/spindoctor/cli/stats/ingest.py
+++ b/src/spindoctor/cli/stats/ingest.py
@@ -106,7 +106,13 @@ def rows_from_metadata(
     classifier = nav.get('image_classifier') or {}
     offset = nav.get('offset_px') or [None, None]
     sigma = nav.get('sigma_px') or [None, None]
+    # A navigated image's epoch comes from its observation (provenance); an
+    # image that never loaded has no provenance, so the navigator records the
+    # epoch it read from the index under ``observation.image_et``.  Either way
+    # every image is placed in time.
     image_et = _finite_or_none(provenance.get('image_et'))
+    if image_et is None:
+        image_et = _finite_or_none(observation.get('image_et'))
     per_technique = nav.get('per_technique') or []
     timing = metadata.get('timing') or {}
     shape_v, shape_u = _image_shape(observation.get('image_shape'))
@@ -114,6 +120,9 @@ def rows_from_metadata(
     image_row: dict[str, Any] = {
         'image_name': image_name,
         'instrument': instrument,
+        # Absent for images that failed to load (no observation was built),
+        # which also have no offset to attribute to a camera.
+        'camera': _str_or_none(observation.get('camera')),
         'image_path': observation.get('image_path'),
         'image_et': image_et,
         'image_date': date_from_image_et(image_et),

--- a/src/spindoctor/cli/stats/report.py
+++ b/src/spindoctor/cli/stats/report.py
@@ -10,19 +10,24 @@ from pathlib import Path
 
 from filecache import FCPath
 
+from spindoctor.cli.stats.classify import datetime_from_image_et
 from spindoctor.cli.stats.report_common import (
     ReportContext,
     add_drilldown,
+    add_instrument_count_table,
     connector,
+    count_pct,
     fmt,
+    image_name_from_filename,
     image_number_from_name,
     offset_stats,
     percentile,
     register_image_number_function,
     rows,
+    safe_filename,
     where_clause,
-    write_bar_chart,
     write_offset_hist,
+    write_stacked_bar_chart,
 )
 from spindoctor.cli.stats.report_sections import (
     add_botsim_section,
@@ -37,192 +42,382 @@ from spindoctor.config import MAIN_LOGGER
 
 __all__ = ['build_report', 'main_report']
 
+# Confidence tiers, in descending-confidence order, always reported.
+_CONFIDENCE_TIERS: tuple[str, ...] = ('high', 'medium', 'low', 'failed', 'conflicted')
+
 
 def _pairwise_disagreements(
     ctx: ReportContext,
-) -> tuple[dict[tuple[str, str], list[float]], dict[str, list[float]]]:
+) -> tuple[dict[tuple[str, str, str], list[float]], dict[tuple[str, str], list[float]]]:
     """Cross-technique agreement data.
 
     Returns:
-        ``(per_pair, per_image_rank)`` where ``per_pair`` maps a sorted
-        technique-name pair to the Euclidean distances between their offsets
-        on images where both produced non-spurious results, and
-        ``per_image_rank`` maps each image's ``confidence_rank`` to that
-        image's maximum pairwise disagreement.  Images with a NULL
-        ``confidence_rank`` contribute to ``per_pair`` but not to
+        ``(per_pair, per_image_rank)`` where ``per_pair`` maps an
+        ``(instrument, technique_a, technique_b)`` triple (the technique
+        names sorted) to the Euclidean distances between those techniques'
+        offsets on images where both produced non-spurious results, and
+        ``per_image_rank`` maps an ``(instrument, confidence_rank)`` pair
+        to each such image's maximum pairwise disagreement.  Images with a
+        NULL ``confidence_rank`` contribute to ``per_pair`` but not to
         ``per_image_rank``.
     """
     sql = (
-        'SELECT t.image_name, i.confidence_rank, t.technique_name, t.offset_dv, t.offset_du '
+        'SELECT t.image_name, i.instrument, i.confidence_rank, t.technique_name, '
+        't.offset_dv, t.offset_du '
         'FROM techniques t JOIN images i ON i.image_name = t.image_name'
         + ctx.where_i
         + connector(ctx.where_i)
         + 't.spurious = 0 AND t.offset_dv IS NOT NULL AND t.offset_du IS NOT NULL '
         'ORDER BY t.image_name, t.technique_name'
     )
-    per_pair: dict[tuple[str, str], list[float]] = {}
-    per_image_rank: dict[str, list[float]] = {}
+    per_pair: dict[tuple[str, str, str], list[float]] = {}
+    per_image_rank: dict[tuple[str, str], list[float]] = {}
     for _image_name, group in itertools.groupby(
         rows(ctx.conn, sql, ctx.params_i), key=lambda r: r[0]
     ):
         entries = list(group)
         if len(entries) < 2:
             continue
-        rank = entries[0][1]
+        instrument = str(entries[0][1])
+        rank = entries[0][2]
         image_max = 0.0
         for a, b in itertools.combinations(entries, 2):
-            delta = math.hypot(a[3] - b[3], a[4] - b[4])
-            pair = (min(a[2], b[2]), max(a[2], b[2]))
+            delta = math.hypot(a[4] - b[4], a[5] - b[5])
+            pair = (instrument, min(a[3], b[3]), max(a[3], b[3]))
             per_pair.setdefault(pair, []).append(delta)
             image_max = max(image_max, delta)
         if rank is not None:
-            per_image_rank.setdefault(str(rank), []).append(image_max)
+            per_image_rank.setdefault((instrument, str(rank)), []).append(image_max)
     return per_pair, per_image_rank
+
+
+def _extreme_image_name(ctx: ReportContext, instrument: str, *, last: bool) -> str:
+    """The lowest- or highest-numbered selected image name of one instrument.
+
+    Parameters:
+        ctx: Report context.
+        instrument: Instrument name to restrict to.
+        last: True for the highest-numbered image, False for the lowest.
+
+    Returns:
+        The image name, or ``'-'`` when the instrument has no selected
+        image whose name contains a number.
+    """
+    order = 'DESC' if last else 'ASC'
+    found = rows(
+        ctx.conn,
+        f'SELECT image_name FROM images{ctx.where}'
+        + connector(ctx.where)
+        + 'instrument = ? AND image_number(image_name) IS NOT NULL '
+        f'ORDER BY image_number(image_name) {order}, image_name LIMIT 1',
+        [*ctx.params, instrument],
+    )
+    if len(found) == 0:
+        return '-'
+    return image_name_from_filename(instrument, str(found[0][0]))
+
+
+def _extreme_times(ctx: ReportContext, instrument: str) -> tuple[str, str]:
+    """The earliest and latest epoch among one instrument's selected images.
+
+    Computed over the images that have an epoch, independently of the
+    image-name ordering: a single image with no recorded epoch at one end
+    of the number range would otherwise hide the whole instrument's time
+    span.
+
+    Parameters:
+        ctx: Report context.
+        instrument: Instrument name to restrict to.
+
+    Returns:
+        ``(first, last)`` UTC timestamps to the second, each ``'-'`` when
+        no selected image of that instrument has an epoch.
+    """
+    found = rows(
+        ctx.conn,
+        f'SELECT MIN(image_et), MAX(image_et) FROM images{ctx.where}'
+        + connector(ctx.where)
+        + 'instrument = ? AND image_et IS NOT NULL',
+        [*ctx.params, instrument],
+    )
+    if len(found) == 0:
+        return '-', '-'
+    return (
+        datetime_from_image_et(found[0][0]) or '-',
+        datetime_from_image_et(found[0][1]) or '-',
+    )
+
+
+def _add_selection_section(ctx: ReportContext) -> None:
+    """Append the per-instrument summary of what the filters selected.
+
+    Image numbers are only comparable within one instrument, so the first
+    and last image are reported per instrument and never pooled.  The image
+    and time bounds are found independently, so the first image is not
+    necessarily the one at the first available time.
+    """
+    ctx.lines += ['## Images selected', '']
+    if ctx.total_images == 0:
+        ctx.lines += ['No images match the filters.', '']
+        return
+    ctx.lines += [
+        '| instrument | images | first image | last image | first avail. date | last avail. date |',
+        '|---|---|---|---|---|---|',
+    ]
+    for instrument in ctx.instruments:
+        first_image = _extreme_image_name(ctx, instrument, last=False)
+        last_image = _extreme_image_name(ctx, instrument, last=True)
+        first_time, last_time = _extreme_times(ctx, instrument)
+        images = count_pct(ctx.images_by_instrument[instrument], ctx.total_images)
+        ctx.lines.append(
+            f'| {instrument} | {images} | {first_image} | {last_image} '
+            f'| {first_time} | {last_time} |'
+        )
+    ctx.lines += ['', f'Total images: {ctx.total_images}', '']
 
 
 def _add_status_sections(ctx: ReportContext) -> None:
     """Append the success/failure counts and the failure-reason breakdown."""
     status_rows = rows(
         ctx.conn,
-        f'SELECT status, COUNT(*) FROM images{ctx.where} GROUP BY status ORDER BY status',
+        f'SELECT status, instrument, COUNT(*) FROM images{ctx.where} '
+        'GROUP BY status, instrument ORDER BY status, instrument',
         ctx.params,
     )
-    total = sum(r[1] for r in status_rows)
-    ctx.lines += ['## Success / failure', '', '| status | images | fraction |', '|---|---|---|']
-    for status, count in status_rows:
-        ctx.lines.append(f'| {status} | {count} | {count / total:.3f} |' if total > 0 else '')
-    ctx.lines += ['', f'Total images: {total}', '']
-    write_bar_chart(
+    by_status: dict[str, dict[str, int]] = {}
+    for status, instrument, count in status_rows:
+        by_status.setdefault(str(status), {})[str(instrument)] = int(count)
+    statuses = sorted(by_status, key=lambda name: (name != 'success', name))
+    ctx.lines += ['## Success / failure', '']
+    add_instrument_count_table(
+        ctx, [([status], by_status[status]) for status in statuses], headers=['status']
+    )
+    write_stacked_bar_chart(
         ctx.output_dir / 'status_counts.png',
-        [str(r[0]) for r in status_rows],
-        [int(r[1]) for r in status_rows],
+        statuses,
+        {
+            instrument: [by_status[status].get(instrument, 0) for status in statuses]
+            for instrument in ctx.instruments
+        },
+        ctx.instruments,
         title='Navigation status',
         xlabel='images',
     )
     ctx.lines += ['![status](status_counts.png)', '']
 
+    # Every non-success status is a failure for reporting purposes, so
+    # `error` rows (SPICE and otherwise) appear here alongside `failed`.
     reason_rows = rows(
         ctx.conn,
-        f'SELECT status_reason, COUNT(*) FROM images{ctx.where}'
+        f'SELECT status, status_reason, instrument, COUNT(*) FROM images{ctx.where}'
         + connector(ctx.where)
-        + "status != 'success' GROUP BY status_reason ORDER BY COUNT(*) DESC, status_reason",
+        + "status != 'success' GROUP BY status, status_reason, instrument "
+        'ORDER BY status, status_reason, instrument',
         ctx.params,
     )
-    if len(reason_rows) > 0:
-        ctx.lines += ['### Failure reasons', '', '| reason | images |', '|---|---|']
-        ctx.lines += [f'| {reason or "(none)"} | {count} |' for reason, count in reason_rows]
-        ctx.lines.append('')
-        name_rows = rows(
-            ctx.conn,
-            f'SELECT status_reason, image_name FROM images{ctx.where}'
-            + connector(ctx.where)
-            + "status != 'success' ORDER BY image_name",
-            ctx.params,
+    if len(reason_rows) == 0:
+        return
+    by_reason: dict[tuple[str, str], dict[str, int]] = {}
+    for status, reason, instrument, count in reason_rows:
+        by_reason.setdefault((str(status), str(reason or '(none)')), {})[str(instrument)] = int(
+            count
         )
-        names_by_reason: dict[str, list[str]] = {}
-        for reason, image_name in name_rows:
-            names_by_reason.setdefault(str(reason or '(none)'), []).append(str(image_name))
-        add_drilldown(
-            ctx,
-            [
-                (str(reason or '(none)'), names_by_reason.get(str(reason or '(none)'), []))
-                for reason, _count in reason_rows
-            ],
-            label='reason',
-            stub_prefix='failure_reason',
+    ordered = sorted(by_reason, key=lambda key: (-sum(by_reason[key].values()), key))
+    ctx.lines += ['### Failure reasons', '']
+    add_instrument_count_table(
+        ctx,
+        [([status, reason], by_reason[(status, reason)]) for status, reason in ordered],
+        headers=['status', 'reason'],
+    )
+    name_rows = rows(
+        ctx.conn,
+        f'SELECT status_reason, instrument, image_name FROM images{ctx.where}'
+        + connector(ctx.where)
+        + "status != 'success' ORDER BY image_name",
+        ctx.params,
+    )
+    names_by_reason: dict[str, list[tuple[str, str]]] = {}
+    for reason, instrument, image_name in name_rows:
+        names_by_reason.setdefault(str(reason or '(none)'), []).append(
+            (str(instrument), str(image_name))
         )
-        write_bar_chart(
-            ctx.output_dir / 'failure_reasons.png',
-            [str(r[0] or '(none)') for r in reason_rows],
-            [int(r[1]) for r in reason_rows],
-            title='Failure reasons',
-            xlabel='images',
-        )
-        ctx.lines += ['![failure reasons](failure_reasons.png)', '']
+    add_drilldown(
+        ctx,
+        [
+            (reason, names_by_reason.get(reason, []))
+            for reason in dict.fromkeys(r for _s, r in ordered)
+        ],
+        label='reason',
+        stub_prefix='failure_reason',
+    )
+    labels = [f'{status}/{reason}' for status, reason in ordered]
+    write_stacked_bar_chart(
+        ctx.output_dir / 'failure_reasons.png',
+        labels,
+        {
+            instrument: [by_reason[key].get(instrument, 0) for key in ordered]
+            for instrument in ctx.instruments
+        },
+        ctx.instruments,
+        title='Failure reasons',
+        xlabel='images',
+    )
+    ctx.lines += ['![failure reasons](failure_reasons.png)', '']
 
 
 def _add_technique_usage_section(ctx: ReportContext) -> None:
-    """Append per-technique run counts and mean confidence."""
+    """Append per-technique image counts, spurious shares, and mean confidence."""
     tech_rows = rows(
         ctx.conn,
-        'SELECT t.technique_name, COUNT(*), SUM(1 - t.spurious), AVG(t.confidence) '
+        'SELECT t.technique_name, i.instrument, COUNT(DISTINCT t.image_name), '
+        'SUM(1 - t.spurious), AVG(t.confidence) '
         'FROM techniques t JOIN images i ON i.image_name = t.image_name'
         + ctx.where_i
-        + ' GROUP BY t.technique_name ORDER BY COUNT(*) DESC, t.technique_name',
+        + ' GROUP BY t.technique_name, i.instrument '
+        'ORDER BY t.technique_name, i.instrument',
         ctx.params_i,
     )
+    if len(tech_rows) == 0:
+        return
+    images: dict[str, dict[str, int]] = {}
+    detail: dict[tuple[str, str], tuple[int, int, float | None]] = {}
+    for name, instrument, n_images, n_good, mean_conf in tech_rows:
+        images.setdefault(str(name), {})[str(instrument)] = int(n_images)
+        detail[(str(name), str(instrument))] = (int(n_images), int(n_good), mean_conf)
+    techniques = sorted(images, key=lambda name: (-sum(images[name].values()), name))
+    ctx.lines += ['## Technique usage', '', 'Images on which each technique ran.', '']
+    add_instrument_count_table(
+        ctx, [([name], images[name]) for name in techniques], headers=['technique']
+    )
     ctx.lines += [
-        '## Technique usage',
+        '### Per-technique detail',
         '',
-        '| technique | runs | non-spurious | mean confidence |',
-        '|---|---|---|---|',
+        '| technique | instrument | images | non-spurious | mean confidence |',
+        '|---|---|---|---|---|',
     ]
-    for name, runs, good, mean_conf in tech_rows:
-        ctx.lines.append(f'| {name} | {runs} | {good} | {fmt(mean_conf)} |')
+    for name in techniques:
+        for instrument in ctx.instruments:
+            entry = detail.get((name, instrument))
+            if entry is None:
+                continue
+            n_images, n_good, mean_conf = entry
+            images_cell = count_pct(n_images, ctx.images_by_instrument[instrument])
+            ctx.lines.append(
+                f'| {name} | {instrument} | {images_cell} '
+                f'| {count_pct(n_good, n_images)} | {fmt(mean_conf)} |'
+            )
     ctx.lines.append('')
-    if len(tech_rows) > 0:
-        write_bar_chart(
-            ctx.output_dir / 'technique_usage.png',
-            [str(r[0]) for r in tech_rows],
-            [int(r[1]) for r in tech_rows],
-            title='Technique runs',
-            xlabel='runs',
-        )
-        ctx.lines += ['![technique usage](technique_usage.png)', '']
+    write_stacked_bar_chart(
+        ctx.output_dir / 'technique_usage.png',
+        techniques,
+        {
+            instrument: [images[name].get(instrument, 0) for name in techniques]
+            for instrument in ctx.instruments
+        },
+        ctx.instruments,
+        title='Images per technique',
+        xlabel='images',
+    )
+    ctx.lines += ['![technique usage](technique_usage.png)', '']
 
 
 def _add_source_usage_section(ctx: ReportContext) -> None:
-    """Append the per-model / per-source feature-usage table."""
+    """Append the per-model / per-source feature-usage tables."""
     source_rows = rows(
         ctx.conn,
-        'SELECT s.source_model, s.source_name, COUNT(DISTINCT s.image_name), '
+        'SELECT s.source_model, s.source_name, i.instrument, COUNT(DISTINCT s.image_name), '
         'SUM(s.n_features), SUM(s.n_gated) '
         'FROM feature_sources s JOIN images i ON i.image_name = s.image_name'
         + ctx.where_i
-        + ' GROUP BY s.source_model, s.source_name '
-        'ORDER BY s.source_model, COUNT(DISTINCT s.image_name) DESC, s.source_name',
+        + ' GROUP BY s.source_model, s.source_name, i.instrument '
+        'ORDER BY s.source_model, s.source_name, i.instrument',
         ctx.params_i,
     )
+    if len(source_rows) == 0:
+        return
+    images: dict[tuple[str, str], dict[str, int]] = {}
+    features: dict[tuple[str, str, str], tuple[int, int]] = {}
+    for model, name, instrument, n_images, n_features, n_gated in source_rows:
+        images.setdefault((str(model), str(name)), {})[str(instrument)] = int(n_images)
+        features[(str(model), str(name), str(instrument))] = (int(n_features), int(n_gated))
+    sources = sorted(images, key=lambda key: (key[0], -sum(images[key].values()), key[1]))
+    ctx.lines += ['## Model and source usage', '', 'Images in which each source appears.', '']
+    add_instrument_count_table(
+        ctx,
+        [([model, name], images[(model, name)]) for model, name in sources],
+        headers=['model', 'source'],
+    )
     ctx.lines += [
-        '## Model and source usage',
+        '### Per-source feature counts',
         '',
-        '| model | source | images | features | gated |',
+        '| model | source | instrument | features | gated |',
         '|---|---|---|---|---|',
     ]
-    for model, name, n_images, n_features, n_gated in source_rows:
-        ctx.lines.append(f'| {model} | {name} | {n_images} | {n_features} | {n_gated} |')
+    for model, name in sources:
+        for instrument in ctx.instruments:
+            entry = features.get((model, name, instrument))
+            if entry is None:
+                continue
+            ctx.lines.append(f'| {model} | {name} | {instrument} | {entry[0]} | {entry[1]} |')
     ctx.lines.append('')
 
 
 def _add_offset_section(ctx: ReportContext) -> None:
-    """Append the fused-offset statistics table and histogram."""
+    """Append the fused-offset statistics and a histogram per camera.
+
+    Pointing error is a property of the camera, not of the spacecraft, so
+    the distributions are grouped by ``(instrument, camera)`` and never
+    pooled (a Cassini NAC pixel is a tenth of a WAC pixel, so pooling the
+    two would describe neither).
+    """
     offset_rows = rows(
         ctx.conn,
-        f'SELECT offset_dv, offset_du FROM images{ctx.where}'
+        f'SELECT instrument, camera, offset_dv, offset_du FROM images{ctx.where}'
         + connector(ctx.where)
-        + "status = 'success' AND offset_dv IS NOT NULL",
+        + "status = 'success' AND offset_dv IS NOT NULL AND offset_du IS NOT NULL "
+        'ORDER BY instrument, camera',
         ctx.params,
     )
-    dv = [float(r[0]) for r in offset_rows]
-    du = [float(r[1]) for r in offset_rows]
+    by_camera: dict[tuple[str, str], tuple[list[float], list[float]]] = {}
+    for instrument, camera, dv, du in offset_rows:
+        entry = by_camera.setdefault((str(instrument), str(camera or '(unknown)')), ([], []))
+        entry[0].append(float(dv))
+        entry[1].append(float(du))
     ctx.lines += [
         '## Offset statistics (successful images)',
         '',
-        '| axis | n | mean | median | stdev | min | max |',
-        '|---|---|---|---|---|---|---|',
+        'Grouped by camera: pointing errors of different cameras are unrelated',
+        'and are never pooled.  Percentages are of the instrument total.',
+        '',
+        '| instrument | camera | axis | images | mean | median | stdev | min | max |',
+        '|---|---|---|---|---|---|---|---|---|',
     ]
-    for axis, values in (('dV', dv), ('dU', du)):
-        stats = offset_stats(values)
-        if stats is None:
-            ctx.lines.append(f'| {axis} | 0 | - | - | - | - | - |')
-        else:
-            ctx.lines.append(
-                f'| {axis} | {len(values)} | {fmt(stats["mean"])} | {fmt(stats["median"])} '
-                f'| {fmt(stats["stdev"])} | {fmt(stats["min"])} | {fmt(stats["max"])} |'
-            )
+    for instrument, camera in sorted(by_camera):
+        dv_values, du_values = by_camera[(instrument, camera)]
+        for axis, values in (('dV', dv_values), ('dU', du_values)):
+            stats = offset_stats(values)
+            images = count_pct(len(values), ctx.images_by_instrument[instrument])
+            if stats is None:
+                ctx.lines.append(
+                    f'| {instrument} | {camera} | {axis} | {images} | - | - | - | - | - |'
+                )
+            else:
+                ctx.lines.append(
+                    f'| {instrument} | {camera} | {axis} | {images} | {fmt(stats["mean"])} '
+                    f'| {fmt(stats["median"])} | {fmt(stats["stdev"])} '
+                    f'| {fmt(stats["min"])} | {fmt(stats["max"])} |'
+                )
     ctx.lines.append('')
-    write_offset_hist(ctx.output_dir / 'offsets_hist.png', dv, du)
-    ctx.lines += ['![offsets](offsets_hist.png)', '']
+    for instrument, camera in sorted(by_camera):
+        dv_values, du_values = by_camera[(instrument, camera)]
+        chart = f'offsets_hist_{safe_filename(f"{instrument}_{camera}")}.png'
+        write_offset_hist(
+            ctx.output_dir / chart,
+            dv_values,
+            du_values,
+            title=f'Fused offset distribution, {instrument} {camera} (successful images)',
+        )
+        ctx.lines += [f'![offsets {instrument} {camera}]({chart})', '']
 
 
 def _add_agreement_sections(ctx: ReportContext) -> None:
@@ -234,24 +429,33 @@ def _add_agreement_sections(ctx: ReportContext) -> None:
         'Euclidean distance between per-technique offsets on images where both',
         'techniques produced non-spurious results.',
         '',
-        '| technique pair | images | median (px) | p95 (px) |',
-        '|---|---|---|---|',
+        '| instrument | technique pair | images | median (px) | p95 (px) |',
+        '|---|---|---|---|---|',
     ]
-    for pair in sorted(per_pair):
-        deltas = per_pair[pair]
+    for instrument, technique_a, technique_b in sorted(per_pair):
+        deltas = per_pair[(instrument, technique_a, technique_b)]
         ctx.lines.append(
-            f'| {pair[0]} vs {pair[1]} | {len(deltas)} | '
+            f'| {instrument} | {technique_a} vs {technique_b} '
+            f'| {count_pct(len(deltas), ctx.images_by_instrument[instrument])} | '
             f'{fmt(statistics.median(deltas))} | {fmt(percentile(deltas, 0.95))} |'
         )
     ctx.lines.append('')
 
     rank_rows = rows(
         ctx.conn,
-        f'SELECT confidence_rank, COUNT(*) FROM images{ctx.where}'
+        f'SELECT confidence_rank, instrument, COUNT(*) FROM images{ctx.where}'
         + connector(ctx.where)
-        + 'confidence_rank IS NOT NULL GROUP BY confidence_rank ORDER BY confidence_rank',
+        + 'confidence_rank IS NOT NULL GROUP BY confidence_rank, instrument '
+        'ORDER BY confidence_rank, instrument',
         ctx.params,
     )
+    by_tier: dict[str, dict[str, int]] = {tier: {} for tier in _CONFIDENCE_TIERS}
+    for rank, instrument, count in rank_rows:
+        by_tier.setdefault(str(rank), {})[str(instrument)] = int(count)
+    # The standard tiers always appear, in tier order, so an empty tier reads
+    # as a real zero rather than a missing row.  Any unrecognized rank from
+    # the database is listed after them rather than dropped.
+    tiers = [*_CONFIDENCE_TIERS, *sorted(set(by_tier) - set(_CONFIDENCE_TIERS))]
     ctx.lines += [
         '## Confidence calibration (agreement as accuracy proxy)',
         '',
@@ -260,23 +464,34 @@ def _add_agreement_sections(ctx: ReportContext) -> None:
         'agreement is the standing production check that confidence tiers are',
         'meaningful (the calibrated anchor is the simulated-scene campaign).',
         '',
-        '| tier | images | with >=2 techniques | median max-disagreement (px) | p95 (px) |',
-        '|---|---|---|---|---|',
     ]
-    for rank, count in rank_rows:
-        disagreements = per_image_rank.get(str(rank), [])
-        ctx.lines.append(
-            f'| {rank} | {count} | {len(disagreements)} | '
-            f'{fmt(statistics.median(disagreements)) if disagreements else "-"} | '
-            f'{fmt(percentile(disagreements, 0.95)) if disagreements else "-"} |'
-        )
+    add_instrument_count_table(ctx, [([tier], by_tier[tier]) for tier in tiers], headers=['tier'])
+    ctx.lines += [
+        '| tier | instrument | images | with >=2 techniques | median max-disagreement (px) '
+        '| p95 (px) |',
+        '|---|---|---|---|---|---|',
+    ]
+    for tier in tiers:
+        for instrument in ctx.instruments:
+            count = by_tier[tier].get(instrument, 0)
+            disagreements = per_image_rank.get((instrument, tier), [])
+            ctx.lines.append(
+                f'| {tier} | {instrument} '
+                f'| {count_pct(count, ctx.images_by_instrument[instrument])} '
+                f'| {count_pct(len(disagreements), count)} | '
+                f'{fmt(statistics.median(disagreements)) if disagreements else "-"} | '
+                f'{fmt(percentile(disagreements, 0.95)) if disagreements else "-"} |'
+            )
     ctx.lines.append('')
     if len(per_image_rank) > 0:
-        ordered_ranks = sorted(per_image_rank)
-        write_bar_chart(
+        write_stacked_bar_chart(
             ctx.output_dir / 'agreement_by_tier.png',
-            ordered_ranks,
-            [len(per_image_rank[r]) for r in ordered_ranks],
+            tiers,
+            {
+                instrument: [len(per_image_rank.get((instrument, tier), [])) for tier in tiers]
+                for instrument in ctx.instruments
+            },
+            ctx.instruments,
             title='Images with cross-technique agreement data, by tier',
             xlabel='images',
         )
@@ -287,39 +502,40 @@ def _add_exclusions_section(ctx: ReportContext) -> None:
     """Append the ensemble outlier-exclusion breakdown."""
     excluded_rows = rows(
         ctx.conn,
-        f'SELECT excluded_from_consensus, COUNT(*) FROM images{ctx.where}'
+        f'SELECT excluded_from_consensus, instrument, COUNT(*) FROM images{ctx.where}'
         + connector(ctx.where)
         + "excluded_from_consensus != '[]' "
-        'GROUP BY excluded_from_consensus ORDER BY COUNT(*) DESC, excluded_from_consensus',
+        'GROUP BY excluded_from_consensus, instrument '
+        'ORDER BY excluded_from_consensus, instrument',
         ctx.params,
     )
     if len(excluded_rows) == 0:
         return
-    ctx.lines += [
-        '## Ensemble outlier exclusions',
-        '',
-        '| excluded techniques | images |',
-        '|---|---|',
-    ]
-    for raw, count in excluded_rows:
-        names = ', '.join(json.loads(raw)) or '(none)'
-        ctx.lines.append(f'| {names} | {count} |')
-    ctx.lines.append('')
+    by_exclusion: dict[str, dict[str, int]] = {}
+    for raw, instrument, count in excluded_rows:
+        label = ', '.join(json.loads(raw)) or '(none)'
+        by_exclusion.setdefault(label, {})[str(instrument)] = int(count)
+    ordered = sorted(by_exclusion, key=lambda key: (-sum(by_exclusion[key].values()), key))
+    ctx.lines += ['## Ensemble outlier exclusions', '']
+    add_instrument_count_table(
+        ctx,
+        [([label], by_exclusion[label]) for label in ordered],
+        headers=['excluded techniques'],
+    )
     name_rows = rows(
         ctx.conn,
-        f'SELECT excluded_from_consensus, image_name FROM images{ctx.where}'
+        f'SELECT excluded_from_consensus, instrument, image_name FROM images{ctx.where}'
         + connector(ctx.where)
         + "excluded_from_consensus != '[]' ORDER BY image_name",
         ctx.params,
     )
-    names_by_exclusion: dict[str, list[str]] = {}
-    for raw, image_name in name_rows:
+    names_by_exclusion: dict[str, list[tuple[str, str]]] = {}
+    for raw, instrument, image_name in name_rows:
         label = ', '.join(json.loads(raw)) or '(none)'
-        names_by_exclusion.setdefault(label, []).append(str(image_name))
-    ordered_labels = [', '.join(json.loads(raw)) or '(none)' for raw, _count in excluded_rows]
+        names_by_exclusion.setdefault(label, []).append((str(instrument), str(image_name)))
     add_drilldown(
         ctx,
-        [(label, names_by_exclusion.get(label, [])) for label in ordered_labels],
+        [(label, names_by_exclusion.get(label, [])) for label in ordered],
         label='exclusion set',
         stub_prefix='excluded',
     )
@@ -385,8 +601,9 @@ def build_report(
             example image names per category, the suspect-offset and
             worst-BOTSIM-pair tables are capped at this many rows, and the
             slowest images are listed.
-        filelists: When True, write one plain-text file per category (one
-            image name per line, full list) under ``filelists/``.
+        filelists: When True, write one plain-text file per category and
+            instrument (one image name per line, full list) under
+            ``filelists/``, in the format ``--image-filelist`` reads.
         suspect_fraction: Fraction of the per-axis maximum expected
             pointing offset at or beyond which a fused offset is flagged
             as suspect.
@@ -442,6 +659,7 @@ def build_report(
     ctx.lines.append(f'Filters: {", ".join(active) if len(active) > 0 else "none (full database)"}')
     ctx.lines.append('')
 
+    _add_selection_section(ctx)
     _add_status_sections(ctx)
     add_failure_taxonomy_section(ctx)
     _add_technique_usage_section(ctx)
@@ -522,8 +740,9 @@ def main_report(cmdline: list[str] | None = None) -> int:
         '--filelists',
         action='store_true',
         default=False,
-        help='Write one plain-text file per category (one image name per '
-        'line, full list) into the filelists/ subdirectory of the output dir',
+        help='Write one plain-text file per category and instrument (one '
+        'image name per line, full list, readable by --image-filelist) into '
+        'the filelists/ subdirectory of the output dir',
     )
     parser.add_argument(
         '--suspect-fraction',

--- a/src/spindoctor/cli/stats/report_common.py
+++ b/src/spindoctor/cli/stats/report_common.py
@@ -4,6 +4,7 @@ import math
 import re
 import sqlite3
 import statistics
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from io import BytesIO
 from typing import Any
@@ -13,18 +14,22 @@ from filecache import FCPath
 __all__ = [
     'ReportContext',
     'add_drilldown',
+    'add_instrument_count_table',
     'connector',
+    'count_pct',
     'fmt',
+    'image_name_from_filename',
     'image_number_from_name',
+    'instrument_color',
     'offset_stats',
     'percentile',
     'register_image_number_function',
     'rows',
     'safe_filename',
     'where_clause',
-    'write_bar_chart',
     'write_offset_hist',
-    'write_value_hist',
+    'write_stacked_bar_chart',
+    'write_stacked_value_hist',
 ]
 
 
@@ -52,6 +57,47 @@ def image_number_from_name(image_name: str | None) -> int | None:
     if match is None:
         return None
     return int(match.group(0))
+
+
+# The database records ``observation.image_name``, which is the source file's
+# basename (``N1454725799_1_CALIB.IMG``).  The dataset layer's notion of an
+# image name is the shorter token its ``--image-filelist`` selection matches
+# against (``N1454725799``), so every name the report prints or writes to a
+# filelist goes through the per-instrument rule below.  An unregistered
+# instrument falls back to the extension-stripped basename.
+_IMAGE_NAME_RULES: dict[str, Callable[[str], str]] = {
+    # [NW]dddddddddd[_d[_CALIB]]
+    'coiss': lambda stem: stem.split('_', 1)[0],
+    # Cddddddd[_GEOMED]
+    'vgiss': lambda stem: stem.split('_', 1)[0],
+    # Cdddddddddd[RS] (no suffix to strip)
+    'gossi': lambda stem: stem,
+    # lor_dddddddddd[_0xddd_sci]
+    'nhlorri': lambda stem: stem[:14],
+}
+
+
+def image_name_from_filename(instrument: str, filename: str) -> str:
+    """The dataset-level image name for a recorded image filename.
+
+    Parameters:
+        instrument: Registered instrument name from the database
+            (``coiss`` / ``vgiss`` / ``gossi`` / ``nhlorri``); an
+            unregistered name only has its extension stripped.
+        filename: The recorded ``images.image_name`` value (a basename,
+            possibly with a directory prefix).
+
+    Returns:
+        The image name in the form ``--image-filelist`` selects on, e.g.
+        ``N1454725799_1_CALIB.IMG`` yields ``N1454725799`` and
+        ``lor_0003103486_0x630_sci.fit`` yields ``lor_0003103486``.
+    """
+    stem = filename.rsplit('/', 1)[-1]
+    dot = stem.rfind('.')
+    if dot > 0:
+        stem = stem[:dot]
+    rule = _IMAGE_NAME_RULES.get(instrument.lower())
+    return rule(stem) if rule is not None else stem
 
 
 def register_image_number_function(conn: sqlite3.Connection) -> None:
@@ -86,9 +132,13 @@ class ReportContext:
         top_n: When positive, categorical sections list up to this many
             example image names per category.
         filelists: When True, categorical sections write one plain-text
-            file per category under ``filelists/``.
+            file per category and instrument under ``filelists/``.
         suspect_fraction: Fraction of the per-axis search limit at or
             beyond which a fused offset is flagged as suspect.
+        images_by_instrument: Selected image count per instrument, in
+            instrument-name order; filled in from the database.
+        instruments: The selected instrument names, in name order.
+        total_images: Total selected images across all instruments.
     """
 
     conn: sqlite3.Connection
@@ -101,9 +151,28 @@ class ReportContext:
     top_n: int = 0
     filelists: bool = False
     suspect_fraction: float = 0.9
+    images_by_instrument: dict[str, int] = field(default_factory=dict)
+    instruments: list[str] = field(default_factory=list)
+    total_images: int = 0
+
+    def __post_init__(self) -> None:
+        """Load the per-instrument image counts the whole report reports against."""
+        counts = rows(
+            self.conn,
+            f'SELECT instrument, COUNT(*) FROM images{self.where} '
+            'GROUP BY instrument ORDER BY instrument',
+            self.params,
+        )
+        self.images_by_instrument = {str(name): int(count) for name, count in counts}
+        self.instruments = list(self.images_by_instrument)
+        self.total_images = sum(self.images_by_instrument.values())
 
     def write_filelist(self, stub: str, names: list[str]) -> str:
         """Write one image name per line into ``filelists/<stub>.txt``.
+
+        The written file is directly consumable by the datasets'
+        ``--image-filelist`` option: one image name per line, with a
+        leading ``#`` comment line naming the category.
 
         Parameters:
             stub: Category identifier; sanitized into a filesystem-safe
@@ -114,9 +183,8 @@ class ReportContext:
             The path of the written file, relative to ``output_dir``.
         """
         relative = f'filelists/{safe_filename(stub)}.txt'
-        (self.output_dir / relative).write_text(
-            ''.join(f'{name}\n' for name in names), encoding='utf-8'
-        )
+        body = f'# {stub} ({len(names)} image(s))\n' + ''.join(f'{name}\n' for name in names)
+        (self.output_dir / relative).write_text(body, encoding='utf-8')
         return relative
 
 
@@ -212,6 +280,56 @@ def fmt(value: float | None, digits: int = 3) -> str:
     return f'{value:.{digits}f}'
 
 
+def count_pct(count: int, total: int) -> str:
+    """Format an image count as ``'5 (3.2%)'``.
+
+    Parameters:
+        count: The number of images.
+        total: The number of images the percentage is taken against; a
+            zero total renders as ``0.0%``.
+
+    Returns:
+        The count followed by its percentage of ``total``.
+    """
+    fraction = count / total if total > 0 else 0.0
+    return f'{count} ({fraction * 100:.1f}%)'
+
+
+def add_instrument_count_table(
+    ctx: ReportContext,
+    table_rows: list[tuple[list[str], dict[str, int]]],
+    *,
+    headers: list[str],
+) -> None:
+    """Append a count table with one column per instrument plus a total.
+
+    Every count cell is rendered by :func:`count_pct`.  An instrument
+    column's percentage is of that instrument's selected images; the total
+    column's percentage is of all selected images.
+
+    Parameters:
+        ctx: Report context.
+        table_rows: ``(leading_cells, counts_by_instrument)`` pairs in the
+            order they should be listed; instruments absent from a row's
+            mapping count zero.
+        headers: Column headings for the leading cells (e.g.
+            ``['status']``); the instrument and total headings are added
+            here.
+    """
+    columns = [*headers, *ctx.instruments, 'total']
+    ctx.lines += [
+        '| ' + ' | '.join(columns) + ' |',
+        '|' + '---|' * len(columns),
+    ]
+    for leading, counts in table_rows:
+        cells = list(leading)
+        for instrument in ctx.instruments:
+            cells.append(count_pct(counts.get(instrument, 0), ctx.images_by_instrument[instrument]))
+        cells.append(count_pct(sum(counts.values()), ctx.total_images))
+        ctx.lines.append('| ' + ' | '.join(cells) + ' |')
+    ctx.lines.append('')
+
+
 def offset_stats(values: list[float]) -> dict[str, float] | None:
     """Mean / median / stdev / min / max summary of a value list.
 
@@ -267,41 +385,88 @@ def safe_filename(stub: str) -> str:
 
 def add_drilldown(
     ctx: ReportContext,
-    categories: list[tuple[str, list[str]]],
+    categories: list[tuple[str, list[tuple[str, str]]]],
     *,
     label: str,
     stub_prefix: str,
 ) -> None:
-    """Append per-category example names and write per-category filelists.
+    """Append per-category example image names and write per-category filelists.
 
-    Honors ``ctx.top_n`` (examples shown inline, alphabetically first N)
-    and ``ctx.filelists`` (full alphabetical lists written to
-    ``filelists/``).  Does nothing when both are off.
+    Both the inline examples and the filelists are grouped by instrument:
+    each category contributes one line (and one file) per instrument that
+    has images in it.  Honors ``ctx.top_n`` (examples shown inline,
+    alphabetically first N) and ``ctx.filelists`` (full alphabetical lists
+    written to ``filelists/``, named ``<stub_prefix>_<category>_<inst>``).
+    Does nothing when both are off.
 
     Parameters:
         ctx: Report context.
-        categories: ``(category_label, image_names)`` pairs in the order
-            they should be listed; names are sorted here.
+        categories: ``(category_label, entries)`` pairs in the order they
+            should be listed, where each entry is an
+            ``(instrument, image_filename)`` pair; filenames are converted
+            to image names by :func:`image_name_from_filename` and sorted
+            here.
         label: Human-readable singular noun for the category kind, used
             in the "Examples (up to N per ...)" line.
-        stub_prefix: Filelist filename prefix; the category label is
-            appended.
+        stub_prefix: Filelist filename prefix; the category label and
+            instrument are appended.
     """
-    categories = [(name, sorted(names)) for name, names in categories if len(names) > 0]
-    if len(categories) == 0:
+    if ctx.top_n <= 0 and not ctx.filelists:
+        return
+    # (category, instrument) -> sorted image names, keeping the caller's
+    # category order and instrument-name order within each category.
+    grouped: list[tuple[str, str, list[str]]] = []
+    for category, entries in categories:
+        by_instrument: dict[str, list[str]] = {}
+        for instrument, filename in entries:
+            by_instrument.setdefault(instrument, []).append(
+                image_name_from_filename(instrument, filename)
+            )
+        for instrument in sorted(by_instrument):
+            grouped.append((category, instrument, sorted(by_instrument[instrument])))
+    if len(grouped) == 0:
         return
     if ctx.top_n > 0:
-        ctx.lines.append(f'Examples (up to {ctx.top_n} per {label}):')
-        ctx.lines.append('')
-        for name, names in categories:
-            ctx.lines.append(f'- {name}: {", ".join(names[: ctx.top_n])}')
+        ctx.lines += [f'Examples (up to {ctx.top_n} per {label} and instrument):', '']
+        for category, instrument, names in grouped:
+            shown = ', '.join(names[: ctx.top_n])
+            ctx.lines.append(f'- {category} / {instrument}: {shown}')
         ctx.lines.append('')
     if ctx.filelists:
         references = [
-            ctx.write_filelist(f'{stub_prefix}_{name}', names) for name, names in categories
+            ctx.write_filelist(f'{stub_prefix}_{category}_{instrument}', names)
+            for category, instrument, names in grouped
         ]
-        ctx.lines.append(f'Full lists: {", ".join(references)}')
-        ctx.lines.append('')
+        ctx.lines += [f'Full lists: {", ".join(references)}', '']
+
+
+# Fixed per-instrument chart colors so a stacked segment means the same
+# instrument in every chart and across runs.
+_INSTRUMENT_COLORS: dict[str, str] = {
+    'coiss': '#4878d0',
+    'vgiss': '#ee854a',
+    'gossi': '#6acc64',
+    'nhlorri': '#d65f5f',
+    'sim': '#956cb4',
+}
+_FALLBACK_COLORS: tuple[str, ...] = ('#8c8c8c', '#797979', '#b3b3b3', '#5c5c5c')
+
+
+def instrument_color(instrument: str, index: int) -> str:
+    """The chart color for an instrument.
+
+    Parameters:
+        instrument: Instrument name.
+        index: The instrument's position in the report's instrument list;
+            picks a fallback color for unregistered instruments.
+
+    Returns:
+        A matplotlib color string.
+    """
+    known = _INSTRUMENT_COLORS.get(instrument.lower())
+    if known is not None:
+        return known
+    return _FALLBACK_COLORS[index % len(_FALLBACK_COLORS)]
 
 
 def import_pyplot() -> Any:
@@ -337,38 +502,98 @@ def _save_figure(fig: Any, plt: Any, path: FCPath) -> None:
     path.write_bytes(buffer.getvalue())
 
 
-def write_bar_chart(
-    path: FCPath, labels: list[str], counts: list[int], *, title: str, xlabel: str
+def write_stacked_bar_chart(
+    path: FCPath,
+    labels: list[str],
+    counts_by_instrument: dict[str, list[int]],
+    instruments: list[str],
+    *,
+    title: str,
+    xlabel: str,
 ) -> None:
-    """Write a horizontal bar chart PNG (deterministic, Agg backend).
+    """Write a horizontal stacked bar chart PNG (deterministic, Agg backend).
+
+    Each bar is one category, segmented by instrument.
 
     Parameters:
         path: Destination PNG path (local or ``filecache`` URL).
-        labels: One bar label per row, top to bottom.
-        counts: Bar lengths matching ``labels``.
+        labels: One bar label per category, top to bottom.
+        counts_by_instrument: Instrument name to one count per category,
+            matching ``labels``; instruments absent here contribute zero.
+        instruments: Instrument names, in stacking order (left to right).
         title: Chart title.
         xlabel: X-axis label.
     """
     plt = import_pyplot()
-    fig, ax = plt.subplots(figsize=(8, max(2.0, 0.4 * len(labels) + 1.0)))
-    positions = range(len(labels))
-    ax.barh(list(positions), counts, color='#4878d0')
-    ax.set_yticks(list(positions))
+    fig, ax = plt.subplots(figsize=(9, max(2.0, 0.4 * len(labels) + 1.5)))
+    positions = list(range(len(labels)))
+    left = [0.0] * len(labels)
+    for index, instrument in enumerate(instruments):
+        counts = counts_by_instrument.get(instrument, [0] * len(labels))
+        ax.barh(
+            positions,
+            counts,
+            left=left,
+            color=instrument_color(instrument, index),
+            label=instrument,
+        )
+        left = [base + value for base, value in zip(left, counts, strict=True)]
+    ax.set_yticks(positions)
     ax.set_yticklabels(labels)
     ax.invert_yaxis()
     ax.set_xlabel(xlabel)
+    ax.set_title(title)
+    if len(instruments) > 0:
+        ax.legend(title='instrument', loc='lower right')
+    fig.tight_layout()
+    _save_figure(fig, plt, path)
+
+
+def write_stacked_value_hist(
+    path: FCPath,
+    values_by_instrument: dict[str, list[float]],
+    instruments: list[str],
+    *,
+    title: str,
+    xlabel: str,
+) -> None:
+    """Write a single-panel stacked histogram PNG, segmented by instrument.
+
+    Parameters:
+        path: Destination PNG path (local or ``filecache`` URL).
+        values_by_instrument: Instrument name to the values to histogram;
+            all instruments share one set of bins.
+        instruments: Instrument names, in stacking order.
+        title: Chart title.
+        xlabel: X-axis label.
+    """
+    plt = import_pyplot()
+    fig, ax = plt.subplots(figsize=(9, 4))
+    series = [values_by_instrument.get(instrument, []) for instrument in instruments]
+    if sum(len(values) for values in series) > 0:
+        ax.hist(
+            series,
+            bins=40,
+            stacked=True,
+            color=[instrument_color(name, index) for index, name in enumerate(instruments)],
+            label=instruments,
+        )
+        ax.legend(title='instrument')
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel('images')
     ax.set_title(title)
     fig.tight_layout()
     _save_figure(fig, plt, path)
 
 
-def write_offset_hist(path: FCPath, dv: list[float], du: list[float]) -> None:
-    """Write the V/U offset histogram PNG.
+def write_offset_hist(path: FCPath, dv: list[float], du: list[float], *, title: str) -> None:
+    """Write a two-panel V/U offset histogram PNG for one instrument.
 
     Parameters:
         path: Destination PNG path (local or ``filecache`` URL).
         dv: Fused V-axis offsets (pixels) of successful images.
         du: Fused U-axis offsets (pixels) of successful images.
+        title: Figure title (the instrument is named by the caller).
     """
     plt = import_pyplot()
     fig, axes = plt.subplots(1, 2, figsize=(10, 4))
@@ -377,26 +602,6 @@ def write_offset_hist(path: FCPath, dv: list[float], du: list[float]) -> None:
             ax.hist(values, bins=40, color='#4878d0')
         ax.set_xlabel(label)
         ax.set_ylabel('images')
-    fig.suptitle('Fused offset distribution (successful images)')
-    fig.tight_layout()
-    _save_figure(fig, plt, path)
-
-
-def write_value_hist(path: FCPath, values: list[float], *, title: str, xlabel: str) -> None:
-    """Write a single-panel histogram PNG for a value list.
-
-    Parameters:
-        path: Destination PNG path (local or ``filecache`` URL).
-        values: Values to histogram; an empty list produces empty axes.
-        title: Chart title.
-        xlabel: X-axis label.
-    """
-    plt = import_pyplot()
-    fig, ax = plt.subplots(figsize=(8, 4))
-    if len(values) > 0:
-        ax.hist(values, bins=40, color='#4878d0')
-    ax.set_xlabel(xlabel)
-    ax.set_ylabel('images')
-    ax.set_title(title)
+    fig.suptitle(title)
     fig.tight_layout()
     _save_figure(fig, plt, path)

--- a/src/spindoctor/cli/stats/report_sections.py
+++ b/src/spindoctor/cli/stats/report_sections.py
@@ -12,11 +12,14 @@ from filecache import FCPath
 from spindoctor.cli.stats.report_common import (
     ReportContext,
     add_drilldown,
+    add_instrument_count_table,
     connector,
+    count_pct,
     fmt,
+    image_name_from_filename,
     percentile,
     rows,
-    write_value_hist,
+    write_stacked_value_hist,
 )
 from spindoctor.cli.stats.schema import IMAGE_COLUMNS
 from spindoctor.config import DEFAULT_CONFIG, Config
@@ -134,15 +137,19 @@ def add_suspect_offset_section(ctx: ReportContext) -> None:
     ]
     suspects: list[tuple[float, str, str, float, float, float, str]] = []
     unresolved: dict[str, int] = {}
+    screened: dict[str, int] = {}
+    suspect_counts: dict[str, int] = {}
     for image_name, instrument, dv, du, shape_v in image_rows:
         limit = resolve_offset_limit(str(instrument), str(image_name), shape_v)
         if isinstance(limit, str):
             reason = f'{instrument}: {limit}'
             unresolved[reason] = unresolved.get(reason, 0) + 1
             continue
+        screened[str(instrument)] = screened.get(str(instrument), 0) + 1
         limit_v, limit_u = limit
         ratio = max(abs(float(dv)) / limit_v, abs(float(du)) / limit_u)
         if ratio >= ctx.suspect_fraction:
+            suspect_counts[str(instrument)] = suspect_counts.get(str(instrument), 0) + 1
             suspects.append(
                 (
                     ratio,
@@ -155,15 +162,20 @@ def add_suspect_offset_section(ctx: ReportContext) -> None:
                 )
             )
     suspects.sort(key=lambda s: (-s[0], s[1]))
-    ctx.lines.append(f'Suspect images: {len(suspects)} of {len(image_rows)} screened.')
-    ctx.lines.append('')
+    n_screened = sum(screened.values())
+    ctx.lines += [
+        f'Suspect images: {count_pct(len(suspects), ctx.total_images)} of {n_screened} screened.',
+        '',
+    ]
+    add_instrument_count_table(ctx, [(['suspect'], suspect_counts)], headers=['category'])
     if len(suspects) > 0:
         shown = suspects[: ctx.top_n] if ctx.top_n > 0 else suspects
         ctx.lines += [
             '| image | instrument | dV | dU | magnitude | limit (v, u) |',
             '|---|---|---|---|---|---|',
         ]
-        for _ratio, name, instrument, dv, du, magnitude, limit_text in shown:
+        for _ratio, filename, instrument, dv, du, magnitude, limit_text in shown:
+            name = image_name_from_filename(instrument, filename)
             ctx.lines.append(
                 f'| {name} | {instrument} | {fmt(dv)} | {fmt(du)} | '
                 f'{fmt(magnitude)} | {limit_text} |'
@@ -171,7 +183,7 @@ def add_suspect_offset_section(ctx: ReportContext) -> None:
         ctx.lines.append('')
         add_drilldown(
             ctx,
-            [('suspect', [s[1] for s in suspects])],
+            [('suspect', [(s[2], s[1]) for s in suspects])],
             label='category',
             stub_prefix='suspect_offsets',
         )
@@ -259,8 +271,10 @@ def add_botsim_section(ctx: ReportContext) -> None:
         for magnitude, clock, nac_name, wac_name, residual_dv, residual_du in residuals[
             : ctx.top_n
         ]:
+            nac_image = image_name_from_filename('coiss', nac_name)
+            wac_image = image_name_from_filename('coiss', wac_name)
             ctx.lines.append(
-                f'| {clock} | {nac_name} | {wac_name} | {fmt(residual_dv)} | '
+                f'| {clock} | {nac_image} | {wac_image} | {fmt(residual_dv)} | '
                 f'{fmt(residual_du)} | {fmt(magnitude)} |'
             )
         ctx.lines.append('')
@@ -316,7 +330,7 @@ def add_failure_taxonomy_section(ctx: ReportContext) -> None:
     """
     failed_rows = rows(
         ctx.conn,
-        f'SELECT image_name, status_reason FROM images{ctx.where}'
+        f'SELECT image_name, instrument, status_reason FROM images{ctx.where}'
         + connector(ctx.where)
         + "status != 'success' ORDER BY image_name",
         ctx.params,
@@ -325,51 +339,61 @@ def add_failure_taxonomy_section(ctx: ReportContext) -> None:
         return
     source_rows = rows(
         ctx.conn,
-        'SELECT i.image_name, i.status, s.source_model, s.source_name '
+        'SELECT i.image_name, i.instrument, i.status, s.source_model, s.source_name '
         'FROM feature_sources s JOIN images i ON i.image_name = s.image_name'
         + ctx.where_i
         + ' ORDER BY i.image_name, s.source_model, s.source_name',
         ctx.params_i,
     )
     sources_by_image: dict[str, list[tuple[str, str]]] = {}
-    for image_name, _status, source_model, source_name in source_rows:
+    for image_name, _instrument, _status, source_model, source_name in source_rows:
         sources_by_image.setdefault(str(image_name), []).append(
             (str(source_model), str(source_name))
         )
 
-    by_category: dict[str, list[str]] = {category: [] for category in _CONTENT_CATEGORIES}
-    reason_counts: dict[tuple[str, str], int] = {}
-    for image_name, status_reason in failed_rows:
+    by_category: dict[str, list[tuple[str, str]]] = {
+        category: [] for category in _CONTENT_CATEGORIES
+    }
+    category_counts: dict[str, dict[str, int]] = {category: {} for category in _CONTENT_CATEGORIES}
+    reason_counts: dict[tuple[str, str], dict[str, int]] = {}
+    for image_name, instrument, status_reason in failed_rows:
         category = _content_category(sources_by_image.get(str(image_name), []))
-        by_category[category].append(str(image_name))
+        by_category[category].append((str(instrument), str(image_name)))
+        counts = category_counts[category]
+        counts[str(instrument)] = counts.get(str(instrument), 0) + 1
         key = (category, str(status_reason or '(none)'))
-        reason_counts[key] = reason_counts.get(key, 0) + 1
+        reason_bucket = reason_counts.setdefault(key, {})
+        reason_bucket[str(instrument)] = reason_bucket.get(str(instrument), 0) + 1
 
+    populated = [c for c in _CONTENT_CATEGORIES if len(by_category[c]) > 0]
     ctx.lines += [
         '## Failure taxonomy by image content',
         '',
         'Failed images classified by what the feature inventory says was in',
         'the scene.',
         '',
-        '| content | failed images |',
-        '|---|---|',
     ]
-    for category in _CONTENT_CATEGORIES:
-        if len(by_category[category]) > 0:
-            ctx.lines.append(f'| {category} | {len(by_category[category])} |')
-    ctx.lines += [
-        '',
-        '| content | reason | images |',
-        '|---|---|---|',
-    ]
-    for category in _CONTENT_CATEGORIES:
-        in_category = sorted(
-            ((reason, count) for (cat, reason), count in reason_counts.items() if cat == category),
-            key=lambda item: (-item[1], item[0]),
-        )
-        for reason, count in in_category:
-            ctx.lines.append(f'| {category} | {reason} | {count} |')
-    ctx.lines.append('')
+    add_instrument_count_table(
+        ctx,
+        [([category], category_counts[category]) for category in populated],
+        headers=['content'],
+    )
+    ordered_reasons = sorted(
+        reason_counts,
+        key=lambda key: (
+            _CONTENT_CATEGORIES.index(key[0]),
+            -sum(reason_counts[key].values()),
+            key[1],
+        ),
+    )
+    add_instrument_count_table(
+        ctx,
+        [
+            ([category, reason], reason_counts[(category, reason)])
+            for category, reason in ordered_reasons
+        ],
+        headers=['content', 'reason'],
+    )
     add_drilldown(
         ctx,
         [(category, by_category[category]) for category in _CONTENT_CATEGORIES],
@@ -378,11 +402,13 @@ def add_failure_taxonomy_section(ctx: ReportContext) -> None:
     )
 
     # Per-body failure shares over all images (successful and failed).
-    body_status: dict[str, dict[str, set[str]]] = {}
-    for image_name, status, source_model, source_name in source_rows:
+    body_status: dict[tuple[str, str], dict[str, set[str]]] = {}
+    for image_name, instrument, status, source_model, source_name in source_rows:
         if _source_kind(str(source_model)) != 'body' or str(source_name) == '(none)':
             continue
-        buckets = body_status.setdefault(str(source_name), {'failed': set(), 'success': set()})
+        buckets = body_status.setdefault(
+            (str(source_name), str(instrument)), {'failed': set(), 'success': set()}
+        )
         bucket = 'success' if str(status) == 'success' else 'failed'
         buckets[bucket].add(str(image_name))
     if len(body_status) > 0:
@@ -400,18 +426,27 @@ def add_failure_taxonomy_section(ctx: ReportContext) -> None:
             'How often each named body appears in failed versus successful',
             'images; a body with a high failure share is a modeling problem.',
             '',
-            '| body | failed images | successful images | failure share |',
-            '|---|---|---|---|',
+            '| body | instrument | failed images | successful images | failure share |',
+            '|---|---|---|---|---|',
         ]
-        for body, buckets in ranked:
+        for (body, instrument), buckets in ranked:
             n_failed = len(buckets['failed'])
             n_success = len(buckets['success'])
             share = n_failed / (n_failed + n_success)
-            ctx.lines.append(f'| {body} | {n_failed} | {n_success} | {share:.3f} |')
+            total = ctx.images_by_instrument[instrument]
+            ctx.lines.append(
+                f'| {body} | {instrument} | {count_pct(n_failed, total)} '
+                f'| {count_pct(n_success, total)} | {share:.3f} |'
+            )
         ctx.lines.append('')
+        by_body: dict[str, list[tuple[str, str]]] = {}
+        for (body, instrument), buckets in ranked:
+            by_body.setdefault(body, []).extend(
+                (instrument, name) for name in sorted(buckets['failed'])
+            )
         add_drilldown(
             ctx,
-            [(body, sorted(buckets['failed'])) for body, buckets in ranked if buckets['failed']],
+            [(body, entries) for body, entries in by_body.items() if len(entries) > 0],
             label='body',
             stub_prefix='failed_body',
         )
@@ -434,23 +469,38 @@ def add_runtime_section(ctx: ReportContext) -> None:
     if len(timing_rows) == 0:
         return
     elapsed = [float(r[2]) for r in timing_rows]
+    by_instrument: dict[str, list[float]] = {}
+    for _image_name, instrument, seconds in timing_rows:
+        by_instrument.setdefault(str(instrument), []).append(float(seconds))
     ctx.lines += [
         '## Run-time statistics',
         '',
-        '| metric | value |',
-        '|---|---|',
-        f'| images with timing | {len(elapsed)} |',
-        f'| total (s) | {fmt(sum(elapsed))} |',
-        f'| min (s) | {fmt(min(elapsed))} |',
-        f'| max (s) | {fmt(max(elapsed))} |',
-        f'| mean (s) | {fmt(statistics.fmean(elapsed))} |',
-        f'| median (s) | {fmt(statistics.median(elapsed))} |',
-        f'| stdev (s) | {fmt(statistics.stdev(elapsed) if len(elapsed) > 1 else 0.0)} |',
-        '',
+        '| instrument | images | total (s) | min (s) | max (s) | mean (s) | median (s) '
+        '| stdev (s) |',
+        '|---|---|---|---|---|---|---|---|',
     ]
-    write_value_hist(
+    series: list[tuple[str, list[float], int]] = [
+        (instrument, by_instrument.get(instrument, []), ctx.images_by_instrument[instrument])
+        for instrument in ctx.instruments
+    ]
+    # The pooled row only says something new once more than one instrument
+    # contributed to it.
+    if len(ctx.instruments) > 1:
+        series.append(('(all)', elapsed, ctx.total_images))
+    for instrument, values, denominator in series:
+        if len(values) == 0:
+            continue
+        stdev = statistics.stdev(values) if len(values) > 1 else 0.0
+        ctx.lines.append(
+            f'| {instrument} | {count_pct(len(values), denominator)} | {fmt(sum(values))} '
+            f'| {fmt(min(values))} | {fmt(max(values))} | {fmt(statistics.fmean(values))} '
+            f'| {fmt(statistics.median(values))} | {fmt(stdev)} |'
+        )
+    ctx.lines.append('')
+    write_stacked_value_hist(
         ctx.output_dir / 'runtime_hist.png',
-        elapsed,
+        by_instrument,
+        ctx.instruments,
         title='Per-image run time',
         xlabel='elapsed (s)',
     )
@@ -464,7 +514,8 @@ def add_runtime_section(ctx: ReportContext) -> None:
             '|---|---|---|',
         ]
         for image_name, instrument, seconds in slowest:
-            ctx.lines.append(f'| {image_name} | {instrument} | {fmt(float(seconds))} |')
+            name = image_name_from_filename(str(instrument), str(image_name))
+            ctx.lines.append(f'| {name} | {instrument} | {fmt(float(seconds))} |')
         ctx.lines.append('')
 
 
@@ -474,38 +525,40 @@ def add_runtime_section(ctx: ReportContext) -> None:
 
 
 def add_offset_by_group_section(ctx: ReportContext) -> None:
-    """Break the fused-offset statistics down by (instrument, image size)."""
+    """Break the fused-offset statistics down by (instrument, camera, image size)."""
     image_rows = rows(
         ctx.conn,
-        f'SELECT instrument, image_shape_v, image_shape_u, offset_dv, offset_du '
+        f'SELECT instrument, camera, image_shape_v, image_shape_u, offset_dv, offset_du '
         f'FROM images{ctx.where}'
         + connector(ctx.where)
         + "status = 'success' AND offset_dv IS NOT NULL AND offset_du IS NOT NULL "
-        'ORDER BY instrument, image_shape_v, image_shape_u',
+        'ORDER BY instrument, camera, image_shape_v, image_shape_u',
         ctx.params,
     )
-    groups: dict[tuple[str, str], list[tuple[float, float]]] = {}
-    for instrument, shape_v, shape_u, dv, du in image_rows:
+    groups: dict[tuple[str, str, str], list[tuple[float, float]]] = {}
+    for instrument, camera, shape_v, shape_u, dv, du in image_rows:
         size = f'{shape_v}x{shape_u}' if shape_v is not None and shape_u is not None else '(none)'
-        groups.setdefault((str(instrument), size), []).append((float(dv), float(du)))
+        key = (str(instrument), str(camera or '(unknown)'), size)
+        groups.setdefault(key, []).append((float(dv), float(du)))
     if len(groups) == 0:
         return
     ctx.lines += [
-        '### By instrument and image size',
+        '### By instrument, camera, and image size',
         '',
-        '| instrument | size (v x u) | n '
+        '| instrument | camera | size (v x u) | images '
         '| dV mean | dV stdev | dV min | dV max '
         '| dU mean | dU stdev | dU min | dU max |',
-        '|---|---|---|---|---|---|---|---|---|---|---|',
+        '|---|---|---|---|---|---|---|---|---|---|---|---|',
     ]
-    for instrument, size in sorted(groups):
-        offsets = groups[(instrument, size)]
+    for instrument, camera, size in sorted(groups):
+        offsets = groups[(instrument, camera, size)]
         dv = [o[0] for o in offsets]
         du = [o[1] for o in offsets]
         stdev_dv = statistics.stdev(dv) if len(dv) > 1 else 0.0
         stdev_du = statistics.stdev(du) if len(du) > 1 else 0.0
+        images = count_pct(len(offsets), ctx.images_by_instrument[instrument])
         ctx.lines.append(
-            f'| {instrument} | {size} | {len(offsets)} '
+            f'| {instrument} | {camera} | {size} | {images} '
             f'| {fmt(statistics.fmean(dv))} | {fmt(stdev_dv)} | {fmt(min(dv))} | {fmt(max(dv))} '
             f'| {fmt(statistics.fmean(du))} | {fmt(stdev_du)} | {fmt(min(du))} | {fmt(max(du))} |'
         )

--- a/src/spindoctor/cli/stats/schema.py
+++ b/src/spindoctor/cli/stats/schema.py
@@ -13,6 +13,7 @@ _SCHEMA = """
 CREATE TABLE IF NOT EXISTS images (
     image_name TEXT PRIMARY KEY,
     instrument TEXT NOT NULL,
+    camera TEXT,
     image_path TEXT,
     image_et REAL,
     image_date TEXT,
@@ -70,6 +71,7 @@ CREATE INDEX IF NOT EXISTS idx_sources_image ON feature_sources(image_name);
 IMAGE_COLUMNS: tuple[str, ...] = (
     'image_name',
     'instrument',
+    'camera',
     'image_path',
     'image_et',
     'image_date',

--- a/src/spindoctor/dataset/dataset.py
+++ b/src/spindoctor/dataset/dataset.py
@@ -20,6 +20,17 @@ class ImageFile:
         label_file_url: Remote URL for the label file.
         results_path_stub: Local path stub for storing results.
         index_file_row: Optional metadata from index files.
+        image_et: Optional observation epoch (TDB seconds past J2000) read
+            from the index row when the file was enumerated.  Known without
+            SPICE and without opening the image, so it is still available
+            for an image whose load fails.  None when the image was not
+            enumerated from an index, or its index row carries no readable
+            time.
+        camera: Optional name of the camera that took the image, read from
+            the index row when the file was enumerated.  Available on the
+            same terms as ``image_et``, and uses the same names as
+            ``ObsInst.camera``.  None when the image was not enumerated
+            from an index, or its index row names no recognized camera.
         extra_params: Optional extra parameters that will be passed to the observation
             class's from_file method when the file is read.
         image_url_resolver: Optional callable ``(image_file_url, label_file_path) ->
@@ -34,6 +45,8 @@ class ImageFile:
     label_file_url: FCPath
     results_path_stub: str
     index_file_row: dict[str, Any] = field(default_factory=dict)
+    image_et: float | None = None
+    camera: str | None = None
     extra_params: dict[str, Any] = field(default_factory=dict)
     image_url_resolver: Callable[[FCPath, Path], FCPath | None] | None = None
     _image_file_path: Path | None = None

--- a/src/spindoctor/dataset/dataset_pds3.py
+++ b/src/spindoctor/dataset/dataset_pds3.py
@@ -7,8 +7,9 @@ from abc import abstractmethod
 from collections.abc import Iterator
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
+import julian
 from filecache import FCPath, FileCache
 from pdstable import PdsTable
 
@@ -38,6 +39,20 @@ class DataSetPDS3(DataSet):
     # Data definitions overriden by subclasses
     _ALL_VOLUME_NAMES: tuple[str, ...] = ()
     _INDEX_COLUMNS: tuple[str, ...] = ()
+    # Index columns holding the image's observation time, in preference order;
+    # the first one present and non-null in a row wins.  These are always read
+    # and land in ``ImageFile.index_file_row``, so an image's epoch is known
+    # from the index alone -- no SPICE, and no need to load the image.  See
+    # :meth:`image_et_from_index_row`.
+    _INDEX_TIME_COLUMNS: tuple[str, ...] = ()
+    # Index columns naming the camera that took the image, in preference order,
+    # read the same way as the time columns.  See
+    # :meth:`camera_from_index_row`.
+    _INDEX_CAMERA_COLUMNS: tuple[str, ...] = ()
+    # Maps the raw index value (upper-cased, stripped) to the camera name the
+    # rest of the system uses -- the same names ``ObsInst.camera`` returns, so
+    # the two sources are interchangeable.
+    _INDEX_CAMERA_MAP: ClassVar[dict[str, str]] = {}
     _VOLUMES_DIR_NAME: str = ''
     # True when every image number in a volume is greater than every image number in
     # all earlier volumes, letting a sequential scan stop once a whole volume is past
@@ -115,6 +130,66 @@ class DataSetPDS3(DataSet):
 
     def __repr__(self) -> str:
         return self.__str__()
+
+    @classmethod
+    def image_et_from_index_row(cls, index_row: dict[str, Any]) -> float | None:
+        """The image's observation epoch, read from its PDS3 index row.
+
+        The index carries every image's time, so this is the one source of
+        an epoch that needs neither SPICE nor the image itself -- which is
+        what lets an image whose navigation died for want of a SPICE kernel
+        still be placed in time.  ``julian`` parses every format the index
+        tables use directly, including day-of-year (``1999-009T08:13:58.687``)
+        and a trailing ``Z``.
+
+        Parameters:
+            index_row: An ``ImageFile.index_file_row``; an empty dict (an
+                image not enumerated from an index) yields None.
+
+        Returns:
+            TDB seconds past J2000, or None when the row carries no
+            readable time (no time column, a masked/null value, or an
+            unparsable one).
+        """
+        for column in cls._INDEX_TIME_COLUMNS:
+            value = index_row.get(column)
+            # PdsTable reports a null cell via a companion ``<column>_mask``.
+            if value is None or index_row.get(f'{column}_mask'):
+                continue
+            try:
+                return float(julian.tdb_from_tai(julian.tai_from_iso(str(value))))
+            except (ValueError, TypeError, KeyError):
+                continue
+        return None
+
+    @classmethod
+    def camera_from_index_row(cls, index_row: dict[str, Any]) -> str | None:
+        """The camera that took the image, read from its PDS3 index row.
+
+        Like :meth:`image_et_from_index_row`, this needs neither SPICE nor
+        the image itself, so an image whose navigation died for want of a
+        SPICE kernel still names its camera.  The result uses the same
+        names as ``ObsInst.camera``, so an observation's camera and this
+        one are interchangeable.
+
+        Parameters:
+            index_row: An ``ImageFile.index_file_row``; an empty dict (an
+                image not enumerated from an index) yields None.
+
+        Returns:
+            The camera name, or None when the row carries no recognized
+            camera value.  An unrecognized value yields None rather than
+            itself: a name the rest of the system does not know would
+            silently split the statistics it feeds.
+        """
+        for column in cls._INDEX_CAMERA_COLUMNS:
+            value = index_row.get(column)
+            if value is None or index_row.get(f'{column}_mask'):
+                continue
+            camera = cls._INDEX_CAMERA_MAP.get(str(value).strip().upper())
+            if camera is not None:
+                return camera
+        return None
 
     @staticmethod
     @abstractmethod
@@ -643,7 +718,14 @@ class DataSetPDS3(DataSet):
                     logger.info(f'        {vol}')
 
         all_volume_names = self._ALL_VOLUME_NAMES
-        index_columns = self._INDEX_COLUMNS + additional_index_columns
+        index_columns = tuple(
+            dict.fromkeys(
+                self._INDEX_COLUMNS
+                + self._INDEX_TIME_COLUMNS
+                + self._INDEX_CAMERA_COLUMNS
+                + additional_index_columns
+            )
+        )
         volumes_dir_name = self._VOLUMES_DIR_NAME
 
         # Restrict volumes to given "volumes" argument
@@ -858,6 +940,8 @@ class DataSetPDS3(DataSet):
                 image_file_url=img_url,
                 label_file_url=label_url,
                 index_file_row=row,
+                image_et=self.image_et_from_index_row(row),
+                camera=self.camera_from_index_row(row),
                 results_path_stub=results_path_stub,
                 image_url_resolver=self._image_url_from_label,
             )

--- a/src/spindoctor/dataset/dataset_pds3_cassini_iss.py
+++ b/src/spindoctor/dataset/dataset_pds3_cassini_iss.py
@@ -2,7 +2,7 @@ import argparse
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 from filecache import FCPath, FileCache
 
@@ -30,6 +30,9 @@ class DataSetPDS3CassiniISS(DataSetPDS3):
         + list(range(_MIN_2xxx_VOL, _MAX_2xxx_VOL + 1))
     )
     _INDEX_COLUMNS = ('FILE_SPECIFICATION_NAME',)
+    _INDEX_TIME_COLUMNS = ('IMAGE_MID_TIME', 'IMAGE_TIME', 'START_TIME')
+    _INDEX_CAMERA_COLUMNS = ('INSTRUMENT_ID',)
+    _INDEX_CAMERA_MAP: ClassVar[dict[str, str]] = {'ISSNA': 'NAC', 'ISSWA': 'WAC'}
     _VOLUMES_DIR_NAME = 'calibrated'
 
     # Methods inherited from DataSetPDS3

--- a/src/spindoctor/dataset/dataset_pds3_galileo_ssi.py
+++ b/src/spindoctor/dataset/dataset_pds3_galileo_ssi.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 from filecache import FCPath, FileCache
 
@@ -21,6 +21,9 @@ class DataSetPDS3GalileoSSI(DataSetPDS3):
     _MAX_VOL = 23
     _ALL_VOLUME_NAMES = tuple(f'GO_{x:04d}' for x in range(_MIN_VOL, _MAX_VOL + 1))
     _INDEX_COLUMNS = ('FILE_SPECIFICATION_NAME',)
+    _INDEX_TIME_COLUMNS = ('IMAGE_TIME',)
+    _INDEX_CAMERA_COLUMNS = ('INSTRUMENT_ID',)
+    _INDEX_CAMERA_MAP: ClassVar[dict[str, str]] = {'SSI': 'SSI'}
     _VOLUMES_DIR_NAME = 'volumes'
 
     # Methods inherited from DataSetPDS3

--- a/src/spindoctor/dataset/dataset_pds3_newhorizons_lorri.py
+++ b/src/spindoctor/dataset/dataset_pds3_newhorizons_lorri.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 from filecache import FCPath, FileCache
 
@@ -28,6 +28,9 @@ class DataSetPDS3NewHorizonsLORRI(DataSetPDS3):
         'NHK2LO_2001',
     )
     _INDEX_COLUMNS = ('FILE_SPECIFICATION_NAME',)
+    _INDEX_TIME_COLUMNS = ('START_TIME',)
+    _INDEX_CAMERA_COLUMNS = ('INSTRUMENT_ID',)
+    _INDEX_CAMERA_MAP: ClassVar[dict[str, str]] = {'LORRI': 'LORRI'}
     _VOLUMES_DIR_NAME = 'volumes'
 
     # Methods inherited from DataSetPDS3

--- a/src/spindoctor/dataset/dataset_pds3_voyager_iss.py
+++ b/src/spindoctor/dataset/dataset_pds3_voyager_iss.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 from filecache import FCPath, FileCache
 
@@ -40,6 +40,13 @@ class DataSetPDS3VoyagerISS(DataSetPDS3):
         + list(range(_MIN_8xxx_VOL2, _MAX_8xxx_VOL2 + 1))
     )
     _INDEX_COLUMNS = ('FILE_SPECIFICATION_NAME',)
+    _INDEX_TIME_COLUMNS = ('IMAGE_TIME',)
+    # Voyager indexes carry no INSTRUMENT_ID; the name spells the camera out.
+    _INDEX_CAMERA_COLUMNS = ('INSTRUMENT_NAME',)
+    _INDEX_CAMERA_MAP: ClassVar[dict[str, str]] = {
+        'NARROW ANGLE CAMERA': 'NAC',
+        'WIDE ANGLE CAMERA': 'WAC',
+    }
     _VOLUMES_DIR_NAME = 'volumes'
     # FDS counts restart per spacecraft/encounter (the volume order interleaves VG1
     # and VG2, and VG2's Neptune counts roll over below VG1's Jupiter counts), so an

--- a/src/spindoctor/navigate_image_files.py
+++ b/src/spindoctor/navigate_image_files.py
@@ -176,6 +176,8 @@ def navigate_image_files(
                     exc,
                     logger=logger,
                     instrument=instrument,
+                    image_et=image_file.image_et,
+                    camera=image_file.camera,
                     timing=build_timing_section(run_start, datetime.now(UTC)),
                 )
                 if write_output_files:
@@ -195,6 +197,7 @@ def navigate_image_files(
                 image_path,
                 image_name,
                 instrument=instrument,
+                camera=snapshot_inst.camera,
                 image_shape=(int(data_shape[0]), int(data_shape[1])),
                 timing=build_timing_section(run_start, datetime.now(UTC)),
             )
@@ -216,11 +219,16 @@ def _metadata_for_load_error(
     *,
     logger: Any,
     instrument: str,
+    image_et: float | None,
+    camera: str | None,
     timing: dict[str, Any],
 ) -> dict[str, Any]:
     """Build a metadata dict for an image-load or kernel-coverage failure.
 
     No image shape is recorded because the load never produced pixel data.
+    The epoch and camera are recorded when the caller could read them from
+    the index, so an image that failed for want of a SPICE kernel is still
+    placed in time and attributed to its camera.
     """
     message = str(exc)
     if any(hint in message for hint in _SPICE_DATA_HINTS):
@@ -229,15 +237,20 @@ def _metadata_for_load_error(
     else:
         logger.exception('Error reading image "%s": %s', image_path, message)
         status_error = 'image_read_error'
+    observation: dict[str, Any] = {
+        'image_path': str(image_path),
+        'image_name': image_name,
+        'instrument': instrument,
+    }
+    if image_et is not None:
+        observation['image_et'] = image_et
+    if camera is not None:
+        observation['camera'] = camera
     return {
         'status': 'error',
         'status_error': status_error,
         'status_exception': message,
-        'observation': {
-            'image_path': str(image_path),
-            'image_name': image_name,
-            'instrument': instrument,
-        },
+        'observation': observation,
         'timing': timing,
     }
 
@@ -248,6 +261,7 @@ def build_metadata_from_result(
     image_name: str,
     *,
     instrument: str,
+    camera: str | None = None,
     image_shape: tuple[int, int] | None = None,
     timing: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -265,6 +279,9 @@ def build_metadata_from_result(
         instrument: Registered instrument name for the observation class
             (see :func:`spindoctor.obs.obs_class_to_inst_name`); written to
             the ``observation.instrument`` field.
+        camera: The camera that took the image (``ObsInst.camera``, e.g.
+            ``'NAC'``); written to the ``observation.camera`` field.  None
+            omits the field.
         image_shape: ``(v, u)`` pixel dimensions of the loaded image data;
             written to the ``observation.image_shape`` field.  None omits
             the field.
@@ -277,6 +294,8 @@ def build_metadata_from_result(
         'image_name': image_name,
         'instrument': instrument,
     }
+    if camera is not None:
+        observation['camera'] = camera
     if image_shape is not None:
         observation['image_shape'] = [int(image_shape[0]), int(image_shape[1])]
     metadata: dict[str, Any] = {

--- a/src/spindoctor/obs/obs_inst.py
+++ b/src/spindoctor/obs/obs_inst.py
@@ -29,6 +29,22 @@ class ObsInst(ABC):
         """Returns the instrument configuration."""
         return self._inst_config
 
+    @property
+    @abstractmethod
+    def camera(self) -> str:
+        """The camera that took this observation.
+
+        Instruments with more than one camera distinguish them here (Cassini
+        ISS and Voyager ISS return ``'NAC'`` or ``'WAC'``); single-camera
+        instruments return their one camera's name.  Pointing error is a
+        property of the camera, not of the instrument, so statistics are
+        grouped by this value.
+
+        Returns:
+            The camera name.
+        """
+        ...
+
     @staticmethod
     @abstractmethod
     def from_file(

--- a/src/spindoctor/obs/obs_inst_cassini_iss.py
+++ b/src/spindoctor/obs/obs_inst_cassini_iss.py
@@ -132,6 +132,15 @@ class ObsCassiniISS(ObsSnapshotInst):
             return 10.5
         return cast(float, 10.5 + np.log(self.texp) / np.log(2.512))
 
+    @property
+    def camera(self) -> str:
+        """The camera that took this observation.
+
+        Returns:
+            The oops detector name: ``'NAC'`` or ``'WAC'``.
+        """
+        return str(self.detector)
+
     def get_public_metadata(self) -> dict[str, Any]:
         """Returns the public metadata for Cassini ISS.
 
@@ -164,7 +173,7 @@ class ObsCassiniISS(ObsSnapshotInst):
             'midtime_scet': (scet_start + scet_end) / 2,
             'end_time_scet': scet_end,
             'image_shape_xy': self.data_shape_uv,
-            'camera': self.detector,
+            'camera': self.camera,
             'exposure_time': self.texp,
             'filters': [self.filter1, self.filter2],
             'sampling': self.sampling,

--- a/src/spindoctor/obs/obs_inst_galileo_ssi.py
+++ b/src/spindoctor/obs/obs_inst_galileo_ssi.py
@@ -109,6 +109,15 @@ class ObsGalileoSSI(ObsSnapshotInst):
             return anchor
         return cast(float, anchor + np.log(self.texp) / np.log(2.512))
 
+    @property
+    def camera(self) -> str:
+        """The camera that took this observation.
+
+        Returns:
+            Always ``'SSI'``; Galileo carries a single camera.
+        """
+        return 'SSI'
+
     def get_public_metadata(self) -> dict[str, Any]:
         """Returns the public metadata for Galileo SSI.
 
@@ -135,7 +144,7 @@ class ObsGalileoSSI(ObsSnapshotInst):
             # 'midtime_scet': (scet_start + scet_end) / 2,
             # 'end_time_scet': scet_end,
             'image_shape_xy': self.data_shape_uv,
-            'camera': 'SSI',
+            'camera': self.camera,
             'exposure_time': self.texp,
             'filters': [self.filter],
         }

--- a/src/spindoctor/obs/obs_inst_newhorizons_lorri.py
+++ b/src/spindoctor/obs/obs_inst_newhorizons_lorri.py
@@ -111,6 +111,15 @@ class ObsNewHorizonsLORRI(ObsSnapshotInst):
             return anchor
         return cast(float, anchor + np.log(self.texp) / np.log(2.512))
 
+    @property
+    def camera(self) -> str:
+        """The camera that took this observation.
+
+        Returns:
+            Always ``'LORRI'``; New Horizons LORRI is a single camera.
+        """
+        return 'LORRI'
+
     def get_public_metadata(self) -> dict[str, Any]:
         """Returns the public metadata for New Horizons LORRI.
 
@@ -137,7 +146,7 @@ class ObsNewHorizonsLORRI(ObsSnapshotInst):
             # 'midtime_scet': (scet_start + scet_end) / 2,
             # 'end_time_scet': scet_end,
             'image_shape_xy': self.data_shape_uv,
-            'camera': 'LORRI',
+            'camera': self.camera,
             'exposure_time': self.texp,
             'filters': [],
         }

--- a/src/spindoctor/obs/obs_inst_sim.py
+++ b/src/spindoctor/obs/obs_inst_sim.py
@@ -182,6 +182,15 @@ class ObsSim(ObsSnapshotInst):
         sigma_eff = max(read_noise_dn, 1.0)
         return 2.5 * math.log10(signal_full_scale_dn / (2.0 * sigma_eff))
 
+    @property
+    def camera(self) -> str:
+        """The camera that took this observation.
+
+        Returns:
+            Always ``'SIM'``; a simulated scene has one synthetic camera.
+        """
+        return 'SIM'
+
     def get_public_metadata(self) -> dict[str, Any]:
         return {
             'image_path': self.image_url,
@@ -189,5 +198,6 @@ class ObsSim(ObsSnapshotInst):
             'instrument_host_lid': 'sim',
             'instrument_lid': 'sim',
             'image_shape_xy': self.data_shape_uv,
+            'camera': self.camera,
             'description': 'Simulated observation from YAML scene',
         }

--- a/src/spindoctor/obs/obs_inst_voyager_iss.py
+++ b/src/spindoctor/obs/obs_inst_voyager_iss.py
@@ -182,6 +182,15 @@ class ObsVoyagerISS(ObsSnapshotInst):
             return anchor
         return cast(float, anchor + np.log(self.texp) / np.log(2.512))
 
+    @property
+    def camera(self) -> str:
+        """The camera that took this observation.
+
+        Returns:
+            The oops detector name: ``'NAC'`` or ``'WAC'``.
+        """
+        return str(self.detector)
+
     def get_public_metadata(self) -> dict[str, Any]:
         """Returns the public metadata for Voyager ISS.
 
@@ -221,7 +230,7 @@ class ObsVoyagerISS(ObsSnapshotInst):
             # 'midtime_scet': (scet_start + scet_end) / 2,
             # 'end_time_scet': scet_end,
             'image_shape_xy': self.data_shape_uv,
-            'camera': self.detector,
+            'camera': self.camera,
             'exposure_time': self.texp,
             'filters': [self.filter],
         }

--- a/tests/spindoctor/cli/backplanes/conftest.py
+++ b/tests/spindoctor/cli/backplanes/conftest.py
@@ -80,6 +80,11 @@ class HermeticObs(ObsSnapshotInst):
         """
         raise NotImplementedError('HermeticObs is constructed directly in tests')
 
+    @property
+    def camera(self) -> str:
+        """Return a fixed camera name (unused by backplanes)."""
+        return 'HERMETIC'
+
     def star_min_usable_vmag(self) -> float:
         """Return a fixed lower star magnitude bound (unused by backplanes)."""
         return 0.0

--- a/tests/spindoctor/cli/stats/test_stats.py
+++ b/tests/spindoctor/cli/stats/test_stats.py
@@ -13,15 +13,21 @@ from filecache import FCPath
 from spindoctor.cli.stats.classify import date_from_image_et
 from spindoctor.cli.stats.ingest import ingest_metadata_files, main_ingest, rows_from_metadata
 from spindoctor.cli.stats.report import build_report, main_report
-from spindoctor.cli.stats.report_common import image_number_from_name
+from spindoctor.cli.stats.report_common import (
+    count_pct,
+    image_name_from_filename,
+    image_number_from_name,
+)
 from spindoctor.cli.stats.report_sections import resolve_offset_limit
 from spindoctor.cli.stats.schema import open_stats_db, upsert_image
+from spindoctor.dataset import DataSetPDS3CassiniISS, DataSetPDS3VoyagerISS
 
 
 def _metadata(
     *,
     image_name: str = 'N1454725799_1_CALIB.IMG',
     instrument: str | None = 'coiss',
+    camera: str | None = 'NAC',
     status: str = 'success',
     status_reason: str = 'ok',
     offset: list[float] | None = None,
@@ -29,15 +35,16 @@ def _metadata(
     confidence_rank: str = 'high',
     per_technique: list[dict[str, Any]] | None = None,
     excluded: list[str] | None = None,
-    image_et: float = 0.0,
+    image_et: float | None = 0.0,
     image_shape: list[int] | None = None,
     elapsed_s: float | None = 3.25,
 ) -> dict[str, Any]:
     """Build a minimal metadata document in the navigate_image_files shape.
 
     ``instrument=None`` omits the ``observation.instrument`` field to model
-    a malformed document.  ``elapsed_s=None`` omits the ``timing`` section;
-    ``image_shape=None`` omits ``observation.image_shape``.
+    a malformed document.  ``camera=None`` omits ``observation.camera``, as
+    happens for an image that never loaded.  ``elapsed_s=None`` omits the
+    ``timing`` section; ``image_shape=None`` omits ``observation.image_shape``.
     """
     if offset is None and status == 'success':
         offset = [1.5, -2.5]
@@ -47,6 +54,8 @@ def _metadata(
     }
     if instrument is not None:
         observation['instrument'] = instrument
+    if camera is not None:
+        observation['camera'] = camera
     if image_shape is not None:
         observation['image_shape'] = image_shape
     doc: dict[str, Any] = {
@@ -154,6 +163,36 @@ def test_image_number_from_name(image_name: str | None, expected: int | None) ->
     assert image_number_from_name(image_name) == expected
 
 
+@pytest.mark.parametrize(
+    ('instrument', 'filename', 'expected'),
+    [
+        ('coiss', 'N1454725799_1_CALIB.IMG', 'N1454725799'),
+        ('coiss', '/holdings/data/W1728613298_8.IMG', 'W1728613298'),
+        ('vgiss', 'C3250013_GEOMED.IMG', 'C3250013'),
+        ('gossi', 'C0349632000R.IMG', 'C0349632000R'),
+        ('nhlorri', 'lor_0003103486_0x630_sci.fit', 'lor_0003103486'),
+        # An unregistered instrument only loses its extension.
+        ('mystery', 'X9999999.IMG', 'X9999999'),
+    ],
+)
+def test_image_name_from_filename(instrument: str, filename: str, expected: str) -> None:
+    assert image_name_from_filename(instrument, filename) == expected
+
+
+def test_image_name_from_filename_is_idempotent() -> None:
+    """Re-deriving a name that is already an image name changes nothing."""
+    assert image_name_from_filename('coiss', 'N1454725799') == 'N1454725799'
+
+
+def test_count_pct_formats_share() -> None:
+    assert count_pct(5, 158) == '5 (3.2%)'
+
+
+def test_count_pct_zero_total() -> None:
+    """An empty denominator renders 0.0% rather than dividing by zero."""
+    assert count_pct(0, 0) == '0 (0.0%)'
+
+
 # --- flattening ---
 
 
@@ -180,6 +219,39 @@ def test_rows_from_metadata_success_document() -> None:
     star_row = next(r for r in source_rows if r['source_model'] == 'stars')
     assert star_row['n_features'] == 1
     assert star_row['n_gated'] == 1
+
+
+def test_rows_from_metadata_records_camera() -> None:
+    """The recorded observation.camera lands in the image row."""
+    image_row, _, _ = rows_from_metadata(_metadata(camera='WAC'), source_file='x.json')
+    assert image_row['camera'] == 'WAC'
+
+
+def test_rows_from_metadata_tolerates_missing_camera() -> None:
+    """The camera is only ever the recorded one; it is never inferred."""
+    doc = _metadata(image_name='N1454725799_1_CALIB.IMG', camera=None)
+    image_row, _, _ = rows_from_metadata(doc, source_file='x.json')
+    assert image_row['camera'] is None
+
+
+def test_rows_from_metadata_falls_back_to_observation_image_et() -> None:
+    """An image that never loaded is dated from observation.image_et."""
+    doc = _metadata(status='error', status_reason='missing_spice_data', offset=None, image_et=None)
+    # No navigation provenance exists for a load failure; the navigator
+    # records the epoch it read from the index on the observation instead.
+    del doc['navigation_result']['provenance']
+    doc['observation']['image_et'] = 0.0
+    image_row, _, _ = rows_from_metadata(doc, source_file='x.json')
+    assert image_row['image_et'] == pytest.approx(0.0)
+    assert image_row['image_date'] == '2000-01-01'
+
+
+def test_rows_from_metadata_provenance_image_et_wins() -> None:
+    """A navigated image is dated from its observation, not the index echo."""
+    doc = _metadata(image_et=100.0)
+    doc['observation']['image_et'] = 999.0
+    image_row, _, _ = rows_from_metadata(doc, source_file='x.json')
+    assert image_row['image_et'] == pytest.approx(100.0)
 
 
 def test_rows_from_metadata_requires_image_name() -> None:
@@ -409,8 +481,11 @@ def test_build_report_writes_markdown_and_charts(tmp_path: Path) -> None:
     report_path = build_report(conn, out)
     conn.close()
     text = report_path.read_text(encoding='utf-8')
-    assert '| success | 2 |' in text
-    assert '| failed | 1 |' in text
+    # One column per instrument, then a total column; every count carries a
+    # percentage of that column's image total.
+    assert '| status | coiss | vgiss | total |' in text
+    assert '| success | 2 (100.0%) | 0 (0.0%) | 2 (66.7%) |' in text
+    assert '| failed | 0 (0.0%) | 1 (100.0%) | 1 (33.3%) |' in text
     assert 'no_features_extracted' in text
     assert 'BodyDiscCorrelateNav' in text
     assert 'IAPETUS' in text
@@ -418,7 +493,106 @@ def test_build_report_writes_markdown_and_charts(tmp_path: Path) -> None:
     assert 'BodyBlobNav' in text  # ensemble exclusion section
     assert (out / 'status_counts.png').exists()
     assert (out / 'technique_usage.png').exists()
-    assert (out / 'offsets_hist.png').exists()
+    # One offset histogram per camera, never pooled.  Only the Cassini
+    # frames navigated successfully, so only the NAC has a distribution.
+    assert (out / 'offsets_hist_coiss_NAC.png').exists()
+
+
+def test_build_report_selection_section(tmp_path: Path) -> None:
+    """The report opens with per-instrument counts and image/date bounds."""
+    conn = _populated_db(tmp_path)
+    out = tmp_path / 'report'
+    report_path = build_report(conn, out)
+    conn.close()
+    text = report_path.read_text(encoding='utf-8')
+    assert '## Images selected' in text
+    assert (
+        '| coiss | 2 (66.7%) | N1000000001 | N1000000002 '
+        '| 2000-01-01T11:58:56 | 2000-01-01T11:58:56 |' in text
+    )
+    assert (
+        '| vgiss | 1 (33.3%) | C3250013 | C3250013 '
+        '| 1980-12-27T01:19:09 | 1980-12-27T01:19:09 |' in text
+    )
+    assert 'Total images: 3' in text
+
+
+def test_build_report_dates_ignore_dateless_extreme_image(tmp_path: Path) -> None:
+    """A dateless image at the number range's edge does not hide the time span."""
+    conn = _populated_db(tmp_path)
+    # Lowest-numbered Cassini frame, and it has no epoch at all.
+    _upsert(
+        conn,
+        _metadata(
+            image_name='N0000000001_1_CALIB.IMG',
+            status='error',
+            status_reason='missing_spice_data',
+            offset=None,
+            image_et=None,
+        ),
+    )
+    out = tmp_path / 'report'
+    report_path = build_report(conn, out)
+    conn.close()
+    text = report_path.read_text(encoding='utf-8')
+    # It takes the "first image" slot, but the dates come from the frames
+    # that actually have an epoch rather than collapsing to '-'.
+    assert (
+        '| coiss | 3 (75.0%) | N0000000001 | N1000000002 '
+        '| 2000-01-01T11:58:56 | 2000-01-01T11:58:56 |' in text
+    )
+
+
+def test_build_report_offsets_separate_nac_from_wac(tmp_path: Path) -> None:
+    """Two cameras of one instrument get their own rows and histograms."""
+    conn = _populated_db(tmp_path)
+    _upsert(
+        conn,
+        _metadata(
+            image_name='W1000000004_1_CALIB.IMG',
+            camera='WAC',
+            image_shape=[512, 512],
+            offset=[0.4, 0.6],
+        ),
+    )
+    out = tmp_path / 'report'
+    report_path = build_report(conn, out)
+    conn.close()
+    text = report_path.read_text(encoding='utf-8')
+    assert '| coiss | NAC | dV | 2 (66.7%) |' in text
+    assert '| coiss | WAC | dV | 1 (33.3%) |' in text
+    assert (out / 'offsets_hist_coiss_NAC.png').exists()
+    assert (out / 'offsets_hist_coiss_WAC.png').exists()
+
+
+def test_build_report_confidence_tiers_always_listed(tmp_path: Path) -> None:
+    """Every standard tier appears, including tiers with no images."""
+    conn = _populated_db(tmp_path)
+    out = tmp_path / 'report'
+    report_path = build_report(conn, out)
+    conn.close()
+    section = report_path.read_text(encoding='utf-8').split('## Confidence calibration')[1]
+    # The fixture has only high / medium / failed images; low and conflicted
+    # must still be reported, as explicit zeros.
+    assert '| high | 1 (50.0%) | 0 (0.0%) | 1 (33.3%) |' in section
+    assert '| low | 0 (0.0%) | 0 (0.0%) | 0 (0.0%) |' in section
+    assert '| conflicted | 0 (0.0%) | 0 (0.0%) | 0 (0.0%) |' in section
+    # Tier order is high, medium, low, failed, conflicted.
+    tiers = [line.split('|')[1].strip() for line in section.splitlines() if line.startswith('| ')]
+    assert tiers[:6] == ['tier', 'high', 'medium', 'low', 'failed', 'conflicted']
+
+
+def test_build_report_offsets_are_per_camera(tmp_path: Path) -> None:
+    """Offset statistics group by camera and are not pooled."""
+    conn = _populated_db(tmp_path)
+    out = tmp_path / 'report'
+    report_path = build_report(conn, out)
+    conn.close()
+    text = report_path.read_text(encoding='utf-8')
+    assert '| instrument | camera | axis | images | mean | median | stdev | min | max |' in text
+    assert '| coiss | NAC | dV | 2 (100.0%) |' in text
+    # The Voyager frame failed, so its camera contributes no offset group.
+    assert '| vgiss |' not in text.split('## Offset statistics')[1].split('##')[0]
 
 
 def test_build_report_accepts_fcpath_output_dir(tmp_path: Path) -> None:
@@ -440,8 +614,13 @@ def test_build_report_instrument_filter(tmp_path: Path) -> None:
     report_path = build_report(conn, out, instrument='vgiss')
     conn.close()
     text = report_path.read_text(encoding='utf-8')
-    assert '| failed | 1 |' in text
-    assert 'success' not in text.split('## Failure taxonomy')[0].split('## Success')[1]
+    assert '| status | vgiss | total |' in text
+    assert '| failed | 1 (100.0%) | 1 (100.0%) |' in text
+    # The Cassini frames are filtered out entirely: no coiss column, and no
+    # success row in the status table.
+    assert 'coiss' not in text
+    status_table = text.split('## Success / failure')[1].split('![status]')[0]
+    assert '| success |' not in status_table
 
 
 def test_build_report_date_filter_excludes_out_of_range(tmp_path: Path) -> None:
@@ -474,7 +653,7 @@ def test_build_report_max_image_filter(tmp_path: Path) -> None:
     text = report_path.read_text(encoding='utf-8')
     # Only the Voyager frame (3250013) falls at or below 5000000.
     assert 'Total images: 1' in text
-    assert '| failed | 1 |' in text
+    assert '| failed | 1 (100.0%) | 1 (100.0%) |' in text
 
 
 def test_build_report_rejects_digitless_image_bound(tmp_path: Path) -> None:
@@ -493,10 +672,13 @@ def test_report_failure_taxonomy_section(tmp_path: Path) -> None:
     text = report_path.read_text(encoding='utf-8')
     assert '## Failure taxonomy by image content' in text
     # The failed Voyager frame recorded one body (IAPETUS) and stars.
-    assert '| single-body | 1 |' in text
-    assert '| single-body | no_features_extracted | 1 |' in text
+    assert '| single-body | 0 (0.0%) | 1 (100.0%) | 1 (33.3%) |' in text
+    assert '| single-body | no_features_extracted | 0 (0.0%) | 1 (100.0%) | 1 (33.3%) |' in text
     assert '### Per-body failure shares' in text
-    assert '| IAPETUS | 1 | 2 | 0.333 |' in text
+    # Failure shares are per (body, instrument): IAPETUS failed on the one
+    # Voyager frame and succeeded on both Cassini frames.
+    assert '| IAPETUS | vgiss | 1 (100.0%) | 0 (0.0%) | 1.000 |' in text
+    assert '| IAPETUS | coiss | 0 (0.0%) | 2 (100.0%) | 0.000 |' in text
 
 
 def test_report_offset_by_group_section(tmp_path: Path) -> None:
@@ -506,8 +688,8 @@ def test_report_offset_by_group_section(tmp_path: Path) -> None:
     report_path = build_report(conn, out)
     conn.close()
     text = report_path.read_text(encoding='utf-8')
-    assert '### By instrument and image size' in text
-    assert '| coiss | 1024x1024 | 2 ' in text
+    assert '### By instrument, camera, and image size' in text
+    assert '| coiss | NAC | 1024x1024 | 2 (100.0%) ' in text
 
 
 def test_report_suspect_offset_section(tmp_path: Path) -> None:
@@ -527,8 +709,8 @@ def test_report_suspect_offset_section(tmp_path: Path) -> None:
     conn.close()
     text = report_path.read_text(encoding='utf-8')
     assert '## Suspect offsets (near the search limit)' in text
-    assert 'Suspect images: 1 of 3 screened.' in text
-    assert '| N1000000003_1_CALIB.IMG | coiss | 49.000 | 10.000 |' in text
+    assert 'Suspect images: 1 (25.0%) of 3 screened.' in text
+    assert '| N1000000003 | coiss | 49.000 | 10.000 |' in text
     assert '(50.0, 140.0)' in text
 
 
@@ -590,11 +772,8 @@ def test_report_botsim_section(tmp_path: Path) -> None:
     # Residuals are 0.0 (consistent pair) and 2.0 (12 - 10*1), median 1.0.
     assert '| median residual (px) | 1.000 |' in text
     assert '| p95 residual (px) | 2.000 |' in text
-    # Worst-pairs table leads with the 2 px pair.
-    assert (
-        '| 1454725900 | N1454725900_1_CALIB.IMG | W1454725900_1_CALIB.IMG '
-        '| 2.000 | 0.000 | 2.000 |' in text
-    )
+    # Worst-pairs table leads with the 2 px pair, named by image name.
+    assert '| 1454725900 | N1454725900 | W1454725900 | 2.000 | 0.000 | 2.000 |' in text
 
 
 def test_report_runtime_section(tmp_path: Path) -> None:
@@ -604,9 +783,10 @@ def test_report_runtime_section(tmp_path: Path) -> None:
     conn.close()
     text = report_path.read_text(encoding='utf-8')
     assert '## Run-time statistics' in text
-    assert '| images with timing | 3 |' in text
-    assert '| total (s) | 9.750 |' in text
-    assert '| median (s) | 3.250 |' in text
+    # Per-instrument rows plus a pooled row; every image now has timing, so
+    # the count is stated as a share rather than "images with timing".
+    assert '| coiss | 2 (100.0%) | 6.500 | 3.250 | 3.250 | 3.250 | 3.250 | 0.000 |' in text
+    assert '| (all) | 3 (100.0%) | 9.750 | 3.250 | 3.250 | 3.250 | 3.250 | 0.000 |' in text
     assert 'Slowest 2 image(s):' in text
     assert (out / 'runtime_hist.png').exists()
 
@@ -630,25 +810,50 @@ def test_report_top_n_lists_examples(tmp_path: Path) -> None:
     report_path = build_report(conn, out, top_n=5)
     conn.close()
     text = report_path.read_text(encoding='utf-8')
-    assert 'Examples (up to 5 per reason):' in text
-    assert '- no_features_extracted: C3250013_GEOMED.IMG' in text
-    assert '- BodyBlobNav: N1000000002_1_CALIB.IMG' in text
+    # Examples are grouped by instrument and use image names, not filenames.
+    assert 'Examples (up to 5 per reason and instrument):' in text
+    assert '- no_features_extracted / vgiss: C3250013' in text
+    assert '- BodyBlobNav / coiss: N1000000002' in text
 
 
 def test_report_filelists_written(tmp_path: Path) -> None:
-    """filelists writes one full image-name list per category."""
+    """filelists writes one full image-name list per category and instrument."""
     conn = _populated_db(tmp_path)
     out = tmp_path / 'report'
     report_path = build_report(conn, out, filelists=True)
     conn.close()
     text = report_path.read_text(encoding='utf-8')
-    reason_list = out / 'filelists' / 'failure_reason_no_features_extracted.txt'
+    reason_list = out / 'filelists' / 'failure_reason_no_features_extracted_vgiss.txt'
     assert reason_list.exists()
-    assert reason_list.read_text(encoding='utf-8') == 'C3250013_GEOMED.IMG\n'
-    excluded_list = out / 'filelists' / 'excluded_BodyBlobNav.txt'
+    assert reason_list.read_text(encoding='utf-8') == (
+        '# failure_reason_no_features_extracted_vgiss (1 image(s))\nC3250013\n'
+    )
+    excluded_list = out / 'filelists' / 'excluded_BodyBlobNav_coiss.txt'
     assert excluded_list.exists()
-    assert excluded_list.read_text(encoding='utf-8') == 'N1000000002_1_CALIB.IMG\n'
-    assert 'filelists/failure_reason_no_features_extracted.txt' in text
+    assert excluded_list.read_text(encoding='utf-8') == (
+        '# excluded_BodyBlobNav_coiss (1 image(s))\nN1000000002\n'
+    )
+    assert 'filelists/failure_reason_no_features_extracted_vgiss.txt' in text
+
+
+def test_report_filelists_are_image_filelist_readable(tmp_path: Path) -> None:
+    """Every filelist line is a comment or a name the dataset layer accepts."""
+    conn = _populated_db(tmp_path)
+    out = tmp_path / 'report'
+    build_report(conn, out, filelists=True)
+    conn.close()
+    validators = {
+        'coiss': DataSetPDS3CassiniISS._img_name_valid,
+        'vgiss': DataSetPDS3VoyagerISS._img_name_valid,
+    }
+    written = sorted((out / 'filelists').glob('*.txt'))
+    assert len(written) > 0
+    for path in written:
+        instrument = path.stem.rsplit('_', 1)[-1]
+        for line in path.read_text(encoding='utf-8').splitlines():
+            if line.startswith('#'):
+                continue
+            assert validators[instrument](line), f'{path.name}: {line!r}'
 
 
 def test_report_csv_export(tmp_path: Path) -> None:

--- a/tests/spindoctor/dataset/test_dataset_pds3.py
+++ b/tests/spindoctor/dataset/test_dataset_pds3.py
@@ -8,8 +8,13 @@ from typing import Any
 import pytest
 from filecache import FCPath
 
+from spindoctor.cli.stats.classify import datetime_from_image_et
 from spindoctor.dataset.dataset import ImageFile
+from spindoctor.dataset.dataset_pds3 import DataSetPDS3
 from spindoctor.dataset.dataset_pds3_cassini_iss import DataSetPDS3CassiniISS
+from spindoctor.dataset.dataset_pds3_galileo_ssi import DataSetPDS3GalileoSSI
+from spindoctor.dataset.dataset_pds3_newhorizons_lorri import DataSetPDS3NewHorizonsLORRI
+from spindoctor.dataset.dataset_pds3_voyager_iss import DataSetPDS3VoyagerISS
 
 
 @pytest.fixture
@@ -592,3 +597,109 @@ def test_resolve_image_url_falls_back_when_resolver_raises(
     assert len(calls) == 1
     captured = capsys.readouterr()
     assert 'Image URL resolution from label' in captured.out + captured.err
+
+
+# --- observation epoch from the index row ---
+
+
+@pytest.mark.parametrize(
+    ('dataset_class', 'row', 'expected_iso'),
+    [
+        # Cassini ISS index times are day-of-year; IMAGE_MID_TIME wins.
+        (
+            DataSetPDS3CassiniISS,
+            {'IMAGE_MID_TIME': '1999-230T02:28:20.833', 'IMAGE_TIME': '1999-230T02:28:22.835'},
+            '1999-08-18T02:28:21',
+        ),
+        # Voyager ISS index times are plain ISO.
+        (DataSetPDS3VoyagerISS, {'IMAGE_TIME': '1978-12-11T00:29:23'}, '1978-12-11T00:29:23'),
+        # Galileo SSI index times carry a trailing Z.
+        (DataSetPDS3GalileoSSI, {'IMAGE_TIME': '1996-06-03T17:05:38.015Z'}, '1996-06-03T17:05:38'),
+        # New Horizons LORRI has no IMAGE_TIME; START_TIME is the epoch.
+        (
+            DataSetPDS3NewHorizonsLORRI,
+            {'START_TIME': '2006-02-24T16:12:48.306'},
+            '2006-02-24T16:12:48',
+        ),
+    ],
+)
+def test_image_et_from_index_row_parses_each_instrument_format(
+    dataset_class: type[DataSetPDS3], row: dict[str, Any], expected_iso: str
+) -> None:
+    """Every instrument's index time format is read without SPICE."""
+    image_et = dataset_class.image_et_from_index_row(row)
+    assert image_et is not None
+    assert datetime_from_image_et(image_et) == expected_iso
+
+
+def test_image_et_from_index_row_prefers_first_available_column() -> None:
+    """A missing preferred column falls through to the next one."""
+    row = {'IMAGE_TIME': '1999-230T02:28:20.833'}
+    image_et = DataSetPDS3CassiniISS.image_et_from_index_row(row)
+    assert image_et is not None
+    assert datetime_from_image_et(image_et) == '1999-08-18T02:28:21'
+
+
+def test_image_et_from_index_row_skips_masked_value() -> None:
+    """A null cell (flagged by PdsTable's companion mask) is skipped."""
+    row = {
+        'IMAGE_MID_TIME': 'UNK',
+        'IMAGE_MID_TIME_mask': True,
+        'IMAGE_TIME': '1999-230T02:28:20.833',
+    }
+    image_et = DataSetPDS3CassiniISS.image_et_from_index_row(row)
+    assert image_et is not None
+    assert datetime_from_image_et(image_et) == '1999-08-18T02:28:21'
+
+
+def test_image_et_from_index_row_unparsable_value() -> None:
+    """An unreadable time yields None rather than raising."""
+    assert DataSetPDS3CassiniISS.image_et_from_index_row({'IMAGE_MID_TIME': 'UNK'}) is None
+
+
+def test_image_et_from_index_row_without_index() -> None:
+    """An image not enumerated from an index has no epoch."""
+    assert DataSetPDS3CassiniISS.image_et_from_index_row({}) is None
+
+
+# --- camera from the index row ---
+
+
+@pytest.mark.parametrize(
+    ('dataset_class', 'row', 'expected'),
+    [
+        (DataSetPDS3CassiniISS, {'INSTRUMENT_ID': 'ISSNA'}, 'NAC'),
+        (DataSetPDS3CassiniISS, {'INSTRUMENT_ID': 'ISSWA'}, 'WAC'),
+        # Voyager indexes name the camera instead of carrying an id.
+        (DataSetPDS3VoyagerISS, {'INSTRUMENT_NAME': 'NARROW ANGLE CAMERA'}, 'NAC'),
+        (DataSetPDS3VoyagerISS, {'INSTRUMENT_NAME': 'WIDE ANGLE CAMERA'}, 'WAC'),
+        (DataSetPDS3GalileoSSI, {'INSTRUMENT_ID': 'SSI'}, 'SSI'),
+        (DataSetPDS3NewHorizonsLORRI, {'INSTRUMENT_ID': 'LORRI'}, 'LORRI'),
+    ],
+)
+def test_camera_from_index_row_maps_each_instrument(
+    dataset_class: type[DataSetPDS3], row: dict[str, Any], expected: str
+) -> None:
+    """Every instrument's index names its camera, without SPICE."""
+    assert dataset_class.camera_from_index_row(row) == expected
+
+
+def test_camera_from_index_row_tolerates_padding_and_case() -> None:
+    """Index values are matched stripped and upper-cased."""
+    assert DataSetPDS3CassiniISS.camera_from_index_row({'INSTRUMENT_ID': ' issna '}) == 'NAC'
+
+
+def test_camera_from_index_row_unrecognized_value() -> None:
+    """An unknown camera yields None rather than a name nothing else knows."""
+    assert DataSetPDS3CassiniISS.camera_from_index_row({'INSTRUMENT_ID': 'ISSXX'}) is None
+
+
+def test_camera_from_index_row_skips_masked_value() -> None:
+    """A null cell is skipped rather than read."""
+    row = {'INSTRUMENT_ID': 'ISSNA', 'INSTRUMENT_ID_mask': True}
+    assert DataSetPDS3CassiniISS.camera_from_index_row(row) is None
+
+
+def test_camera_from_index_row_without_index() -> None:
+    """An image not enumerated from an index has no camera."""
+    assert DataSetPDS3CassiniISS.camera_from_index_row({}) is None

--- a/tests/spindoctor/obs/test_obs_inst.py
+++ b/tests/spindoctor/obs/test_obs_inst.py
@@ -19,6 +19,10 @@ class _ConcreteObsInst(ObsInst):
     def from_file(path: Any, **kwargs: Any) -> Any:
         raise NotImplementedError
 
+    @property
+    def camera(self) -> str:
+        return 'TEST'
+
     def star_min_usable_vmag(self) -> float:
         return 0.0
 

--- a/tests/spindoctor/test_navigate_image_files.py
+++ b/tests/spindoctor/test_navigate_image_files.py
@@ -53,6 +53,8 @@ class _FakeSnapshot:
         self.extdata = self.data
         self._sensor_mask = np.ones(self.data.shape, bool)
         self.midtime = midtime
+        # Stands in for ObsInst.camera, written to observation.camera.
+        self.camera = 'NAC'
 
     def extfov_data_sensor_mask(self) -> np.ndarray:
         return self._sensor_mask
@@ -82,7 +84,9 @@ def _make_fake_obs_class(
     return _FakeObsClass
 
 
-def _make_image_files(tmp_path: Path) -> ImageFiles:
+def _make_image_files(
+    tmp_path: Path, *, image_et: float | None = None, camera: str | None = None
+) -> ImageFiles:
     """Build an ImageFiles batch with a single placeholder image."""
     img_path = tmp_path / 'fake_image.IMG'
     img_path.write_bytes(b'\x00')
@@ -94,6 +98,8 @@ def _make_image_files(tmp_path: Path) -> ImageFiles:
                 image_file_url=FCPath(str(img_path)),
                 label_file_url=FCPath(str(label_path)),
                 results_path_stub='fake_image',
+                image_et=image_et,
+                camera=camera,
             )
         ]
     )
@@ -147,6 +153,64 @@ def test_navigate_image_files_writes_metadata(tmp_path: Path) -> None:
     metadata_path = results_root / 'fake_image_metadata.json'
     assert metadata_path.exists()
     assert success is False  # no real-scene models registered
+
+
+def test_navigate_image_files_records_camera(tmp_path: Path) -> None:
+    """The observation's camera is written to observation.camera."""
+    obs_class = _make_fake_obs_class()
+    image_files = _make_image_files(tmp_path)
+    _success, metadata = navigate_image_files(
+        obs_class,
+        image_files,
+        FCPath(str(tmp_path / 'results')),
+        write_output_files=False,
+    )
+    assert metadata['observation']['camera'] == 'NAC'
+
+
+def test_navigate_image_files_load_error_records_index_epoch_and_camera(tmp_path: Path) -> None:
+    """A SPICE-kernel failure keeps the epoch and camera the index supplied."""
+    obs_class = _make_fake_obs_class(
+        raise_on_load=RuntimeError('SPICE(NOFRAMECONNECT) -- insufficient information')
+    )
+    image_files = _make_image_files(tmp_path, image_et=-11784634.984, camera='WAC')
+    _success, metadata = navigate_image_files(
+        obs_class,
+        image_files,
+        FCPath(str(tmp_path / 'results')),
+        write_output_files=False,
+    )
+    assert metadata['status_error'] == 'missing_spice_data'
+    assert metadata['observation']['image_et'] == -11784634.984
+    assert metadata['observation']['camera'] == 'WAC'
+
+
+def test_navigate_image_files_load_error_without_index_details(tmp_path: Path) -> None:
+    """An image with no index row records neither epoch nor camera."""
+    obs_class = _make_fake_obs_class(raise_on_load=OSError('boom'))
+    image_files = _make_image_files(tmp_path, image_et=None, camera=None)
+    _success, metadata = navigate_image_files(
+        obs_class,
+        image_files,
+        FCPath(str(tmp_path / 'results')),
+        write_output_files=False,
+    )
+    assert 'image_et' not in metadata['observation']
+    assert 'camera' not in metadata['observation']
+
+
+def test_navigate_image_files_prefers_observation_camera(tmp_path: Path) -> None:
+    """On a successful load the observation's own camera wins over the index."""
+    obs_class = _make_fake_obs_class()
+    image_files = _make_image_files(tmp_path, camera='WAC')
+    _success, metadata = navigate_image_files(
+        obs_class,
+        image_files,
+        FCPath(str(tmp_path / 'results')),
+        write_output_files=False,
+    )
+    # The fake snapshot reports NAC; the index row here says WAC.
+    assert metadata['observation']['camera'] == 'NAC'
 
 
 def test_navigate_image_files_blank_image_yields_no_signal(tmp_path: Path) -> None:


### PR DESCRIPTION
Reworks `sd_stats_report` so every figure is attributable to an instrument and a camera, and records the two facts it needs at their source.

## Report

- **Percentages everywhere.** Every image count reads `5 (3.2%)`. An instrument column's percentage is of that instrument's images; the total column's is of all selected images, so each column sums to 100% on its own.
- **Instrument breakdown.** Count tables get one column per instrument plus a total. Tables of *statistics* (offsets, run time, per-body shares, cross-technique agreement) get an instrument column instead — a total column is meaningless for a mean or a stdev.
- **Offsets group by camera** and are never pooled. On the sample data the reason is stark: NAC `dU` stdev is 26.5 px against WAC's 2.0 px. The pooled figure described neither camera.
- **New "Images selected" header.** Per-instrument counts, first/last image, and first/last available date. Image numbers only compare within an instrument, so bounds are never pooled. The date bounds are computed independently of image order, so one dateless image at an edge can't hide the instrument's time span.
- **Failure reasons carry their status**, so non-SPICE errors are visible alongside outright failures.
- **Confidence tiers** always read high/medium/low/failed/conflicted, empty tiers included — a missing tier is a real zero, not a gap.
- **Charts stack by instrument** with a fixed color per instrument, run-time histogram included.
- **Example lists and filelists use image names**, grouped by instrument with the instrument in the filename, in the format `--image-filelist` reads. These are the tokens that option actually selects on — the extension-stripped basename validates but silently matches nothing.

## Camera

`ObsInst` grows a `camera` property, implemented per instrument; each `get_public_metadata` now reads it rather than repeating a literal. `navigate_image_files` records it as `observation.camera`.

## Epoch and camera from the PDS3 index

The index names every image's time and camera, so a dataset reads both when it enumerates and passes them on `ImageFile`. Neither needs SPICE nor opens the image — which is why an image whose load dies for want of a kernel is still placed in time and attributed to its camera.

| Instrument | Time column | Camera column | Values |
|---|---|---|---|
| Cassini ISS | `IMAGE_MID_TIME` | `INSTRUMENT_ID` | `ISSNA`/`ISSWA` → NAC/WAC |
| Voyager ISS | `IMAGE_TIME` | `INSTRUMENT_NAME` | `NARROW`/`WIDE ANGLE CAMERA` |
| Galileo SSI | `IMAGE_TIME` | `INSTRUMENT_ID` | `SSI` |
| NH LORRI | `START_TIME` | `INSTRUMENT_ID` | `LORRI` |

Nothing is inferred from image names: an unrecognized camera value yields `None` rather than a name the rest of the system can't group by.

## Verification

- Full suite: **2665 passed, 79 skipped, 7 xfailed**. `ruff`, `ruff format`, and `mypy --strict` clean across 338 files.
- Exercised end-to-end against real holdings, not just fixtures. For `W1313634908` — a real `missing_spice_data` casualty — the index yields `camera=WAC, 1999-08-18T02:28:21`, matching to 0.5 ms the epoch SPICE itself printed inside the failure that killed the navigation.
- Simulating the full chain over 100 real results: **0 images without a camera, 0 without a date** (was 7 dateless), splitting 66 NAC / 34 WAC.
- A test walks every written filelist through the real `_img_name_valid` validators, so the format can't drift out of `--image-filelist` compatibility.

## Notes for reviewers

- **The `images` table gains a `camera` column, so an existing database is rejected and must be re-ingested.** Ingestion is idempotent and cheap by design; the error message says exactly this.
- Existing results predate `observation.camera` and the error-path epoch, so they need re-navigating before the report reflects either. Verified against scratch copies; no results on disk were rewritten.
- An image navigated by explicit path rather than enumerated from an index has an empty index row, so both fields stay `None` there. Nothing is invented to fill them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNJS38p5zE26jUnGMqCiEb