### PR TITLE
feat: prove the cross-technique agreement estimator on known-truth sims

### DIFF
--- a/docs/dev_guide/dev_guide.rst
+++ b/docs/dev_guide/dev_guide.rst
@@ -15,6 +15,7 @@ This guide is intended for developers who want to understand, modify, or extend 
    dev_guide_backplanes
    dev_guide_pds4
    dev_guide_simulator
+   dev_guide_agreement_estimator
    dev_guide_support
    dev_guide_testing
    dev_guide_extending

--- a/docs/dev_guide/dev_guide_agreement_estimator.rst
+++ b/docs/dev_guide/dev_guide_agreement_estimator.rst
@@ -91,8 +91,11 @@ measurable by construction; the campaign record holds the numbers):
   rank-one ring. The shared-covariance assumption must hold across the
   pair (similar apparent size and geometry), and same-technique
   cross-body pairs must first be shown uncorrelated: correlation there
-  collapses the separation silently (measured in the campaign; the
-  disc-vs-disc pair on one frame is *not* clean in the current sim).
+  corrupts the separation silently while the system stays
+  well-conditioned. The campaign measured exactly this failure -- the
+  limb-vs-limb pair on one frame carries a large common-mode error in
+  the current sim -- and restoring correct recovery required declaring
+  that pair's covariance in the solve rather than assuming it away.
 
 Bias independence and the shared preprocessing layer
 ====================================================

--- a/docs/dev_guide/dev_guide_agreement_estimator.rst
+++ b/docs/dev_guide/dev_guide_agreement_estimator.rst
@@ -1,0 +1,140 @@
+=====================================================
+Agreement Estimator (Per-Technique Covariance)
+=====================================================
+
+Overview
+========
+
+When two or more navigation techniques measure the same frame's pointing
+offset, their disagreement carries information about each technique's own
+error. The agreement estimator turns that information into per-technique
+error *covariances*: given per-frame offsets from several techniques, every
+pairwise difference obeys
+
+.. code-block:: text
+
+    Cov(o_i - o_j) = C_i + C_j          (independent errors)
+
+and with enough distinct pairs the individual ``C_i`` separate -- the
+generalized "three-cornered hat". This is the machinery that lets the
+cross-technique agreement study report a per-technique accuracy number on
+real frames, where no external ground truth exists.
+
+The estimator lives in ``util/agreement/estimator.py`` (measurement-layer
+tooling, not part of the distributed package), with the validation campaign
+around it in the same directory and its dated record in
+``util/agreement/CAMPAIGN_20260719.md``.
+
+Design: full matrix form, never scalar sigmas
+=============================================
+
+A limb fit's error is strongly anisotropic -- tight perpendicular to the
+visible arc, loose along it -- and the arc orientation rotates from frame
+to frame. A straight ring edge measures the offset only along the ring
+radial direction (rank one). Writing the identities with scalar sigmas is
+therefore wrong; the estimator carries everything in matrix form:
+
+- Each technique's unknown is a symmetric 2x2 covariance (three elements)
+  expressed in the technique's own *basis frame* -- the fixed image frame,
+  or a per-frame rotating frame (the limb arc direction) that the design
+  matrix rotates into image coordinates frame by frame. Rotating
+  anisotropy is handled by the solve itself, without orientation binning.
+- A rank-one technique (straight ring edge) carries a single variance
+  unknown, and every equation involving it is projected onto that frame's
+  measurement axis first. The tangential component of its reported offset
+  is never consumed.
+- Techniques may share a parameter group (the same technique on two bodies
+  in one frame), which asserts one common covariance across the group --
+  an explicit stationarity assumption the cohort binning must justify.
+- A pair suspected of correlated errors can be declared, adding its
+  symmetric cross-covariance as unknowns instead of assuming independence;
+  the cohort must be over-determined enough to carry them.
+
+Identifiability is an output, not an assumption: the solve reports the
+design matrix's singular spectrum, the null space mapped back to parameter
+names, and a per-parameter identifiability score. Cohort mean differences
+are subtracted before the second moments, so deterministic biases between
+techniques land in a separate mean channel rather than inflating the
+covariances.
+
+Where per-technique covariance is recoverable
+=============================================
+
+Validated on planted-truth simulated scenes (each technique's true error is
+measurable by construction; the campaign record holds the numbers):
+
+- **One resolved body, limb + disc only.** Not separable: one matrix
+  equation, two unknown matrices. Only the *combined* covariance
+  ``C_limb + C_disc`` is determined; the split is a three-dimensional null
+  space, demonstrated empirically (any multiple of the null directions
+  fits the data identically). Report pairwise combined covariance only.
+- **Body + straight ring edge, radial direction frozen across the
+  cohort.** The ring leg constrains each body technique only along that
+  one axis: the ring variance and each technique's radial-radial
+  projection become identifiable (the full limb+disc sum closes the
+  system along the radial axis), but the split of the remaining elements
+  stays degenerate (two-dimensional null space).
+- **Body + straight ring edge, radial direction varying across the
+  cohort.** Fully identifiable: as the radial axis sweeps, the rank-one
+  equations probe every direction, and all covariance elements of limb,
+  disc, and the ring variance separate. Orientation diversity is the
+  lever -- a cohort whose ring geometry never rotates cannot be rescued
+  by more frames.
+- **Anisotropic (partial-arc) limb + ring only.** The limb deviatoric
+  (anisotropy) part separates when the arc-to-radial relative angle
+  varies, but the isotropic part of the limb covariance and the ring
+  variance remain entangled (one-dimensional null space). Adding the disc
+  closes it.
+- **Two resolved bodies (limb + disc each).** With the same-technique
+  covariance shared across the two bodies, cross-body pairs separate limb
+  from disc in full 2x2 form -- this is what a second body adds over the
+  rank-one ring. The shared-covariance assumption must hold across the
+  pair (similar apparent size and geometry), and same-technique
+  cross-body pairs must first be shown uncorrelated: correlation there
+  collapses the separation silently (measured in the campaign; the
+  disc-vs-disc pair on one frame is *not* clean in the current sim).
+
+Bias independence and the shared preprocessing layer
+====================================================
+
+The distance-transform techniques (limb, terminator, ring edge) consume
+shared per-image products built once per navigation: the smoothed gradient,
+the edge distance transform, and the noise-sigma estimate (see
+:doc:`dev_guide_techniques_image_derivatives`). A bias in that shared layer
+moves those techniques *together* -- which the pairwise differences then
+cancel, hiding exactly the error the agreement study most needs to see.
+
+The validation campaign injects a controlled bias into those shared
+products (a harness-level patch translating the gradient/DT images by a
+per-scene random shift, and separately scaling the shared noise sigma) and
+measures the induced coupling for the pivotal pairs. Consequences for any
+consumer of the estimator:
+
+- Techniques that sample the shared gradient/DT products (limb, ring edge)
+  track a bias in that layer essentially one-for-one; their pairwise
+  difference is blind to it, and a joint solve without a declared pair
+  covariance misattributes the shared component onto the *other*
+  techniques in the system. Limb-DT and ring-edge-DT must not be treated
+  as independent through this layer.
+- Techniques that read the image directly (disc correlation, blob
+  centroid) are structurally decoupled from the gradient/DT products;
+  measured couplings and residual caveats are in the campaign record.
+- Declaring the suspect pair covariance in an over-determined cohort
+  recovers the injected coupling instead of hiding it -- the estimator's
+  mechanism for keeping a correlated pair in the solve honestly, when the
+  cohort can carry it. Otherwise the pair is excluded from joint solves
+  and only its combined covariance is reported.
+
+Scope of the verdict
+====================
+
+These results are exact statements about the estimator's mathematics and
+about the navigation algorithms on simulated scenes whose truth is planted
+by construction (the verification axis of the simulator's capability
+envelope; see :ref:`sim-capability-envelope`). The bias-independence
+verdict in particular is the simulator's verdict: it establishes what the
+solve detects when a shared bias exists, and which couplings exist in the
+rendered regime measured. It does not certify that real-image biases are
+independent -- that requires the real-data closure checks of the agreement
+study itself, and every real-frame application inherits the identifiability
+map's constraints per composition.

--- a/docs/dev_guide/dev_guide_agreement_estimator.rst
+++ b/docs/dev_guide/dev_guide_agreement_estimator.rst
@@ -48,14 +48,39 @@ therefore wrong; the estimator carries everything in matrix form:
   an explicit stationarity assumption the cohort binning must justify.
 - A pair suspected of correlated errors can be declared, adding its
   symmetric cross-covariance as unknowns instead of assuming independence;
-  the cohort must be over-determined enough to carry them.
+  the cohort must be over-determined enough to carry them. Two model
+  restrictions apply: a full/full pair's cross-covariance is a single
+  image-frame-constant matrix (no rotating form), and a pair involving a
+  rank-one technique carries one scalar, which assumes the projected
+  coupling is the same along every axis (exact only for an isotropic
+  shared error).
 
 Identifiability is an output, not an assumption: the solve reports the
 design matrix's singular spectrum, the null space mapped back to parameter
-names, and a per-parameter identifiability score. Cohort mean differences
-are subtracted before the second moments, so deterministic biases between
-techniques land in a separate mean channel rather than inflating the
-covariances.
+names, and a per-parameter identifiability score.
+
+Bias handling deserves precision, because the naive claim is false.
+Each pair's differences are centered by a fitted mean model before the
+second moments: constant (image-frame) terms always, plus rotating-frame
+mean components for every member declared rotating. The consequences:
+
+- A deterministic bias that is *constant in the image frame* lands in
+  the mean channel and never touches the covariances.
+- A *geometry-locked* bias -- constant in a rotating frame, like a limb
+  or disc fit pulled radially toward its body -- has image-frame mean
+  near zero over an orientation-diverse cohort. If its technique is
+  declared rotating, the mean model absorbs it (and reports the fitted
+  bias). If not, nothing is subtracted and the bias aliases into the
+  recovered covariance as ``C + mu mu^T`` -- silently, with the system
+  well-conditioned and, in general, no negative-variance symptom; shared
+  between two techniques it additionally creates undeclared cross terms
+  that corrupt every recovered value. Orientation diversity is therefore
+  double-edged: the same sweep that makes the system identifiable
+  converts geometry-locked biases from harmless constants into silent
+  covariance pollution. Mitigations are declaring the rotating basis or
+  estimating means bin-wise in each technique's own frame.
+- Biases locked to geometry the model does not carry (illumination
+  direction, arc fraction) are not absorbed and still alias.
 
 Where per-technique covariance is recoverable
 =============================================

--- a/util/agreement/CAMPAIGN_20260719.md
+++ b/util/agreement/CAMPAIGN_20260719.md
@@ -1,13 +1,14 @@
 # Agreement-estimator validation campaign 20260719
 
 Tracked record of the seed-20260719 estimator-validation campaign
-(issue #224; WS-0 of `plans/VALIDATION_AND_CALIBRATION_PLAN.md`): the
-recover-known-error test of the covariance-components solve, the
-per-composition identifiability map, and the bias-independence
-measurements through the shared preprocessing layer.  Generated
-artifacts (row files, the full generated report with every table) live
-under `_work/agreement/` (gitignored); this file preserves the numbers
-and conclusions that outlive them.
+(issue #224; the agreement-estimator validation stage of
+`plans/VALIDATION_AND_CALIBRATION_PLAN.md`): the recover-known-error
+test of the covariance-components solve, the per-composition
+identifiability map, and the bias-independence measurements through
+the shared preprocessing layer.  Generated artifacts (row files, the
+full generated reports with every table) live under
+`_work/agreement/` (gitignored); this file preserves the numbers and
+conclusions that outlive them.
 
 ## Campaign summary
 
@@ -20,8 +21,15 @@ Injection passes on `limb_disc_ring_diverse` only: `dt_shift` (400
 scenes, per-scene bias ~ N(0, 0.7 px) per axis through the shared
 gradient/edge-DT products) and `noise_scale` (400 scenes, shared
 noise-sigma scaled by log-uniform 2-8x), 2.9 min each, 0 errors.
-Analysis: `analyze.py` over the three row files; solves use 200
-bootstrap replicates (seed 1) for the 95% CIs quoted below.
+
+Analysis: `analyze.py` over the three row files.  The quoted numbers
+are from the mean-model analysis pass (`report_v2`): pair differences
+are centered by a fitted mean model (constant terms plus
+rotating-frame mean columns for every rotating-basis member -- see
+"Geometry-locked biases" below), and the 95% CIs use 200 bootstrap
+replicates (seed 1) that re-fit the mean model on each resample.  The
+earlier constant-centering pass (`report_v1`) is retained as the
+comparison that demonstrates the rotating-bias aliasing.
 
 Every scene plants a known (offset_v, offset_u); each technique's true
 error is its offset minus the planted truth.  All recovered-vs-truth
@@ -43,10 +51,10 @@ comparisons below are against that construction.
   which couplings exist in the rendered regime measured.  It does not
   establish that real-image biases are independent; that check belongs
   to the agreement study's own real-data closure tests (the
-  over-determined-frame closure of WS-1).  Per the capability envelope
-  in `docs/dev_guide/dev_guide_simulator.rst`, planted-truth recovery
-  is the axis on which the simulator's word is final -- accuracy
-  claims about real frames are not.
+  over-determined-frame closure).  Per the capability envelope in
+  `docs/dev_guide/dev_guide_simulator.rst`, planted-truth recovery is
+  the axis on which the simulator's word is final -- accuracy claims
+  about real frames are not.
 - **Estimator input hygiene.**  The solve consumes only technique
   offsets plus geometry angles derived from the idealized scene
   parameters (ring radial direction, limb arc orientation) -- the same
@@ -59,6 +67,42 @@ comparisons below are against that construction.
   blob-only orchestrator run on ring-bearing scenes; the orchestrator
   otherwise skips the fallback).  RingAnnulusNav was collected but is
   spurious on most straight-ringlet scenes and enters no solve.
+
+## Geometry-locked biases and the mean channel
+
+What the estimator's bias handling does and does not do -- the
+distinction every claim below leans on:
+
+- A deterministic inter-technique bias that is **constant in the image
+  frame** is subtracted by the pair mean model's constant terms and
+  never touches the covariances.
+- A bias that is **constant in a rotating frame** (a limb or disc fit
+  pulled radially toward its body -- geometry-locked error) has
+  image-frame mean ~0 over an orientation-diverse cohort.  Plain
+  constant centering sees *nothing*, and `R mu mu^T R^T` enters every
+  second-moment equation as if it were covariance -- silently, with
+  the system well-conditioned, every identifiability score 1.0, and
+  (in general) **no negative-variance symptom**.  Demonstrated on
+  synthetic frames with the campaign's own machinery (limb rotating
+  bias mu = (-2, 0), true C_limb = diag(0.3, 0.5), n = 6000):
+  constant centering reports a pair mean of (0.003, 0.001) -- nothing
+  -- while recovering limb c11 = **4.29 vs truth 0.3** (= C + mu^2, a
+  14x inflation).  With the bias shared by two techniques (limb
+  mu = (-2, 0) and disc mu = (-1.5, 0), both rotating), the undeclared
+  cross term corrupts *everything*: disc c11 recovered **-0.34** vs
+  truth 0.05, ring s2 **1.50** vs truth 0.01.
+- The solve therefore fits **rotating-frame mean columns** for every
+  member declared `basis='rotating'` (the declaration arms them), and
+  those columns absorb the geometry-locked bias and expose it in the
+  `pair_mean_model` output.  On the same synthetic frames the mean
+  model returns limb c11 = 0.29 (truth 0.3) and, in the shared-bias
+  case with both members declared rotating, disc c11 = +0.05 and ring
+  s2 = 0.01 -- full repair, with the fitted mu columns reading -2.00
+  and -1.50.  These recoveries are pinned by the unit suite.
+- **Limits:** absorption follows the declaration (an undeclared member
+  still aliases), and only rotations the model carries are absorbed --
+  a bias locked to *unmodeled* geometry (e.g. illumination direction,
+  see the cross-body finding below) still aliases into covariance.
 
 ## Stage 0a: recover-known-error and identifiability
 
@@ -79,7 +123,10 @@ Degeneracies are demonstrated, not asserted: every degenerate solve
 reports its null-space directions explicitly (e.g. limb+disc alone:
 `+0.71*limb:c11 - 0.71*disc:c11` etc.), the unit suite verifies that
 adding a null vector leaves every residual unchanged, and the
-condition number is infinite for each rank-deficient cohort.
+condition number is infinite for each rank-deficient cohort.  Report
+tables suppress bootstrap CIs on parameters whose identifiability is
+below 0.6 (an interval on an arbitrary minimum-norm split would be
+noise).
 
 ### Recover-known-error results (selected, px^2)
 
@@ -102,7 +149,7 @@ recovery within CI on every element:
 
 **limb_disc_ring_diverse (400 frames, 3 techniques, condition
 3.7).**  Fully identifiable from orientation diversity alone: limb
-[+1.688, -0.138, +1.645] vs truth [+1.666, -0.060, +1.495], disc and
+[+1.685, -0.134, +1.647] vs truth [+1.666, -0.060, +1.495], disc and
 ring recovered near zero with CIs covering their (tiny) truths.  CIs
 are notably wider than the 4-technique variant -- the rank-1 ring leg
 carries fourth-moment noise.
@@ -118,43 +165,75 @@ restores every value:
 
 | parameter | recovered [95% CI] | truth |
 |---|---|---|
-| limb:c11 | +2.005 [+1.546, +2.511] | +1.959 / +2.060 (RHEA / DIONE) |
-| limb:c22 | +2.141 [+1.702, +2.606] | +2.334 / +1.949 |
+| limb:c11 | +2.005 [+1.545, +2.507] | +1.959 / +2.060 (RHEA / DIONE) |
+| limb:c22 | +2.141 [+1.696, +2.589] | +2.334 / +1.949 |
 | disc:c11 | +0.0002 [+0.0001, +0.0004] | +0.0005 |
-| cov(limb,limb):s11 | +1.445 [+1.044, +1.854] | +1.482 (measured) |
+| cov(limb,limb):s11 | +1.445 [+1.043, +1.852] | +1.482 (measured) |
 
 The disc-disc cross-body pair is also correlated (+0.514) but at
 ~3e-4 px^2 it is immaterial; declaring both within-group pairs would
 re-degenerate the system (verified: null dimension 3), so the rule is
 *declare the material pairs only*.
 
-**limb_ring_aniso families (400 frames each).**  The composition-level
-algebra behaves exactly as mapped (frozen relative angle: 3-dim null;
-diverse: 1-dim null with the predicted `trace/2 + s2` trade and the
-deviatoric identifiable).  Two honest deficiencies in this regime:
+**Cross-body limb-limb coupling: partial diagnosis.**  The +1.48 px^2
+coupling is *not* a planted-offset gain error: corr(error, planted
+offset) is at most 0.08 on any axis, and removing a linear
+planted-offset trend leaves the coupling at +0.715.  A material part
+*is* deterministic illumination-locked error -- the two bodies share
+the scene's illumination_angle and phase_angle by construction, and
+regressing each body's limb error on illumination harmonics plus
+phase explains ~20% of the limb error variance per axis (R^2
+0.19-0.23) and drops the coupling from +0.716 to +0.642.  This is the
+same geometry-locked-bias class as the rotating-frame aliasing above,
+locked to an angle (illumination) the estimator's mean model does not
+carry.  The remaining ~0.64 correlation is **unexplained**; the
+shared-DT-grid / subpixel-phase attribution in earlier drafts of this
+record is conjecture, not measurement.
 
-- The clipped-arc limb error is dominated by a systematic ~-2.1 px
-  *radial mean bias* (limb fitted toward the body center; mean error
-  (-2.16, -0.02) in the arc frame), which lands in the estimator's
-  mean channel as designed and leaves the covariances unpolluted --
-  but it is a striking technique behavior on partial arcs that WS-1
-  binning must expect.
-- Where the aniso cohort is algebraically identifiable (the
-  limb+disc+ring variant, condition 2.9), the recovered values still
-  miss truth materially (e.g. ring:s2 -0.353 [-0.668, -0.002] vs
-  truth +0.003): the clipped-arc regime's errors are heteroscedastic
-  (arc fraction varies per scene) and heavy-tailed, violating the
-  within-cohort stationarity the moment equations assume.  The
-  diagnosable symptom is a *negative recovered variance* whose CI
-  excludes zero -- treat that as a solve rejection, not a number.
+**limb_ring_aniso families (400 frames each).**  The
+composition-level algebra behaves exactly as mapped (frozen relative
+angle: 3-dim null; diverse: 1-dim null with the predicted
+`trace/2 + s2` trade and the deviatoric identifiable).  The regime's
+substantive findings:
+
+- **Both body techniques carry geometry-locked radial biases** on the
+  clipped body, measured in the arc frame: limb mean error
+  (-2.16, -0.02) px (fitted toward the body center), disc mean error
+  (-0.62, -0.02) px in the diverse cohort.  In the image frame these
+  means average to ~0 over the diverse cohort -- exactly the aliasing
+  configuration above.
+- **The constant-centering analysis was corrupted by that aliasing
+  and its cross terms.**  In `report_v1` the algebraically
+  identifiable limb+disc+ring solve on the diverse cohort recovered
+  limb c11 +3.18 vs truth +2.36, disc c11 +3.23, and ring s2
+  **-0.353 [-0.668, -0.002]** vs truth +0.003; the same cohort's
+  truth-based pair table shows disc-vs-limb cross-covariance
+  **+0.532 px^2** and blob-vs-limb **-0.554 px^2** -- the shared
+  geometry-locked-bias cross terms, not noise correlation.
+- **The rotating mean model repairs it.**  With limb *and* disc
+  declared rotating (arming their mean columns), the same solve
+  returns limb [+2.323, -0.044, +2.221] and disc
+  [+2.842, +0.242, +2.703] -- every element within CI of the
+  arc-frame truths [+2.361, +0.057, +2.733] / [+2.767, +0.183,
+  +2.268] -- and ring s2 +0.069 [-0.167, +0.313], covering truth
+  instead of excluding it; residual RMS drops 6.37 to 5.27.
+- The frozen-angle variant keeps a residual miss (ring s2 -0.242
+  [-0.438, -0.038]): there the arc angle is constant, so the rotating
+  bias is an image-frame constant and was already absorbed -- the
+  miss is attributed to the regime's heteroscedastic
+  (arc-fraction-dependent) and heavy-tailed errors violating
+  within-cohort stationarity.  A negative recovered variance with a
+  CI excluding zero remains a solve *rejection* symptom -- but see
+  consequence 3 below: its absence proves nothing.
 
 Truth-based intrinsic pair couplings in the clean single-body cohorts
 are small (all |corr| <= 0.15; limb-disc -0.057, limb-ring -0.004,
 disc-ring +0.067), supporting the independence assumption *in this
 regime* for the pairs the solves rely on.  The clipped-body cohorts
 show material intrinsic couplings (blob-disc up to +0.83 correlation
-where both centroid the same partial silhouette) -- blob and disc must
-not share a solve on partial bodies.
+where both centroid the same partial silhouette, plus the
+geometry-locked cross terms above) -- blob and disc must not share a
+solve on partial bodies.
 
 ## Stage 0b: bias independence through the shared layer
 
@@ -172,7 +251,7 @@ slope of offset delta vs injected bias):
 | instance | slope dv | slope du | interpretation |
 |---|---|---|---|
 | limb | +0.967 | +1.022 | tracks the shared-layer bias one-for-one |
-| ring | +1.116 | +1.209 | tracks it (amplified slightly by the radial fit geometry) |
+| ring | +1.116 | +1.209 | tracks it, with a >1 response whose mechanism is unverified (plausibly the radial fit geometry; not established) |
 | disc | +0.000 | +0.000 | structurally decoupled (reads the image, not the DT) |
 | blob | +0.000 | +0.000 | structurally decoupled |
 
@@ -185,14 +264,18 @@ Truth-based pair coupling, control vs injected:
 | disc vs ring | +0.000 (+0.067) | +0.001 (+0.033) |
 | limb vs blob | -0.005 (-0.022) | -0.006 (-0.018) |
 
-The injected coupling (expected value sigma^2 = 0.49 px^2 per axis)
-appears in limb-ring at +0.58 px^2 and nowhere else.
+The injected per-axis bias variance is sigma^2 = 0.49 px^2; because
+both techniques respond with slopes near or above 1, the *expected*
+induced coupling is approximately `slope_limb * slope_ring * 0.49`
+~ 0.58 px^2, and the truth-measured coupling on the injected cohort is
+**+0.581 px^2** -- the reference every solve-side number below is
+judged against.
 
 **Misattribution when independence is assumed.**  On the injected
 cohort, the independence-assumed 4-technique solve stays
 well-conditioned and *silently redistributes* the shared component:
-ring:s2 recovered +0.302 vs truth +0.591 (the limb-ring difference
-cancels the common bias), disc inflated to ~+0.09 (truth +0.001),
+ring:s2 recovered +0.300 vs truth +0.591 (the limb-ring difference
+cancels the common bias), disc inflated to ~+0.10 (truth +0.001),
 blob inflated to ~+0.19/+0.12 (truth +0.05/+0.03).  The residual RMS
 barely moves (3.44 vs 3.30 control) -- *the solve does not flag the
 violation on its own at this over-determination level*; agreement
@@ -202,12 +285,19 @@ masks the shared bias exactly as the plan warned.
 (blob present for over-determination) recovers the injected coupling
 and repairs every corrupted value:
 
-| parameter | recovered [95% CI] | expected |
+| parameter | recovered [95% CI] | reference |
 |---|---|---|
-| cov(limb,ring):gamma | +0.468 [+0.294, +0.624] | +0.49 (= 0.7^2) |
-| ring:s2 | +0.614 [+0.527, +0.694] | +0.591 (truth) |
-| disc:c11 | -0.003 [-0.043, +0.035] | +0.001 |
-| limb:c11 | +1.947 [+1.547, +2.346] | +1.981 |
+| cov(limb,ring):gamma | +0.471 [+0.295, +0.629] | +0.581 (truth-measured) |
+| ring:s2 | +0.614 [+0.523, +0.689] | +0.591 (truth) |
+| disc:c11 | -0.003 [-0.042, +0.035] | +0.001 |
+| limb:c11 | +1.946 [+1.548, +2.343] | +1.981 |
+
+The recovered gamma sits ~0.11 below the truth-measured +0.581
+(covered by the CI, but a one-sided miss): the declared scalar-gamma
+model assumes an axis-independent (isotropic) projected coupling,
+while the actual induced coupling inherits the techniques'
+direction-dependent response slopes -- the model restriction
+documented in the estimator, visible here as a mild underestimate.
 
 ### noise_scale: shared noise sigma scaled 2-8x
 
@@ -221,8 +311,8 @@ couplings stay small (limb-ring +0.010 px^2, corr +0.082).  Verdict:
 at these scales the shared noise estimate is a dropout/scatter
 channel, not a coherent cross-technique bias channel -- but the
 selection effect (which scenes survive) is itself shared and should
-be treated as a common-mode feasibility coupling in WS-1 cohort
-construction.
+be treated as a common-mode feasibility coupling when the agreement
+study builds cohorts.
 
 The third shared element named by the plan, the feature reliability
 gate, acts on feature admission (binary), not on offsets; its
@@ -246,9 +336,12 @@ open question below.
   clean cohort) remains unprobed -- the plan's PSF concern stays open
   until a PSF-bearing campaign injects at that layer.
 - **Cross-body same-technique (limb@A vs limb@B): NOT independent**
-  (+0.72 correlation, +1.48 px^2) even with no injection -- a shared
-  subpixel-phase / shared-preprocessing common mode in the clean sim.
-  Multi-body separation is only trustworthy with the pair declared.
+  (+0.72 correlation, +1.48 px^2) even with no injection.  Partially
+  diagnosed: ~20% of the limb error variance is illumination-locked
+  deterministic error shared through the common scene illumination
+  (coupling drops to +0.64 when regressed out); the remainder is
+  unexplained.  Multi-body separation is only trustworthy with the
+  pair declared.
 - **blob vs disc on partial bodies: NOT independent** (+0.83
   correlation in the clipped-body cohort); never share a solve there.
 
@@ -263,26 +356,44 @@ open question below.
    the declared-pair solve with a decoupled technique
    (disc-NCC-class) is the working pattern that both detects and
    absorbs the shared-layer component.
-3. Negative recovered variances with CIs excluding zero are a solve
-   *rejection criterion* (stationarity/independence violation), not a
-   result.
+3. Solve rejection and its limits: a negative recovered variance
+   whose CI excludes zero indicates a stationarity or independence
+   violation and rejects the solve -- but the symptom is
+   necessary-not-sufficient.  A geometry-locked shared bias can
+   corrupt every recovered value with *no* negative variance anywhere
+   (demonstrated in "Geometry-locked biases" above), so an
+   all-positive, well-conditioned solve must not be read as clean.
 4. Within-bin stationarity is load-bearing: the clipped-arc cohort
    shows that geometry-dependent error scale (arc fraction) corrupts
-   identifiable solves.  WS-1 bins must control the geometry that
+   identifiable solves.  Cohort bins must control the geometry that
    sets error scale, exactly as the plan's binning section requires.
