### PR TITLE
test: reconcile library sidecars with post-Track-B behavior

### DIFF
--- a/tests/integration/image_library/images/body_full_fov/N1699263827_1_CALIB.yaml
+++ b/tests/integration/image_library/images/body_full_fov/N1699263827_1_CALIB.yaml
@@ -20,10 +20,11 @@ ground_truth:
     Selection: ENCELADUS | <30; {"apparent_diameter_px": 788.6, "center_phase_deg": 21.271, "filter": "CL1", "lat_coverage_deg": 161.4, "target": "ENCELADUS", "year": "2011"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.377, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav'], per-technique offsets={"BodyDiscCorrelateNav": [17.5, -19.3281], "BodyLimbNav": [18.2049, -19.6064]}.
+    Primary ratchet 2026-07-16: after the 2026-07-14 NCC-covariance rederivation BodyLimbNav is the highest-confidence technique; disc and limb still agree at the operator-verified offset and the navigation is unchanged. Ratcheted BodyDiscCorrelateNav -> BodyLimbNav.
 expected:
   status: success
   confidence_tier: medium
-  primary_technique: BodyDiscCorrelateNav
+  primary_technique: BodyLimbNav
   techniques_must_run:
   - BodyDiscCorrelateNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/body_irregular/N1490836866_1_CALIB.yaml
+++ b/tests/integration/image_library/images/body_irregular/N1490836866_1_CALIB.yaml
@@ -20,9 +20,10 @@ ground_truth:
     Selection: EPIMETHEUS | 90-120; {"apparent_diameter_px": 300.4, "center_phase_deg": 115.464, "filter": "P60", "target": "EPIMETHEUS", "year": "2005"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.4, rank=low, techniques=['BodyBlobNav', 'BodyTerminatorNav'], per-technique offsets={"BodyBlobNav": [-7.9295, -43.2614], "BodyTerminatorNav": [-38.2005, -51.6002]}.
+    Tier ratchet 2026-07-16: the 2026-07-14 NCC/blob covariance rederivation adds a size-scaled centroid-model-error term, so the sigma-based tier gate now rates the unchanged, ground-truth-consistent BodyBlobNav solution low. Ratcheted medium -> low.
 expected:
   status: success
-  confidence_tier: medium
+  confidence_tier: low
   primary_technique: BodyBlobNav
   techniques_must_run:
   - BodyBlobNav

--- a/tests/integration/image_library/images/body_irregular/N1506381259_1_CALIB.yaml
+++ b/tests/integration/image_library/images/body_irregular/N1506381259_1_CALIB.yaml
@@ -20,9 +20,10 @@ ground_truth:
     Selection: HYPERION | 30-60; {"apparent_diameter_px": 738.0, "center_phase_deg": 51.588, "filter": "CL1", "target": "HYPERION", "year": "2005"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.4, rank=low, techniques=['BodyBlobNav', 'BodyTerminatorNav'], per-technique offsets={"BodyBlobNav": [-27.4105, 52.8001], "BodyTerminatorNav": [-6.4798, -128.4403]}.
+    Tier ratchet 2026-07-16: the 2026-07-14 NCC/blob covariance rederivation adds a size-scaled centroid-model-error term, so the sigma-based tier gate now rates the unchanged, ground-truth-consistent BodyBlobNav solution low. Ratcheted medium -> low.
 expected:
   status: success
-  confidence_tier: medium
+  confidence_tier: low
   primary_technique: BodyBlobNav
   techniques_must_run:
   - BodyBlobNav

--- a/tests/integration/image_library/images/body_irregular/N1571691490_1_CALIB.yaml
+++ b/tests/integration/image_library/images/body_irregular/N1571691490_1_CALIB.yaml
@@ -20,9 +20,10 @@ ground_truth:
     Selection: HYPERION | 90-120; {"apparent_diameter_px": 356.0, "center_phase_deg": 110.214, "filter": "P60", "target": "HYPERION", "year": "2007"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.4, rank=low, techniques=['BodyBlobNav', 'BodyTerminatorNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [0.0, 0.0], "BodyBlobNav": [8.091, -25.1623], "BodyTerminatorNav": [2.6409, -77.0677], "StarRefineNav": [0.0, 0.0]}.
+    Tier ratchet 2026-07-16: the 2026-07-14 NCC/blob covariance rederivation adds a size-scaled centroid-model-error term, so the sigma-based tier gate now rates the unchanged, ground-truth-consistent BodyBlobNav solution low. Ratcheted medium -> low.
 expected:
   status: success
-  confidence_tier: medium
+  confidence_tier: low
   primary_technique: BodyBlobNav
   techniques_must_run:
   - BodyBlobNav

--- a/tests/integration/image_library/images/body_irregular/N1644754596_1_CALIB.yaml
+++ b/tests/integration/image_library/images/body_irregular/N1644754596_1_CALIB.yaml
@@ -20,9 +20,10 @@ ground_truth:
     Selection: CALYPSO | 90-120; {"apparent_diameter_px": 223.4, "center_phase_deg": 90.781, "filter": "CL1", "target": "CALYPSO", "year": "2010"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.4, rank=low, techniques=['BodyBlobNav', 'BodyTerminatorNav'], per-technique offsets={"BodyBlobNav": [4.871, 14.6622], "BodyTerminatorNav": [8.9123, 24.4093]}.
+    Tier ratchet 2026-07-16: the 2026-07-14 NCC/blob covariance rederivation adds a size-scaled centroid-model-error term, so the sigma-based tier gate now rates the unchanged, ground-truth-consistent BodyBlobNav solution low. Ratcheted medium -> low.
 expected:
   status: success
-  confidence_tier: medium
+  confidence_tier: low
   primary_technique: BodyBlobNav
   techniques_must_run:
   - BodyBlobNav

--- a/tests/integration/image_library/images/body_irregular/N1644757096_1_CALIB.yaml
+++ b/tests/integration/image_library/images/body_irregular/N1644757096_1_CALIB.yaml
@@ -20,9 +20,10 @@ ground_truth:
     Selection: CALYPSO | 30-60; {"apparent_diameter_px": 181.9, "center_phase_deg": 32.287, "filter": "CL1", "target": "CALYPSO", "year": "2010"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.4, rank=low, techniques=['BodyBlobNav', 'BodyTerminatorNav'], per-technique offsets={"BodyBlobNav": [13.4533, -3.7217], "BodyTerminatorNav": [14.8509, -3.0129]}.
+    Tier ratchet 2026-07-16: the 2026-07-14 NCC/blob covariance rederivation adds a size-scaled centroid-model-error term, so the sigma-based tier gate now rates the unchanged, ground-truth-consistent BodyBlobNav solution low. Ratcheted medium -> low.
 expected:
   status: success
-  confidence_tier: medium
+  confidence_tier: low
   primary_technique: BodyBlobNav
   techniques_must_run:
   - BodyBlobNav

--- a/tests/integration/image_library/images/body_irregular/N1669606966_1_CALIB.yaml
+++ b/tests/integration/image_library/images/body_irregular/N1669606966_1_CALIB.yaml
@@ -20,9 +20,10 @@ ground_truth:
     Selection: HYPERION | 60-90; {"apparent_diameter_px": 753.8, "center_phase_deg": 80.932, "filter": "CL1", "target": "HYPERION", "year": "2010"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.4, rank=low, techniques=['BodyBlobNav', 'BodyTerminatorNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"StarUniqueMatchNav": [0.0, 0.0], "BodyBlobNav": [14.2106, -23.9386], "BodyTerminatorNav": [38.9556, -22.708], "StarRefineNav": [0.0, 0.0]}.
+    Tier ratchet 2026-07-16: the 2026-07-14 NCC/blob covariance rederivation adds a size-scaled centroid-model-error term, so the sigma-based tier gate now rates the unchanged, ground-truth-consistent BodyBlobNav solution low. Ratcheted medium -> low.
 expected:
   status: success
-  confidence_tier: medium
+  confidence_tier: low
   primary_technique: BodyBlobNav
   techniques_must_run:
   - BodyBlobNav

--- a/tests/integration/image_library/images/body_irregular/N1828122657_1_CALIB.yaml
+++ b/tests/integration/image_library/images/body_irregular/N1828122657_1_CALIB.yaml
@@ -20,9 +20,10 @@ ground_truth:
     Selection: EPIMETHEUS | <30; {"apparent_diameter_px": 630.4, "center_phase_deg": 28.482, "filter": "P120", "target": "EPIMETHEUS", "year": "2015"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.4, rank=low, techniques=['BodyBlobNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"StarUniqueMatchNav": [0.0, 0.0], "BodyBlobNav": [-25.983, -54.4295], "StarRefineNav": [0.0, 0.0]}.
+    Tier ratchet 2026-07-16: the 2026-07-14 NCC/blob covariance rederivation adds a size-scaled centroid-model-error term, so the sigma-based tier gate now rates the unchanged, ground-truth-consistent BodyBlobNav solution low. Ratcheted medium -> low.
 expected:
   status: success
-  confidence_tier: medium
+  confidence_tier: low
   primary_technique: BodyBlobNav
   techniques_must_run:
   - BodyBlobNav

--- a/tests/integration/image_library/images/body_partial_overflow/N1816644691_1_CALIB.yaml
+++ b/tests/integration/image_library/images/body_partial_overflow/N1816644691_1_CALIB.yaml
@@ -20,10 +20,11 @@ ground_truth:
     Selection: DIONE | 60-90; {"apparent_diameter_px": 1264.2, "center_phase_deg": 88.576, "filter": "CL1", "lat_coverage_deg": 58.2, "target": "DIONE", "year": "2015"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.375, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav'], per-technique offsets={"BodyDiscCorrelateNav": [4.5, 11.5], "BodyLimbNav": [3.9629, 11.7921]}.
+    Primary ratchet 2026-07-16: after the 2026-07-14 NCC-covariance rederivation BodyLimbNav is the highest-confidence technique; disc and limb still agree at the operator-verified offset and the navigation is unchanged. Ratcheted BodyDiscCorrelateNav -> BodyLimbNav.
 expected:
   status: success
   confidence_tier: medium
-  primary_technique: BodyDiscCorrelateNav
+  primary_technique: BodyLimbNav
   techniques_must_run:
   - BodyDiscCorrelateNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_only_flat/N1863267861_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_only_flat/N1863267861_1_CALIB.yaml
@@ -39,9 +39,10 @@ ground_truth:
     confidence=0.952, rank=high, status_reason=rank_1_only; RingEdgeNav
     raw fit (-48.1864, 9.4187) projects to -27.4128 px along the normal,
     identical to the voted representative point.
+    Tier ratchet 2026-07-16: the 2026-07-14 rank-aware ensemble policy caps a fused result with rank-deficient covariance at medium (the unobservable along-edge axis is an assumption, not a measurement); the RingEdgeNav fit and its projection onto the operator-verified normal are unchanged. Ratcheted high -> medium.
 expected:
   status: success
-  confidence_tier: high
+  confidence_tier: medium
   status_reason: rank_1_only
   primary_technique: RingEdgeNav
   techniques_must_run:

--- a/tests/integration/image_library/images/ring_only_flat/N1863268207_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_only_flat/N1863268207_1_CALIB.yaml
@@ -39,9 +39,10 @@ ground_truth:
     confidence=0.952, rank=high, status_reason=rank_1_only; RingEdgeNav
     raw fit (-46.4616, -20.4941) projects to -20.4941 px along the normal,
     identical to the voted representative point.
+    Tier ratchet 2026-07-16: the 2026-07-14 rank-aware ensemble policy caps a fused result with rank-deficient covariance at medium (the unobservable along-edge axis is an assumption, not a measurement); the RingEdgeNav fit and its projection onto the operator-verified normal are unchanged. Ratcheted high -> medium.
 expected:
   status: success
-  confidence_tier: high
+  confidence_tier: medium
   status_reason: rank_1_only
   primary_technique: RingEdgeNav
   techniques_must_run:

--- a/tests/integration/image_library/images/ring_only_flat/N1863269418_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_only_flat/N1863269418_1_CALIB.yaml
@@ -41,9 +41,10 @@ ground_truth:
     confidence=0.952, rank=high, status_reason=rank_1_only; RingEdgeNav
     raw fit (-44.4916, -3.5032) projects to -3.5032 px along the normal,
     identical to the voted representative point.
+    Tier ratchet 2026-07-16: the 2026-07-14 rank-aware ensemble policy caps a fused result with rank-deficient covariance at medium (the unobservable along-edge axis is an assumption, not a measurement); the RingEdgeNav fit and its projection onto the operator-verified normal are unchanged. Ratcheted high -> medium.
 expected:
   status: success
-  confidence_tier: high
+  confidence_tier: medium
   status_reason: rank_1_only
   primary_technique: RingEdgeNav
   techniques_must_run:

--- a/tests/integration/image_library/images/ring_only_flat/N1863269466_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_only_flat/N1863269466_1_CALIB.yaml
@@ -41,9 +41,10 @@ ground_truth:
     confidence=0.952, rank=high, status_reason=rank_1_only; RingEdgeNav
     raw fit (-39.4646, 1.5777) projects to 1.5777 px along the normal,
     identical to the voted representative point.
+    Tier ratchet 2026-07-16: the 2026-07-14 rank-aware ensemble policy caps a fused result with rank-deficient covariance at medium (the unobservable along-edge axis is an assumption, not a measurement); the RingEdgeNav fit and its projection onto the operator-verified normal are unchanged. Ratcheted high -> medium.
 expected:
   status: success
-  confidence_tier: high
+  confidence_tier: medium
   status_reason: rank_1_only
   primary_technique: RingEdgeNav
   techniques_must_run:

--- a/tests/integration/image_library/images/ring_only_flat/N1863269574_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_only_flat/N1863269574_1_CALIB.yaml
@@ -39,9 +39,10 @@ ground_truth:
     confidence=0.952, rank=high, status_reason=rank_1_only; RingEdgeNav
     raw fit (-49.4562, 4.4777) projects to 4.4777 px along the normal,
     identical to the voted representative point.
+    Tier ratchet 2026-07-16: the 2026-07-14 rank-aware ensemble policy caps a fused result with rank-deficient covariance at medium (the unobservable along-edge axis is an assumption, not a measurement); the RingEdgeNav fit and its projection onto the operator-verified normal are unchanged. Ratcheted high -> medium.
 expected:
   status: success
-  confidence_tier: high
+  confidence_tier: medium
   status_reason: rank_1_only
   primary_technique: RingEdgeNav
   techniques_must_run:

--- a/tests/integration/image_library/images/ring_plus_body/N1484688342_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_plus_body/N1484688342_1_CALIB.yaml
@@ -20,10 +20,11 @@ ground_truth:
     Selection: MIMAS | >120 | -10.0; {"apparent_diameter_px": 55.5, "center_phase_deg": 126.28, "filter": "P0", "ring_edges_in_frame": ["keeler_a_ring_oe_2005_05_01_2005_08_01.inner", "keeler_a_ring_oe_2005_05_01_2005_08_01.outer", "keeler_a_ring_oe_2006_01_01_2009_07_01.inner", "keeler_a_ring_oe_2006_01_01_2009_07_01.outer", "keeler_a_ring_oe_2010_01_01_2013_08_01.inner", "keeler_a_ring_oe_2010_01_01_2013_08_01.outer"], "ring_opening_deg": -5.01, "target": "MIMAS", "year": "2005"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.817, rank=high, techniques=['BodyLimbNav', 'RingEdgeNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyLimbNav": [9.1482, -19.2175], "RingEdgeNav": [10.1821, -26.8157], "StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [0.0, 0.0], "StarRefineNav": [9.6853, -18.4109]}.
+    Primary ratchet 2026-07-16: RingEdgeNav is the highest-confidence technique and the ring edge is the legitimate primary for this ring_plus_body scene; applies the 2026-07-13 D6 reconciliation decision, which was documented at the time but never committed. Ratcheted BodyLimbNav -> RingEdgeNav.
 expected:
   status: success
   confidence_tier: medium
-  primary_technique: BodyLimbNav
+  primary_technique: RingEdgeNav
   techniques_must_run:
   - BodyLimbNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_plus_body/N1503576135_2_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_plus_body/N1503576135_2_CALIB.yaml
@@ -20,10 +20,12 @@ ground_truth:
     Selection: TETHYS | 60-90 | -0.0; {"apparent_diameter_px": 83.5, "center_phase_deg": 87.242, "filter": "CL1", "ring_edges_in_frame": ["huygens_gap.inner", "huygens_gap.outer", "huygens_ringlet.inner", "huygens_ringlet.outer", "strange_ringlet.inner", "strange_ringlet.outer"], "ring_opening_deg": -4.163, "target": "TETHYS", "year": "2005"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.39, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'RingEdgeNav'], per-technique offsets={"BodyDiscCorrelateNav": [10.3047, -6.1016], "BodyLimbNav": [10.0362, -5.974], "RingEdgeNav": [-9.9986, 57.0368]}.
+    Primary ratchet 2026-07-16: RingEdgeNav is the highest-confidence technique and the ring edge is the legitimate primary for this ring_plus_body scene; applies the 2026-07-13 D6 reconciliation decision, which was documented at the time but never committed. Ratcheted BodyDiscCorrelateNav -> RingEdgeNav.
+    Tier ratchet 2026-07-16: the fused tier is now high with the navigation itself unchanged, consistent with the 2026-07-14 NCC-covariance rederivation tightening the fused sigma. Ratcheted medium -> high to the measured tier.
 expected:
   status: success
-  confidence_tier: medium
-  primary_technique: BodyDiscCorrelateNav
+  confidence_tier: high
+  primary_technique: RingEdgeNav
   techniques_must_run:
   - BodyLimbNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_plus_body/N1572472169_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_plus_body/N1572472169_1_CALIB.yaml
@@ -20,10 +20,11 @@ ground_truth:
     Selection: TETHYS | <30 | 0.0; {"apparent_diameter_px": 63.8, "center_phase_deg": 24.526, "filter": "BL1", "ring_edges_in_frame": ["keeler_a_ring_oe_2005_05_01_2005_08_01.inner", "keeler_a_ring_oe_2005_05_01_2005_08_01.outer", "keeler_a_ring_oe_2006_01_01_2009_07_01.inner", "keeler_a_ring_oe_2006_01_01_2009_07_01.outer", "keeler_a_ring_oe_2010_01_01_2013_08_01.inner", "keeler_a_ring_oe_2010_01_01_2013_08_01.outer"], "ring_opening_deg": 1.962, "target": "TETHYS", "year": "2007"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.367, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'RingEdgeNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyDiscCorrelateNav": [0.2422, 15.5], "BodyLimbNav": [0.1807, 15.6359], "RingEdgeNav": [10.9977, 38.9643], "StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [-0.4354, 14.7186], "StarRefineNav": [-0.4209, 14.7127]}.
+    Primary ratchet 2026-07-16: RingEdgeNav is the highest-confidence technique and the ring edge is the legitimate primary for this ring_plus_body scene; applies the 2026-07-13 D6 reconciliation decision, which was documented at the time but never committed. Ratcheted BodyLimbNav -> RingEdgeNav.
 expected:
   status: success
   confidence_tier: high
-  primary_technique: BodyLimbNav
+  primary_technique: RingEdgeNav
   techniques_must_run:
   - BodyLimbNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_plus_body/N1598065103_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_plus_body/N1598065103_1_CALIB.yaml
@@ -20,10 +20,11 @@ ground_truth:
     Selection: ENCELADUS | <30 | -0.0; {"apparent_diameter_px": 90.3, "center_phase_deg": 17.211, "filter": "CL1", "ring_edges_in_frame": ["huygens_gap.inner", "huygens_gap.outer", "huygens_ringlet.inner", "huygens_ringlet.outer", "strange_ringlet.inner", "strange_ringlet.outer"], "ring_opening_deg": -2.091, "target": "ENCELADUS", "year": "2008"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.388, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'RingEdgeNav'], per-technique offsets={"BodyDiscCorrelateNav": [6.5703, 17.1875], "BodyLimbNav": [6.7784, 17.1911], "RingEdgeNav": [42.9999, 16.047]}.
+    Primary ratchet 2026-07-16: RingEdgeNav is the highest-confidence technique and the ring edge is the legitimate primary for this ring_plus_body scene; applies the 2026-07-13 D6 reconciliation decision, which was documented at the time but never committed. Ratcheted BodyDiscCorrelateNav -> RingEdgeNav.
 expected:
   status: success
   confidence_tier: medium
-  primary_technique: BodyDiscCorrelateNav
+  primary_technique: RingEdgeNav
   techniques_must_run:
   - BodyLimbNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_plus_body/N1598093741_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_plus_body/N1598093741_1_CALIB.yaml
@@ -20,10 +20,12 @@ ground_truth:
     Selection: MIMAS | <30 | 0.0; {"apparent_diameter_px": 52.0, "center_phase_deg": 15.277, "filter": "CL1", "ring_edges_in_frame": ["keeler_a_ring_oe_2005_05_01_2005_08_01.inner", "keeler_a_ring_oe_2005_05_01_2005_08_01.outer", "keeler_a_ring_oe_2006_01_01_2009_07_01.inner", "keeler_a_ring_oe_2006_01_01_2009_07_01.outer", "keeler_a_ring_oe_2010_01_01_2013_08_01.inner", "keeler_a_ring_oe_2010_01_01_2013_08_01.outer"], "ring_opening_deg": 2.218, "target": "MIMAS", "year": "2008"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.383, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'RingEdgeNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyDiscCorrelateNav": [10.2422, -13.6328], "BodyLimbNav": [9.9672, -13.7982], "RingEdgeNav": [-14.0018, -29.9983], "StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [0.0, 0.0], "StarRefineNav": [12.8436, -14.3323]}.
+    Primary ratchet 2026-07-16: RingEdgeNav is the highest-confidence technique and the ring edge is the legitimate primary for this ring_plus_body scene; applies the 2026-07-13 D6 reconciliation decision, which was documented at the time but never committed. Ratcheted BodyDiscCorrelateNav -> RingEdgeNav.
+    Tier ratchet 2026-07-16: the fused tier is now high with the navigation itself unchanged, consistent with the 2026-07-14 NCC-covariance rederivation tightening the fused sigma. Ratcheted medium -> high to the measured tier.
 expected:
   status: success
-  confidence_tier: medium
-  primary_technique: BodyDiscCorrelateNav
+  confidence_tier: high
+  primary_technique: RingEdgeNav
   techniques_must_run:
   - BodyLimbNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_plus_body/N1633925572_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_plus_body/N1633925572_1_CALIB.yaml
@@ -23,10 +23,11 @@ ground_truth:
     First-curation pipeline snapshot (2026-07): status=success, confidence=0.5, rank=low, techniques=['BodyLimbNav', 'BodyTerminatorNav', 'RingEdgeNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyLimbNav": [-0.8144, -8.6168], "RingEdgeNav": [-39.8367, -11.9602], "StarUniqueMatchNav": [-0.9198, -8.6333], "BodyTerminatorNav": [15.9311, -14.004], "StarRefineNav": [-0.9198, -8.6333]}.
     Operator comment: appended: batch-1 candidate rescued by relaxed gates (was not in the batch-1 review selection)
     A later clean run of the default pipeline (2026-07-13) navigates this frame at high/0.50 after the confidence recalibration that followed first curation; expected.confidence_tier reflects that current behavior. The frame no longer needs the relaxed-gate rescue its earlier snapshot was taken under.
+    Primary ratchet 2026-07-16: RingEdgeNav is the highest-confidence technique and the ring edge is the legitimate primary for this ring_plus_body scene; applies the 2026-07-13 D6 reconciliation decision, which was documented at the time but never committed. Ratcheted StarRefineNav -> RingEdgeNav.
 expected:
   status: success
   confidence_tier: high
-  primary_technique: StarRefineNav
+  primary_technique: RingEdgeNav
   techniques_must_run:
   - StarRefineNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_plus_body/N1747232897_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_plus_body/N1747232897_1_CALIB.yaml
@@ -20,10 +20,12 @@ ground_truth:
     Selection: MIMAS | 30-60 | -10.0; {"apparent_diameter_px": 62.8, "center_phase_deg": 31.35, "filter": "CL1", "ring_edges_in_frame": ["huygens_gap.inner", "huygens_gap.outer", "huygens_ringlet.inner", "huygens_ringlet.outer", "strange_ringlet.inner", "strange_ringlet.outer"], "ring_opening_deg": -5.01, "target": "MIMAS", "year": "2013"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.426, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'RingEdgeNav'], per-technique offsets={"BodyDiscCorrelateNav": [3.9688, -20.7891], "BodyLimbNav": [3.9904, -21.095], "RingEdgeNav": [-2.8987, -16.9884]}.
+    Primary ratchet 2026-07-16: RingEdgeNav is the highest-confidence technique and the ring edge is the legitimate primary for this ring_plus_body scene; applies the 2026-07-13 D6 reconciliation decision, which was documented at the time but never committed. Ratcheted BodyDiscCorrelateNav -> RingEdgeNav.
+    Tier ratchet 2026-07-16: the fused tier is now high with the navigation itself unchanged, consistent with the 2026-07-14 NCC-covariance rederivation tightening the fused sigma. Ratcheted medium -> high to the measured tier.
 expected:
   status: success
-  confidence_tier: medium
-  primary_technique: BodyDiscCorrelateNav
+  confidence_tier: high
+  primary_technique: RingEdgeNav
   techniques_must_run:
   - BodyLimbNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_plus_body/N1855878123_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_plus_body/N1855878123_1_CALIB.yaml
@@ -20,10 +20,11 @@ ground_truth:
     Selection: MIMAS | <30 | -0.0; {"apparent_diameter_px": 377.2, "center_phase_deg": 28.928, "filter": "CL1", "ring_edges_in_frame": ["keeler_a_ring_oe_2005_05_01_2005_08_01.inner", "keeler_a_ring_oe_2005_05_01_2005_08_01.outer", "keeler_a_ring_oe_2006_01_01_2009_07_01.inner", "keeler_a_ring_oe_2006_01_01_2009_07_01.outer", "keeler_a_ring_oe_2010_01_01_2013_08_01.inner", "keeler_a_ring_oe_2010_01_01_2013_08_01.outer"], "ring_opening_deg": -1.092, "target": "MIMAS", "year": "2016"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.383, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'RingEdgeNav'], per-technique offsets={"BodyDiscCorrelateNav": [-0.8281, 7.5], "BodyLimbNav": [-1.4926, 7.9716], "RingEdgeNav": [39.947, -112.8006]}.
+    Primary ratchet 2026-07-16: RingEdgeNav is the highest-confidence technique and the ring edge is the legitimate primary for this ring_plus_body scene; applies the 2026-07-13 D6 reconciliation decision, which was documented at the time but never committed. Ratcheted BodyDiscCorrelateNav -> RingEdgeNav.
 expected:
   status: success
   confidence_tier: medium
-  primary_technique: BodyDiscCorrelateNav
+  primary_technique: RingEdgeNav
   techniques_must_run:
   - BodyDiscCorrelateNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/scattered_light/C3446143_GEOMED.yaml
+++ b/tests/integration/image_library/images/scattered_light/C3446143_GEOMED.yaml
@@ -20,9 +20,10 @@ ground_truth:
     Selection: VGISS | 1980; {"filter": "CH4_JS", "gradient_amplitude": 23.62485, "gradient_score": 7.6, "surrogate": "Saturn-target frame, nothing resolved in FOV", "target": "SATURN", "texp_s": 7.68, "year": "1980"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.399, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyDiscCorrelateNav": [-28.2578, -5.75], "BodyLimbNav": [-28.2054, -5.8645], "StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [0.0, 0.0], "StarRefineNav": [-30.7778, -2.8347]}.
+    Tier ratchet 2026-07-16: the 2026-07-14 NCC-covariance rederivation tightens the fused sigma past the high-tier gate and the fused confidence sits at the 0.99 combined-confidence cap via the two-technique agreement boost; per-technique results are essentially unchanged. Pinned as measured behavior with a caveat recorded in the reconcile decisions file: a tier increase produced by a covariance rescale alone, with disc and limb errors likely correlated, may overstate the fused certainty. Ratcheted medium -> high.
 expected:
   status: success
-  confidence_tier: medium
+  confidence_tier: high
   primary_technique: BodyDiscCorrelateNav
   techniques_must_run:
   - BodyLimbNav

--- a/tests/integration/image_library/images/scattered_light/C3448723_GEOMED.yaml
+++ b/tests/integration/image_library/images/scattered_light/C3448723_GEOMED.yaml
@@ -21,9 +21,10 @@ ground_truth:
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     First-curation pipeline snapshot (2026-07): status=success, confidence=0.401, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyDiscCorrelateNav": [-28.9297, -16.7656], "BodyLimbNav": [-28.8277, -17.0884], "StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [0.0, 0.0], "StarRefineNav": [-27.4357, -17.1837]}.
     A later clean run of the default pipeline (2026-07-13) navigates this frame at medium/0.99 after the confidence recalibration that followed first curation; expected.confidence_tier reflects that current behavior. The frame no longer needs the relaxed-gate rescue its earlier snapshot was taken under.
+    Tier ratchet 2026-07-16: the 2026-07-14 NCC-covariance rederivation tightens the fused sigma past the high-tier gate (the fused confidence already sat at the 0.99 combined-confidence cap); per-technique results are essentially unchanged. Pinned as measured behavior with a caveat recorded in the reconcile decisions file: a tier increase produced by a covariance rescale alone, with disc and limb errors likely correlated, may overstate the fused certainty. Ratcheted medium -> high.
 expected:
   status: success
-  confidence_tier: medium
+  confidence_tier: high
   primary_technique: BodyDiscCorrelateNav
   techniques_must_run:
   - BodyLimbNav


### PR DESCRIPTION
Reconciles the operator-curated library sidecars with post-Track-B pipeline
behavior, per the issue #288 attribution (evidence packet at
`/seti/newnav/rms-nav-baseline/attr288/ATTRIBUTION.md` on ringlet; decisions
file at `_work/calibration/288_reconcile_decisions.md` in the working tree).

## Re-baseline

Full library run on this branch's base (main @ 3a919c2): **53 FAIL / 22 PASS
(75 frames)** — byte-identical to the packet's 52-frame failing set on every
shared frame, plus the new batch-006 sidecar `C1205021_GEOMED` (PR #286,
merged after the packet), which fails `expected confidence_tier=medium, got
high`. PR #300 changed nothing at frame level.

## What this PR changes (24 sidecars, expected pins only)

- **8 ring_plus_body frames — the un-landed D6 primary ratchet** (documented
  "Applied" in `_work/calibration/D6_ratchet_decisions.md` on 2026-07-13 but
  never committed): `primary_technique -> RingEdgeNav` on N1484688342,
  N1503576135, N1572472169, N1598065103, N1598093741, N1633925572,
  N1747232897, N1855878123. Measured behavior matches the documented decision
  on all 8. Three of them (N1503576135, N1598093741, N1747232897) additionally
  ratchet tier medium -> high: that move is NOT in the D6 doc — it is
  in-window drift with the d694188 signature (navigation unchanged, fused
  sigma tightened), pinned as measured and flagged in the decisions file.
- **11 frames flipped by d694188 (#278 NCC-covariance rederivation)** —
  navigation byte-identical, only the covariance model moved:
  - 7 body_irregular tier medium -> low (N1490836866, N1506381259,
    N1571691490, N1644754596, N1644757096, N1669606966, N1828122657).
  - 2 primary BodyDiscCorrelateNav -> BodyLimbNav (N1699263827, N1816644691);
    rederived covariances reorder the per-technique confidences; noted as a
    watch item against the D6 disc-over-limb ordering.
  - 2 scattered_light tier medium -> high (C3446143_GEOMED, C3448723_GEOMED)
    — pinned **with a skepticism caveat**: the 0.99 fused confidence is
    exactly `COMBINED_CONFIDENCE_CAP`, reached because the covariance rescale
    pushes the limb result past the 10%-of-max precision-weight significance
    threshold and unlocks the 1.5x two-member agreement boost; the tier flip
    itself is the fused sigma crossing the 0.5 px high gate. Disc and limb
    measure the same scattered-light gradient in the same image, so their
    errors are correlated while the fusion assumes independence; residuals vs
    ground truth are ~0.9-1.2 px. Recorded in the decisions file as a
    candidate ensemble-overconfidence artifact (#222-family confidence
    honesty); the pin documents, it does not certify.
- **5 ring_only_flat frames flipped by 27ada67 (#270 rank-aware ensemble)** —
  tier high -> medium per the deliberate rank-1 tier cap (N1863267861,
  N1863268207, N1863269418, N1863269466, N1863269574); fits are dead on the
  operator-verified edge normal, unchanged.

Every edit appends a dated rationale line to `ground_truth.notes` (matching
the 37fec7f ratchet precedent) and touches only the `expected` block.

## Left red on purpose

- **26 deliberately-red frames** from PR #262 (16 held primary pins incl. the
  StarRefineNav family, 6 standing-marker status pins, 4 known tier/offset
  gaps) — untouched, awaiting their referenced issues.
- **C1205021_GEOMED** (batch 006, post-packet): medium pin vs measured high;
  its own provenance notes record rank=high at review time. Left for the
  batch-006 followup to adjudicate; outside the #288 attribution set.
- **N1853392805 and N1716186428** — the two genuine Track B regressions,
  investigated below, sidecars unchanged.

## Investigation: N1853392805 (Prometheus, broken by 1ab0395 / PR #277)

**Mechanism.** Prometheus is tagged `highly_irregular` in
config_220_body_shape.yaml; PR #277 suppresses LIMB_ARC / TERMINATOR_ARC /
BODY_DISC for such bodies once resolved past 3 px. At 54.5 px the frame loses
all shape features ("Body PROMETHEUS is highly_irregular and resolved
(predicted diameter 54.49 px > 3.00 px)" in the run log) and falls back to
BodyBlobNav: (-3.138, -3.872), conf 0.400, du error 1.815 px > the 1.5 px
gate. Pre-exclusion (442cfab), BodyTerminatorNav delivered (-3.318, -5.689),
45/45 inliers, RMS 1.05 px — the operator ground truth to 3 decimals — while
disc and limb were already spurious/self-gated (limb du was 2.0 px off,
consistent with the 2.6 km ~ 1.6 px ellipsoid residual at 1.58 km/px).

**Is the criterion wrong or the fallback?** The criterion is deliberate
policy: issue #24 names Prometheus explicitly ("only ... when they are far
enough away that they appear to be points"). So this is not a
misclassification bug. The cost is that the terminator technique — whose
per-vertex sigma already widens with the ellipsoid residual and which
degraded gracefully here — is discarded along with the genuinely-broken limb
and disc, and the blob fallback is inherently ~2-px-class on this body: its
own phase_irregularity_factor predicts ~2.3 px centroid sigma at this size
and phase, and the measured 1.8 px du bias matches. The frame's 1.0 px ground
truth gate is therefore unsatisfiable by the current pipeline (the
body_irregular class passes on identical fallback behavior only because its
ground-truth uncertainty is 2.0 px).

**Verdict.** Code is right by operator decision; the sidecar pin correctly
documents that the frame is 1-px navigable in principle. Keep red pending
adjudication.

**Recommended fix and blast radius.** Operator options: (a) accept
2-px-class navigation for resolved highly-irregular bodies and re-verify this
frame's ground-truth uncertainty (2.0 px would pass the blob); (b) soften the
exclusion to keep TERMINATOR_ARC for synchronous rotators with SPICE-known
orientation (Prometheus/Pandora, as opposed to chaotic Hyperion) — supported
by this frame but n=1; (c) shape models (#23). A scale-aware exclusion
threshold (suppress only when the ellipsoid residual exceeds ~1 px at the
observed range, instead of the fixed 3 px resolved test) would also stop
excluding bodies whose ellipsoid error is below the noise floor. Blast radius
of (a) is one sidecar; (b)/(c) touch nav_model_body feature emission for the
five highly_irregular bodies and need library + sim regression runs.

## Investigation: N1716186428 (Tethys, broken by 48e6154 / PR #275)

**Mechanism.** The old `raw_rms_px` pooled the 1e6 sentinel of
polarity-rejected vertices, so one rejected vertex drove it to
~1e6/sqrt(N) and the `raw_rms_px > threshold` spurious gate degenerated into
"any polarity rejection is spurious". This frame's limb fit carries 181/1428
(12.7%) polarity-rejected vertices; the old pooled value (3.6e5 px,
instrumented re-run) made it auto-spurious -> all techniques spurious ->
status failed, matching the operator's judgment. 48e6154 correctly averages
over accepted vertices only (3.82 px, under the sigma-scaled threshold
max(3.0, 5 x sigma_min)); inlier fraction 87% and LM displacement ~1 px pass
their gates, so BodyLimbNav now reports conf 0.695 -> success/medium at
(16.106, -13.993) — dv agrees with ground truth (16.48, -19.78) but du is
5.79 px off.

**Root cause of the wrong lock** (instrumented run): the coarse NCC integer
seed is already at (16, -13) — 6.8 px off in du — so the mis-lock happens in
the coarse mask-overlap search itself (the ellipsoid limb mask correlates
best with a crater-rim-shifted edge field on a limb the operator noted is
"obviously not a perfect ellipsoid"). The LM trust region (4 px) cannot
escape it, and the LM exits at its 30-iteration cap with converged=False —
a signal no gate reads. The sidecar's Phase-4 note (LM walking away from a
good coarse seed) describes the old failure mode; the trust region fixed
that, and the failure moved upstream.

**Verdict.** The code change is right (the old gate falsely killed clean
multi-body fits, issue #237); its protection of this frame was accidental —
a degenerate gate happened to catch a genuinely bad fit. The sidecar pin
(failed) is right: the new success is a plausible-but-wrong lock. Keep red.

**Recommended fix and blast radius.** Restore principled coverage for what
the degenerate gate caught by accident: (1) a per-body polarity-rejection-
fraction term in the limb/terminator spurious gate (this frame trips at
12.7%; the #237 multi-body case — rejections concentrated on a small
secondary body while the dominant limb fits cleanly — survives a per-body
evaluation); (2) treat converged=False (iteration-cap exit) as a spurious
input, after a campaign count to bound false positives; (3) longer term, a
coarse-NCC peak-quality check (#179 family). Blast radius: gate tightening
in dt-fitting techniques only; requires re-running the calibration campaign
and the library to confirm no new false rejections.

## Post-change library state (verified)

Full library run on this branch: **29 FAIL / 46 PASS (75 frames)** — the new
#288 gate control set, composed exactly of:
- 26 deliberately-red PR #262 holds (unchanged),
- 2 under-investigation regressions (N1853392805, N1716186428),
- 1 batch-006 frame outside this batch's scope (C1205021_GEOMED).

All 24 re-pinned frames pass. The default (non-integration) suite is
unaffected (2702 passed, 7 xfailed): sidecars are test data read only by the
integration library tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HoCUAeNeMz5bFmGk2iVBf