-5. The estimator's mean channel works: deterministic inter-technique
-   biases (the -2.1 px clipped-limb radial bias) do not pollute the
-   covariances, but they are the dominant error on some cohorts and
-   must be reported alongside any covariance.
+5. Bias handling must match the bias's frame.  An image-frame
+   constant inter-technique bias lands in the mean channel and leaves
+   the covariances clean.  A geometry-locked bias (constant in a
+   rotating frame -- the -2.1 px clipped-limb and -0.6 px
+   clipped-disc radial pulls measured here) aliases into recovered
+   covariance as `C + mu mu^T` unless its technique is declared
+   rotating so the solve's rotating mean columns absorb it; when
+   shared between techniques it additionally creates undeclared cross
+   terms that corrupt the whole solve.  **Orientation diversity is
+   therefore both the identifiability lever (consequence 1) and the
+   bias-aliasing hazard**: the same diversity that closes the system
+   converts geometry-locked biases from harmless constants into
+   silent covariance pollution.  Mitigations: declare rotating bases
+   (arming the rotating mean columns), or estimate means bin-wise in
+   each technique's basis frame before pooling.  Biases locked to
+   geometry the model does not carry (illumination, as measured in
+   the cross-body cohort) are NOT absorbed and remain a hazard.
 
 ## Open questions
 
 - **Weighting.**  The solve is OLS over per-frame moment equations
   with bootstrap CIs.  A GLS/ML weighting (inverse fourth-moment
   weights) would tighten CIs, at the cost of iterating on the answer;
-  OLS was chosen because WS-1 consumes the identifiability structure
-  and honest CIs more than it needs minimum-variance point estimates.
-  Revisit if WS-1's real cohorts are CI-limited.
+  OLS was chosen because the agreement study consumes the
+  identifiability structure and honest CIs more than it needs
+  minimum-variance point estimates.  Revisit if the real cohorts are
+  CI-limited.
 - **Positivity.**  Nothing constrains recovered variances to be
   nonnegative; small negative values (magnitude within CI of zero)
   appear routinely on near-zero parameters.  A projected /
@@ -294,6 +405,24 @@ open question below.
   wrong-lock tails (visible in the aniso cohorts).  A trimmed or
   Huberized moment estimator is the natural extension; unexplored
   here.
+- **Mean-model geometry coverage.**  The rotating mean columns carry
+  only the rotations the specs declare.  Biases locked to other
+  geometry (illumination direction, arc fraction, resolution) still
+  alias; extending the mean model with caller-supplied regressors
+  (e.g. illumination harmonics) is the natural next step and would
+  directly address the measured cross-body illumination coupling.
+- **Cross-body residual coupling.**  After removing the
+  illumination-locked component, ~0.64 correlation between same-frame
+  limb fits remains unexplained.  Diagnosing it (shared DT grid?
+  shared noise realization? another shared deterministic axis?) is
+  open; until then the limb-limb pair covariance must be declared in
+  any multi-body solve.
+- **Declared-pair model form.**  Full/full pair covariances are
+  image-frame constant and rank1-involving pairs use a scalar
+  (isotropic) gamma; the dt_shift detection shows the isotropy
+  restriction costs ~20% underestimate against a direction-dependent
+  coupling.  A rotating or anisotropic pair-covariance
+  parameterization is unimplemented.
 - **Reliability-gate injection.**  The gate's common-mode effect is
   feature dropout; measuring it needs a selection-effect design
   (which frames survive under gate perturbation), not an offset
@@ -302,10 +431,11 @@ open question below.
   scenes render no PSF stage, so the shared-PSF-edge-bias suspicion
   against the limb/disc base pair is unprobed.  A follow-up injection
   through a PSF-bearing render (the realism-validated chain) is the
-  next measurement the WS-1 base pair needs before it is called clean
-  on real frames.
-- **Clipped-limb radial bias.**  The ~-2.1 px inward mean bias of
-  partial-arc limb fits in this regime is a technique-behavior
-  observation from this campaign that deserves its own diagnosis
-  (possible frame-edge contamination of the boundary polyline or
-  coarse-seed asymmetry); it is recorded here, not diagnosed.
+  next measurement the base pair needs before it is called clean on
+  real frames.
+- **Clipped-body radial biases.**  The ~-2.1 px (limb) and ~-0.6 px
+  (disc) inward mean biases of partial-body fits in this regime are
+  technique-behavior observations from this campaign that deserve
+  their own diagnosis (possible frame-edge contamination of the
+  boundary polyline or coarse-seed asymmetry); they are recorded and
+  absorbed by the estimator's rotating mean columns, not diagnosed.

--- a/util/agreement/CAMPAIGN_20260719.md
+++ b/util/agreement/CAMPAIGN_20260719.md
@@ -103,6 +103,11 @@ distinction every claim below leans on:
   still aliases), and only rotations the model carries are absorbed --
   a bias locked to *unmodeled* geometry (e.g. illumination direction,
   see the cross-body finding below) still aliases into covariance.
+  Fitting the mean model also costs degrees of freedom: with up to
+  ~5-7 columns per pair, the centered second moments deflate by
+  roughly k/n (~1-2% at the campaign's n = 400), and the estimator's
+  overfit guard drops back to constant-only columns below 4 samples
+  per column.
 
 ## Stage 0a: recover-known-error and identifiability
 

--- a/util/agreement/CAMPAIGN_20260719.md
+++ b/util/agreement/CAMPAIGN_20260719.md
@@ -1,0 +1,311 @@
+# Agreement-estimator validation campaign 20260719
+
+Tracked record of the seed-20260719 estimator-validation campaign
+(issue #224; WS-0 of `plans/VALIDATION_AND_CALIBRATION_PLAN.md`): the
+recover-known-error test of the covariance-components solve, the
+per-composition identifiability map, and the bias-independence
+measurements through the shared preprocessing layer.  Generated
+artifacts (row files, the full generated report with every table) live
+under `_work/agreement/` (gitignored); this file preserves the numbers
+and conclusions that outlive them.
+
+## Campaign summary
+
+Campaign seed 20260719.  Control pass: 2400 scenes, 400 per family
+across the six compositions (`limb_disc`, `limb_disc_ring_fixed`,
+`limb_disc_ring_diverse`, `limb_ring_aniso_fixed`,
+`limb_ring_aniso_diverse`, `multi_body`), 0 errors, 19.5 min at 8
+workers (shared machine; cores 10-11 offline per the standing setup).
+Injection passes on `limb_disc_ring_diverse` only: `dt_shift` (400
+scenes, per-scene bias ~ N(0, 0.7 px) per axis through the shared
+gradient/edge-DT products) and `noise_scale` (400 scenes, shared
+noise-sigma scaled by log-uniform 2-8x), 2.9 min each, 0 errors.
+Analysis: `analyze.py` over the three row files; solves use 200
+bootstrap replicates (seed 1) for the 95% CIs quoted below.
+
+Every scene plants a known (offset_v, offset_u); each technique's true
+error is its offset minus the planted truth.  All recovered-vs-truth
+comparisons below are against that construction.
+
+## Basis and scope
+
+- **Clean-scene basis.**  Scenes are smooth ellipsoids and face-on
+  straight ringlets with Poisson noise plus a 2-8 DN read-noise draw:
+  no planted model error (no mesh relief, pose scatter, photometric
+  mismatch), no empirical instrument chain, no PSF stage.  This is
+  deliberate -- the campaign validates the *estimator's mathematics*
+  on known errors, not technique robustness -- but it means every
+  covariance below is a floor-regime value for this cohort, not a
+  shippable technique accuracy number, and every independence verdict
+  is conditional on this rendering regime.
+- **This verdict is the sim's.**  The bias-independence stage
+  establishes what the solve detects when a shared bias exists, and
+  which couplings exist in the rendered regime measured.  It does not
+  establish that real-image biases are independent; that check belongs
+  to the agreement study's own real-data closure tests (the
+  over-determined-frame closure of WS-1).  Per the capability envelope
+  in `docs/dev_guide/dev_guide_simulator.rst`, planted-truth recovery
+  is the axis on which the simulator's word is final -- accuracy
+  claims about real frames are not.
+- **Estimator input hygiene.**  The solve consumes only technique
+  offsets plus geometry angles derived from the idealized scene
+  parameters (ring radial direction, limb arc orientation) -- the same
+  quantities SPICE predictions supply on real frames.  Planted truth
+  is read only by the measurement layer (this directory), mirroring
+  `util/calibration`; nothing under `src/spindoctor/nav_*` touches
+  truth keys, and the boundary guard suite passes unchanged.
+- **Techniques carried.**  BodyLimbNav (limb), BodyDiscCorrelateNav
+  (disc), RingEdgeNav (ring, rank-1 radial), BodyBlobNav (blob, via a
+  blob-only orchestrator run on ring-bearing scenes; the orchestrator
+  otherwise skips the fallback).  RingAnnulusNav was collected but is
+  spurious on most straight-ringlet scenes and enters no solve.
+
+## Stage 0a: recover-known-error and identifiability
+
+### The identifiability map
+
+| composition | identifiable | not identifiable | plan expectation |
+|---|---|---|---|
+| limb+disc only | combined `C_limb + C_disc`, all elements | any split (3-dim null space) | confirmed: not separable |
+| limb+disc+ring, radial frozen | ring `s2`; each body technique's radial-radial projection; the full sum | the split orthogonal to the radial axis (2-dim null) | confirmed, and slightly stronger: `s2` and the per-technique radial projections are certified |
+| limb+disc+ring, radial diverse | all 7 unknowns (condition 3.7) | -- | full-matrix solve over rotating axes closes the system |
+| limb+disc+ring+blob | all 10 unknowns (condition 2.0-2.5), even with the radial frozen | -- | a 4th full-rank estimator substitutes for orientation diversity |
+| partial-arc limb + ring, relative angle frozen | one combination (the radial-projected total) | everything else (3-dim null of 4) | confirmed: orientation control or full-matrix carry is mandatory |
+| partial-arc limb + ring, relative angle diverse | the limb deviatoric (anisotropy) incl. `c12` | `trace(C_limb)/2 + s2` trade (1-dim null) | confirmed: rotation handled in matrix form; isotropic part needs a 3rd estimator |
+| multi-body, naive | algebraically everything (condition 1.7) | values are *wrong* (see below): cross-body limb-limb coupling violates independence | plan's "multi-body adds the orthogonal axis" holds only under cross-body independence, which fails here |
+| multi-body + declared limb-limb pair covariance | all 9 unknowns, including the coupling itself | -- | the declared-pair mechanism restores correct recovery |
+
+Degeneracies are demonstrated, not asserted: every degenerate solve
+reports its null-space directions explicitly (e.g. limb+disc alone:
+`+0.71*limb:c11 - 0.71*disc:c11` etc.), the unit suite verifies that
+adding a null vector leaves every residual unchanged, and the
+condition number is infinite for each rank-deficient cohort.
+
+### Recover-known-error results (selected, px^2)
+
+**limb_disc (400 frames).**  Split unidentifiable as predicted
+(identifiability 0.500 on every parameter); the identifiable combined
+covariance recovers the truth: `c11` sum 1.711 vs truth 1.702, `c22`
+sum 2.132 vs 2.126.
+
+**limb_disc_ring_fixed + blob (400 frames, condition 2.5).**  Exact
+recovery within CI on every element:
+
+| parameter | recovered [95% CI] | truth |
+|---|---|---|
+| limb:c11 | +1.899 [+1.382, +2.371] | +1.898 |
+| limb:c12 | -0.088 [-0.315, +0.163] | -0.087 |
+| limb:c22 | +1.737 [+1.266, +2.277] | +1.742 |
+| disc:c11 | +0.002 [-0.003, +0.006] | +0.001 |
+| ring:s2 | -0.003 [-0.009, +0.002] | +0.002 |
+| blob:c11 | +0.021 [+0.013, +0.030] | +0.018 |
+
+**limb_disc_ring_diverse (400 frames, 3 techniques, condition
+3.7).**  Fully identifiable from orientation diversity alone: limb
+[+1.688, -0.138, +1.645] vs truth [+1.666, -0.060, +1.495], disc and
+ring recovered near zero with CIs covering their (tiny) truths.  CIs
+are notably wider than the 4-technique variant -- the rank-1 ring leg
+carries fourth-moment noise.
+
+**multi_body, naive vs declared (400 frames).**  The naive solve is
+well-conditioned (1.7) and *wrong*: recovered limb [+1.042, +0.048,
++1.129] vs truth ~[+2.0, -0.08, +2.1], recovered disc [+0.482,
+-0.065, +0.506] vs truth ~0.0005 -- the cross-body limb-limb error
+coupling (measured truth cross-covariance +1.482 px^2, correlation
++0.716) cancels in the limb-limb difference and the least-squares fit
+misattributes it onto the disc.  Declaring `cov(limb@A, limb@B)`
+restores every value:
+
+| parameter | recovered [95% CI] | truth |
+|---|---|---|
+| limb:c11 | +2.005 [+1.546, +2.511] | +1.959 / +2.060 (RHEA / DIONE) |
+| limb:c22 | +2.141 [+1.702, +2.606] | +2.334 / +1.949 |
+| disc:c11 | +0.0002 [+0.0001, +0.0004] | +0.0005 |
+| cov(limb,limb):s11 | +1.445 [+1.044, +1.854] | +1.482 (measured) |
+
+The disc-disc cross-body pair is also correlated (+0.514) but at
+~3e-4 px^2 it is immaterial; declaring both within-group pairs would
+re-degenerate the system (verified: null dimension 3), so the rule is
+*declare the material pairs only*.
+
+**limb_ring_aniso families (400 frames each).**  The composition-level
+algebra behaves exactly as mapped (frozen relative angle: 3-dim null;
+diverse: 1-dim null with the predicted `trace/2 + s2` trade and the
+deviatoric identifiable).  Two honest deficiencies in this regime:
+
+- The clipped-arc limb error is dominated by a systematic ~-2.1 px
+  *radial mean bias* (limb fitted toward the body center; mean error
+  (-2.16, -0.02) in the arc frame), which lands in the estimator's
+  mean channel as designed and leaves the covariances unpolluted --
+  but it is a striking technique behavior on partial arcs that WS-1
+  binning must expect.
+- Where the aniso cohort is algebraically identifiable (the
+  limb+disc+ring variant, condition 2.9), the recovered values still
+  miss truth materially (e.g. ring:s2 -0.353 [-0.668, -0.002] vs
+  truth +0.003): the clipped-arc regime's errors are heteroscedastic
+  (arc fraction varies per scene) and heavy-tailed, violating the
+  within-cohort stationarity the moment equations assume.  The
+  diagnosable symptom is a *negative recovered variance* whose CI
+  excludes zero -- treat that as a solve rejection, not a number.
+
+Truth-based intrinsic pair couplings in the clean single-body cohorts
+are small (all |corr| <= 0.15; limb-disc -0.057, limb-ring -0.004,
+disc-ring +0.067), supporting the independence assumption *in this
+regime* for the pairs the solves rely on.  The clipped-body cohorts
+show material intrinsic couplings (blob-disc up to +0.83 correlation
+where both centroid the same partial silhouette) -- blob and disc must
+not share a solve on partial bodies.
+
+## Stage 0b: bias independence through the shared layer
+
+Injection is through the *shared per-image products* only -- the
+orchestrator-level `compute_all_image_derivatives` (gradient
+magnitude, edge distance transform, gradient vector) and
+`estimate_image_noise_sigma` -- as harness monkeypatches in
+`collect.py`.  No production hook was added.
+
+### dt_shift: per-scene N(0, 0.7 px) translation of the DT products
+
+Paired per-scene response (same scenes with and without injection;
+slope of offset delta vs injected bias):
+
+| instance | slope dv | slope du | interpretation |
+|---|---|---|---|
+| limb | +0.967 | +1.022 | tracks the shared-layer bias one-for-one |
+| ring | +1.116 | +1.209 | tracks it (amplified slightly by the radial fit geometry) |
+| disc | +0.000 | +0.000 | structurally decoupled (reads the image, not the DT) |
+| blob | +0.000 | +0.000 | structurally decoupled |
+
+Truth-based pair coupling, control vs injected:
+
+| pair | control cov (corr) | dt_shift cov (corr) |
+|---|---|---|
+| limb vs ring | -0.000 (-0.004) | **+0.581 (+0.501)** |
+| limb vs disc | -0.002 (-0.057) | -0.001 (-0.026) |
+| disc vs ring | +0.000 (+0.067) | +0.001 (+0.033) |
+| limb vs blob | -0.005 (-0.022) | -0.006 (-0.018) |
+
+The injected coupling (expected value sigma^2 = 0.49 px^2 per axis)
+appears in limb-ring at +0.58 px^2 and nowhere else.
+
+**Misattribution when independence is assumed.**  On the injected
+cohort, the independence-assumed 4-technique solve stays
+well-conditioned and *silently redistributes* the shared component:
+ring:s2 recovered +0.302 vs truth +0.591 (the limb-ring difference
+cancels the common bias), disc inflated to ~+0.09 (truth +0.001),
+blob inflated to ~+0.19/+0.12 (truth +0.05/+0.03).  The residual RMS
+barely moves (3.44 vs 3.30 control) -- *the solve does not flag the
+violation on its own at this over-determination level*; agreement
+masks the shared bias exactly as the plan warned.
+
+**Detection via the declared pair.**  Declaring `cov(limb, ring)`
+(blob present for over-determination) recovers the injected coupling
+and repairs every corrupted value:
+
+| parameter | recovered [95% CI] | expected |
+|---|---|---|
+| cov(limb,ring):gamma | +0.468 [+0.294, +0.624] | +0.49 (= 0.7^2) |
+| ring:s2 | +0.614 [+0.527, +0.694] | +0.591 (truth) |
+| disc:c11 | -0.003 [-0.043, +0.035] | +0.001 |
+| limb:c11 | +1.947 [+1.547, +2.346] | +1.981 |
+
+### noise_scale: shared noise sigma scaled 2-8x
+
+The noise-sigma channel couples through *feasibility*, not smoothly
+through offsets: the limb goes spurious on 153/400 scenes (the raised
+DT threshold erases weak limb edges), and where it survives its
+offset moves by 2.14 px RMS with only weak dependence on the factor
+(corr +0.12) -- re-lock scatter, not a proportional bias.  Ring moves
+0.44 px RMS; disc and blob are exactly unchanged.  Induced pair
+couplings stay small (limb-ring +0.010 px^2, corr +0.082).  Verdict:
+at these scales the shared noise estimate is a dropout/scatter
+channel, not a coherent cross-technique bias channel -- but the
+selection effect (which scenes survive) is itself shared and should
+be treated as a common-mode feasibility coupling in WS-1 cohort
+construction.
+
+The third shared element named by the plan, the feature reliability
+gate, acts on feature admission (binary), not on offsets; its
+common-mode effect is the same selection-effect class as the
+noise-sigma channel and was not separately injected.  Recorded as an
+open question below.
+
+### Pair verdicts (this sim, this regime)
+
+- **limb-DT vs ring-DT: NOT independent through the shared layer.**
+  Both track a gradient/DT-layer bias with slope ~1; their pairwise
+  difference is blind to it.  On real frames this pair must either be
+  excluded from joint solves or carried with a declared pair
+  covariance and enough over-determination (a decoupled technique in
+  the same solve) to measure it.
+- **limb-DT vs disc-NCC: independent through the gradient/DT layer**
+  (response slope 0.000; coupling unchanged under injection; control
+  correlation -0.057).  This clears the base pairing *for this
+  coupling channel in this rendered regime only*: disc and limb still
+  share the source image, and a PSF-edge bias (not rendered in this
+  clean cohort) remains unprobed -- the plan's PSF concern stays open
+  until a PSF-bearing campaign injects at that layer.
+- **Cross-body same-technique (limb@A vs limb@B): NOT independent**
+  (+0.72 correlation, +1.48 px^2) even with no injection -- a shared
+  subpixel-phase / shared-preprocessing common mode in the clean sim.
+  Multi-body separation is only trustworthy with the pair declared.
+- **blob vs disc on partial bodies: NOT independent** (+0.83
+  correlation in the clipped-body cohort); never share a solve there.
+
+## Consequences for the agreement study
+
+1. Per-technique covariance may be reported from body+ring cohorts
+   only where ring-radial orientation diversity exists (or a
+   verified-decoupled third estimator joins the solve); with frozen
+   geometry, report the radial-radial projections and the combined
+   covariance, nothing more.
+2. The DT pair (limb, ring) must never be treated as independent;
+   the declared-pair solve with a decoupled technique
+   (disc-NCC-class) is the working pattern that both detects and
+   absorbs the shared-layer component.
+3. Negative recovered variances with CIs excluding zero are a solve
+   *rejection criterion* (stationarity/independence violation), not a
+   result.
+4. Within-bin stationarity is load-bearing: the clipped-arc cohort
+   shows that geometry-dependent error scale (arc fraction) corrupts
+   identifiable solves.  WS-1 bins must control the geometry that
+   sets error scale, exactly as the plan's binning section requires.
+5. The estimator's mean channel works: deterministic inter-technique
+   biases (the -2.1 px clipped-limb radial bias) do not pollute the
+   covariances, but they are the dominant error on some cohorts and
+   must be reported alongside any covariance.
+
+## Open questions
+
+- **Weighting.**  The solve is OLS over per-frame moment equations
+  with bootstrap CIs.  A GLS/ML weighting (inverse fourth-moment
+  weights) would tighten CIs, at the cost of iterating on the answer;
+  OLS was chosen because WS-1 consumes the identifiability structure
+  and honest CIs more than it needs minimum-variance point estimates.
+  Revisit if WS-1's real cohorts are CI-limited.
+- **Positivity.**  Nothing constrains recovered variances to be
+  nonnegative; small negative values (magnitude within CI of zero)
+  appear routinely on near-zero parameters.  A projected /
+  semidefinite-constrained variant would look cleaner but would
+  destroy the negative-variance rejection diagnostic (consequence 3);
+  if constrained solves are ever adopted, the unconstrained solve
+  must still be run for diagnosis.
+- **Robustness to tails.**  Second-moment equations are sensitive to
+  wrong-lock tails (visible in the aniso cohorts).  A trimmed or
+  Huberized moment estimator is the natural extension; unexplored
+  here.
+- **Reliability-gate injection.**  The gate's common-mode effect is
+  feature dropout; measuring it needs a selection-effect design
+  (which frames survive under gate perturbation), not an offset
+  regression.  Not done in this campaign.
+- **PSF-layer coupling for limb vs disc.**  This campaign's clean
+  scenes render no PSF stage, so the shared-PSF-edge-bias suspicion
+  against the limb/disc base pair is unprobed.  A follow-up injection
+  through a PSF-bearing render (the realism-validated chain) is the
+  next measurement the WS-1 base pair needs before it is called clean
+  on real frames.
+- **Clipped-limb radial bias.**  The ~-2.1 px inward mean bias of
+  partial-arc limb fits in this regime is a technique-behavior
+  observation from this campaign that deserves its own diagnosis
+  (possible frame-edge contamination of the boundary polyline or
+  coarse-seed asymmetry); it is recorded here, not diagnosed.

--- a/util/agreement/README.md
+++ b/util/agreement/README.md
@@ -1,0 +1,123 @@
+# Cross-technique agreement estimator (validation tooling)
+
+Offline tooling that validates the covariance-components estimator the
+cross-technique agreement study relies on, on truth-known simulated
+scenes (issue #224 / WS-0 of `plans/VALIDATION_AND_CALIBRATION_PLAN.md`).
+The estimator separates per-technique 2x2 error covariances from nothing
+but the techniques' pairwise disagreements; before any real-image
+per-technique number is trusted, this campaign proves on planted-truth
+scenes (a) where that solve is identifiable at all, per scene
+composition, and (b) whether the compared techniques stay
+bias-independent through their shared preprocessing layer.
+
+Everything here is a repo-checkout script (not part of the distributed
+package); generated artifacts go under `_work/agreement/` (gitignored).
+The dated campaign record (`CAMPAIGN_20260719.md`, this directory)
+preserves the numbers and conclusions that outlive them.
+
+## Pieces
+
+1. **`estimator.py`** — the covariance-components solve itself, the
+   component the agreement study consumes.  Truth-free by construction:
+   input is per-frame technique offsets plus geometry angles, output is
+   per-technique covariance matrices *with an identifiability report*
+   (singular spectrum, null space mapped to parameter names,
+   per-parameter scores, bootstrap CIs).  Full matrix form throughout:
+   rotating anisotropy bases (limb arcs), rank-1 instances (straight
+   ring edges), shared parameter groups (same technique on two bodies),
+   and declared suspect-pair cross-covariances.
+2. **`scene_gen.py`** — seeded scene families whose *estimator
+   composition* is the controlled variable: `limb_disc`,
+   `limb_disc_ring_fixed` / `_diverse` (frozen vs drawn ring radial
+   direction), `limb_ring_aniso_fixed` / `_diverse` (clipped body,
+   genuinely anisotropic limb covariance), `multi_body`.  Scenes are
+   deliberately clean (smooth ellipsoids, moderate noise): the campaign
+   validates the estimator's mathematics, not technique robustness.
+3. **`collect.py`** — navigates every scene in-process and writes one
+   JSONL row per scene: planted truth, geometry angles, and every
+   per-technique result from each configured run (multi-body scenes run
+   once per body via `only_models='body_sim:<NAME>'`; ring scenes add a
+   blob-only run for a shared-layer-independent extra estimator).
+
+   ```bash
+   venv/bin/python util/agreement/collect.py \
+       --per-family 400 --workers 8 --out _work/agreement/rows.jsonl
+   ```
+
+   `--injection dt_shift` re-runs with the shared gradient / edge-DT
+   products translated by a per-scene random bias, and
+   `--injection noise_scale` with the shared noise-sigma estimate
+   scaled — both as harness-level monkeypatches of the orchestrator
+   module (no production seam).  Injected values are drawn from the
+   campaign seed and recorded per row.
+
+   ```bash
+   venv/bin/python util/agreement/collect.py \
+       --per-family 400 --families limb_disc_ring_diverse \
+       --injection dt_shift --workers 8 \
+       --out _work/agreement/rows_dt.jsonl
+   ```
+
+4. **`analyze.py`** — produces the Markdown report: per composition, the
+   truth-free solve next to the truth-based reference (empirical error
+   covariance against planted offsets), the null-space demonstration for
+   degenerate compositions, and — when injected row files are supplied —
+   the bias-independence tables (truth-based pair coupling per
+   condition, paired per-scene injection response, solve-side detection
+   with a declared pair covariance).
+
+   ```bash
+   venv/bin/python util/agreement/analyze.py _work/agreement/rows.jsonl \
+       --dt-rows _work/agreement/rows_dt.jsonl \
+       --noise-rows _work/agreement/rows_noise.jsonl \
+       --out _work/agreement/report.md
+   ```
+
+5. **`tests/`** — pytest suite for the estimator (synthetic-Gaussian
+   recovery and degeneracy demonstrations for every composition regime)
+   and the scene generator (determinism, schema validity, geometry
+   invariants).  `util/` is outside the repo's CI pytest/ruff/mypy
+   scope; run them directly:
+
+   ```bash
+   venv/bin/python -m pytest util/agreement/tests -q
+   ruff check util/agreement && ruff format --check util/agreement
+   MYPYPATH=src mypy --strict util/agreement/estimator.py \
+       util/agreement/scene_gen.py util/agreement/analyze.py \
+       util/agreement/collect.py
+   ```
+
+## Reading the estimator output
+
+- **Identifiability score** (per parameter, in [0, 1]): the squared
+  projection of that parameter's axis onto the row space of the design
+  matrix.  1.0 means the cohort determines it; near 0 means it lies in
+  the null space and the returned (minimum-norm) value is arbitrary.
+- **Null-space directions**: linear combinations of parameters that can
+  be shifted freely without changing any observable — the explicit form
+  of "this composition cannot separate these techniques".
+- **Pair mean difference**: the cohort mean of each pairwise offset
+  difference, subtracted before the second moments.  Deterministic
+  shared biases land here, not in the covariances.
+- **Declared pair covariances**: adding `pair_covariances=[(i, j)]`
+  turns an assumed-independent pair into a measured one; the cohort must
+  be over-determined enough to carry the extra unknowns (check the
+  scores).
+
+## Caveats
+
+- **Truth basis.**  Planted offsets are ground truth by construction, so
+  recovered-vs-planted comparisons here are exact statements about the
+  estimator and the navigation algorithms on these scenes.  They are
+  *not* real-image accuracy claims; the campaign record spells out the
+  sim-scope limitation (see the capability-envelope section of
+  `docs/dev_guide/dev_guide_simulator.rst`).
+- **Information boundary.**  This directory is measurement-layer code
+  (like `util/calibration`): it may read planted truth.  Nothing under
+  `src/spindoctor/nav_*` touches truth keys, and the injection is a
+  harness monkeypatch, not a production hook.
+- **Clean-scene basis.**  The campaign's scenes carry no planted model
+  error (no mesh relief, pose scatter, or photometric mismatch), so the
+  measured per-technique covariances are near-floor values specific to
+  this validation cohort — inputs for checking the solve, not shippable
+  technique accuracy numbers.

--- a/util/agreement/README.md
+++ b/util/agreement/README.md
@@ -2,7 +2,8 @@
 
 Offline tooling that validates the covariance-components estimator the
 cross-technique agreement study relies on, on truth-known simulated
-scenes (issue #224 / WS-0 of `plans/VALIDATION_AND_CALIBRATION_PLAN.md`).
+scenes (issue #224; the agreement-estimator validation stage of
+`plans/VALIDATION_AND_CALIBRATION_PLAN.md`).
 The estimator separates per-technique 2x2 error covariances from nothing
 but the techniques' pairwise disagreements; before any real-image
 per-technique number is trusted, this campaign proves on planted-truth
@@ -96,13 +97,23 @@ preserves the numbers and conclusions that outlive them.
 - **Null-space directions**: linear combinations of parameters that can
   be shifted freely without changing any observable — the explicit form
   of "this composition cannot separate these techniques".
-- **Pair mean difference**: the cohort mean of each pairwise offset
-  difference, subtracted before the second moments.  Deterministic
-  shared biases land here, not in the covariances.
+- **Pair mean channel**: each pair's differences are centered by a
+  fitted mean model before the second moments -- constant (image-frame)
+  terms always, plus rotating-frame mean columns for every
+  `basis='rotating'` member (reported in `pair_mean_model`).  A bias
+  *constant in the image frame* lands here and leaves the covariances
+  clean.  A *geometry-locked* bias (constant in a rotating frame) is
+  absorbed only when its technique is declared rotating: undeclared, it
+  has image-frame mean ~0 over a diverse cohort and aliases into the
+  recovered covariance as `C + mu mu^T` -- silently, well-conditioned,
+  and with no negative-variance symptom.  Biases locked to geometry the
+  model does not carry (e.g. illumination) still alias.
 - **Declared pair covariances**: adding `pair_covariances=[(i, j)]`
   turns an assumed-independent pair into a measured one; the cohort must
   be over-determined enough to carry the extra unknowns (check the
-  scores).
+  scores).  Model restrictions: a full/full pair's matrix is
+  image-frame constant, and a rank1-involving pair's scalar `gamma`
+  assumes an axis-independent (isotropic) projected coupling.
 
 ## Caveats
 

--- a/util/agreement/README.md
+++ b/util/agreement/README.md
@@ -107,7 +107,10 @@ preserves the numbers and conclusions that outlive them.
   has image-frame mean ~0 over a diverse cohort and aliases into the
   recovered covariance as `C + mu mu^T` -- silently, well-conditioned,
   and with no negative-variance symptom.  Biases locked to geometry the
-  model does not carry (e.g. illumination) still alias.
+  model does not carry (e.g. illumination) still alias.  Fitting k mean
+  columns per pair deflates the centered second moments by roughly k/n
+  (~1-2% at k <= 7, n = 400); an overfit guard falls back to
+  constant-only columns below 4 samples per column.
 - **Declared pair covariances**: adding `pair_covariances=[(i, j)]`
   turns an assumed-independent pair into a measured one; the cohort must
   be over-determined enough to carry the extra unknowns (check the

--- a/util/agreement/analyze.py
+++ b/util/agreement/analyze.py
@@ -121,8 +121,16 @@ def build_cohort(rows: list[dict[str, Any]], family: str) -> list[CohortFrame]:
         axis: dict[str, float] = {}
         if 'ring_radial_deg' in geometry and 'ring' in offsets:
             axis['ring'] = math.radians(float(geometry['ring_radial_deg']))
-        if 'limb_arc_outward_deg' in geometry and 'limb' in offsets:
-            basis['limb'] = math.radians(float(geometry['limb_arc_outward_deg']))
+        if 'limb_arc_outward_deg' in geometry:
+            # The arc direction is the rotating basis for every technique
+            # navigating the clipped body: the limb (anisotropic covariance)
+            # and the disc (its inward pull toward the body center is a
+            # geometry-locked bias the solve's rotating mean columns must
+            # be able to absorb).
+            arc = math.radians(float(geometry['limb_arc_outward_deg']))
+            for name in ('limb', 'disc'):
+                if name in offsets:
+                    basis[name] = arc
         frames.append(
             CohortFrame(
                 scene_id=row['scene_id'],
@@ -303,8 +311,13 @@ def report_solve(
     out.append('|---|---|---|---|')
     for k, name in enumerate(result.param_names):
         ci = result.bootstrap_ci.get(name)
-        ci_str = f'[{ci[0]:+.4f}, {ci[1]:+.4f}]' if ci else 'n/a'
         ident = result.identifiability[name]
+        # A CI on an unidentifiable parameter would just resample the
+        # arbitrary minimum-norm split; suppress it.
+        if ci is None or ident < 0.6:
+            ci_str = '--'
+        else:
+            ci_str = f'[{ci[0]:+.4f}, {ci[1]:+.4f}]'
         flag = '' if ident > 0.99 else ' (NOT identifiable)' if ident < 0.6 else ' (partial)'
         out.append(f'| {name} | {result.params[k]:+.4f} | {ci_str} | {ident:.3f}{flag} |')
     out.append('')
@@ -415,9 +428,20 @@ def report_injection_response(
         arr = np.asarray(deltas[name])
         if arr.shape[0] < 5:
             continue
-        slope_v = float(np.polyfit(arr[:, 0], arr[:, 2], 1)[0])
-        slope_u = float(np.polyfit(arr[:, 1], arr[:, 3], 1)[0])
-        resid = np.stack([arr[:, 2] - slope_v * arr[:, 0], arr[:, 3] - slope_u * arr[:, 1]], axis=1)
+        fit_v = np.polyfit(arr[:, 0], arr[:, 2], 1)
+        fit_u = np.polyfit(arr[:, 1], arr[:, 3], 1)
+        slope_v = float(fit_v[0])
+        slope_u = float(fit_u[0])
+        # Residuals about the full fitted line (slope AND intercept); using
+        # the slope alone would inflate the RMS whenever the intercept is
+        # nonzero.
+        resid = np.stack(
+            [
+                arr[:, 2] - np.polyval(fit_v, arr[:, 0]),
+                arr[:, 3] - np.polyval(fit_u, arr[:, 1]),
+            ],
+            axis=1,
+        )
         rms = float(np.sqrt(np.mean(resid**2)))
         out.append(f'| {name} | {arr.shape[0]} | {slope_v:+.3f} | {slope_u:+.3f} | {rms:.3f} |')
     out.append('')
@@ -496,7 +520,12 @@ def _specs_for_family(
     if family in ('limb_disc_ring_fixed', 'limb_disc_ring_diverse'):
         return [([limb_img, disc, ring], no_pairs), ([limb_img, disc, ring, blob], no_pairs)]
     if family in ('limb_ring_aniso_fixed', 'limb_ring_aniso_diverse'):
-        return [([limb_rot, ring], no_pairs), ([limb_rot, disc, ring], no_pairs)]
+        # The disc on the clipped body is declared rotating too: its pull
+        # toward the body center is a geometry-locked bias that must be
+        # absorbed by the rotating mean columns, not aliased into the
+        # covariances (its covariance is then reported in the arc frame).
+        disc_rot = EstimatorSpec('disc', 'full', basis='rotating')
+        return [([limb_rot, ring], no_pairs), ([limb_rot, disc_rot, ring], no_pairs)]
     if family == 'multi_body':
         multi = [
             EstimatorSpec('limb@RHEA', 'full', group='limb'),
@@ -582,10 +611,13 @@ def main(argv: list[str] | None = None) -> int:
             cohort = build_cohort(inj_rows, family)
             out.append(f'### Injection: {label} (`{path}`)')
             out.append('')
-            out.append(
-                f'Injection parameters: sigma_px '
-                f'{inj_manifest.get("injection_sigma_px", "?")} (dt_shift only).'
-            )
+            if label == 'dt_shift':
+                out.append(
+                    f'Injection parameters: per-scene bias ~ N(0, sigma_px = '
+                    f'{inj_manifest.get("injection_sigma_px", "?")}) per axis.'
+                )
+            else:
+                out.append('Injection parameters: shared noise sigma scaled log-uniform 2-8x.')
             out.append('')
             report_pair_truth(out, cohort, pivotal, f'{label}: truth-based pair coupling')
             if label == 'noise_scale':

--- a/util/agreement/analyze.py
+++ b/util/agreement/analyze.py
@@ -1,0 +1,552 @@
+"""Analyze agreement rows: identifiability map + bias-independence measurements.
+
+Consumes the JSONL rows written by ``collect.py`` and produces a Markdown
+report with, per composition cohort:
+
+- the truth-free covariance-components solve (recovered matrices, singular
+  spectrum, null space, per-parameter identifiability, bootstrap CIs);
+- the truth-based reference (each technique's empirical error covariance
+  against the planted offset, in the estimator's own basis frame), which the
+  recovered values are checked against;
+- the identifiability-map entry: which covariance elements the composition
+  determines, and the explicit null-space demonstration where it does not.
+
+When injected-cohort row files are supplied (``--dt-rows`` /
+``--noise-rows``), the report adds the bias-independence stage: truth-based
+cross-technique error covariances and correlations for the pivotal pairs
+under each injection condition, the paired per-scene response of every
+technique to the injected shared-layer bias, and the solve-side detection
+check (declared pair covariance recovering the injected coupling; the
+independence-assumed solve's misattribution).
+
+Run:
+
+    venv/bin/python util/agreement/analyze.py _work/agreement/rows.jsonl \
+        --dt-rows _work/agreement/rows_dt.jsonl \
+        --noise-rows _work/agreement/rows_noise.jsonl \
+        --out _work/agreement/report.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+HERE = Path(__file__).parent
+sys.path.insert(0, str(HERE))
+
+from estimator import (  # noqa: E402
+    EstimatorSpec,
+    FrameSample,
+    SolveResult,
+    solve_covariance_components,
+)
+
+# Instance-name mapping: technique class -> estimator instance name.
+_TECH_TO_INSTANCE = {
+    'BodyLimbNav': 'limb',
+    'BodyDiscCorrelateNav': 'disc',
+    'RingEdgeNav': 'ring',
+    'BodyBlobNav': 'blob',
+}
+
+
+@dataclass(frozen=True)
+class CohortFrame:
+    """One scene's assembled estimator sample plus its planted truth."""
+
+    scene_id: str
+    sample: FrameSample
+    truth: tuple[float, float]
+
+
+def load_rows(path: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Load a rows file, returning (manifest, rows)."""
+    with path.open() as f:
+        lines = [json.loads(line) for line in f]
+    manifest = lines[0] if lines and lines[0].get('manifest') else {}
+    rows = [row for row in lines if not row.get('manifest')]
+    return manifest, rows
+
+
+def _instance_offsets(row: dict[str, Any]) -> dict[str, tuple[float, float]]:
+    """Extract non-spurious per-instance offsets from a row's runs."""
+    offsets: dict[str, tuple[float, float]] = {}
+    for run_key, techniques in row['runs'].items():
+        for tech in techniques:
+            if tech['spurious'] or tech['at_edge']:
+                continue
+            name = _TECH_TO_INSTANCE.get(tech['name'])
+            if name is None:
+                continue
+            if run_key.startswith('body:'):
+                instance = f'{name}@{run_key.split(":", 1)[1]}'
+            else:
+                instance = name
+            offsets[instance] = (float(tech['offset_v']), float(tech['offset_u']))
+    return offsets
+
+
+def build_cohort(rows: list[dict[str, Any]], family: str) -> list[CohortFrame]:
+    """Assemble estimator frames for one family's rows.
+
+    Ring instances take their per-frame radial axis, and the clipped-limb
+    families take the limb's rotating basis angle, from the row geometry
+    (derived from the idealized scene parameters, not truth keys).
+
+    Parameters:
+        rows: All rows from a collection pass.
+        family: Family to select.
+
+    Returns:
+        The cohort frames (scenes with an error or fewer than two usable
+        instances are dropped).
+    """
+    frames: list[CohortFrame] = []
+    for row in rows:
+        if row['family'] != family or 'error' in row:
+            continue
+        offsets = _instance_offsets(row)
+        if len(offsets) < 2:
+            continue
+        geometry = row['geometry']
+        basis: dict[str, float] = {}
+        axis: dict[str, float] = {}
+        if 'ring_radial_deg' in geometry and 'ring' in offsets:
+            axis['ring'] = math.radians(float(geometry['ring_radial_deg']))
+        if 'limb_arc_outward_deg' in geometry and 'limb' in offsets:
+            basis['limb'] = math.radians(float(geometry['limb_arc_outward_deg']))
+        frames.append(
+            CohortFrame(
+                scene_id=row['scene_id'],
+                sample=FrameSample(offsets=offsets, basis_angle_rad=basis, axis_angle_rad=axis),
+                truth=(float(row['planted']['dv']), float(row['planted']['du'])),
+            )
+        )
+    return frames
+
+
+def _rot(theta: float) -> np.ndarray:
+    """Rotation matrix with basis vectors at ``theta`` as columns."""
+    c, s = math.cos(theta), math.sin(theta)
+    return np.array([[c, -s], [s, c]])
+
+
+def truth_covariance(
+    cohort: list[CohortFrame], instance: str, *, basis: str = 'image'
+) -> tuple[np.ndarray, np.ndarray, int] | None:
+    """Empirical error mean and covariance for one instance vs planted truth.
+
+    Parameters:
+        cohort: Cohort frames.
+        instance: Instance name.
+        basis: ``'image'`` or ``'rotating'`` (uses the frame's basis angle).
+
+    Returns:
+        ``(mean, covariance, n)`` in the requested basis, or ``None`` when
+        the instance appears on fewer than 3 frames.
+    """
+    errors = []
+    for frame in cohort:
+        if instance not in frame.sample.offsets:
+            continue
+        o = frame.sample.offsets[instance]
+        e = np.array([o[0] - frame.truth[0], o[1] - frame.truth[1]])
+        if basis == 'rotating':
+            theta = frame.sample.basis_angle_rad.get(instance, 0.0)
+            e = _rot(theta).T @ e
+        errors.append(e)
+    if len(errors) < 3:
+        return None
+    arr = np.asarray(errors)
+    return arr.mean(axis=0), np.cov(arr.T, ddof=1), len(errors)
+
+
+def truth_radial_variance(
+    cohort: list[CohortFrame], instance: str
+) -> tuple[float, float, int] | None:
+    """Empirical mean and variance of a rank1 instance's radial error."""
+    values = []
+    for frame in cohort:
+        if instance not in frame.sample.offsets or instance not in frame.sample.axis_angle_rad:
+            continue
+        alpha = frame.sample.axis_angle_rad[instance]
+        a = np.array([math.cos(alpha), math.sin(alpha)])
+        o = frame.sample.offsets[instance]
+        e = np.array([o[0] - frame.truth[0], o[1] - frame.truth[1]])
+        values.append(float(a @ e))
+    if len(values) < 3:
+        return None
+    arr = np.asarray(values)
+    return float(arr.mean()), float(arr.var(ddof=1)), len(values)
+
+
+def truth_cross_covariance(
+    cohort: list[CohortFrame], instance_a: str, instance_b: str
+) -> tuple[float, float, int] | None:
+    """Truth-based scalar cross-covariance and correlation for a pair.
+
+    Both errors are projected onto the ring radial axis when either member
+    is the ring (a rank1 instance's tangential component is meaningless);
+    otherwise the statistic is the mean of the two per-axis covariances /
+    correlations (a single scalar summary of the 2-D coupling).
+
+    Parameters:
+        cohort: Cohort frames.
+        instance_a: First instance.
+        instance_b: Second instance.
+
+    Returns:
+        ``(covariance, correlation, n)`` or ``None`` below 3 samples.
+    """
+    e_a: list[np.ndarray] = []
+    e_b: list[np.ndarray] = []
+    project = 'ring' in (instance_a, instance_b)
+    for frame in cohort:
+        if instance_a not in frame.sample.offsets or instance_b not in frame.sample.offsets:
+            continue
+        o_a = frame.sample.offsets[instance_a]
+        o_b = frame.sample.offsets[instance_b]
+        ea = np.array([o_a[0] - frame.truth[0], o_a[1] - frame.truth[1]])
+        eb = np.array([o_b[0] - frame.truth[0], o_b[1] - frame.truth[1]])
+        if project:
+            alpha = frame.sample.axis_angle_rad.get(
+                'ring', frame.sample.basis_angle_rad.get('ring', 0.0)
+            )
+            a = np.array([math.cos(alpha), math.sin(alpha)])
+            ea = np.array([float(a @ ea)])
+            eb = np.array([float(a @ eb)])
+        e_a.append(ea)
+        e_b.append(eb)
+    if len(e_a) < 3:
+        return None
+    arr_a = np.asarray(e_a)
+    arr_b = np.asarray(e_b)
+    covs = []
+    corrs = []
+    for k in range(arr_a.shape[1]):
+        cov = float(np.cov(arr_a[:, k], arr_b[:, k], ddof=1)[0, 1])
+        sd_a = float(arr_a[:, k].std(ddof=1))
+        sd_b = float(arr_b[:, k].std(ddof=1))
+        covs.append(cov)
+        corrs.append(cov / (sd_a * sd_b) if sd_a > 0 and sd_b > 0 else 0.0)
+    return float(np.mean(covs)), float(np.mean(corrs)), len(e_a)
+
+
+def _fmt_matrix(m: np.ndarray) -> str:
+    """Compact one-line 2x2 matrix rendering."""
+    return f'[{m[0, 0]:+.4f} {m[0, 1]:+.4f}; {m[1, 0]:+.4f} {m[1, 1]:+.4f}]'
+
+
+def _null_space_description(result: SolveResult) -> list[str]:
+    """Human-readable null-space directions (coefficients on parameters)."""
+    lines = []
+    for k in range(result.null_space.shape[0]):
+        vec = result.null_space[k]
+        terms = [
+            f'{vec[i]:+.2f}*{name}'
+            for i, name in enumerate(result.param_names)
+            if abs(vec[i]) > 0.05
+        ]
+        lines.append('  '.join(terms))
+    return lines
+
+
+def report_solve(
+    out: list[str],
+    cohort: list[CohortFrame],
+    specs: list[EstimatorSpec],
+    title: str,
+    *,
+    pair_covariances: list[tuple[str, str]] | None = None,
+    n_bootstrap: int = 200,
+) -> SolveResult:
+    """Run one solve and append its report section to ``out``.
+
+    Parameters:
+        out: Markdown line accumulator.
+        cohort: Cohort frames.
+        specs: Estimator instances for the solve.
+        title: Section title.
+        pair_covariances: Optional declared suspect pairs.
+        n_bootstrap: Bootstrap replicates.
+
+    Returns:
+        The solve result.
+    """
+    frames = [c.sample for c in cohort]
+    result = solve_covariance_components(
+        frames,
+        specs,
+        pair_covariances=pair_covariances or [],
+        n_bootstrap=n_bootstrap,
+        bootstrap_seed=1,
+    )
+    out.append(f'### {title}')
+    out.append('')
+    out.append(
+        f'{result.n_frames} frames, {result.n_equations} equations, '
+        f'{len(result.param_names)} unknowns; condition number '
+        f'{"inf" if math.isinf(result.condition_number) else f"{result.condition_number:.1f}"}; '
+        f'null-space dimension {result.null_space.shape[0]}; '
+        f'residual RMS {result.residual_rms:.4f} px^2.'
+    )
+    out.append('')
+    out.append('| parameter | recovered | 95% CI | identifiability |')
+    out.append('|---|---|---|---|')
+    for k, name in enumerate(result.param_names):
+        ci = result.bootstrap_ci.get(name)
+        ci_str = f'[{ci[0]:+.4f}, {ci[1]:+.4f}]' if ci else 'n/a'
+        ident = result.identifiability[name]
+        flag = '' if ident > 0.99 else ' (NOT identifiable)' if ident < 0.6 else ' (partial)'
+        out.append(f'| {name} | {result.params[k]:+.4f} | {ci_str} | {ident:.3f}{flag} |')
+    out.append('')
+    null_lines = _null_space_description(result)
+    if null_lines:
+        out.append('Null-space directions (any multiple can be added to the')
+        out.append('solution without changing any observable):')
+        out.append('')
+        for line in null_lines:
+            out.append(f'- `{line}`')
+        out.append('')
+    return result
+
+
+def report_truth_reference(
+    out: list[str], cohort: list[CohortFrame], specs: list[EstimatorSpec]
+) -> None:
+    """Append the truth-based per-instance error statistics to ``out``."""
+    out.append('Truth reference (empirical error stats vs planted offsets, in')
+    out.append('each instance basis frame):')
+    out.append('')
+    out.append('| instance | n | mean error | covariance |')
+    out.append('|---|---|---|---|')
+    for spec in specs:
+        if spec.kind == 'rank1':
+            radial = truth_radial_variance(cohort, spec.name)
+            if radial is None:
+                continue
+            mean, var, n = radial
+            out.append(f'| {spec.name} (radial) | {n} | {mean:+.4f} | s2 = {var:.5f} |')
+        else:
+            stats = truth_covariance(cohort, spec.name, basis=spec.basis)
+            if stats is None:
+                continue
+            mean_vec, cov, n = stats
+            out.append(
+                f'| {spec.name} | {n} | ({mean_vec[0]:+.4f}, {mean_vec[1]:+.4f}) '
+                f'| {_fmt_matrix(cov)} |'
+            )
+    out.append('')
+
+
+def report_pair_truth(
+    out: list[str], cohort: list[CohortFrame], pairs: list[tuple[str, str]], title: str
+) -> None:
+    """Append truth-based cross-covariance stats for the given pairs."""
+    out.append(f'#### {title}')
+    out.append('')
+    out.append('| pair | n | cross-covariance (px^2) | correlation |')
+    out.append('|---|---|---|---|')
+    for a, b in pairs:
+        stats = truth_cross_covariance(cohort, a, b)
+        if stats is None:
+            out.append(f'| {a} vs {b} | <3 | n/a | n/a |')
+            continue
+        cov, corr, n = stats
+        out.append(f'| {a} vs {b} | {n} | {cov:+.5f} | {corr:+.3f} |')
+    out.append('')
+
+
+def report_injection_response(
+    out: list[str],
+    control: list[dict[str, Any]],
+    injected: list[dict[str, Any]],
+    family: str,
+) -> None:
+    """Paired per-scene response of each technique to the injected bias.
+
+    For every technique present (non-spurious) in both the control and the
+    injected pass of the same scene, regress the offset delta against the
+    injected (bias_v, bias_u); a slope near 1 means the technique tracks
+    the shared-layer bias one-for-one, near 0 means it is decoupled.
+
+    Parameters:
+        out: Markdown accumulator.
+        control: Control rows.
+        injected: Injected rows (dt_shift).
+        family: Family to pair on.
+    """
+    ctrl_by_id = {r['scene_id']: r for r in control if r['family'] == family and 'error' not in r}
+    deltas: dict[str, list[tuple[float, float, float, float]]] = {}
+    for row in injected:
+        if row['family'] != family or 'error' in row:
+            continue
+        ctrl = ctrl_by_id.get(row['scene_id'])
+        if ctrl is None or row['injection'].get('kind') != 'dt_shift':
+            continue
+        bias_v = float(row['injection']['bias_v'])
+        bias_u = float(row['injection']['bias_u'])
+        inj_off = _instance_offsets(row)
+        ctl_off = _instance_offsets(ctrl)
+        for name in set(inj_off) & set(ctl_off):
+            deltas.setdefault(name, []).append(
+                (
+                    bias_v,
+                    bias_u,
+                    inj_off[name][0] - ctl_off[name][0],
+                    inj_off[name][1] - ctl_off[name][1],
+                )
+            )
+    out.append('Paired per-scene response to the injected DT-layer shift')
+    out.append('(slope of offset delta vs injected bias; 1 = fully coupled,')
+    out.append('0 = decoupled from the shared products):')
+    out.append('')
+    out.append('| instance | n | slope dv/bias_v | slope du/bias_u | residual RMS (px) |')
+    out.append('|---|---|---|---|---|')
+    for name in sorted(deltas):
+        arr = np.asarray(deltas[name])
+        if arr.shape[0] < 5:
+            continue
+        slope_v = float(np.polyfit(arr[:, 0], arr[:, 2], 1)[0])
+        slope_u = float(np.polyfit(arr[:, 1], arr[:, 3], 1)[0])
+        resid = np.stack([arr[:, 2] - slope_v * arr[:, 0], arr[:, 3] - slope_u * arr[:, 1]], axis=1)
+        rms = float(np.sqrt(np.mean(resid**2)))
+        out.append(f'| {name} | {arr.shape[0]} | {slope_v:+.3f} | {slope_u:+.3f} | {rms:.3f} |')
+    out.append('')
+
+
+def _specs_for_family(family: str) -> list[list[EstimatorSpec]]:
+    """The solve configurations reported for each family."""
+    limb_img = EstimatorSpec('limb', 'full')
+    limb_rot = EstimatorSpec('limb', 'full', basis='rotating')
+    disc = EstimatorSpec('disc', 'full')
+    ring = EstimatorSpec('ring', 'rank1')
+    blob = EstimatorSpec('blob', 'full')
+    if family == 'limb_disc':
+        return [[limb_img, disc]]
+    if family in ('limb_disc_ring_fixed', 'limb_disc_ring_diverse'):
+        return [[limb_img, disc, ring], [limb_img, disc, ring, blob]]
+    if family in ('limb_ring_aniso_fixed', 'limb_ring_aniso_diverse'):
+        return [[limb_rot, ring], [limb_rot, disc, ring]]
+    if family == 'multi_body':
+        return [
+            [
+                EstimatorSpec('limb@RHEA', 'full', group='limb'),
+                EstimatorSpec('limb@DIONE', 'full', group='limb'),
+                EstimatorSpec('disc@RHEA', 'full', group='disc'),
+                EstimatorSpec('disc@DIONE', 'full', group='disc'),
+            ]
+        ]
+    raise ValueError(f'unknown family {family!r}')
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Produce the identifiability / bias-independence report."""
+    parser = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+    parser.add_argument('rows', type=Path, help='control (no-injection) rows file')
+    parser.add_argument('--dt-rows', type=Path, default=None)
+    parser.add_argument('--noise-rows', type=Path, default=None)
+    parser.add_argument('--out', type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    manifest, rows = load_rows(args.rows)
+    out: list[str] = []
+    out.append('# Agreement-estimator validation report')
+    out.append('')
+    out.append(
+        f'Control rows: `{args.rows}` (campaign seed '
+        f'{manifest.get("campaign_seed", "?")}, per-family '
+        f'{manifest.get("per_family", "?")}).'
+    )
+    out.append('')
+
+    families = [f for f in manifest.get('families', []) if any(r['family'] == f for r in rows)]
+    out.append('## Stage 0a: identifiability per composition')
+    out.append('')
+    for family in families:
+        cohort = build_cohort(rows, family)
+        out.append(f'## Composition: {family}')
+        out.append('')
+        n_rows = sum(1 for r in rows if r['family'] == family)
+        n_err = sum(1 for r in rows if r['family'] == family and 'error' in r)
+        out.append(f'{n_rows} scenes ({n_err} errors), {len(cohort)} usable frames.')
+        out.append('')
+        spec_sets = _specs_for_family(family)
+        for specs in spec_sets:
+            names = '+'.join(s.name for s in specs)
+            usable = [c for c in cohort if sum(1 for s in specs if s.name in c.sample.offsets) >= 2]
+            result = report_solve(out, usable, specs, f'{family}: solve over {names}')
+            report_truth_reference(out, usable, specs)
+            del result
+
+    if args.dt_rows is not None or args.noise_rows is not None:
+        out.append('## Stage 0b: bias independence through the shared layer')
+        out.append('')
+        family = 'limb_disc_ring_diverse'
+        control_cohort = build_cohort(rows, family)
+        pivotal = [('limb', 'disc'), ('limb', 'ring'), ('disc', 'ring'), ('limb', 'blob')]
+        report_pair_truth(
+            out, control_cohort, pivotal, 'Control (no injection): truth-based pair coupling'
+        )
+        for label, path in (('dt_shift', args.dt_rows), ('noise_scale', args.noise_rows)):
+            if path is None:
+                continue
+            inj_manifest, inj_rows = load_rows(path)
+            cohort = build_cohort(inj_rows, family)
+            out.append(f'### Injection: {label} (`{path}`)')
+            out.append('')
+            out.append(
+                f'Injection parameters: sigma_px '
+                f'{inj_manifest.get("injection_sigma_px", "?")} (dt_shift only).'
+            )
+            out.append('')
+            report_pair_truth(out, cohort, pivotal, f'{label}: truth-based pair coupling')
+            if label == 'dt_shift':
+                report_injection_response(out, rows, inj_rows, family)
+                out.append('Solve-side detection (declared limb-ring pair covariance,')
+                out.append('blob included for over-determination):')
+                out.append('')
+                specs = [
+                    EstimatorSpec('limb', 'full'),
+                    EstimatorSpec('disc', 'full'),
+                    EstimatorSpec('ring', 'rank1'),
+                    EstimatorSpec('blob', 'full'),
+                ]
+                usable = [
+                    c for c in cohort if sum(1 for s in specs if s.name in c.sample.offsets) >= 2
+                ]
+                report_solve(
+                    out,
+                    usable,
+                    specs,
+                    f'{label}: independence-assumed solve (misattribution check)',
+                )
+                report_solve(
+                    out,
+                    usable,
+                    specs,
+                    f'{label}: solve with declared cov(limb,ring)',
+                    pair_covariances=[('limb', 'ring')],
+                )
+                report_truth_reference(out, usable, specs)
+
+    text = '\n'.join(out) + '\n'
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text)
+        print(f'Wrote {args.out}')
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/util/agreement/analyze.py
+++ b/util/agreement/analyze.py
@@ -423,6 +423,60 @@ def report_injection_response(
     out.append('')
 
 
+def report_noise_response(
+    out: list[str],
+    control: list[dict[str, Any]],
+    injected: list[dict[str, Any]],
+    family: str,
+) -> None:
+    """Paired per-scene offset deltas under the noise-sigma scaling injection.
+
+    Reports each technique's RMS offset change between the control and the
+    noise-scaled pass of the same scene, plus the correlation of the delta
+    magnitude with the injected scale factor -- a small RMS with no factor
+    dependence means the shared noise-sigma channel does not couple offsets
+    at these scales.
+
+    Parameters:
+        out: Markdown accumulator.
+        control: Control rows.
+        injected: Injected rows (noise_scale).
+        family: Family to pair on.
+    """
+    ctrl_by_id = {r['scene_id']: r for r in control if r['family'] == family and 'error' not in r}
+    deltas: dict[str, list[tuple[float, float]]] = {}
+    for row in injected:
+        if row['family'] != family or 'error' in row:
+            continue
+        ctrl = ctrl_by_id.get(row['scene_id'])
+        if ctrl is None or row['injection'].get('kind') != 'noise_scale':
+            continue
+        factor = float(row['injection']['factor'])
+        inj_off = _instance_offsets(row)
+        ctl_off = _instance_offsets(ctrl)
+        for name in set(inj_off) & set(ctl_off):
+            mag = math.hypot(
+                inj_off[name][0] - ctl_off[name][0], inj_off[name][1] - ctl_off[name][1]
+            )
+            deltas.setdefault(name, []).append((factor, mag))
+    out.append('Paired per-scene offset change under the noise-sigma scaling')
+    out.append('(RMS |delta offset| and its correlation with the scale factor):')
+    out.append('')
+    out.append('| instance | n | RMS |delta| (px) | corr(|delta|, factor) |')
+    out.append('|---|---|---|---|')
+    for name in sorted(deltas):
+        arr = np.asarray(deltas[name])
+        if arr.shape[0] < 5:
+            continue
+        rms = float(np.sqrt(np.mean(arr[:, 1] ** 2)))
+        if arr[:, 1].std() > 0 and arr[:, 0].std() > 0:
+            corr = float(np.corrcoef(arr[:, 0], arr[:, 1])[0, 1])
+        else:
+            corr = 0.0
+        out.append(f'| {name} | {arr.shape[0]} | {rms:.4f} | {corr:+.3f} |')
+    out.append('')
+
+
 def _specs_for_family(family: str) -> list[list[EstimatorSpec]]:
     """The solve configurations reported for each family."""
     limb_img = EstimatorSpec('limb', 'full')
@@ -483,9 +537,13 @@ def main(argv: list[str] | None = None) -> int:
         for specs in spec_sets:
             names = '+'.join(s.name for s in specs)
             usable = [c for c in cohort if sum(1 for s in specs if s.name in c.sample.offsets) >= 2]
-            result = report_solve(out, usable, specs, f'{family}: solve over {names}')
+            report_solve(out, usable, specs, f'{family}: solve over {names}')
             report_truth_reference(out, usable, specs)
-            del result
+        # Intrinsic pair couplings (truth-based): the independence
+        # assumption every undeclared pair rides on, measured per cohort.
+        all_instances = sorted({n for c in cohort for n in c.sample.offsets})
+        pairs = [(a, b) for i, a in enumerate(all_instances) for b in all_instances[i + 1 :]]
+        report_pair_truth(out, cohort, pairs, f'{family}: truth-based pair coupling (no injection)')
 
     if args.dt_rows is not None or args.noise_rows is not None:
         out.append('## Stage 0b: bias independence through the shared layer')
@@ -509,6 +567,8 @@ def main(argv: list[str] | None = None) -> int:
             )
             out.append('')
             report_pair_truth(out, cohort, pivotal, f'{label}: truth-based pair coupling')
+            if label == 'noise_scale':
+                report_noise_response(out, rows, inj_rows, family)
             if label == 'dt_shift':
                 report_injection_response(out, rows, inj_rows, family)
                 out.append('Solve-side detection (declared limb-ring pair covariance,')

--- a/util/agreement/analyze.py
+++ b/util/agreement/analyze.py
@@ -486,7 +486,7 @@ def report_noise_response(
     out.append('Paired per-scene offset change under the noise-sigma scaling')
     out.append('(RMS |delta offset| and its correlation with the scale factor):')
     out.append('')
-    out.append('| instance | n | RMS |delta| (px) | corr(|delta|, factor) |')
+    out.append(r'| instance | n | RMS \|delta\| (px) | corr(\|delta\|, factor) |')
     out.append('|---|---|---|---|')
     for name in sorted(deltas):
         arr = np.asarray(deltas[name])

--- a/util/agreement/analyze.py
+++ b/util/agreement/analyze.py
@@ -477,28 +477,41 @@ def report_noise_response(
     out.append('')
 
 
-def _specs_for_family(family: str) -> list[list[EstimatorSpec]]:
-    """The solve configurations reported for each family."""
+def _specs_for_family(
+    family: str,
+) -> list[tuple[list[EstimatorSpec], list[tuple[str, str]]]]:
+    """The solve configurations reported for each family.
+
+    Returns:
+        List of ``(specs, declared_pair_covariances)`` per solve.
+    """
     limb_img = EstimatorSpec('limb', 'full')
     limb_rot = EstimatorSpec('limb', 'full', basis='rotating')
     disc = EstimatorSpec('disc', 'full')
     ring = EstimatorSpec('ring', 'rank1')
     blob = EstimatorSpec('blob', 'full')
+    no_pairs: list[tuple[str, str]] = []
     if family == 'limb_disc':
-        return [[limb_img, disc]]
+        return [([limb_img, disc], no_pairs)]
     if family in ('limb_disc_ring_fixed', 'limb_disc_ring_diverse'):
-        return [[limb_img, disc, ring], [limb_img, disc, ring, blob]]
+        return [([limb_img, disc, ring], no_pairs), ([limb_img, disc, ring, blob], no_pairs)]
     if family in ('limb_ring_aniso_fixed', 'limb_ring_aniso_diverse'):
-        return [[limb_rot, ring], [limb_rot, disc, ring]]
+        return [([limb_rot, ring], no_pairs), ([limb_rot, disc, ring], no_pairs)]
     if family == 'multi_body':
-        return [
-            [
-                EstimatorSpec('limb@RHEA', 'full', group='limb'),
-                EstimatorSpec('limb@DIONE', 'full', group='limb'),
-                EstimatorSpec('disc@RHEA', 'full', group='disc'),
-                EstimatorSpec('disc@DIONE', 'full', group='disc'),
-            ]
+        multi = [
+            EstimatorSpec('limb@RHEA', 'full', group='limb'),
+            EstimatorSpec('limb@DIONE', 'full', group='limb'),
+            EstimatorSpec('disc@RHEA', 'full', group='disc'),
+            EstimatorSpec('disc@DIONE', 'full', group='disc'),
         ]
+        # The naive solve assumes cross-body same-technique independence;
+        # the second declares the limb-limb pair covariance instead of
+        # assuming it away (the measured coupling is material at ~1.5 px^2,
+        # while the disc-disc coupling, though correlated, is ~1e-4 px^2 --
+        # immaterial in magnitude, and declaring both within-group pairs
+        # would make the system degenerate again).
+        declared = [('limb@RHEA', 'limb@DIONE')]
+        return [(multi, no_pairs), (multi, declared)]
     raise ValueError(f'unknown family {family!r}')
 
 
@@ -534,10 +547,18 @@ def main(argv: list[str] | None = None) -> int:
         out.append(f'{n_rows} scenes ({n_err} errors), {len(cohort)} usable frames.')
         out.append('')
         spec_sets = _specs_for_family(family)
-        for specs in spec_sets:
+        for specs, declared_pairs in spec_sets:
             names = '+'.join(s.name for s in specs)
+            if declared_pairs:
+                names += ' (declared pair covariances)'
             usable = [c for c in cohort if sum(1 for s in specs if s.name in c.sample.offsets) >= 2]
-            report_solve(out, usable, specs, f'{family}: solve over {names}')
+            report_solve(
+                out,
+                usable,
+                specs,
+                f'{family}: solve over {names}',
+                pair_covariances=declared_pairs,
+            )
             report_truth_reference(out, usable, specs)
         # Intrinsic pair couplings (truth-based): the independence
         # assumption every undeclared pair rides on, measured per cohort.

--- a/util/agreement/collect.py
+++ b/util/agreement/collect.py
@@ -1,0 +1,320 @@
+"""Collect agreement rows: navigate composition scenes, record per-technique offsets.
+
+For every generated scene (see ``scene_gen``) this runs the autonomous
+pipeline in-process and writes one JSON line per scene: the planted
+(offset_v, offset_u) truth, the scene's geometry angles, and every
+per-technique result from each configured run.  Single-body compositions
+navigate once with every model; the multi_body composition navigates once
+per body (``only_models='body_sim:<NAME>'``) so each body contributes its
+own limb/disc estimates; ring-bearing compositions add a blob-only run
+(``only_techniques=['BodyBlobNav']``) to supply an extra estimator that
+never touches the shared gradient/DT products.
+
+Shared-bias injection (the bias-independence stage) is harness-level only:
+``--injection dt_shift`` monkeypatches the orchestrator module's
+``compute_all_image_derivatives`` so every DT technique sees the shared
+gradient / edge-distance-transform products translated by a per-scene
+random bias, and ``--injection noise_scale`` monkeypatches
+``estimate_image_noise_sigma`` to scale the single shared noise estimate.
+Nothing under ``src/`` changes; the injected values are recorded per row.
+
+Run (from an activated project venv; ``source /seti/newnav/setup.sh``):
+
+    venv/bin/python util/agreement/collect.py \
+        --per-family 400 --workers 8 --out _work/agreement/rows.jsonl
+
+The campaign seed defaults to 20260719; pass ``--seed`` to draw a different
+campaign.  Rows are written incrementally so a partial run is still usable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import multiprocessing
+import random
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+HERE = Path(__file__).parent
+REPO = HERE.parent.parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(REPO / 'src'))
+
+from scene_gen import FAMILIES, generate_scenes  # noqa: E402
+
+DEFAULT_SEED = 20260719
+DEFAULT_OUT = REPO / '_work/agreement/rows.jsonl'
+
+INJECTION_KINDS = ('none', 'dt_shift', 'noise_scale')
+
+
+def _runs_for_family(family: str) -> list[dict[str, Any]]:
+    """Return the orchestrator run configurations for a scene family.
+
+    Parameters:
+        family: Scene family name.
+
+    Returns:
+        List of run dicts with ``key``, ``only_models``, ``only_techniques``.
+    """
+    if family == 'multi_body':
+        return [
+            {'key': 'body:RHEA', 'only_models': 'body_sim:RHEA', 'only_techniques': '*'},
+            {'key': 'body:DIONE', 'only_models': 'body_sim:DIONE', 'only_techniques': '*'},
+        ]
+    runs: list[dict[str, Any]] = [{'key': 'full', 'only_models': '*', 'only_techniques': '*'}]
+    if 'ring' in family:
+        # BodyBlobNav is a fallback the orchestrator skips whenever a primary
+        # body technique produced a result, so the shared-layer-independent
+        # blob estimate needs its own restricted run.
+        runs.append({'key': 'blob', 'only_models': '*', 'only_techniques': ['BodyBlobNav']})
+    return runs
+
+
+def _draw_injection(kind: str, scene_id: str, seed: int, sigma_px: float) -> dict[str, Any]:
+    """Draw the per-scene injection values (recorded in the row).
+
+    Parameters:
+        kind: One of :data:`INJECTION_KINDS`.
+        scene_id: Scene identifier (part of the draw key).
+        seed: Campaign seed (part of the draw key).
+        sigma_px: Per-axis standard deviation of the dt_shift bias draw.
+
+    Returns:
+        Dict describing the injection (``{'kind': 'none'}`` when disabled).
+    """
+    if kind == 'none':
+        return {'kind': 'none'}
+    rng = random.Random(f'{seed}/{scene_id}/inject')
+    if kind == 'dt_shift':
+        return {
+            'kind': 'dt_shift',
+            'bias_v': rng.gauss(0.0, sigma_px),
+            'bias_u': rng.gauss(0.0, sigma_px),
+        }
+    return {
+        'kind': 'noise_scale',
+        'factor': math.exp(rng.uniform(math.log(2.0), math.log(8.0))),
+    }
+
+
+def _apply_injection(injection: dict[str, Any]) -> list[tuple[Any, str, Any]]:
+    """Monkeypatch the shared preprocessing layer per the injection spec.
+
+    The patch targets the orchestrator module's imported references, so
+    every technique downstream of the shared per-image products sees the
+    injected version while techniques that read the image directly are
+    untouched.
+
+    Parameters:
+        injection: Draw from :func:`_draw_injection`.
+
+    Returns:
+        List of ``(module, attribute, original)`` entries for restoration.
+    """
+    import numpy as np
+
+    import spindoctor.nav_orchestrator.orchestrator as orch_mod
+
+    patched: list[tuple[Any, str, Any]] = []
+    if injection['kind'] == 'dt_shift':
+        from scipy.ndimage import shift as nd_shift
+
+        bias = (float(injection['bias_v']), float(injection['bias_u']))
+        real_compute = orch_mod.compute_all_image_derivatives  # type: ignore[attr-defined]
+
+        def injected_compute(
+            image_ext: Any, image_noise_sigma: float, *, config: Any = None
+        ) -> Any:
+            gradient, edge_dt, gradient_vu = real_compute(
+                image_ext, image_noise_sigma, config=config
+            )
+            kw = {'order': 1, 'mode': 'nearest'}
+            gradient = nd_shift(gradient, bias, **kw)
+            edge_dt = nd_shift(edge_dt, bias, **kw)
+            gradient_vu = np.stack(
+                [
+                    nd_shift(gradient_vu[..., 0], bias, **kw),
+                    nd_shift(gradient_vu[..., 1], bias, **kw),
+                ],
+                axis=-1,
+            )
+            return gradient, edge_dt, gradient_vu
+
+        patched.append((orch_mod, 'compute_all_image_derivatives', real_compute))
+        orch_mod.compute_all_image_derivatives = injected_compute  # type: ignore[attr-defined]
+    elif injection['kind'] == 'noise_scale':
+        factor = float(injection['factor'])
+        real_noise = orch_mod.estimate_image_noise_sigma  # type: ignore[attr-defined]
+
+        def injected_noise(image: Any, sensor_mask: Any) -> float:
+            return factor * float(real_noise(image, sensor_mask))
+
+        patched.append((orch_mod, 'estimate_image_noise_sigma', real_noise))
+        orch_mod.estimate_image_noise_sigma = injected_noise  # type: ignore[attr-defined,assignment]
+    return patched
+
+
+def _restore(patched: list[tuple[Any, str, Any]]) -> None:
+    """Undo :func:`_apply_injection`."""
+    for module, attribute, original in patched:
+        setattr(module, attribute, original)
+
+
+def _navigate_one(
+    task: tuple[str, str, dict[str, Any], dict[str, Any], dict[str, Any]],
+) -> dict[str, Any]:
+    """Worker: navigate one scene through its configured runs."""
+    scene_id, family, sim_params, geometry, injection = task
+    import numpy as np
+
+    from spindoctor.nav_model import build_models_for_obs
+    from spindoctor.nav_orchestrator import NavOrchestrator
+    from spindoctor.obs.obs_inst_sim import ObsSim
+
+    row: dict[str, Any] = {
+        'scene_id': scene_id,
+        'family': family,
+        'planted': {
+            'dv': float(sim_params.get('offset_v', 0.0)),
+            'du': float(sim_params.get('offset_u', 0.0)),
+        },
+        'geometry': geometry,
+        'injection': injection,
+        'runs': {},
+    }
+    patched = _apply_injection(injection)
+    try:
+        # The path is a label only (sim_params overrides the file read), but
+        # FCPath resolves it, so it must sit under a real directory.
+        obs = ObsSim.from_file(f'/tmp/{scene_id}.json', sim_params=sim_params)
+        for run in _runs_for_family(family):
+            orchestrator = NavOrchestrator(
+                build_models_for_obs(obs),
+                only_models=run['only_models'],
+                only_techniques=run['only_techniques'],
+            )
+            result = orchestrator.navigate(obs)
+            techniques = []
+            for tr in result.per_technique:
+                cov = np.asarray(tr.covariance_px2, dtype=float)[:2, :2]
+                techniques.append(
+                    {
+                        'name': tr.technique_name,
+                        'offset_v': float(tr.offset_px[0]),
+                        'offset_u': float(tr.offset_px[1]),
+                        'covariance_px2': [float(x) for x in cov.ravel()],
+                        'confidence': float(tr.confidence),
+                        'spurious': bool(tr.spurious),
+                        'at_edge': bool(tr.at_edge),
+                    }
+                )
+            row['runs'][run['key']] = techniques
+    except Exception as exc:
+        row['error'] = f'{type(exc).__name__}: {exc}'
+    finally:
+        _restore(patched)
+    return row
+
+
+def _init_worker() -> None:
+    """Pin per-worker threading and silence the per-image logger.
+
+    One BLAS/OpenMP thread per worker: the pool already saturates the
+    cores.  The env vars must be set before the worker's first numpy
+    import, which is why this runs in the pool initializer.
+    """
+    import os
+
+    for var in (
+        'OMP_NUM_THREADS',
+        'OPENBLAS_NUM_THREADS',
+        'MKL_NUM_THREADS',
+        'NUMEXPR_NUM_THREADS',
+    ):
+        os.environ[var] = '1'
+    import pdslogger
+
+    from spindoctor.config.logger import IMAGE_LOGGER, MAIN_LOGGER
+
+    null_handler = pdslogger.NULL_HANDLER
+    for logger in (IMAGE_LOGGER, MAIN_LOGGER):
+        logger.remove_all_handlers()
+        logger.add_handler(null_handler)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Generate scenes, navigate them in a worker pool, write JSONL rows."""
+    parser = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+    parser.add_argument('--per-family', type=int, default=400)
+    parser.add_argument('--families', default=','.join(FAMILIES))
+    parser.add_argument('--workers', type=int, default=8)
+    parser.add_argument('--seed', type=int, default=DEFAULT_SEED)
+    parser.add_argument('--injection', choices=INJECTION_KINDS, default='none')
+    parser.add_argument(
+        '--injection-sigma-px',
+        type=float,
+        default=0.7,
+        help='per-axis sigma of the dt_shift bias draw',
+    )
+    parser.add_argument('--out', type=Path, default=DEFAULT_OUT)
+    args = parser.parse_args(argv)
+
+    families = [f.strip() for f in args.families.split(',') if f.strip()]
+    tasks = []
+    for family in families:
+        for scene_id, sim_params, geometry in generate_scenes(
+            family, args.per_family, campaign_seed=args.seed
+        ):
+            injection = _draw_injection(
+                args.injection, scene_id, args.seed, args.injection_sigma_px
+            )
+            tasks.append((scene_id, family, sim_params, geometry, injection))
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    start = time.monotonic()
+    done = 0
+    failed = 0
+    with args.out.open('w') as out:
+        out.write(
+            json.dumps(
+                {
+                    'manifest': True,
+                    'campaign_seed': args.seed,
+                    'per_family': args.per_family,
+                    'families': families,
+                    'injection': args.injection,
+                    'injection_sigma_px': args.injection_sigma_px,
+                    'n_scenes': len(tasks),
+                }
+            )
+            + '\n'
+        )
+        with multiprocessing.Pool(
+            processes=args.workers, initializer=_init_worker, maxtasksperchild=200
+        ) as pool:
+            for row in pool.imap_unordered(_navigate_one, tasks, chunksize=4):
+                out.write(json.dumps(row, sort_keys=True) + '\n')
+                done += 1
+                if 'error' in row:
+                    failed += 1
+                if done % 100 == 0:
+                    elapsed = time.monotonic() - start
+                    rate = done / elapsed
+                    remaining = (len(tasks) - done) / rate if rate > 0 else 0
+                    print(
+                        f'{done}/{len(tasks)} rows ({failed} errors), '
+                        f'{rate:.1f}/s, ~{remaining / 60:.1f} min left',
+                        flush=True,
+                    )
+    elapsed = time.monotonic() - start
+    print(f'Wrote {done} rows ({failed} errors) to {args.out} in {elapsed / 60:.1f} min')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/util/agreement/estimator.py
+++ b/util/agreement/estimator.py
@@ -31,6 +31,31 @@ technique in one frame), which asserts the technique's error covariance is
 common across the group's instances within the cohort -- an explicit
 stationarity assumption the caller must be able to defend.
 
+Bias handling: before the second moments are formed, each pair's
+differences are centered by a fitted *mean model*, not just a constant.
+The model always carries the constant (image-frame) term, and for every
+``basis='rotating'`` member it additionally carries that member's
+rotating-frame mean components ``R(theta) @ mu`` -- so a technique bias
+that is constant in the technique's own rotating frame (a limb fit pulled
+radially toward its body) is absorbed instead of aliasing into the
+recovered covariance.  The hazard this guards against is real: an
+*undeclared* rotating-frame bias has image-frame mean ~0 over an
+orientation-diverse cohort, the constant channel sees nothing, and
+``R mu mu^T R^T`` enters every second-moment equation as if it were
+covariance -- silently, with the system well-conditioned.  Declaring
+``basis='rotating'`` for a technique therefore does two jobs: it makes the
+covariance stationary in the right frame *and* it arms the rotating mean
+columns for that technique.  Biases locked to geometry the model does not
+carry (e.g. illumination direction) are NOT absorbed and still alias.
+
+Declared pair covariances carry two model restrictions the caller must
+accept: a full/full pair's ``S_ij`` is a single image-frame-constant
+symmetric matrix (there is no rotating option, even when a member is
+``basis='rotating'``), and a pair involving a rank1 instance carries one
+scalar ``gamma`` -- the projected cross-covariance is assumed independent
+of the projection axis, i.e. ``S_ij = gamma * I`` (exact for an isotropic
+shared bias, an approximation otherwise).
+
 Identifiability is part of the output, not an assumption: the solve reports
 the design matrix's singular spectrum, the (numerical) null space mapped
 back to parameter names, and a per-parameter identifiability score.  A
@@ -46,7 +71,7 @@ the unit direction ``(cos(alpha), sin(alpha))`` in (v, u) coordinates.
 from __future__ import annotations
 
 import math
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -64,9 +89,17 @@ __all__ = [
 PairKey = tuple[str, str]
 
 # Two rank-1 instances can only be differenced when their measurement axes
-# are parallel to within this |cos| tolerance; otherwise the pair carries no
-# common measured component and is skipped for that frame.
-_RANK1_PARALLEL_MIN_ABS_COS = 0.99
+# are parallel to within this |cos| tolerance.  The tolerance must be tight:
+# the two techniques share the frame's true offset t, and the difference of
+# the projections carries a truth leak (a_i - sign * a_j) . t that does NOT
+# cancel -- at |cos| = 0.99 (about 8 deg) a 4 px true offset leaks ~0.5 px
+# into the "difference".  At 0.9999 (0.8 deg) the leak is under ~0.06 px.
+_RANK1_PARALLEL_MIN_ABS_COS = 0.9999
+
+# The per-pair mean model falls back to constant-only columns when the pair
+# has fewer than this many samples per fitted column (guards against
+# soaking up second-moment signal with an overfitted mean on tiny cohorts).
+_MEAN_MODEL_MIN_SAMPLES_PER_COLUMN = 4
 
 
 @dataclass(frozen=True)
@@ -83,7 +116,10 @@ class EstimatorSpec:
         basis: ``'image'`` when the covariance is stationary in image
             coordinates; ``'rotating'`` when it is stationary in a
             per-frame frame whose angle each :class:`FrameSample` supplies
-            (only meaningful for ``kind='full'``).
+            (only meaningful for ``kind='full'``).  Declaring
+            ``'rotating'`` also arms the instance's rotating-frame mean
+            columns in the pair mean model, so a bias constant in that
+            frame is absorbed rather than aliased into the covariance.
         group: Parameter-sharing key.  Instances with the same group share
             one set of covariance unknowns (asserting a common error
             covariance across the instances); defaults to ``name``.
@@ -150,10 +186,21 @@ class SolveResult:
         rank1_variances: Per-group scalar variance for every rank1 group.
         pair_covariances: Recovered symmetric cross-covariance per declared
             pair (2x2 image-frame matrix for full/full pairs, scalar for
-            pairs involving a rank1 instance).
-        pair_mean_diff: Per differenced pair, the cohort mean difference
-            that was subtracted before forming second moments (the bias
-            channel; 2-vector for full/full pairs, scalar otherwise).
+            pairs involving a rank1 instance; see the module docstring for
+            the model restrictions those forms carry).
+        pair_mean_diff: Per differenced pair, the *raw image-frame* cohort
+            mean of the differences (2-vector for full/full pairs, scalar
+            otherwise).  This is the constant bias channel only: a bias
+            constant in a rotating frame averages toward zero here and is
+            instead captured by the fitted mean model
+            (``pair_mean_model``).
+        pair_mean_model: Per differenced pair, the fitted mean-model
+            coefficients as ``{column_label: value}`` (labels: ``const_v``
+            / ``const_u`` or ``const`` / ``axis_v`` / ``axis_u``, plus
+            ``<name>:mu1`` / ``<name>:mu2`` rotating-frame mean components
+            per rotating member).  When two members share one rotation
+            angle the split between their mu columns is minimum-norm; only
+            the combined fitted mean function is meaningful then.
         singular_values: Singular values of the design matrix, descending.
         condition_number: Ratio of largest to smallest singular value
             (``inf`` for an exactly rank-deficient system).
@@ -168,8 +215,9 @@ class SolveResult:
         n_equations: Scalar equations assembled.
         residual_rms: Root-mean-square residual of the fitted equations.
         bootstrap_ci: Optional per-parameter (lo, hi) percentile interval
-            from frame-resampling; empty when bootstrap was not requested.
-            Intervals for unidentifiable parameters are not meaningful.
+            from frame-resampling (the pair mean models are re-fitted per
+            replicate); empty when bootstrap was not requested.  Intervals
+            for unidentifiable parameters are not meaningful.
     """
 
     param_names: tuple[str, ...]
@@ -178,6 +226,7 @@ class SolveResult:
     rank1_variances: dict[str, float]
     pair_covariances: dict[PairKey, NDArray[np.float64] | float]
     pair_mean_diff: dict[PairKey, NDArray[np.float64] | float]
+    pair_mean_model: dict[PairKey, dict[str, float]]
     singular_values: NDArray[np.float64]
     condition_number: float
     null_space: NDArray[np.float64]
@@ -225,6 +274,12 @@ def _vech_quadratic(alpha: float) -> NDArray[np.float64]:
     a1 = math.cos(alpha)
     a2 = math.sin(alpha)
     return np.array([a1 * a1, 2.0 * a1 * a2, a2 * a2], dtype=np.float64)
+
+
+def _rot(theta: float) -> NDArray[np.float64]:
+    """Rotation matrix whose columns are the basis vectors at ``theta``."""
+    c, s = math.cos(theta), math.sin(theta)
+    return np.array([[c, -s], [s, c]], dtype=np.float64)
 
 
 @dataclass(frozen=True)
@@ -323,25 +378,31 @@ def _axis_angle(spec: EstimatorSpec, frame: FrameSample) -> float:
 
 
 @dataclass(frozen=True)
-class _PairEquations:
-    """Per-frame design/target blocks for one instance pair.
+class _PairData:
+    """Precomputed per-pair samples: raw diffs, mean design, cov design.
 
-    ``rows[f]`` and ``targets[f]`` hold that frame's equations (1 or 3 rows).
-    ``frame_index[f]`` maps back to the cohort frame index for bootstrap
-    resampling.
+    ``diffs`` is ``(n, 2)`` for full/full pairs and ``(n, 1)`` otherwise.
+    ``mean_design`` is ``(n, d, k)`` (per-sample design block of the mean
+    model), ``cov_rows`` is ``(n, d_eq, n_params)`` (per-sample block of
+    covariance equations; ``d_eq`` is 3 for full/full, 1 for scalar).
     """
 
-    rows: list[NDArray[np.float64]]
-    targets: list[NDArray[np.float64]]
+    full_full: bool
     frame_index: list[int]
+    diffs: NDArray[np.float64]
+    mean_design: NDArray[np.float64]
+    mean_columns: tuple[str, ...]
+    cov_rows: NDArray[np.float64]
 
 
-def _difference_samples(
+def _build_pair_data(
     frames: Sequence[FrameSample],
     spec_i: EstimatorSpec,
     spec_j: EstimatorSpec,
-) -> tuple[list[int], NDArray[np.float64], list[tuple[float, float]]]:
-    """Collect raw per-frame differences for one pair.
+    layout: _ParamLayout,
+    mean_model: str,
+) -> _PairData | None:
+    """Collect one pair's samples, mean-model design, and covariance rows.
 
     For a full/full pair the difference is the 2-vector ``o_i - o_j``.  When
     either member is rank1 the difference is the scalar projection of both
@@ -349,157 +410,224 @@ def _difference_samples(
     only meaningful along that axis).  A rank1/rank1 pair contributes only on
     frames where the two axes are parallel within tolerance.
 
-    Parameters:
-        frames: The cohort.
-        spec_i: First pair member.
-        spec_j: Second pair member.
-
-    Returns:
-        ``(frame_indices, diffs, angles)`` where ``diffs`` is ``(n, 2)`` for
-        full/full pairs and ``(n, 1)`` otherwise, and ``angles`` carries the
-        per-sample ``(basis_or_axis_i, basis_or_axis_j)`` angles needed to
-        rebuild design rows.
-    """
-    indices: list[int] = []
-    diffs: list[list[float]] = []
-    angles: list[tuple[float, float]] = []
-    for f_idx, frame in enumerate(frames):
-        if spec_i.name not in frame.offsets or spec_j.name not in frame.offsets:
-            continue
-        o_i = frame.offsets[spec_i.name]
-        o_j = frame.offsets[spec_j.name]
-        if spec_i.kind == 'full' and spec_j.kind == 'full':
-            indices.append(f_idx)
-            diffs.append([o_i[0] - o_j[0], o_i[1] - o_j[1]])
-            angles.append((_basis_angle(spec_i, frame), _basis_angle(spec_j, frame)))
-        elif spec_i.kind == 'rank1' and spec_j.kind == 'rank1':
-            alpha_i = _axis_angle(spec_i, frame)
-            alpha_j = _axis_angle(spec_j, frame)
-            if abs(math.cos(alpha_i - alpha_j)) < _RANK1_PARALLEL_MIN_ABS_COS:
-                continue
-            a_i = (math.cos(alpha_i), math.sin(alpha_i))
-            a_j = (math.cos(alpha_j), math.sin(alpha_j))
-            s_i = a_i[0] * o_i[0] + a_i[1] * o_i[1]
-            s_j = a_j[0] * o_j[0] + a_j[1] * o_j[1]
-            # Express both along axis i (they are parallel within tolerance;
-            # a sign flip between the axes flips s_j's sign).
-            sign = 1.0 if math.cos(alpha_i - alpha_j) >= 0 else -1.0
-            indices.append(f_idx)
-            diffs.append([s_i - sign * s_j])
-            angles.append((alpha_i, alpha_j))
-        else:
-            # Exactly one member is rank1: project both onto its axis.  The
-            # angle tuple stays positional -- slot 0 for spec_i, slot 1 for
-            # spec_j -- holding the axis angle for the rank1 member and the
-            # basis angle for the full member.
-            rank1_spec = spec_i if spec_i.kind == 'rank1' else spec_j
-            alpha = _axis_angle(rank1_spec, frame)
-            a = (math.cos(alpha), math.sin(alpha))
-            s_i = a[0] * o_i[0] + a[1] * o_i[1]
-            s_j = a[0] * o_j[0] + a[1] * o_j[1]
-            indices.append(f_idx)
-            diffs.append([s_i - s_j])
-            angle_i = alpha if spec_i.kind == 'rank1' else _basis_angle(spec_i, frame)
-            angle_j = alpha if spec_j.kind == 'rank1' else _basis_angle(spec_j, frame)
-            angles.append((angle_i, angle_j))
-    if not indices:
-        return [], np.zeros((0, 1), dtype=np.float64), []
-    return indices, np.asarray(diffs, dtype=np.float64).reshape(len(indices), -1), angles
-
-
-def _pair_equations(
-    frames: Sequence[FrameSample],
-    spec_i: EstimatorSpec,
-    spec_j: EstimatorSpec,
-    layout: _ParamLayout,
-) -> tuple[_PairEquations, NDArray[np.float64] | float] | None:
-    """Build the moment equations for one instance pair.
-
-    The cohort mean difference is subtracted before squaring, so the
-    second moments are central: a deterministic shared bias between the two
-    instances lands in the returned mean, not in the covariance system.
+    The mean model's columns are the constant (image-frame) terms plus, for
+    every ``basis='rotating'`` member, that member's rotating-frame mean
+    components; with ``mean_model='constant'`` only the constant terms are
+    kept (the pre-rotating-mean behavior, retained for comparison).  An
+    image-frame-constant shared bias is absorbed by the constant columns; a
+    rotating-frame bias is absorbed only when its member is declared
+    rotating -- an undeclared one aliases into the covariance equations
+    (see the module docstring).
 
     Parameters:
         frames: The cohort.
         spec_i: First pair member.
         spec_j: Second pair member.
         layout: Parameter layout.
+        mean_model: ``'auto'`` or ``'constant'``.
 
     Returns:
-        ``(equations, mean_diff)`` or ``None`` when the pair never co-occurs.
+        The pair data, or ``None`` when the pair never co-occurs.
     """
-    indices, diffs, angles = _difference_samples(frames, spec_i, spec_j)
-    if len(indices) == 0:
-        return None
-    mean = diffs.mean(axis=0)
-    centered = diffs - mean
     pair_slice = _pair_slice(layout, spec_i.name, spec_j.name)
-    rows: list[NDArray[np.float64]] = []
-    targets: list[NDArray[np.float64]] = []
-    frame_index: list[int] = []
     full_full = spec_i.kind == 'full' and spec_j.kind == 'full'
-    for k, f_idx in enumerate(indices):
+    rotating_members = [
+        (spec, sign)
+        for spec, sign in ((spec_i, 1.0), (spec_j, -1.0))
+        if spec.kind == 'full' and spec.basis == 'rotating'
+    ]
+    # 'constant' reproduces plain mean-centering (image-frame vector for
+    # full/full pairs, scalar for projected pairs); 'auto' adds the
+    # image-frame constant vector projected onto the varying axis (scalar
+    # pairs) and the rotating-frame mean columns per rotating member.
+    if full_full:
+        mean_columns = ['const_v', 'const_u']
+    elif mean_model == 'auto':
+        mean_columns = ['const', 'axis_v', 'axis_u']
+    else:
+        mean_columns = ['const']
+    if mean_model == 'auto':
+        for spec, _ in rotating_members:
+            mean_columns.extend([f'{spec.name}:mu1', f'{spec.name}:mu2'])
+    n_cols = len(mean_columns)
+
+    frame_index: list[int] = []
+    diffs: list[NDArray[np.float64]] = []
+    designs: list[NDArray[np.float64]] = []
+    cov_blocks: list[NDArray[np.float64]] = []
+    for f_idx, frame in enumerate(frames):
+        if spec_i.name not in frame.offsets or spec_j.name not in frame.offsets:
+            continue
+        o_i = np.asarray(frame.offsets[spec_i.name], dtype=np.float64)
+        o_j = np.asarray(frame.offsets[spec_j.name], dtype=np.float64)
         if full_full:
-            d = centered[k]
-            target = np.array([d[0] * d[0], d[0] * d[1], d[1] * d[1]], dtype=np.float64)
+            d = o_i - o_j
+            design = np.zeros((2, n_cols), dtype=np.float64)
+            design[:, 0:2] = np.eye(2)
+            col = 2
+            for spec, sign in rotating_members if mean_model == 'auto' else []:
+                design[:, col : col + 2] = sign * _rot(_basis_angle(spec, frame))
+                col += 2
             block = np.zeros((3, layout.n_params), dtype=np.float64)
-            block[:, layout.group_slices[spec_i.group_key]] += _vech_rotation(angles[k][0])
-            block[:, layout.group_slices[spec_j.group_key]] += _vech_rotation(angles[k][1])
+            block[:, layout.group_slices[spec_i.group_key]] += _vech_rotation(
+                _basis_angle(spec_i, frame)
+            )
+            block[:, layout.group_slices[spec_j.group_key]] += _vech_rotation(
+                _basis_angle(spec_j, frame)
+            )
             if pair_slice is not None:
                 block[:, pair_slice] += -2.0 * np.eye(3)
+            frame_index.append(f_idx)
+            diffs.append(d)
+            designs.append(design)
+            cov_blocks.append(block)
+            continue
+        if spec_i.kind == 'rank1' and spec_j.kind == 'rank1':
+            alpha_i = _axis_angle(spec_i, frame)
+            alpha_j = _axis_angle(spec_j, frame)
+            cos_between = math.cos(alpha_i - alpha_j)
+            if abs(cos_between) < _RANK1_PARALLEL_MIN_ABS_COS:
+                continue
+            axis = alpha_i
+            a_i = np.array([math.cos(alpha_i), math.sin(alpha_i)])
+            a_j = np.array([math.cos(alpha_j), math.sin(alpha_j)])
+            sign_j = 1.0 if cos_between >= 0 else -1.0
+            s = float(a_i @ o_i) - sign_j * float(a_j @ o_j)
         else:
-            s = centered[k, 0]
-            target = np.array([s * s], dtype=np.float64)
-            block = np.zeros((1, layout.n_params), dtype=np.float64)
-            # The projection axis is the rank1 member's axis angle, held in
-            # that member's positional slot (for rank1/rank1 pairs slot 0).
-            axis = angles[k][0] if spec_i.kind == 'rank1' else angles[k][1]
-            for spec, angle_pos in ((spec_i, 0), (spec_j, 1)):
-                sl = layout.group_slices[spec.group_key]
-                if spec.kind == 'rank1':
-                    block[0, sl] += 1.0
-                else:
-                    theta = angles[k][angle_pos]
-                    block[0, sl] += _vech_quadratic(axis) @ _vech_rotation(theta)
-            if pair_slice is not None:
-                block[0, pair_slice] += -2.0
-        rows.append(block)
-        targets.append(target)
+            rank1_spec = spec_i if spec_i.kind == 'rank1' else spec_j
+            axis = _axis_angle(rank1_spec, frame)
+            a = np.array([math.cos(axis), math.sin(axis)])
+            s = float(a @ o_i) - float(a @ o_j)
+        design = np.zeros((1, n_cols), dtype=np.float64)
+        design[0, 0] = 1.0
+        if mean_model == 'auto':
+            design[0, 1] = math.cos(axis)
+            design[0, 2] = math.sin(axis)
+            col = 3
+            for spec, sign in rotating_members:
+                a_row = np.array([math.cos(axis), math.sin(axis)]) @ _rot(_basis_angle(spec, frame))
+                design[0, col : col + 2] = sign * a_row
+                col += 2
+        block = np.zeros((1, layout.n_params), dtype=np.float64)
+        for spec in (spec_i, spec_j):
+            sl = layout.group_slices[spec.group_key]
+            if spec.kind == 'rank1':
+                block[0, sl] += 1.0
+            else:
+                theta = _basis_angle(spec, frame)
+                block[0, sl] += _vech_quadratic(axis) @ _vech_rotation(theta)
+        if pair_slice is not None:
+            block[0, pair_slice] += -2.0
         frame_index.append(f_idx)
-    mean_out: NDArray[np.float64] | float = mean if full_full else float(mean[0])
-    return _PairEquations(rows=rows, targets=targets, frame_index=frame_index), mean_out
+        diffs.append(np.array([s], dtype=np.float64))
+        designs.append(design)
+        cov_blocks.append(block)
+    if not frame_index:
+        return None
+    diffs_arr = np.stack(diffs)
+    design_arr = np.stack(designs)
+    cov_arr = np.stack(cov_blocks)
+    # Overfit guard: with too few samples per mean-model column, fall back
+    # to the constant-only columns so the mean fit cannot soak up
+    # second-moment signal.
+    min_needed = _MEAN_MODEL_MIN_SAMPLES_PER_COLUMN * n_cols
+    if diffs_arr.shape[0] < min_needed:
+        keep = 2 if full_full else 1
+        design_arr = design_arr[:, :, :keep]
+        mean_columns = mean_columns[:keep]
+    return _PairData(
+        full_full=full_full,
+        frame_index=frame_index,
+        diffs=diffs_arr,
+        mean_design=design_arr,
+        mean_columns=tuple(mean_columns),
+        cov_rows=cov_arr,
+    )
+
+
+def _fit_mean(pair: _PairData, counts: dict[int, int] | None) -> NDArray[np.float64]:
+    """Fit the pair's mean-model coefficients by (weighted) least squares.
+
+    Parameters:
+        pair: The pair data.
+        counts: Optional frame multiset (bootstrap replicate); ``None``
+            weights every sample once.
+
+    Returns:
+        Coefficient vector aligned with ``pair.mean_columns`` (minimum-norm
+        where the design is collinear, e.g. two members sharing one
+        rotation angle).
+    """
+    n, _, k = pair.mean_design.shape
+    if counts is None:
+        weights = np.ones(n, dtype=np.float64)
+    else:
+        weights = np.array(
+            [float(counts.get(f_idx, 0)) for f_idx in pair.frame_index], dtype=np.float64
+        )
+    mask = weights > 0
+    if not mask.any():
+        return np.zeros(k, dtype=np.float64)
+    sqrt_w = np.sqrt(weights[mask])[:, None]
+    rows = (pair.mean_design[mask] * sqrt_w[:, :, None]).reshape(-1, k)
+    target = (pair.diffs[mask] * sqrt_w).reshape(-1)
+    beta, _, _, _ = np.linalg.lstsq(rows, target, rcond=None)
+    return np.asarray(beta, dtype=np.float64)
+
+
+def _pair_targets(pair: _PairData, beta: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Centered second-moment targets per sample given mean coefficients.
+
+    Parameters:
+        pair: The pair data.
+        beta: Mean-model coefficients.
+
+    Returns:
+        ``(n, 3)`` vech outer-product targets for full/full pairs,
+        ``(n, 1)`` squared-residual targets otherwise.
+    """
+    residuals = pair.diffs - pair.mean_design @ beta
+    if pair.full_full:
+        r0 = residuals[:, 0]
+        r1 = residuals[:, 1]
+        return np.stack([r0 * r0, r0 * r1, r1 * r1], axis=1)
+    r = residuals[:, 0]
+    return (r * r)[:, None]
 
 
 def _assemble(
-    pair_eqs: Iterable[_PairEquations],
+    pairs: Sequence[_PairData],
     n_params: int,
-    keep_frames: NDArray[np.intp] | None = None,
+    counts: dict[int, int] | None,
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-    """Stack per-pair equation blocks into a single (A, y) system.
+    """Assemble the (A, y) system: fit means, center, stack equations.
+
+    The pair mean models are (re-)fitted on exactly the frames present in
+    ``counts`` (with multiplicity), so bootstrap replicates re-center on
+    their own resample rather than reusing the full-cohort mean.
 
     Parameters:
-        pair_eqs: Equation blocks from every pair.
+        pairs: Pair data blocks.
         n_params: Width of the design matrix.
-        keep_frames: Optional multiset of frame indices (bootstrap resample);
-            a frame's equations are repeated per occurrence.  ``None`` keeps
-            every equation once.
+        counts: Optional frame multiset; ``None`` keeps every equation once.
 
     Returns:
         Design matrix ``A`` and target vector ``y``.
     """
-    counts: dict[int, int] | None = None
-    if keep_frames is not None:
-        counts = {}
-        for idx in keep_frames:
-            counts[int(idx)] = counts.get(int(idx), 0) + 1
     a_blocks: list[NDArray[np.float64]] = []
     y_blocks: list[NDArray[np.float64]] = []
-    for eqs in pair_eqs:
-        for block, target, f_idx in zip(eqs.rows, eqs.targets, eqs.frame_index, strict=True):
-            repeat = 1 if counts is None else counts.get(f_idx, 0)
-            for _ in range(repeat):
-                a_blocks.append(block)
-                y_blocks.append(target)
+    for pair in pairs:
+        beta = _fit_mean(pair, counts)
+        targets = _pair_targets(pair, beta)
+        if counts is None:
+            repeats = np.ones(len(pair.frame_index), dtype=np.intp)
+        else:
+            repeats = np.array([counts.get(f_idx, 0) for f_idx in pair.frame_index], dtype=np.intp)
+        mask = repeats > 0
+        if not mask.any():
+            continue
+        a_blocks.append(np.repeat(pair.cov_rows[mask], repeats[mask], axis=0).reshape(-1, n_params))
+        y_blocks.append(np.repeat(targets[mask], repeats[mask], axis=0).reshape(-1))
     if not a_blocks:
         return np.zeros((0, n_params), dtype=np.float64), np.zeros(0, dtype=np.float64)
     return np.vstack(a_blocks), np.concatenate(y_blocks)
@@ -510,6 +638,7 @@ def solve_covariance_components(
     specs: Sequence[EstimatorSpec],
     *,
     pair_covariances: Sequence[PairKey] = (),
+    mean_model: Literal['auto', 'constant'] = 'auto',
     practical_sv_ratio: float = 1e-6,
     n_bootstrap: int = 0,
     bootstrap_seed: int = 0,
@@ -517,10 +646,12 @@ def solve_covariance_components(
     """Solve the covariance-components system for a cohort of frames.
 
     Every co-occurring instance pair contributes central second-moment
-    equations; the stacked linear system is solved by minimum-norm least
-    squares.  Identifiability is diagnosed from the design matrix's singular
-    spectrum and reported per parameter -- a degenerate composition returns
-    its null space explicitly rather than failing.
+    equations (centered by the fitted per-pair mean model; see the module
+    docstring for what the mean model does and does not absorb); the
+    stacked linear system is solved by minimum-norm least squares.
+    Identifiability is diagnosed from the design matrix's singular
+    spectrum and reported per parameter -- a degenerate composition
+    returns its null space explicitly rather than failing.
 
     Parameters:
         frames: Cohort of per-frame samples.
@@ -529,11 +660,20 @@ def solve_covariance_components(
             cross-covariance should be solved for instead of assumed zero.
             Declaring a pair adds unknowns; the cohort must be
             over-determined enough to carry them (check the returned
-            identifiability scores).
+            identifiability scores).  Model restrictions: a full/full
+            pair's matrix is image-frame constant (no rotating option),
+            and a rank1-involving pair's scalar ``gamma`` assumes the
+            projected cross-covariance is axis-independent
+            (``S = gamma * I``).
+        mean_model: ``'auto'`` (default) fits constant plus rotating-frame
+            mean columns for rotating members; ``'constant'`` fits the
+            constant term only (retained to demonstrate the aliasing an
+            unmodeled rotating bias produces).
         practical_sv_ratio: Singular values below this fraction of the
             largest are treated as null directions.
         n_bootstrap: Number of frame-resampling bootstrap replicates for
-            percentile confidence intervals (0 disables).
+            percentile confidence intervals (0 disables).  Each replicate
+            re-fits the pair mean models on its own resample.
         bootstrap_seed: Seed for the bootstrap resampler.
 
     Returns:
@@ -551,23 +691,27 @@ def solve_covariance_components(
     if len(specs) < 2:
         raise ValueError('at least two estimator instances are required')
     layout = _build_layout(specs, pair_covariances)
-    pair_blocks: dict[PairKey, _PairEquations] = {}
+    pair_data: dict[PairKey, _PairData] = {}
     pair_means: dict[PairKey, NDArray[np.float64] | float] = {}
+    pair_mean_models: dict[PairKey, dict[str, float]] = {}
     for i in range(len(specs)):
         for j in range(i + 1, len(specs)):
-            built = _pair_equations(frames, specs[i], specs[j], layout)
+            built = _build_pair_data(frames, specs[i], specs[j], layout, mean_model)
             if built is None:
                 continue
-            eqs, mean = built
-            pair_blocks[(specs[i].name, specs[j].name)] = eqs
-            pair_means[(specs[i].name, specs[j].name)] = mean
-    a_mat, y_vec = _assemble(pair_blocks.values(), layout.n_params)
+            key = (specs[i].name, specs[j].name)
+            pair_data[key] = built
+            raw_mean = built.diffs.mean(axis=0)
+            pair_means[key] = raw_mean if built.full_full else float(raw_mean[0])
+            beta_full = _fit_mean(built, None)
+            pair_mean_models[key] = {
+                label: float(beta_full[k]) for k, label in enumerate(built.mean_columns)
+            }
+    pairs = list(pair_data.values())
+    a_mat, y_vec = _assemble(pairs, layout.n_params, None)
     if a_mat.shape[0] == 0:
         raise ValueError('no pair of instances ever co-occurs; nothing to solve')
-    params, _, _, sv = np.linalg.lstsq(a_mat, y_vec, rcond=None)
-    sv = np.sort(np.asarray(sv, dtype=np.float64))[::-1]
-    # np.linalg.lstsq returns only nonzero singular values for rank-deficient
-    # systems on some backends; recompute the full spectrum for diagnostics.
+    params, _, _, _ = np.linalg.lstsq(a_mat, y_vec, rcond=None)
     _, full_sv, vt = np.linalg.svd(a_mat, full_matrices=False)
     sv_max = float(full_sv[0]) if full_sv.size else 0.0
     null_mask = full_sv < practical_sv_ratio * sv_max
@@ -583,21 +727,21 @@ def solve_covariance_components(
 
     covariances: dict[str, NDArray[np.float64]] = {}
     rank1_variances: dict[str, float] = {}
-    for key, sl in layout.group_slices.items():
-        if layout.group_kind[key] == 'full':
+    for key_str, sl in layout.group_slices.items():
+        if layout.group_kind[key_str] == 'full':
             c11, c12, c22 = params[sl]
-            covariances[key] = np.array([[c11, c12], [c12, c22]], dtype=np.float64)
+            covariances[key_str] = np.array([[c11, c12], [c12, c22]], dtype=np.float64)
         else:
-            rank1_variances[key] = float(params[sl][0])
+            rank1_variances[key_str] = float(params[sl][0])
     pair_cov_out: dict[PairKey, NDArray[np.float64] | float] = {}
-    for pair, sl in layout.pair_slices.items():
+    for pair_key, sl in layout.pair_slices.items():
         vals = params[sl]
         if vals.size == 3:
-            pair_cov_out[pair] = np.array(
+            pair_cov_out[pair_key] = np.array(
                 [[vals[0], vals[1]], [vals[1], vals[2]]], dtype=np.float64
             )
         else:
-            pair_cov_out[pair] = float(vals[0])
+            pair_cov_out[pair_key] = float(vals[0])
 
     bootstrap_ci: dict[str, tuple[float, float]] = {}
     if n_bootstrap > 0:
@@ -605,8 +749,11 @@ def solve_covariance_components(
         n_frames = len(frames)
         samples = np.empty((n_bootstrap, layout.n_params), dtype=np.float64)
         for b in range(n_bootstrap):
-            resample = rng.integers(0, n_frames, size=n_frames).astype(np.intp)
-            a_b, y_b = _assemble(pair_blocks.values(), layout.n_params, keep_frames=resample)
+            resample = rng.integers(0, n_frames, size=n_frames)
+            b_counts: dict[int, int] = {}
+            for idx in resample:
+                b_counts[int(idx)] = b_counts.get(int(idx), 0) + 1
+            a_b, y_b = _assemble(pairs, layout.n_params, b_counts)
             if a_b.shape[0] == 0:
                 samples[b] = np.nan
                 continue
@@ -622,6 +769,7 @@ def solve_covariance_components(
         rank1_variances=rank1_variances,
         pair_covariances=pair_cov_out,
         pair_mean_diff=pair_means,
+        pair_mean_model=pair_mean_models,
         singular_values=np.asarray(full_sv, dtype=np.float64),
         condition_number=condition,
         null_space=np.asarray(null_space, dtype=np.float64),

--- a/util/agreement/estimator.py
+++ b/util/agreement/estimator.py
@@ -308,7 +308,9 @@ def _basis_angle(spec: EstimatorSpec, frame: FrameSample) -> float:
     """Return the basis angle for a full instance on a frame (0 for image)."""
     if spec.basis == 'rotating':
         if spec.name not in frame.basis_angle_rad:
-            raise ValueError(f'frame is missing basis_angle_rad for rotating instance {spec.name!r}')
+            raise ValueError(
+                f'frame is missing basis_angle_rad for rotating instance {spec.name!r}'
+            )
         return float(frame.basis_angle_rad[spec.name])
     return 0.0
 
@@ -611,9 +613,7 @@ def solve_covariance_components(
             samples[b], _, _, _ = np.linalg.lstsq(a_b, y_b, rcond=None)
         lo = np.nanpercentile(samples, 2.5, axis=0)
         hi = np.nanpercentile(samples, 97.5, axis=0)
-        bootstrap_ci = {
-            name: (float(lo[k]), float(hi[k])) for k, name in enumerate(layout.names)
-        }
+        bootstrap_ci = {name: (float(lo[k]), float(hi[k])) for k, name in enumerate(layout.names)}
 
     return SolveResult(
         param_names=layout.names,

--- a/util/agreement/estimator.py
+++ b/util/agreement/estimator.py
@@ -1,0 +1,633 @@
+"""Cross-technique covariance-components estimator (truth-free solve).
+
+Estimates per-technique 2x2 error covariance matrices from nothing but the
+techniques' own offsets on shared frames -- the generalized three-cornered-hat
+solve the agreement study consumes.  Given per-frame offsets from two or more
+estimator instances, every pairwise difference supplies moment equations
+
+    E[(o_i - o_j)(o_i - o_j)^T] = C_i + C_j - 2 * S_ij
+
+(with ``S_ij`` the symmetric part of the cross-covariance, zero unless the
+pair is explicitly declared suspect), and the module solves the resulting
+linear system for the unknown covariance elements by least squares.
+
+The solve is carried in full matrix form, never scalar sigmas:
+
+- A ``full`` estimator instance carries a symmetric 2x2 covariance --
+  three unknowns ``(c_11, c_12, c_22)`` -- expressed in its own *basis
+  frame*.  The basis frame is either the fixed image frame or a per-frame
+  rotating frame (e.g. a limb fit's covariance is anisotropic in the
+  arc-aligned frame, and that frame rotates from image to image); the
+  per-frame basis angle rotates the unknown into image coordinates inside
+  the design matrix, so anisotropy that rotates frame to frame is handled
+  by the solve itself rather than by orientation binning.
+- A ``rank1`` estimator instance (a straight ring edge) measures the offset
+  only along a per-frame axis; it carries a single variance unknown, and
+  every equation involving it is projected onto that frame's axis before
+  entering the system.
+
+Instances may share a parameter ``group`` (two bodies navigated by the same
+technique in one frame), which asserts the technique's error covariance is
+common across the group's instances within the cohort -- an explicit
+stationarity assumption the caller must be able to defend.
+
+Identifiability is part of the output, not an assumption: the solve reports
+the design matrix's singular spectrum, the (numerical) null space mapped
+back to parameter names, and a per-parameter identifiability score.  A
+degenerate cohort (e.g. limb+disc alone: one matrix equation, two unknown
+matrices) yields an explicit null space instead of a silently arbitrary
+answer; the minimum-norm solution is returned with those directions flagged
+unidentifiable.
+
+All angles follow the (v, u) image convention: an angle ``alpha`` denotes
+the unit direction ``(cos(alpha), sin(alpha))`` in (v, u) coordinates.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Literal
+
+import numpy as np
+from numpy.typing import NDArray
+
+__all__ = [
+    'EstimatorSpec',
+    'FrameSample',
+    'PairKey',
+    'SolveResult',
+    'solve_covariance_components',
+]
+
+PairKey = tuple[str, str]
+
+# Two rank-1 instances can only be differenced when their measurement axes
+# are parallel to within this |cos| tolerance; otherwise the pair carries no
+# common measured component and is skipped for that frame.
+_RANK1_PARALLEL_MIN_ABS_COS = 0.99
+
+
+@dataclass(frozen=True)
+class EstimatorSpec:
+    """One estimator instance participating in the solve.
+
+    Parameters:
+        name: Instance name, unique within the solve (e.g. ``'limb'`` or
+            ``'limb@RHEA'``).
+        kind: ``'full'`` for a 2-D offset estimate with a full 2x2
+            covariance; ``'rank1'`` for an estimate constrained only along
+            a per-frame axis (a straight ring edge), carrying a single
+            variance unknown.
+        basis: ``'image'`` when the covariance is stationary in image
+            coordinates; ``'rotating'`` when it is stationary in a
+            per-frame frame whose angle each :class:`FrameSample` supplies
+            (only meaningful for ``kind='full'``).
+        group: Parameter-sharing key.  Instances with the same group share
+            one set of covariance unknowns (asserting a common error
+            covariance across the instances); defaults to ``name``.
+
+    Raises:
+        ValueError: if ``kind`` / ``basis`` combinations are inconsistent.
+    """
+
+    name: str
+    kind: Literal['full', 'rank1']
+    basis: Literal['image', 'rotating'] = 'image'
+    group: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate the kind/basis combination."""
+        if self.kind not in ('full', 'rank1'):
+            raise ValueError(f'kind must be full or rank1; got {self.kind!r}')
+        if self.basis not in ('image', 'rotating'):
+            raise ValueError(f'basis must be image or rotating; got {self.basis!r}')
+        if self.kind == 'rank1' and self.basis == 'rotating':
+            raise ValueError('rank1 instances take their axis per frame; basis must be image')
+
+    @property
+    def group_key(self) -> str:
+        """The parameter-sharing key (``group`` or the instance name)."""
+        return self.group if self.group is not None else self.name
+
+
+@dataclass(frozen=True)
+class FrameSample:
+    """Per-frame technique offsets plus the frame's geometry angles.
+
+    Parameters:
+        offsets: Mapping from instance name to its measured ``(dv, du)``
+            offset on this frame.  Instances absent from a frame simply
+            contribute no equations there.
+        basis_angle_rad: Per-instance basis-frame angle (radians, image
+            (v, u) convention) for ``basis='rotating'`` instances; ignored
+            for image-basis instances.
+        axis_angle_rad: Per-instance measurement-axis angle (radians) for
+            ``rank1`` instances; required for each rank1 instance present
+            in ``offsets``.
+    """
+
+    offsets: Mapping[str, tuple[float, float]]
+    basis_angle_rad: Mapping[str, float] = field(default_factory=dict)
+    axis_angle_rad: Mapping[str, float] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SolveResult:
+    """Output of :func:`solve_covariance_components`.
+
+    Parameters:
+        param_names: Ordered unknown names.  Covariance elements are
+            ``'<group>:c11'`` / ``'<group>:c12'`` / ``'<group>:c22'`` (in
+            the group's basis frame), rank-1 variances ``'<group>:s2'``,
+            and declared pair covariances ``'cov(<i>,<j>):<elem>'``.
+        params: Minimum-norm least-squares solution, aligned with
+            ``param_names``.  Values along unidentifiable directions are
+            arbitrary (minimum-norm); consult ``identifiability``.
+        covariances: Per-group symmetric 2x2 covariance (basis frame)
+            assembled from ``params`` for every ``full`` group.
+        rank1_variances: Per-group scalar variance for every rank1 group.
+        pair_covariances: Recovered symmetric cross-covariance per declared
+            pair (2x2 image-frame matrix for full/full pairs, scalar for
+            pairs involving a rank1 instance).
+        pair_mean_diff: Per differenced pair, the cohort mean difference
+            that was subtracted before forming second moments (the bias
+            channel; 2-vector for full/full pairs, scalar otherwise).
+        singular_values: Singular values of the design matrix, descending.
+        condition_number: Ratio of largest to smallest singular value
+            (``inf`` for an exactly rank-deficient system).
+        null_space: ``(k, n_params)`` orthonormal rows spanning the
+            numerical null space at ``practical_sv_ratio``; empty when the
+            system is fully identifiable.
+        identifiability: Per-parameter score in [0, 1]: the squared
+            projection of the parameter axis onto the identifiable row
+            space.  1.0 means fully determined; ~0 means the parameter
+            lives in the null space and its returned value is arbitrary.
+        n_frames: Frames consumed.
+        n_equations: Scalar equations assembled.
+        residual_rms: Root-mean-square residual of the fitted equations.
+        bootstrap_ci: Optional per-parameter (lo, hi) percentile interval
+            from frame-resampling; empty when bootstrap was not requested.
+            Intervals for unidentifiable parameters are not meaningful.
+    """
+
+    param_names: tuple[str, ...]
+    params: NDArray[np.float64]
+    covariances: dict[str, NDArray[np.float64]]
+    rank1_variances: dict[str, float]
+    pair_covariances: dict[PairKey, NDArray[np.float64] | float]
+    pair_mean_diff: dict[PairKey, NDArray[np.float64] | float]
+    singular_values: NDArray[np.float64]
+    condition_number: float
+    null_space: NDArray[np.float64]
+    identifiability: dict[str, float]
+    n_frames: int
+    n_equations: int
+    residual_rms: float
+    bootstrap_ci: dict[str, tuple[float, float]]
+
+
+def _vech_rotation(theta: float) -> NDArray[np.float64]:
+    """Return M with ``vech(R C R^T) = M @ vech(C)`` for a rotation by theta.
+
+    ``R`` maps basis coordinates into image coordinates; its columns are the
+    basis vectors ``(cos t, sin t)`` and ``(-sin t, cos t)``.  ``vech`` packs
+    a symmetric 2x2 as ``(c11, c12, c22)``.
+
+    Parameters:
+        theta: Basis-frame angle in radians.
+
+    Returns:
+        The 3x3 rotation-action matrix on vech coordinates.
+    """
+    c = math.cos(theta)
+    s = math.sin(theta)
+    return np.array(
+        [
+            [c * c, -2.0 * c * s, s * s],
+            [c * s, c * c - s * s, -c * s],
+            [s * s, 2.0 * c * s, c * c],
+        ],
+        dtype=np.float64,
+    )
+
+
+def _vech_quadratic(alpha: float) -> NDArray[np.float64]:
+    """Return q with ``a^T C a = q @ vech(C)`` for the unit axis at alpha.
+
+    Parameters:
+        alpha: Axis angle in radians (image (v, u) convention).
+
+    Returns:
+        Length-3 coefficient row on image-frame vech coordinates.
+    """
+    a1 = math.cos(alpha)
+    a2 = math.sin(alpha)
+    return np.array([a1 * a1, 2.0 * a1 * a2, a2 * a2], dtype=np.float64)
+
+
+@dataclass(frozen=True)
+class _ParamLayout:
+    """Internal parameter bookkeeping for the linear system."""
+
+    names: tuple[str, ...]
+    group_slices: dict[str, slice]
+    group_kind: dict[str, str]
+    pair_slices: dict[PairKey, slice]
+    n_params: int
+
+
+def _build_layout(
+    specs: Sequence[EstimatorSpec], pair_covariances: Sequence[PairKey]
+) -> _ParamLayout:
+    """Assign parameter-vector slices to groups and declared pairs.
+
+    Parameters:
+        specs: Estimator instances (validated by the caller).
+        pair_covariances: Declared suspect pairs, as instance-name tuples.
+
+    Returns:
+        The parameter layout.
+
+    Raises:
+        ValueError: on group kind conflicts or unknown pair members.
+    """
+    by_name = {spec.name: spec for spec in specs}
+    names: list[str] = []
+    group_slices: dict[str, slice] = {}
+    group_kind: dict[str, str] = {}
+    for spec in specs:
+        key = spec.group_key
+        if key in group_kind:
+            if group_kind[key] != spec.kind:
+                raise ValueError(f'group {key!r} mixes full and rank1 instances')
+            continue
+        group_kind[key] = spec.kind
+        start = len(names)
+        if spec.kind == 'full':
+            names.extend([f'{key}:c11', f'{key}:c12', f'{key}:c22'])
+        else:
+            names.append(f'{key}:s2')
+        group_slices[key] = slice(start, len(names))
+    pair_slices: dict[PairKey, slice] = {}
+    for pair in pair_covariances:
+        i_name, j_name = pair
+        if i_name not in by_name or j_name not in by_name:
+            raise ValueError(f'pair {pair!r} names an unknown instance')
+        start = len(names)
+        if by_name[i_name].kind == 'full' and by_name[j_name].kind == 'full':
+            names.extend(
+                [
+                    f'cov({i_name},{j_name}):s11',
+                    f'cov({i_name},{j_name}):s12',
+                    f'cov({i_name},{j_name}):s22',
+                ]
+            )
+        else:
+            names.append(f'cov({i_name},{j_name}):gamma')
+        pair_slices[pair] = slice(start, len(names))
+    return _ParamLayout(
+        names=tuple(names),
+        group_slices=group_slices,
+        group_kind=group_kind,
+        pair_slices=pair_slices,
+        n_params=len(names),
+    )
+
+
+def _pair_slice(layout: _ParamLayout, i_name: str, j_name: str) -> slice | None:
+    """Return the declared-pair slice for (i, j) in either order, or None."""
+    for key in ((i_name, j_name), (j_name, i_name)):
+        if key in layout.pair_slices:
+            return layout.pair_slices[key]
+    return None
+
+
+def _basis_angle(spec: EstimatorSpec, frame: FrameSample) -> float:
+    """Return the basis angle for a full instance on a frame (0 for image)."""
+    if spec.basis == 'rotating':
+        if spec.name not in frame.basis_angle_rad:
+            raise ValueError(f'frame is missing basis_angle_rad for rotating instance {spec.name!r}')
+        return float(frame.basis_angle_rad[spec.name])
+    return 0.0
+
+
+def _axis_angle(spec: EstimatorSpec, frame: FrameSample) -> float:
+    """Return the measurement-axis angle for a rank1 instance on a frame."""
+    if spec.name not in frame.axis_angle_rad:
+        raise ValueError(f'frame is missing axis_angle_rad for rank1 instance {spec.name!r}')
+    return float(frame.axis_angle_rad[spec.name])
+
+
+@dataclass(frozen=True)
+class _PairEquations:
+    """Per-frame design/target blocks for one instance pair.
+
+    ``rows[f]`` and ``targets[f]`` hold that frame's equations (1 or 3 rows).
+    ``frame_index[f]`` maps back to the cohort frame index for bootstrap
+    resampling.
+    """
+
+    rows: list[NDArray[np.float64]]
+    targets: list[NDArray[np.float64]]
+    frame_index: list[int]
+
+
+def _difference_samples(
+    frames: Sequence[FrameSample],
+    spec_i: EstimatorSpec,
+    spec_j: EstimatorSpec,
+) -> tuple[list[int], NDArray[np.float64], list[tuple[float, float]]]:
+    """Collect raw per-frame differences for one pair.
+
+    For a full/full pair the difference is the 2-vector ``o_i - o_j``.  When
+    either member is rank1 the difference is the scalar projection of both
+    offsets onto the frame's measurement axis (a rank1 instance's offset is
+    only meaningful along that axis).  A rank1/rank1 pair contributes only on
+    frames where the two axes are parallel within tolerance.
+
+    Parameters:
+        frames: The cohort.
+        spec_i: First pair member.
+        spec_j: Second pair member.
+
+    Returns:
+        ``(frame_indices, diffs, angles)`` where ``diffs`` is ``(n, 2)`` for
+        full/full pairs and ``(n, 1)`` otherwise, and ``angles`` carries the
+        per-sample ``(basis_or_axis_i, basis_or_axis_j)`` angles needed to
+        rebuild design rows.
+    """
+    indices: list[int] = []
+    diffs: list[list[float]] = []
+    angles: list[tuple[float, float]] = []
+    for f_idx, frame in enumerate(frames):
+        if spec_i.name not in frame.offsets or spec_j.name not in frame.offsets:
+            continue
+        o_i = frame.offsets[spec_i.name]
+        o_j = frame.offsets[spec_j.name]
+        if spec_i.kind == 'full' and spec_j.kind == 'full':
+            indices.append(f_idx)
+            diffs.append([o_i[0] - o_j[0], o_i[1] - o_j[1]])
+            angles.append((_basis_angle(spec_i, frame), _basis_angle(spec_j, frame)))
+        elif spec_i.kind == 'rank1' and spec_j.kind == 'rank1':
+            alpha_i = _axis_angle(spec_i, frame)
+            alpha_j = _axis_angle(spec_j, frame)
+            if abs(math.cos(alpha_i - alpha_j)) < _RANK1_PARALLEL_MIN_ABS_COS:
+                continue
+            a_i = (math.cos(alpha_i), math.sin(alpha_i))
+            a_j = (math.cos(alpha_j), math.sin(alpha_j))
+            s_i = a_i[0] * o_i[0] + a_i[1] * o_i[1]
+            s_j = a_j[0] * o_j[0] + a_j[1] * o_j[1]
+            # Express both along axis i (they are parallel within tolerance;
+            # a sign flip between the axes flips s_j's sign).
+            sign = 1.0 if math.cos(alpha_i - alpha_j) >= 0 else -1.0
+            indices.append(f_idx)
+            diffs.append([s_i - sign * s_j])
+            angles.append((alpha_i, alpha_j))
+        else:
+            # Exactly one member is rank1: project both onto its axis.  The
+            # angle tuple stays positional -- slot 0 for spec_i, slot 1 for
+            # spec_j -- holding the axis angle for the rank1 member and the
+            # basis angle for the full member.
+            rank1_spec = spec_i if spec_i.kind == 'rank1' else spec_j
+            alpha = _axis_angle(rank1_spec, frame)
+            a = (math.cos(alpha), math.sin(alpha))
+            s_i = a[0] * o_i[0] + a[1] * o_i[1]
+            s_j = a[0] * o_j[0] + a[1] * o_j[1]
+            indices.append(f_idx)
+            diffs.append([s_i - s_j])
+            angle_i = alpha if spec_i.kind == 'rank1' else _basis_angle(spec_i, frame)
+            angle_j = alpha if spec_j.kind == 'rank1' else _basis_angle(spec_j, frame)
+            angles.append((angle_i, angle_j))
+    if not indices:
+        return [], np.zeros((0, 1), dtype=np.float64), []
+    return indices, np.asarray(diffs, dtype=np.float64).reshape(len(indices), -1), angles
+
+
+def _pair_equations(
+    frames: Sequence[FrameSample],
+    spec_i: EstimatorSpec,
+    spec_j: EstimatorSpec,
+    layout: _ParamLayout,
+) -> tuple[_PairEquations, NDArray[np.float64] | float] | None:
+    """Build the moment equations for one instance pair.
+
+    The cohort mean difference is subtracted before squaring, so the
+    second moments are central: a deterministic shared bias between the two
+    instances lands in the returned mean, not in the covariance system.
+
+    Parameters:
+        frames: The cohort.
+        spec_i: First pair member.
+        spec_j: Second pair member.
+        layout: Parameter layout.
+
+    Returns:
+        ``(equations, mean_diff)`` or ``None`` when the pair never co-occurs.
+    """
+    indices, diffs, angles = _difference_samples(frames, spec_i, spec_j)
+    if len(indices) == 0:
+        return None
+    mean = diffs.mean(axis=0)
+    centered = diffs - mean
+    pair_slice = _pair_slice(layout, spec_i.name, spec_j.name)
+    rows: list[NDArray[np.float64]] = []
+    targets: list[NDArray[np.float64]] = []
+    frame_index: list[int] = []
+    full_full = spec_i.kind == 'full' and spec_j.kind == 'full'
+    for k, f_idx in enumerate(indices):
+        if full_full:
+            d = centered[k]
+            target = np.array([d[0] * d[0], d[0] * d[1], d[1] * d[1]], dtype=np.float64)
+            block = np.zeros((3, layout.n_params), dtype=np.float64)
+            block[:, layout.group_slices[spec_i.group_key]] += _vech_rotation(angles[k][0])
+            block[:, layout.group_slices[spec_j.group_key]] += _vech_rotation(angles[k][1])
+            if pair_slice is not None:
+                block[:, pair_slice] += -2.0 * np.eye(3)
+        else:
+            s = centered[k, 0]
+            target = np.array([s * s], dtype=np.float64)
+            block = np.zeros((1, layout.n_params), dtype=np.float64)
+            # The projection axis is the rank1 member's axis angle, held in
+            # that member's positional slot (for rank1/rank1 pairs slot 0).
+            axis = angles[k][0] if spec_i.kind == 'rank1' else angles[k][1]
+            for spec, angle_pos in ((spec_i, 0), (spec_j, 1)):
+                sl = layout.group_slices[spec.group_key]
+                if spec.kind == 'rank1':
+                    block[0, sl] += 1.0
+                else:
+                    theta = angles[k][angle_pos]
+                    block[0, sl] += _vech_quadratic(axis) @ _vech_rotation(theta)
+            if pair_slice is not None:
+                block[0, pair_slice] += -2.0
+        rows.append(block)
+        targets.append(target)
+        frame_index.append(f_idx)
+    mean_out: NDArray[np.float64] | float = mean if full_full else float(mean[0])
+    return _PairEquations(rows=rows, targets=targets, frame_index=frame_index), mean_out
+
+
+def _assemble(
+    pair_eqs: Iterable[_PairEquations],
+    n_params: int,
+    keep_frames: NDArray[np.intp] | None = None,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Stack per-pair equation blocks into a single (A, y) system.
+
+    Parameters:
+        pair_eqs: Equation blocks from every pair.
+        n_params: Width of the design matrix.
+        keep_frames: Optional multiset of frame indices (bootstrap resample);
+            a frame's equations are repeated per occurrence.  ``None`` keeps
+            every equation once.
+
+    Returns:
+        Design matrix ``A`` and target vector ``y``.
+    """
+    counts: dict[int, int] | None = None
+    if keep_frames is not None:
+        counts = {}
+        for idx in keep_frames:
+            counts[int(idx)] = counts.get(int(idx), 0) + 1
+    a_blocks: list[NDArray[np.float64]] = []
+    y_blocks: list[NDArray[np.float64]] = []
+    for eqs in pair_eqs:
+        for block, target, f_idx in zip(eqs.rows, eqs.targets, eqs.frame_index, strict=True):
+            repeat = 1 if counts is None else counts.get(f_idx, 0)
+            for _ in range(repeat):
+                a_blocks.append(block)
+                y_blocks.append(target)
+    if not a_blocks:
+        return np.zeros((0, n_params), dtype=np.float64), np.zeros(0, dtype=np.float64)
+    return np.vstack(a_blocks), np.concatenate(y_blocks)
+
+
+def solve_covariance_components(
+    frames: Sequence[FrameSample],
+    specs: Sequence[EstimatorSpec],
+    *,
+    pair_covariances: Sequence[PairKey] = (),
+    practical_sv_ratio: float = 1e-6,
+    n_bootstrap: int = 0,
+    bootstrap_seed: int = 0,
+) -> SolveResult:
+    """Solve the covariance-components system for a cohort of frames.
+
+    Every co-occurring instance pair contributes central second-moment
+    equations; the stacked linear system is solved by minimum-norm least
+    squares.  Identifiability is diagnosed from the design matrix's singular
+    spectrum and reported per parameter -- a degenerate composition returns
+    its null space explicitly rather than failing.
+
+    Parameters:
+        frames: Cohort of per-frame samples.
+        specs: Estimator instances (unique names).
+        pair_covariances: Instance-name pairs whose symmetric
+            cross-covariance should be solved for instead of assumed zero.
+            Declaring a pair adds unknowns; the cohort must be
+            over-determined enough to carry them (check the returned
+            identifiability scores).
+        practical_sv_ratio: Singular values below this fraction of the
+            largest are treated as null directions.
+        n_bootstrap: Number of frame-resampling bootstrap replicates for
+            percentile confidence intervals (0 disables).
+        bootstrap_seed: Seed for the bootstrap resampler.
+
+    Returns:
+        The :class:`SolveResult`.
+
+    Raises:
+        ValueError: on duplicate instance names, an empty cohort, or a
+            cohort that yields no equations.
+    """
+    if len(frames) == 0:
+        raise ValueError('frames must be non-empty')
+    names = [spec.name for spec in specs]
+    if len(set(names)) != len(names):
+        raise ValueError(f'instance names must be unique; got {names!r}')
+    if len(specs) < 2:
+        raise ValueError('at least two estimator instances are required')
+    layout = _build_layout(specs, pair_covariances)
+    pair_blocks: dict[PairKey, _PairEquations] = {}
+    pair_means: dict[PairKey, NDArray[np.float64] | float] = {}
+    for i in range(len(specs)):
+        for j in range(i + 1, len(specs)):
+            built = _pair_equations(frames, specs[i], specs[j], layout)
+            if built is None:
+                continue
+            eqs, mean = built
+            pair_blocks[(specs[i].name, specs[j].name)] = eqs
+            pair_means[(specs[i].name, specs[j].name)] = mean
+    a_mat, y_vec = _assemble(pair_blocks.values(), layout.n_params)
+    if a_mat.shape[0] == 0:
+        raise ValueError('no pair of instances ever co-occurs; nothing to solve')
+    params, _, _, sv = np.linalg.lstsq(a_mat, y_vec, rcond=None)
+    sv = np.sort(np.asarray(sv, dtype=np.float64))[::-1]
+    # np.linalg.lstsq returns only nonzero singular values for rank-deficient
+    # systems on some backends; recompute the full spectrum for diagnostics.
+    _, full_sv, vt = np.linalg.svd(a_mat, full_matrices=False)
+    sv_max = float(full_sv[0]) if full_sv.size else 0.0
+    null_mask = full_sv < practical_sv_ratio * sv_max
+    null_space = vt[null_mask]
+    sv_min = float(full_sv[~null_mask][-1]) if (~null_mask).any() else 0.0
+    condition = math.inf if null_mask.any() or sv_min == 0.0 else sv_max / sv_min
+    row_space = vt[~null_mask]
+    identifiability = {
+        name: float(np.sum(row_space[:, k] ** 2)) for k, name in enumerate(layout.names)
+    }
+    residual = a_mat @ params - y_vec
+    residual_rms = float(np.sqrt(np.mean(residual**2))) if residual.size else 0.0
+
+    covariances: dict[str, NDArray[np.float64]] = {}
+    rank1_variances: dict[str, float] = {}
+    for key, sl in layout.group_slices.items():
+        if layout.group_kind[key] == 'full':
+            c11, c12, c22 = params[sl]
+            covariances[key] = np.array([[c11, c12], [c12, c22]], dtype=np.float64)
+        else:
+            rank1_variances[key] = float(params[sl][0])
+    pair_cov_out: dict[PairKey, NDArray[np.float64] | float] = {}
+    for pair, sl in layout.pair_slices.items():
+        vals = params[sl]
+        if vals.size == 3:
+            pair_cov_out[pair] = np.array(
+                [[vals[0], vals[1]], [vals[1], vals[2]]], dtype=np.float64
+            )
+        else:
+            pair_cov_out[pair] = float(vals[0])
+
+    bootstrap_ci: dict[str, tuple[float, float]] = {}
+    if n_bootstrap > 0:
+        rng = np.random.default_rng(bootstrap_seed)
+        n_frames = len(frames)
+        samples = np.empty((n_bootstrap, layout.n_params), dtype=np.float64)
+        for b in range(n_bootstrap):
+            resample = rng.integers(0, n_frames, size=n_frames).astype(np.intp)
+            a_b, y_b = _assemble(pair_blocks.values(), layout.n_params, keep_frames=resample)
+            if a_b.shape[0] == 0:
+                samples[b] = np.nan
+                continue
+            samples[b], _, _, _ = np.linalg.lstsq(a_b, y_b, rcond=None)
+        lo = np.nanpercentile(samples, 2.5, axis=0)
+        hi = np.nanpercentile(samples, 97.5, axis=0)
+        bootstrap_ci = {
+            name: (float(lo[k]), float(hi[k])) for k, name in enumerate(layout.names)
+        }
+
+    return SolveResult(
+        param_names=layout.names,
+        params=np.asarray(params, dtype=np.float64),
+        covariances=covariances,
+        rank1_variances=rank1_variances,
+        pair_covariances=pair_cov_out,
+        pair_mean_diff=pair_means,
+        singular_values=np.asarray(full_sv, dtype=np.float64),
+        condition_number=condition,
+        null_space=np.asarray(null_space, dtype=np.float64),
+        identifiability=identifiability,
+        n_frames=len(frames),
+        n_equations=int(a_mat.shape[0]),
+        residual_rms=residual_rms,
+        bootstrap_ci=bootstrap_ci,
+    )

--- a/util/agreement/scene_gen.py
+++ b/util/agreement/scene_gen.py
@@ -277,6 +277,7 @@ def _gen_limb_ring_aniso(
     # body (rejection-sample the offset and line distance).
     h = 0.0
     radial_deg = 0.0
+    clearance = radius + 14.0
     for attempt in range(64):
         if diverse:
             delta = rng.uniform(-60.0, 60.0)
@@ -284,11 +285,27 @@ def _gen_limb_ring_aniso(
             delta = _FIXED_ANISO_RELATIVE_DEG
         radial_deg = (theta_deg + 180.0 + delta) % 360.0
         h = rng.uniform(60.0, 100.0)
-        if _line_clears_body(radial_deg, h, (center_v, center_u), radius + 14.0):
+        if _line_clears_body(radial_deg, h, (center_v, center_u), clearance):
             break
         if not diverse and attempt >= 8:
             # The frozen relative angle must not be resampled; widen h only.
             h = rng.uniform(80.0, 105.0)
+    if not _line_clears_body(radial_deg, h, (center_v, center_u), clearance):
+        # Deterministic fallback (no further RNG draws, so the normal
+        # path's stream -- and therefore every recorded campaign scene --
+        # is unchanged): the line exactly opposite the arc at a large h is
+        # always clear, because its distance from the body center is
+        # h + dist * cos(delta) with dist <= 0.65 * radius, which exceeds
+        # radius + 14 for h = 100 at every drawn geometry.  The fixed
+        # family keeps its frozen relative angle.
+        delta = 0.0 if diverse else _FIXED_ANISO_RELATIVE_DEG
+        radial_deg = (theta_deg + 180.0 + delta) % 360.0
+        h = 100.0
+        if not _line_clears_body(radial_deg, h, (center_v, center_u), clearance):
+            raise RuntimeError(
+                f'aniso ring placement failed clearance even at fallback: '
+                f'radius={radius:.1f} dist={dist:.1f} delta={delta:.1f}'
+            )
     a = rng.uniform(*_RING_A_RANGE)
     params['ring_system'] = _ring_system(radial_deg, h, a, rng)
     geometry = {

--- a/util/agreement/scene_gen.py
+++ b/util/agreement/scene_gen.py
@@ -1,0 +1,374 @@
+"""Composition-controlled sim scenes for the agreement-estimator validation.
+
+Generates seeded sim_params dicts (the same flat mapping the calibration
+campaign feeds ObsSim) for cohorts whose *estimator composition* is the
+controlled variable, together with the geometry angles the covariance solve
+needs:
+
+- limb_disc              : one resolved body, fully in frame; BodyLimbNav and
+                           BodyDiscCorrelateNav both run (no ring).
+- limb_disc_ring_fixed   : the same body plus a straight face-on ringlet whose
+                           radial direction is FROZEN across the cohort (the
+                           degenerate rank-1 regime the identifiability map
+                           must demonstrate).
+- limb_disc_ring_diverse : identical except the ring radial direction is drawn
+                           uniformly per scene (the orientation-diverse regime
+                           the full-matrix solve needs).
+- limb_ring_aniso_fixed  : a large partially-clipped body (anisotropic limb
+                           covariance, arc orientation frozen) plus the ring
+                           at a frozen relative angle.
+- limb_ring_aniso_diverse: the clipped-body arc orientation AND the ring
+                           radial direction drawn per scene (the rotating-
+                           anisotropy trap carried in full matrix form).
+- multi_body             : two resolved bodies (RHEA and DIONE), each large
+                           enough for limb + disc; the collector navigates
+                           each body separately via the model filter.
+
+Scenes are deliberately clean -- smooth ellipsoids, moderate noise, no
+planted model error -- because this campaign validates the estimator's
+mathematics against known-by-construction errors, not the techniques'
+robustness (that is the calibration campaign's job).  All randomness comes
+from a caller-seeded ``random.Random`` keyed by (campaign_seed, family,
+index), so any scene regenerates without replaying the campaign.
+
+Angle convention: an angle ``alpha`` (degrees here, radians in the
+estimator) denotes the image-plane unit direction ``(cos alpha, sin alpha)``
+in (v, u) coordinates.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from collections.abc import Callable
+from typing import Any
+
+FAMILIES = (
+    'limb_disc',
+    'limb_disc_ring_fixed',
+    'limb_disc_ring_diverse',
+    'limb_ring_aniso_fixed',
+    'limb_ring_aniso_diverse',
+    'multi_body',
+)
+
+FRAME_SIZE = 256
+_FRAME_CENTER = FRAME_SIZE / 2.0
+
+# Frozen directions for the *_fixed cohorts (degrees).  Arbitrary but fixed:
+# the point is that they do not vary across the cohort.
+_FIXED_RING_RADIAL_DEG = 200.0
+_FIXED_ARC_THETA_DEG = 40.0
+# Relative angle between the clipped-limb outward-arc direction and the ring
+# radial direction in the aniso_fixed cohort (degrees).
+_FIXED_ANISO_RELATIVE_DEG = -20.0
+
+# Ring semimajor-axis range (px): large enough that the edge crossing the
+# frame is nearly straight (sagitta under ~6 px across the full frame), the
+# rank-1 regime the estimator declares for the ring instance.
+_RING_A_RANGE = (1200.0, 2500.0)
+# Distance range of the ring-edge line from the frame center (px).  The
+# lower bound clears the fully-framed body (radius <= 65 px, center within
+# 10 px of frame center) with margin; the upper bound keeps the ringlet
+# well inside the frame.
+_RING_H_RANGE = (92.0, 105.0)
+
+# Bodies drawn for the single-body cohorts (regular, near-spherical).
+_BODY_NAMES = ('RHEA', 'DIONE', 'TETHYS')
+
+
+def _base(rng: random.Random) -> dict[str, Any]:
+    """Common sim_params skeleton: planted offset, moderate noise.
+
+    Parameters:
+        rng: Scene-local random generator.
+
+    Returns:
+        The base scene parameter dict (no bodies or rings yet).
+    """
+    return {
+        'instrument': 'coiss_nac',
+        'size_v': FRAME_SIZE,
+        'size_u': FRAME_SIZE,
+        'random_seed': rng.randrange(2**31),
+        'exposure_sec': 1.0,
+        'bodies': [],
+        'noise': {
+            'poisson': True,
+            'read_noise_dn': math.exp(rng.uniform(math.log(2.0), math.log(8.0))),
+        },
+        'offset_v': rng.uniform(-3.0, 3.0),
+        'offset_u': rng.uniform(-3.0, 3.0),
+        'offset_rotation_deg': 0.0,
+    }
+
+
+def _framed_body(rng: random.Random) -> tuple[dict[str, Any], float, float]:
+    """One smooth ellipsoid body fully inside the frame, limb-eligible.
+
+    The diameter range (104-130 px) clears the simulated body model's
+    100 px limb-emission floor with rasterization margin while leaving the
+    whole silhouette inside the frame, so BodyLimbNav (closed,
+    near-isotropic limb) and BodyDiscCorrelateNav both run.
+
+    Parameters:
+        rng: Scene-local random generator.
+
+    Returns:
+        ``(body_entry, center_v, center_u)``.
+    """
+    diameter = rng.uniform(104.0, 130.0)
+    center_v = _FRAME_CENTER + rng.uniform(-10.0, 10.0)
+    center_u = _FRAME_CENTER + rng.uniform(-10.0, 10.0)
+    body = {
+        'name': rng.choice(_BODY_NAMES),
+        'center_v': center_v,
+        'center_u': center_u,
+        'axis1': diameter,
+        'axis2': diameter * rng.uniform(0.97, 1.0),
+        'axis3': diameter * rng.uniform(0.96, 1.0),
+        'illumination_angle': rng.uniform(0.0, 360.0),
+        'phase_angle': rng.uniform(10.0, 45.0),
+    }
+    return body, center_v, center_u
+
+
+def _ring_system(radial_deg: float, h: float, a: float, rng: random.Random) -> dict[str, Any]:
+    """A face-on straight-edge ringlet crossing the frame.
+
+    The edge line passes at distance ``h`` from the frame center along the
+    radial direction ``radial_deg``; the ring center sits ``a`` pixels
+    behind it, so over the 256 px frame the edges are nearly straight
+    (rank-1).  Face-on (opening 90 deg) keeps the drawn radial direction an
+    exact image-plane direction.
+
+    Parameters:
+        radial_deg: Radial (increasing-radius) direction at the crossing.
+        h: Signed distance of the ringlet mid-line from the frame center.
+        a: Ring semimajor axis (px).
+        rng: Scene-local random generator (optical depth, width).
+
+    Returns:
+        The ``ring_system`` scene block.
+    """
+    phi = math.radians(radial_deg)
+    mid_v = _FRAME_CENTER + h * math.cos(phi)
+    mid_u = _FRAME_CENTER + h * math.sin(phi)
+    return {
+        'geometry': {
+            'center_v': mid_v - a * math.cos(phi),
+            'center_u': mid_u - a * math.sin(phi),
+            'opening_deg_obs': 90.0,
+            'opening_deg_sun': 90.0,
+            'node_deg': 0.0,
+        },
+        'features': [
+            {
+                'name': 'SATURN-1',
+                'kind': 'ringlet',
+                'tau': math.exp(rng.uniform(math.log(0.8), math.log(2.5))),
+                'width': rng.uniform(8.0, 16.0),
+                'navigable': True,
+                'orbit': {'a': a, 'ae': 0.0, 'long_peri': 0.0, 'rate_peri': 0.0},
+            }
+        ],
+    }
+
+
+def _gen_limb_disc(rng: random.Random) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Fully-framed body: limb + disc, no ring."""
+    params = _base(rng)
+    body, _, _ = _framed_body(rng)
+    params['bodies'] = [body]
+    geometry = {'composition': 'limb_disc'}
+    return params, geometry
+
+
+def _gen_limb_disc_ring(
+    rng: random.Random, *, diverse: bool
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Fully-framed body plus a straight ringlet clear of the body.
+
+    Parameters:
+        rng: Scene-local random generator.
+        diverse: Draw the ring radial direction uniformly per scene when
+            True; freeze it at the cohort constant when False.
+    """
+    params = _base(rng)
+    body, _, _ = _framed_body(rng)
+    params['bodies'] = [body]
+    radial_deg = rng.uniform(0.0, 360.0) if diverse else _FIXED_RING_RADIAL_DEG
+    h = rng.uniform(*_RING_H_RANGE)
+    a = rng.uniform(*_RING_A_RANGE)
+    params['ring_system'] = _ring_system(radial_deg, h, a, rng)
+    geometry = {
+        'composition': 'limb_disc_ring',
+        'ring_radial_deg': radial_deg,
+    }
+    return params, geometry
+
+
+def _line_clears_body(
+    radial_deg: float, h: float, body_center_vu: tuple[float, float], clearance: float
+) -> bool:
+    """True when the ring mid-line stays ``clearance`` px from the body center.
+
+    The (nearly straight) ringlet mid-line is the line perpendicular to the
+    radial direction at signed distance ``h`` from the frame center; the
+    signed distance of any point from it is the point's radial coordinate
+    minus ``h``.
+
+    Parameters:
+        radial_deg: Ring radial direction (degrees).
+        h: Signed distance of the mid-line from the frame center.
+        body_center_vu: Body center in image coordinates.
+        clearance: Required distance (px).
+
+    Returns:
+        Whether the line clears the body.
+    """
+    phi = math.radians(radial_deg)
+    rel_v = body_center_vu[0] - _FRAME_CENTER
+    rel_u = body_center_vu[1] - _FRAME_CENTER
+    body_radial = rel_v * math.cos(phi) + rel_u * math.sin(phi)
+    return abs(body_radial - h) >= clearance
+
+
+def _gen_limb_ring_aniso(
+    rng: random.Random, *, diverse: bool
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Clipped large body (anisotropic limb arc) plus the straight ringlet.
+
+    The body center sits ~0.55-0.65 radii from the frame center along the
+    arc direction ``theta``, so roughly half the limb is visible: the limb
+    covariance is genuinely anisotropic, tight along the outward-arc
+    (radial) direction ``theta + 180`` and loose along the arc tangent.
+    The ring's radial direction is drawn around the clear side, offset from
+    the arc direction by a relative angle that is frozen for the fixed
+    cohort and drawn uniformly (within the clearance envelope) for the
+    diverse cohort.  Low phase keeps the lit-region boundary close to the
+    geometric limb so the DT fit stays on the arc.
+
+    Parameters:
+        rng: Scene-local random generator.
+        diverse: Draw arc/ring directions per scene when True.
+    """
+    params = _base(rng)
+    radius = rng.uniform(100.0, 120.0)
+    theta_deg = rng.uniform(0.0, 360.0) if diverse else _FIXED_ARC_THETA_DEG
+    theta = math.radians(theta_deg)
+    dist = rng.uniform(0.55, 0.65) * radius
+    center_v = _FRAME_CENTER + dist * math.cos(theta)
+    center_u = _FRAME_CENTER + dist * math.sin(theta)
+    diameter = 2.0 * radius
+    body = {
+        'name': rng.choice(_BODY_NAMES),
+        'center_v': center_v,
+        'center_u': center_u,
+        'axis1': diameter,
+        'axis2': diameter * rng.uniform(0.985, 1.0),
+        'axis3': diameter * rng.uniform(0.98, 1.0),
+        'illumination_angle': rng.uniform(0.0, 360.0),
+        'phase_angle': rng.uniform(8.0, 14.0),
+    }
+    params['bodies'] = [body]
+    # Ring on the clear side: radial direction opposite the arc direction
+    # plus a relative offset, with a numerical clearance check against the
+    # body (rejection-sample the offset and line distance).
+    h = 0.0
+    radial_deg = 0.0
+    for attempt in range(64):
+        if diverse:
+            delta = rng.uniform(-60.0, 60.0)
+        else:
+            delta = _FIXED_ANISO_RELATIVE_DEG
+        radial_deg = (theta_deg + 180.0 + delta) % 360.0
+        h = rng.uniform(60.0, 100.0)
+        if _line_clears_body(radial_deg, h, (center_v, center_u), radius + 14.0):
+            break
+        if not diverse and attempt >= 8:
+            # The frozen relative angle must not be resampled; widen h only.
+            h = rng.uniform(80.0, 105.0)
+    a = rng.uniform(*_RING_A_RANGE)
+    params['ring_system'] = _ring_system(radial_deg, h, a, rng)
+    geometry = {
+        'composition': 'limb_ring_aniso',
+        'ring_radial_deg': radial_deg,
+        'limb_arc_outward_deg': (theta_deg + 180.0) % 360.0,
+    }
+    return params, geometry
+
+
+def _gen_multi_body(rng: random.Random) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Two resolved bodies, each limb + disc eligible, well separated."""
+    params = _base(rng)
+    phase = rng.uniform(10.0, 40.0)
+    illumination = rng.uniform(0.0, 360.0)
+    bodies = []
+    for name, base_v, base_u, dia_lo, dia_hi in (
+        ('RHEA', 68.0, 68.0, 100.0, 115.0),
+        ('DIONE', 188.0, 188.0, 100.0, 112.0),
+    ):
+        diameter = rng.uniform(dia_lo, dia_hi)
+        bodies.append(
+            {
+                'name': name,
+                'center_v': base_v + rng.uniform(-6.0, 6.0),
+                'center_u': base_u + rng.uniform(-6.0, 6.0),
+                'axis1': diameter,
+                'axis2': diameter * rng.uniform(0.97, 1.0),
+                'axis3': diameter * rng.uniform(0.96, 1.0),
+                'illumination_angle': illumination,
+                'phase_angle': phase,
+            }
+        )
+    params['bodies'] = bodies
+    geometry = {'composition': 'multi_body', 'body_names': ['RHEA', 'DIONE']}
+    return params, geometry
+
+
+_GENERATORS: dict[str, Callable[[random.Random], tuple[dict[str, Any], dict[str, Any]]]] = {
+    'limb_disc': _gen_limb_disc,
+    'limb_disc_ring_fixed': lambda rng: _gen_limb_disc_ring(rng, diverse=False),
+    'limb_disc_ring_diverse': lambda rng: _gen_limb_disc_ring(rng, diverse=True),
+    'limb_ring_aniso_fixed': lambda rng: _gen_limb_ring_aniso(rng, diverse=False),
+    'limb_ring_aniso_diverse': lambda rng: _gen_limb_ring_aniso(rng, diverse=True),
+    'multi_body': _gen_multi_body,
+}
+
+
+def generate_scenes(
+    family: str, count: int, *, campaign_seed: int
+) -> list[tuple[str, dict[str, Any], dict[str, Any]]]:
+    """Return ``count`` seeded scenes as ``(scene_id, sim_params, geometry)``.
+
+    Each scene draws from its own ``random.Random`` seeded by
+    ``(campaign_seed, family, index)`` so any single scene regenerates
+    without replaying the campaign.  ``geometry`` carries the angle
+    metadata the estimator consumes (ring radial direction, limb arc
+    orientation) -- derived from the same idealized scene parameters the
+    navigator is told, never from truth keys.
+
+    Parameters:
+        family: One of :data:`FAMILIES`.
+        count: Number of scenes.
+        campaign_seed: Campaign-level seed recorded in the output manifest.
+
+    Returns:
+        List of ``(scene_id, sim_params, geometry)`` triples.
+
+    Raises:
+        ValueError: for an unknown family name.
+    """
+    from spindoctor.sim.scene import validate_sim_params
+
+    if family not in _GENERATORS:
+        raise ValueError(f'unknown scene family {family!r}; valid: {sorted(_GENERATORS)}')
+    generator = _GENERATORS[family]
+    scenes = []
+    for index in range(count):
+        rng = random.Random(f'{campaign_seed}/{family}/{index}')
+        scene_id = f'{family}_{index:05d}'
+        params, geometry = generator(rng)
+        scenes.append((scene_id, validate_sim_params(params, source=scene_id), geometry))
+    return scenes

--- a/util/agreement/tests/test_estimator.py
+++ b/util/agreement/tests/test_estimator.py
@@ -17,7 +17,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from estimator import (  # noqa: E402
+from estimator import (
     EstimatorSpec,
     FrameSample,
     solve_covariance_components,
@@ -281,9 +281,7 @@ def test_declared_pair_covariance_recovers_common_mode() -> None:
         EstimatorSpec('ring', 'rank1'),
         EstimatorSpec('blob', 'full'),
     ]
-    result = solve_covariance_components(
-        frames, specs, pair_covariances=[('limb', 'ring')]
-    )
+    result = solve_covariance_components(frames, specs, pair_covariances=[('limb', 'ring')])
     gamma = result.pair_covariances[('limb', 'ring')]
     assert isinstance(gamma, float)
     assert gamma == pytest.approx(sigma_common**2, abs=0.05)

--- a/util/agreement/tests/test_estimator.py
+++ b/util/agreement/tests/test_estimator.py
@@ -435,3 +435,168 @@ def test_rank1_pair_skipped_when_axes_perpendicular() -> None:
     specs = [EstimatorSpec('r1', 'rank1'), EstimatorSpec('r2', 'rank1')]
     with pytest.raises(ValueError, match='co-occurs'):
         solve_covariance_components(frames, specs)
+
+
+def _rotating_bias_frames(
+    rng: np.random.Generator,
+    n: int,
+    mu_limb: tuple[float, float],
+    mu_disc: tuple[float, float] | None,
+) -> list[FrameSample]:
+    """Frames with geometry-locked (rotating-frame) technique biases.
+
+    The limb error is drawn in a per-frame rotating basis with a constant
+    bias ``mu_limb`` in that basis; when ``mu_disc`` is given the disc
+    error also carries a rotating bias with the same per-frame angle (the
+    partial-body situation where both techniques are pulled toward the
+    body center).  A rank1 ring with a diverse axis completes the system.
+
+    Parameters:
+        rng: Random generator.
+        n: Number of frames.
+        mu_limb: Limb bias in the rotating frame.
+        mu_disc: Optional disc bias in the same rotating frame.
+
+    Returns:
+        The frame list.
+    """
+    c_limb = np.array([[0.3, 0.0], [0.0, 0.5]])
+    c_disc = np.array([[0.05, 0.0], [0.0, 0.05]])
+    s2_ring = 0.01
+    frames: list[FrameSample] = []
+    for _ in range(n):
+        theta = float(rng.uniform(0.0, 2.0 * math.pi))
+        r = _rot(theta)
+        e_l = r @ (_draw(rng, c_limb) + np.asarray(mu_limb))
+        e_d = _draw(rng, c_disc)
+        if mu_disc is not None:
+            e_d = e_d + r @ np.asarray(mu_disc)
+        alpha = float(rng.uniform(0.0, 2.0 * math.pi))
+        a = np.array([math.cos(alpha), math.sin(alpha)])
+        t = np.array([-a[1], a[0]])
+        e_r = float(rng.normal(0.0, math.sqrt(s2_ring))) * a + float(rng.normal(0.0, 30.0)) * t
+        frames.append(
+            FrameSample(
+                offsets={
+                    'limb': (float(e_l[0]), float(e_l[1])),
+                    'disc': (float(e_d[0]), float(e_d[1])),
+                    'ring': (float(e_r[0]), float(e_r[1])),
+                },
+                basis_angle_rad={'limb': theta, 'disc': theta},
+                axis_angle_rad={'ring': alpha},
+            )
+        )
+    return frames
+
+
+def test_rotating_bias_aliases_under_constant_centering() -> None:
+    """A rotating-frame bias is invisible to constant centering and aliases.
+
+    The image-frame mean of a rotating bias is ~0 over a diverse cohort,
+    so the constant channel subtracts nothing and mu mu^T lands in the
+    recovered covariance (C + mu mu^T) with the system fully identifiable
+    and no negative-variance symptom anywhere.
+    """
+    rng = np.random.default_rng(30)
+    frames = _rotating_bias_frames(rng, 5000, (-2.0, 0.0), None)
+    specs = [
+        EstimatorSpec('limb', 'full', basis='rotating'),
+        EstimatorSpec('disc', 'full'),
+        EstimatorSpec('ring', 'rank1'),
+    ]
+    result = solve_covariance_components(frames, specs, mean_model='constant')
+    mean = result.pair_mean_diff[('limb', 'disc')]
+    assert isinstance(mean, np.ndarray)
+    # The constant bias channel sees nothing...
+    assert float(np.abs(mean).max()) < 0.1
+    # ...and the limb variance is inflated to ~ C + mu^2 = 0.3 + 4.0.
+    assert result.covariances['limb'][0, 0] == pytest.approx(4.3, abs=0.3)
+    assert result.null_space.shape[0] == 0
+
+
+def test_rotating_mean_model_absorbs_geometry_locked_bias() -> None:
+    """Experiment A: the rotating mean columns restore the true covariance."""
+    rng = np.random.default_rng(31)
+    frames = _rotating_bias_frames(rng, 6000, (-2.0, 0.0), None)
+    specs = [
+        EstimatorSpec('limb', 'full', basis='rotating'),
+        EstimatorSpec('disc', 'full'),
+        EstimatorSpec('ring', 'rank1'),
+    ]
+    result = solve_covariance_components(frames, specs)
+    assert result.covariances['limb'][0, 0] == pytest.approx(0.3, abs=0.06)
+    assert result.covariances['limb'][1, 1] == pytest.approx(0.5, abs=0.08)
+    assert result.rank1_variances['ring'] == pytest.approx(0.01, abs=0.05)
+    # The fitted mean model exposes the bias it absorbed.
+    model = result.pair_mean_model[('limb', 'ring')]
+    assert model['limb:mu1'] == pytest.approx(-2.0, abs=0.1)
+
+
+def test_shared_rotating_bias_repaired_when_both_declared() -> None:
+    """Experiment B: shared rotating biases stop corrupting the solve.
+
+    With limb and disc both biased in the same rotating frame and both
+    declared rotating, the mean model absorbs the shared component: the
+    disc covariance no longer goes negative and every value returns to
+    truth.  (With disc left undeclared the corruption persists -- the
+    absorption follows the declaration.)
+    """
+    rng = np.random.default_rng(32)
+    frames = _rotating_bias_frames(rng, 6000, (-2.0, 0.0), (-1.5, 0.0))
+    specs_declared = [
+        EstimatorSpec('limb', 'full', basis='rotating'),
+        EstimatorSpec('disc', 'full', basis='rotating'),
+        EstimatorSpec('ring', 'rank1'),
+    ]
+    result = solve_covariance_components(frames, specs_declared)
+    assert result.covariances['limb'][0, 0] == pytest.approx(0.3, abs=0.06)
+    assert result.covariances['disc'][0, 0] == pytest.approx(0.05, abs=0.05)
+    assert result.covariances['disc'][0, 0] > 0.0
+    assert result.rank1_variances['ring'] == pytest.approx(0.01, abs=0.05)
+    # Undeclared disc: the corruption persists (documented limitation).
+    specs_naive = [
+        EstimatorSpec('limb', 'full', basis='rotating'),
+        EstimatorSpec('disc', 'full'),
+        EstimatorSpec('ring', 'rank1'),
+    ]
+    naive = solve_covariance_components(frames, specs_naive, mean_model='constant')
+    assert naive.covariances['disc'][0, 0] < 0.0
+
+
+def test_bootstrap_coverage_rate() -> None:
+    """Bootstrap CIs cover the truth for nearly all identifiable parameters.
+
+    Not a single-parameter spot check: all nine parameters of a fully
+    identifiable three-technique system are checked at once.  At 95%
+    nominal coverage the expectation is ~8.55 covered; requiring at least
+    7 catches gross miscoverage while tolerating the ~7% chance of two
+    marginal misses (percentile bootstrap on variance parameters is
+    slightly anti-conservative even with per-replicate re-centering).
+    """
+    rng = np.random.default_rng(33)
+    frames = _make_frames(rng, 1500, with_blob=True)
+    specs = [
+        EstimatorSpec('limb', 'full'),
+        EstimatorSpec('disc', 'full'),
+        EstimatorSpec('blob', 'full'),
+    ]
+    result = solve_covariance_components(frames, specs, n_bootstrap=150, bootstrap_seed=9)
+    truth = {
+        'limb': C_LIMB,
+        'disc': C_DISC,
+        'blob': C_BLOB,
+    }
+    covered = 0
+    total = 0
+    for group, cov in truth.items():
+        for name, value in (
+            (f'{group}:c11', cov[0, 0]),
+            (f'{group}:c12', cov[0, 1]),
+            (f'{group}:c22', cov[1, 1]),
+        ):
+            lo, hi = result.bootstrap_ci[name]
+            total += 1
+            if lo <= value <= hi:
+                covered += 1
+    assert total == 9
+    assert covered >= 7

--- a/util/agreement/tests/test_estimator.py
+++ b/util/agreement/tests/test_estimator.py
@@ -561,6 +561,12 @@ def test_shared_rotating_bias_repaired_when_both_declared() -> None:
     ]
     naive = solve_covariance_components(frames, specs_naive, mean_model='constant')
     assert naive.covariances['disc'][0, 0] < 0.0
+    # And auto mode does NOT rescue an undeclared member: the limb's mean
+    # columns absorb only the limb-disc difference of the shared bias, so
+    # the disc's own rotating bias still aliases (c11 inflated an order of
+    # magnitude above the 0.05 truth, though no longer negative).
+    auto_naive = solve_covariance_components(frames, specs_naive)
+    assert auto_naive.covariances['disc'][0, 0] > 0.3
 
 
 def test_bootstrap_coverage_rate() -> None:

--- a/util/agreement/tests/test_estimator.py
+++ b/util/agreement/tests/test_estimator.py
@@ -1,0 +1,439 @@
+"""Unit tests for the covariance-components estimator on synthetic errors.
+
+Every test draws technique errors from known covariances, feeds only the
+resulting offsets to the solve, and checks recovery (where the composition
+identifies the parameters) or the explicit degeneracy report (where it
+cannot).  No spindoctor imports: the estimator is a standalone module.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from estimator import (  # noqa: E402
+    EstimatorSpec,
+    FrameSample,
+    solve_covariance_components,
+)
+
+
+def _rot(theta: float) -> np.ndarray:
+    """Rotation matrix whose columns are the basis vectors at ``theta``."""
+    c, s = math.cos(theta), math.sin(theta)
+    return np.array([[c, -s], [s, c]])
+
+
+def _draw(rng: np.random.Generator, cov: np.ndarray) -> np.ndarray:
+    """One 2-D zero-mean Gaussian draw with covariance ``cov``."""
+    return rng.multivariate_normal([0.0, 0.0], cov)
+
+
+C_LIMB = np.array([[0.04, 0.01], [0.01, 0.36]])
+C_DISC = np.array([[0.09, -0.02], [-0.02, 0.16]])
+C_BLOB = np.array([[0.25, 0.0], [0.0, 0.25]])
+S2_RING = 0.0025
+
+
+def _make_frames(
+    rng: np.random.Generator,
+    n: int,
+    *,
+    with_ring: bool = False,
+    ring_axis: str = 'diverse',
+    limb_rotating: bool = False,
+    with_blob: bool = False,
+    common_limb_ring: float = 0.0,
+) -> list[FrameSample]:
+    """Build synthetic frames for the standard limb/disc/ring/blob setup.
+
+    Parameters:
+        rng: Random generator.
+        n: Number of frames.
+        with_ring: Include the rank1 ring instance.
+        ring_axis: ``'diverse'`` for a uniform per-frame axis angle,
+            ``'fixed'`` for a constant axis.
+        limb_rotating: Draw the limb error in a per-frame rotating basis.
+        with_blob: Include an isotropic full-rank blob instance.
+        common_limb_ring: Standard deviation of an isotropic common-mode
+            error added to both limb and ring (the injected shared bias).
+
+    Returns:
+        The frame list.
+    """
+    truth = np.zeros(2)
+    frames: list[FrameSample] = []
+    for _ in range(n):
+        theta = float(rng.uniform(0.0, 2.0 * math.pi)) if limb_rotating else 0.0
+        r_mat = _rot(theta)
+        e_limb = r_mat @ _draw(rng, C_LIMB)
+        e_disc = _draw(rng, C_DISC)
+        offsets = {
+            'limb': (truth[0] + e_limb[0], truth[1] + e_limb[1]),
+            'disc': (truth[0] + e_disc[0], truth[1] + e_disc[1]),
+        }
+        basis = {'limb': theta}
+        axis: dict[str, float] = {}
+        common = np.zeros(2)
+        if common_limb_ring > 0.0:
+            common = rng.normal(0.0, common_limb_ring, size=2)
+            offsets['limb'] = (offsets['limb'][0] + common[0], offsets['limb'][1] + common[1])
+        if with_ring:
+            alpha = float(rng.uniform(0.0, 2.0 * math.pi)) if ring_axis == 'diverse' else 0.7
+            a_vec = np.array([math.cos(alpha), math.sin(alpha)])
+            s_err = float(rng.normal(0.0, math.sqrt(S2_RING))) + float(a_vec @ common)
+            # The rank1 instance reports a 2-D offset whose tangential part
+            # is garbage; the solve must only ever use the axis projection.
+            garbage = float(rng.normal(0.0, 30.0))
+            t_vec = np.array([-a_vec[1], a_vec[0]])
+            o_ring = truth + s_err * a_vec + garbage * t_vec
+            offsets['ring'] = (float(o_ring[0]), float(o_ring[1]))
+            axis['ring'] = alpha
+        if with_blob:
+            e_blob = _draw(rng, C_BLOB)
+            offsets['blob'] = (truth[0] + e_blob[0], truth[1] + e_blob[1])
+        frames.append(FrameSample(offsets=offsets, basis_angle_rad=basis, axis_angle_rad=axis))
+    return frames
+
+
+def test_three_full_rank_recovery() -> None:
+    """Three co-occurring full-rank techniques recover all three matrices."""
+    rng = np.random.default_rng(11)
+    frames = _make_frames(rng, 6000, with_blob=True)
+    specs = [
+        EstimatorSpec('limb', 'full'),
+        EstimatorSpec('disc', 'full'),
+        EstimatorSpec('blob', 'full'),
+    ]
+    result = solve_covariance_components(frames, specs)
+    assert result.null_space.shape[0] == 0
+    np.testing.assert_allclose(result.covariances['limb'], C_LIMB, atol=0.03)
+    np.testing.assert_allclose(result.covariances['disc'], C_DISC, atol=0.03)
+    np.testing.assert_allclose(result.covariances['blob'], C_BLOB, atol=0.03)
+
+
+def test_three_full_rank_identifiability_scores() -> None:
+    """A fully identifiable system scores ~1 on every parameter."""
+    rng = np.random.default_rng(12)
+    frames = _make_frames(rng, 500, with_blob=True)
+    specs = [
+        EstimatorSpec('limb', 'full'),
+        EstimatorSpec('disc', 'full'),
+        EstimatorSpec('blob', 'full'),
+    ]
+    result = solve_covariance_components(frames, specs)
+    for name, score in result.identifiability.items():
+        assert score > 0.99, name
+
+
+def test_limb_disc_alone_not_separable() -> None:
+    """One matrix equation, two unknown matrices: 3-dim null space."""
+    rng = np.random.default_rng(13)
+    frames = _make_frames(rng, 3000)
+    specs = [EstimatorSpec('limb', 'full'), EstimatorSpec('disc', 'full')]
+    result = solve_covariance_components(frames, specs)
+    assert result.null_space.shape[0] == 3
+    assert result.condition_number == math.inf
+
+
+def test_limb_disc_alone_recovers_combined_sum() -> None:
+    """The combined covariance survives even though the split does not."""
+    rng = np.random.default_rng(14)
+    frames = _make_frames(rng, 6000)
+    specs = [EstimatorSpec('limb', 'full'), EstimatorSpec('disc', 'full')]
+    result = solve_covariance_components(frames, specs)
+    combined = result.covariances['limb'] + result.covariances['disc']
+    np.testing.assert_allclose(combined, C_LIMB + C_DISC, atol=0.04)
+
+
+def test_limb_disc_alone_solution_not_unique() -> None:
+    """Adding a null-space vector leaves the residual unchanged."""
+    rng = np.random.default_rng(15)
+    frames = _make_frames(rng, 200)
+    specs = [EstimatorSpec('limb', 'full'), EstimatorSpec('disc', 'full')]
+    result = solve_covariance_components(frames, specs)
+    assert result.null_space.shape[0] > 0
+    # Rebuild the residual for the reported params and for a shifted copy.
+    shifted = result.params + 5.0 * result.null_space[0]
+    diffs = []
+    for frame in frames:
+        o_l = np.asarray(frame.offsets['limb'])
+        o_d = np.asarray(frame.offsets['disc'])
+        diffs.append(o_l - o_d)
+    d_arr = np.asarray(diffs) - np.mean(diffs, axis=0)
+    targets = np.stack(
+        [d_arr[:, 0] ** 2, d_arr[:, 0] * d_arr[:, 1], d_arr[:, 1] ** 2], axis=1
+    ).ravel()
+    design = np.tile(np.hstack([np.eye(3), np.eye(3)]), (len(frames), 1))
+    res_a = design @ result.params - targets
+    res_b = design @ shifted - targets
+    np.testing.assert_allclose(res_a, res_b, atol=1e-9)
+
+
+def test_ring_diverse_axis_makes_system_identifiable() -> None:
+    """limb+disc+ring with a rotating radial axis recovers everything."""
+    rng = np.random.default_rng(16)
+    frames = _make_frames(rng, 8000, with_ring=True, ring_axis='diverse')
+    specs = [
+        EstimatorSpec('limb', 'full'),
+        EstimatorSpec('disc', 'full'),
+        EstimatorSpec('ring', 'rank1'),
+    ]
+    result = solve_covariance_components(frames, specs)
+    assert result.null_space.shape[0] == 0
+    np.testing.assert_allclose(result.covariances['limb'], C_LIMB, atol=0.04)
+    np.testing.assert_allclose(result.covariances['disc'], C_DISC, atol=0.04)
+    assert result.rank1_variances['ring'] == pytest.approx(S2_RING, abs=0.02)
+
+
+def test_ring_fixed_axis_degenerates() -> None:
+    """A frozen radial axis leaves a 2-dim null space (radial-only split).
+
+    With the axis fixed, the ring leg constrains each body technique's
+    covariance only along that axis: the ring variance and the per-technique
+    radial-radial projections stay identifiable (the full limb+disc sum
+    closes them), but the split of the remaining elements does not.
+    """
+    rng = np.random.default_rng(17)
+    frames = _make_frames(rng, 6000, with_ring=True, ring_axis='fixed')
+    specs = [
+        EstimatorSpec('limb', 'full'),
+        EstimatorSpec('disc', 'full'),
+        EstimatorSpec('ring', 'rank1'),
+    ]
+    result = solve_covariance_components(frames, specs)
+    assert result.null_space.shape[0] == 2
+    assert result.identifiability['ring:s2'] > 0.99
+    assert result.identifiability['limb:c11'] < 0.99
+    # The radial-radial projection is the identifiable per-technique combo:
+    # q(alpha) . vech(C) survives the degeneracy and matches truth.
+    alpha = 0.7
+    q = np.array(
+        [
+            math.cos(alpha) ** 2,
+            2.0 * math.cos(alpha) * math.sin(alpha),
+            math.sin(alpha) ** 2,
+        ]
+    )
+    c_hat = result.covariances['limb']
+    radial_hat = float(q @ [c_hat[0, 0], c_hat[0, 1], c_hat[1, 1]])
+    radial_true = float(q @ [C_LIMB[0, 0], C_LIMB[0, 1], C_LIMB[1, 1]])
+    assert radial_hat == pytest.approx(radial_true, abs=0.04)
+
+
+def test_rotating_limb_basis_recovery() -> None:
+    """A limb covariance stationary only in its rotating frame is recovered."""
+    rng = np.random.default_rng(18)
+    frames = _make_frames(
+        rng, 8000, with_ring=True, ring_axis='diverse', limb_rotating=True, with_blob=True
+    )
+    specs = [
+        EstimatorSpec('limb', 'full', basis='rotating'),
+        EstimatorSpec('disc', 'full'),
+        EstimatorSpec('ring', 'rank1'),
+        EstimatorSpec('blob', 'full'),
+    ]
+    result = solve_covariance_components(frames, specs)
+    assert result.null_space.shape[0] == 0
+    np.testing.assert_allclose(result.covariances['limb'], C_LIMB, atol=0.05)
+
+
+def test_rotating_limb_without_rotation_flag_is_wrong() -> None:
+    """Ignoring the rotation misreads the limb anisotropy (the plan's trap)."""
+    rng = np.random.default_rng(19)
+    frames = _make_frames(rng, 6000, with_blob=True, limb_rotating=True)
+    specs = [
+        EstimatorSpec('limb', 'full'),  # wrong: treats basis as image-fixed
+        EstimatorSpec('disc', 'full'),
+        EstimatorSpec('blob', 'full'),
+    ]
+    result = solve_covariance_components(frames, specs)
+    # The rotating anisotropic limb looks isotropic when averaged in image
+    # coordinates: the recovered off-diagonal collapses and the diagonal
+    # elements average, hiding the 9x anisotropy.
+    c = result.covariances['limb']
+    mean_diag = (C_LIMB[0, 0] + C_LIMB[1, 1]) / 2.0
+    assert c[0, 0] == pytest.approx(mean_diag, abs=0.05)
+    assert c[1, 1] == pytest.approx(mean_diag, abs=0.05)
+
+
+def test_declared_pair_covariance_recovers_common_mode() -> None:
+    """A shared limb+ring error shows up in the declared pair covariance."""
+    rng = np.random.default_rng(20)
+    sigma_common = 0.5
+    frames = _make_frames(
+        rng,
+        8000,
+        with_ring=True,
+        ring_axis='diverse',
+        with_blob=True,
+        common_limb_ring=sigma_common,
+    )
+    specs = [
+        EstimatorSpec('limb', 'full'),
+        EstimatorSpec('disc', 'full'),
+        EstimatorSpec('ring', 'rank1'),
+        EstimatorSpec('blob', 'full'),
+    ]
+    result = solve_covariance_components(
+        frames, specs, pair_covariances=[('limb', 'ring')]
+    )
+    gamma = result.pair_covariances[('limb', 'ring')]
+    assert isinstance(gamma, float)
+    assert gamma == pytest.approx(sigma_common**2, abs=0.05)
+    # The limb covariance must absorb the common mode (it is a real part of
+    # the limb error), inflated by sigma_common^2 on the diagonal.
+    np.testing.assert_allclose(
+        result.covariances['limb'],
+        C_LIMB + np.eye(2) * sigma_common**2,
+        atol=0.06,
+    )
+
+
+def test_undeclared_common_mode_misattributes() -> None:
+    """Without the declared pair, the solve misattributes the common mode.
+
+    The limb-ring common error cancels in the limb-ring difference, so the
+    three-cornered-hat shifts it onto the techniques outside the coupled
+    pair -- the classic agreement-masks-shared-bias failure the campaign
+    must demonstrate.
+    """
+    rng = np.random.default_rng(21)
+    sigma_common = 0.5
+    frames = _make_frames(
+        rng,
+        8000,
+        with_ring=True,
+        ring_axis='diverse',
+        with_blob=True,
+        common_limb_ring=sigma_common,
+    )
+    specs = [
+        EstimatorSpec('limb', 'full'),
+        EstimatorSpec('disc', 'full'),
+        EstimatorSpec('ring', 'rank1'),
+        EstimatorSpec('blob', 'full'),
+    ]
+    result = solve_covariance_components(frames, specs)
+    # The recovered limb covariance understates the true limb error (which
+    # includes the common mode): the shared component cancels in the
+    # limb-ring difference and the least-squares fit spreads the resulting
+    # inconsistency, so a material fraction of the common-mode variance
+    # vanishes from the limb estimate.
+    true_limb = C_LIMB + np.eye(2) * sigma_common**2
+    understated = float(np.trace(true_limb - result.covariances['limb'])) / 2.0
+    assert understated > 0.3 * sigma_common**2
+
+
+def test_shared_group_across_bodies() -> None:
+    """Two limb instances sharing a group separate limb from disc."""
+    rng = np.random.default_rng(22)
+    frames = []
+    for _ in range(6000):
+        e_l_a = _draw(rng, C_LIMB)
+        e_l_b = _draw(rng, C_LIMB)
+        e_d_a = _draw(rng, C_DISC)
+        e_d_b = _draw(rng, C_DISC)
+        frames.append(
+            FrameSample(
+                offsets={
+                    'limb@A': (e_l_a[0], e_l_a[1]),
+                    'limb@B': (e_l_b[0], e_l_b[1]),
+                    'disc@A': (e_d_a[0], e_d_a[1]),
+                    'disc@B': (e_d_b[0], e_d_b[1]),
+                }
+            )
+        )
+    specs = [
+        EstimatorSpec('limb@A', 'full', group='limb'),
+        EstimatorSpec('limb@B', 'full', group='limb'),
+        EstimatorSpec('disc@A', 'full', group='disc'),
+        EstimatorSpec('disc@B', 'full', group='disc'),
+    ]
+    result = solve_covariance_components(frames, specs)
+    assert result.null_space.shape[0] == 0
+    np.testing.assert_allclose(result.covariances['limb'], C_LIMB, atol=0.03)
+    np.testing.assert_allclose(result.covariances['disc'], C_DISC, atol=0.03)
+
+
+def test_pair_mean_diff_reports_bias() -> None:
+    """A deterministic offset between techniques lands in the mean channel."""
+    rng = np.random.default_rng(23)
+    frames = []
+    for _ in range(2000):
+        e_l = _draw(rng, C_LIMB)
+        e_d = _draw(rng, C_DISC)
+        frames.append(
+            FrameSample(
+                offsets={
+                    'limb': (0.4 + e_l[0], -0.2 + e_l[1]),
+                    'disc': (e_d[0], e_d[1]),
+                }
+            )
+        )
+    specs = [EstimatorSpec('limb', 'full'), EstimatorSpec('disc', 'full')]
+    result = solve_covariance_components(frames, specs)
+    mean = result.pair_mean_diff[('limb', 'disc')]
+    assert isinstance(mean, np.ndarray)
+    np.testing.assert_allclose(mean, [0.4, -0.2], atol=0.03)
+    # The bias must NOT inflate the recovered combined covariance.
+    combined = result.covariances['limb'] + result.covariances['disc']
+    np.testing.assert_allclose(combined, C_LIMB + C_DISC, atol=0.05)
+
+
+def test_bootstrap_intervals_cover_truth() -> None:
+    """Bootstrap CIs on an identifiable system cover the true diagonal."""
+    rng = np.random.default_rng(24)
+    frames = _make_frames(rng, 1500, with_blob=True)
+    specs = [
+        EstimatorSpec('limb', 'full'),
+        EstimatorSpec('disc', 'full'),
+        EstimatorSpec('blob', 'full'),
+    ]
+    result = solve_covariance_components(frames, specs, n_bootstrap=100, bootstrap_seed=7)
+    lo, hi = result.bootstrap_ci['limb:c22']
+    assert lo < C_LIMB[1, 1]
+    assert hi > C_LIMB[1, 1]
+
+
+def test_duplicate_names_rejected() -> None:
+    """Duplicate instance names raise."""
+    frames = [FrameSample(offsets={'a': (0.0, 0.0), 'b': (0.0, 0.0)})]
+    specs = [EstimatorSpec('a', 'full'), EstimatorSpec('a', 'full')]
+    with pytest.raises(ValueError, match='unique'):
+        solve_covariance_components(frames, specs)
+
+
+def test_empty_cohort_rejected() -> None:
+    """An empty frame list raises."""
+    specs = [EstimatorSpec('a', 'full'), EstimatorSpec('b', 'full')]
+    with pytest.raises(ValueError, match='non-empty'):
+        solve_covariance_components([], specs)
+
+
+def test_missing_axis_angle_rejected() -> None:
+    """A rank1 instance without its per-frame axis raises."""
+    frames = [FrameSample(offsets={'a': (0.0, 0.0), 'r': (0.0, 0.0)})]
+    specs = [EstimatorSpec('a', 'full'), EstimatorSpec('r', 'rank1')]
+    with pytest.raises(ValueError, match='axis_angle_rad'):
+        solve_covariance_components(frames, specs)
+
+
+def test_rank1_pair_skipped_when_axes_perpendicular() -> None:
+    """Two rank1 instances with orthogonal axes share no measured component."""
+    frames = [
+        FrameSample(
+            offsets={'r1': (0.1, 0.0), 'r2': (0.0, 0.1)},
+            axis_angle_rad={'r1': 0.0, 'r2': math.pi / 2.0},
+        )
+        for _ in range(10)
+    ]
+    specs = [EstimatorSpec('r1', 'rank1'), EstimatorSpec('r2', 'rank1')]
+    with pytest.raises(ValueError, match='co-occurs'):
+        solve_covariance_components(frames, specs)

--- a/util/agreement/tests/test_scene_gen.py
+++ b/util/agreement/tests/test_scene_gen.py
@@ -1,0 +1,134 @@
+"""Tests for the agreement campaign scene generator.
+
+Requires the spindoctor package on the path (schema validation); run from
+the repo checkout with ``PYTHONPATH=src``.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+sys.path.insert(0, str(_HERE.parent.parent.parent / 'src'))
+
+from scene_gen import (  # noqa: E402
+    FAMILIES,
+    FRAME_SIZE,
+    generate_scenes,
+)
+
+_SEED = 987654
+
+
+@pytest.mark.parametrize('family', FAMILIES)
+def test_generation_is_deterministic(family: str) -> None:
+    """The same seed regenerates identical scenes."""
+    first = generate_scenes(family, 5, campaign_seed=_SEED)
+    second = generate_scenes(family, 5, campaign_seed=_SEED)
+    assert first == second
+
+
+@pytest.mark.parametrize('family', FAMILIES)
+def test_scenes_validate_against_schema(family: str) -> None:
+    """Every generated scene passes the sim schema (validated inline)."""
+    scenes = generate_scenes(family, 10, campaign_seed=_SEED)
+    assert len(scenes) == 10
+    for scene_id, params, geometry in scenes:
+        assert scene_id.startswith(family)
+        assert 'offset_v' in params
+        assert 'composition' in geometry
+
+
+def test_unknown_family_rejected() -> None:
+    """An unknown family raises with the valid list."""
+    with pytest.raises(ValueError, match='unknown scene family'):
+        generate_scenes('nope', 1, campaign_seed=_SEED)
+
+
+def test_limb_disc_body_fully_in_frame() -> None:
+    """The limb_disc body silhouette stays inside the frame."""
+    for _, params, _ in generate_scenes('limb_disc', 25, campaign_seed=_SEED):
+        body = params['bodies'][0]
+        radius = body['axis1'] / 2.0
+        for key, center in (('center_v', body['center_v']), ('center_u', body['center_u'])):
+            assert center - radius > 0.0, key
+            assert center + radius < FRAME_SIZE, key
+        assert body['axis1'] >= 104.0
+
+
+def test_ring_line_clears_framed_body() -> None:
+    """The ringlet mid-line keeps clear of the fully-framed body."""
+    for _, params, geometry in generate_scenes('limb_disc_ring_diverse', 25, campaign_seed=_SEED):
+        body = params['bodies'][0]
+        phi = math.radians(geometry['ring_radial_deg'])
+        geom = params['ring_system']['geometry']
+        a = params['ring_system']['features'][0]['orbit']['a']
+        # Mid-line point: ring center plus a along the radial direction.
+        pv = geom['center_v'] + a * math.cos(phi)
+        pu = geom['center_u'] + a * math.sin(phi)
+        # Distance from the body center to the line through (pv, pu)
+        # perpendicular to phi.
+        dist = abs(
+            (body['center_v'] - pv) * math.cos(phi) + (body['center_u'] - pu) * math.sin(phi)
+        )
+        assert dist > body['axis1'] / 2.0 + 8.0
+
+
+def test_aniso_ring_line_clears_clipped_body() -> None:
+    """The aniso families' ringlet line clears the large clipped body."""
+    for family in ('limb_ring_aniso_fixed', 'limb_ring_aniso_diverse'):
+        for _, params, geometry in generate_scenes(family, 25, campaign_seed=_SEED):
+            body = params['bodies'][0]
+            phi = math.radians(geometry['ring_radial_deg'])
+            geom = params['ring_system']['geometry']
+            a = params['ring_system']['features'][0]['orbit']['a']
+            pv = geom['center_v'] + a * math.cos(phi)
+            pu = geom['center_u'] + a * math.sin(phi)
+            dist = abs(
+                (body['center_v'] - pv) * math.cos(phi) + (body['center_u'] - pu) * math.sin(phi)
+            )
+            assert dist > body['axis1'] / 2.0 + 8.0, family
+
+
+def test_fixed_families_freeze_their_angles() -> None:
+    """The *_fixed cohorts hold their control angles constant."""
+    radials = {
+        geometry['ring_radial_deg']
+        for _, _, geometry in generate_scenes('limb_disc_ring_fixed', 20, campaign_seed=_SEED)
+    }
+    assert radials == {200.0}
+    aniso = generate_scenes('limb_ring_aniso_fixed', 20, campaign_seed=_SEED)
+    arcs = {geometry['limb_arc_outward_deg'] for _, _, geometry in aniso}
+    assert arcs == {220.0}
+    relative = {
+        round((geometry['ring_radial_deg'] - geometry['limb_arc_outward_deg']) % 360.0, 6)
+        for _, _, geometry in aniso
+    }
+    assert relative == {340.0}
+
+
+def test_diverse_families_spread_their_angles() -> None:
+    """The *_diverse cohorts draw a spread of control angles."""
+    radials = [
+        geometry['ring_radial_deg']
+        for _, _, geometry in generate_scenes('limb_disc_ring_diverse', 40, campaign_seed=_SEED)
+    ]
+    assert len({round(r, 3) for r in radials}) > 30
+    spread = max(radials) - min(radials)
+    assert spread > 180.0
+
+
+def test_multi_body_names_and_separation() -> None:
+    """multi_body scenes carry RHEA and DIONE, well separated."""
+    for _, params, geometry in generate_scenes('multi_body', 25, campaign_seed=_SEED):
+        names = [b['name'] for b in params['bodies']]
+        assert names == ['RHEA', 'DIONE']
+        assert geometry['body_names'] == ['RHEA', 'DIONE']
+        b1, b2 = params['bodies']
+        gap = math.hypot(b1['center_v'] - b2['center_v'], b1['center_u'] - b2['center_u'])
+        assert gap > (b1['axis1'] + b2['axis1']) / 2.0 + 20.0


### PR DESCRIPTION
Builds and validates the statistical estimator that the planned real-image agreement study depends on. Closes #224.

**Base is `rf_sim_realism`, not `main`.** That branch carries the simulator realism work this validation runs on top of; this PR should merge there and reach `main` only with it.

---

## 1. The problem: there is no ground truth for these images

SpinDoctor determines where a spacecraft camera was actually pointing by comparing an observed image against a model built from SPICE kernels. The output is a pixel offset: "the predicted position is wrong by this much."

The obvious question is how accurate those offsets are. For these archival images there is no way to answer it directly, because **no independent measurement of the true pointing exists.** There is no better instrument to check against, no surveyed reference, and no later mission that re-measured the same frames. Every candidate check is circular in some way:

- Comparing against SPICE reconstructed pointing measures the thing being corrected, not the correction.
- Comparing against the previous generation of this software is same-lineage, and its subpixel layer was never trusted -- it is why the rewrite happened.
- Comparing against a simulator measures the simulator, unless that simulator was built independently of the navigator.

## 2. The proposed answer, and the assumption buried inside it

The plan (`plans/VALIDATION_AND_CALIBRATION_PLAN.md`) works around the missing ground truth with **cross-technique agreement**. The navigator can often solve the same frame more than one way: fit a moon's lit limb, correlate its disc, fit a ring edge, plate-solve a star field. Each technique produces its own estimate of the same pointing offset. Where two disagree by a small amount, that is evidence both are accurate to roughly that level -- no external truth required.

Turning disagreements into per-technique error estimates is a **variance-components** problem. With three or more techniques you can, in principle, algebraically separate each one's individual error from the observed pairwise disagreements -- the same idea as the "three-cornered hat" used to separate clock stabilities.

That machinery rests on three assumptions, none of which had been tested:

1. **Identifiability** -- that the system of equations can actually be solved for the individual error terms, rather than only for sums of them.
2. **Independence** -- that the techniques' errors are uncorrelated. If two techniques share a bias, they agree *because they are wrong together*, and the agreement reads as accuracy. This is exactly the failure mode the whole approach exists to avoid.
3. **The right quantity** -- that what is recovered is a full 2x2 covariance matrix, not a single number. Pointing error is two-dimensional and these techniques are strongly anisotropic: a ring edge constrains position across the edge and says almost nothing along it. Collapsing that to one scalar discards the structure that matters.

If any assumption fails, "per-technique sigma" is a number that looks authoritative and is wrong. **This PR tests all three before anything is built on them.**

## 3. The approach: validate the validator on known truth

The estimator is exercised on simulated scenes where each technique's true error is known *by construction* -- the offset is planted, so truth is not estimated, it is the input. If the solve cannot recover known covariances in simulation, it certainly cannot be trusted on real frames.

## 4. What was built

Everything is under `util/agreement/`, plus one Developer Guide page. **No `src/` changes** -- navigation behavior is byte-identical to the base commit. The bias injection needed for Stage 0b is done by wrapping functions in the test harness, so no measurement hook was added to production code.

### `estimator.py` -- the solve
Full 2x2 matrix form throughout, never scalar sigmas. It handles:

- **Rotating anisotropy.** A limb arc's error ellipse is oriented by the geometry of that frame, which rotates from frame to frame. The solve carries each technique's covariance in its own rotating basis rather than averaging ellipses of different orientations into mush.
- **Rank-1 instances.** A straight ring edge constrains one direction only. It enters as a projection rather than a full matrix, so its unconstrained direction is not silently assigned a fabricated variance.
- **Declared pair covariances.** When two techniques are *known* to be correlated, that coupling can be declared and solved for instead of assumed away.
- **An identifiability report.** Every solve returns its own singular spectrum, its null space mapped back to parameter names, per-parameter scores, and bootstrap confidence intervals -- so a caller can tell what was actually determined from what was merely returned.

Critically, `estimator.py` **consumes only per-frame technique offsets and geometry angles -- never planted truth.** It is the same code that will run on real frames. Truth appears only in `analyze.py`, the validation layer that grades the answers.

### The campaign harness
`scene_gen.py` (six seeded scene families), `collect.py` (runs navigation, serializes results, performs the Stage 0b injections), `analyze.py` (compares recovered values against planted truth and generates the report).

### The campaign
Seed 20260719: 2400 control scenes plus two injection passes of 400 each, zero errors, about 25 minutes of compute. Recorded in `util/agreement/CAMPAIGN_20260719.md`.

## 5. What the campaign found

### 5a. Identifiability map (which questions are answerable at all)

Each result below was demonstrated empirically -- where the solve degenerates, the degeneracy is shown, not asserted.

| Scene composition | Result |
|---|---|
| limb + disc only | **Not separable.** One matrix equation, two unknowns; 3-dimensional null space. Only the *combined* covariance is recoverable (recovered 1.711 vs truth 1.702). |
| limb + disc + ring, fixed radial direction | Ring variance and each body technique's radial-radial projection are recoverable; the perpendicular split is not. |
| limb + disc + ring, diverse radial directions | **Fully identifiable** from orientation diversity alone. |
| the above, plus a blob centroid | Fully identifiable even without diversity, matching truth element by element (limb recovered [1.899, -0.088, 1.737] vs truth [1.898, -0.087, 1.742]). |
| partial-arc limb + ring | Fixed relative angle gives only the radial projection; diverse angles recover the shape but leave one direction traded. |
| multi-body | **Well-conditioned and wrong** -- see below. |

The practical consequence: **the agreement study can only report per-technique covariance for certain scene compositions.** For others it must report combined pairwise disagreement and say so. That boundary is now published rather than guessed.

### 5b. The multi-body trap

Two moons in one frame, each navigated by limb fitting, looks like an ideal case: two independent measurements. The naive solve produces a well-conditioned answer with every diagnostic reading healthy -- and it is wrong. The two limb fits' errors are **correlated at +0.72**, and the solve has nowhere to put that correlation, so it **misattributes it onto the disc technique** (recovering 0.48 where truth is 0.0005).

Declaring the limb-limb pair restores every value, including the coupling itself. Part of the correlation traces to shared illumination geometry (regression explains about 20%); the remainder is unexplained and is recorded as unexplained rather than given a plausible-sounding cause.

### 5c. Bias independence -- the load-bearing question

The DT-based techniques (limb, terminator, ring edge) do not each process the image from scratch. They consume **shared per-image products**: a gradient image, an edge distance transform, a single noise estimate. A bias in that shared layer moves all of them together. That is the realistic way these techniques become correlated, so the test injects bias *there* rather than into each technique separately.

**limb vs ring edge: NOT independent.** Both track the injected bias with slope about 1 (limb +0.97 to +1.02, ring +1.12 to +1.21), inducing a cross-covariance of +0.581 px^2. The independence-assuming solve does not report this -- it **silently redistributes** the coupling, understating ring variance (0.302 against a true 0.591) while inflating others, with residuals that barely move. Declaring the pair recovers it correctly.

**limb vs disc correlation: no response through this channel** (slope 0.000). This is the more load-bearing pair, since the base equation of the whole method is the limb-disc difference. But the result is narrower than it sounds: it holds for the gradient/distance-transform channel, in a regime without a point-spread function. The suspicion that limb and disc share a **PSF edge bias** is untested and is recorded as required follow-up, not quietly treated as cleared.

**Consequence for the agreement study:** the limb-ring pair must be declared or excluded from joint solves. It cannot be assumed clean.

## 6. What independent review changed

Two fresh-context adversarial review passes, both re-deriving the mathematics and reconstructing the identifiability design matrices rather than reading the code and agreeing with it.

The first pass found a defect worth describing in full, because it is the exact failure mode this PR exists to prevent.

The estimator subtracts a mean before computing covariances, so that a constant offset between two techniques is recorded as a *bias* and does not inflate the *variance*. The original code claimed this handled deterministic biases generally. It does not. It subtracts a mean that is constant **in image coordinates**. A bias locked to *geometry* -- for example the measured -2.1 px inward bias on partial-arc limb fits, which points along the arc and therefore rotates as the geometry rotates -- has an image-frame mean of approximately **zero** across a diverse set of frames. Nothing gets subtracted, and the bias enters the covariance instead, as `C + mu mu^T`.

The reviewer demonstrated it: a rotating bias inflated a recovered variance **14x** (4.264 against a truth of 0.3) while the mean channel reported (0.003, 0.001) -- seeing nothing. With two techniques sharing such a bias, a recovered variance went **negative** while the solve still reported every parameter identifiable and every diagnostic healthy. There was no symptom.

This mattered beyond the immediate bug: the campaign's own guidance recommends seeking **orientation diversity** to make more parameters identifiable -- and orientation diversity is precisely what turns a geometry-locked bias from a harmless constant into invisible covariance corruption.

The fix implements **rotating-frame mean unknowns** in the solve. Both reproductions are pinned as tests (the inflated variance returns to 0.292; the negative variance returns to +0.047). The campaign's worst-fitting scene family was rediagnosed under the corrected estimator: its ring variance now covers truth instead of excluding it, and residual error dropped from 6.37 to 5.27.

The second pass verified every finding by independent rederivation and returned CLEAN, with the mean model's design matrix checked for the collinearity traps the fix could have introduced.

Also corrected in review: bootstrap intervals now re-fit per replicate, confidence intervals are suppressed for parameters that are not identifiable, the declared-pair model's restrictions are documented, and a comparison reference that flattered the result was replaced with the correct one.

## 7. Verification

- 41 tests pass; `ruff`, `ruff format --check`, `mypy --strict` clean.
- `./scripts/run-all-checks.sh -i`: the library-suite red set is **byte-identical to the recorded 45-frame baseline** on `rf_sim_realism`, as expected given no `src/` changes. Sphinx builds clean.
- Independent of this branch: the regression baseline for `N1597846115_2_CALIB` also fails at base. That frame's sidecar was re-ratcheted during the earlier recalibration but its recorded regression baseline was not updated alongside it. It belongs to the pending sidecar re-ratchet, and is noted here so it is not mistaken for a regression.

## 8. What this does and does not establish

It establishes that the estimator recovers known covariances where the identifiability map says it can, and that one of the two pivotal technique pairs is measurably correlated through shared preprocessing.

Every open thread is tracked rather than living in the campaign record alone: #320 (probe the limb-disc pair for a shared PSF edge bias -- the outstanding piece of Stage 0b, and a gate on this study's base equation), #321 (the undiagnosed partial-arc limb inward bias, which is a navigation finding in its own right), #322 (cross-body limb correlation, constraining multi-body cohorts), #323 (no injection design for the reliability gate's selection effect), #324 (these tests do not run in CI). #224 and #225 carry the outcome and its consequences for the study.

**Every verdict here is the simulator's**, measured on clean scenes. The record says so rather than implying broader authority. Three specific limits are recorded as open questions rather than papered over: the PSF-layer probe of the limb-disc pair, injection through the reliability gate, and an undiagnosed inward radial bias on partial-arc limb fits that the mean channel surfaced and no one has yet explained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HoCUAeNeMz5bFmGk2iVBf
