### PR TITLE
fix: address results-file filter review findings from #300

### DIFF
--- a/docs/user_guide/user_guide_navigation.rst
+++ b/docs/user_guide/user_guide_navigation.rst
@@ -175,9 +175,15 @@ For PDS3 datasets (``coiss``, ``coiss_pds3``, ``coiss_cruise``, ``coiss_cruise_p
   ``--has-offset-error``, but restricted to fatal errors caused by / not caused
   by missing SPICE data.
 
-The results-file filters answer "file exists" questions by walking the results
-tree once per selected volume, and read metadata contents in batches, so they
-are efficient even when the results root is a cloud location.
+The results-file filters answer their questions three ways, all efficient even
+when the results root is a cloud location. Presence filters
+(``--has-offset-file`` / ``--has-png-file``) and the error filters
+(``--has-offset-error`` and its SPICE variants) walk the results tree once per
+selected volume and test each candidate against the collected file set. Pure
+absence filters (``--has-no-offset-file`` / ``--has-no-png-file`` with no
+presence or error filter active) do not walk the tree; they answer with batched
+``exists()`` calls. The error filters additionally retrieve the matched metadata
+files in batches to inspect their contents.
 
 Miscellaneous
 ^^^^^^^^^^^^^

--- a/src/spindoctor/dataset/dataset_pds3.py
+++ b/src/spindoctor/dataset/dataset_pds3.py
@@ -724,7 +724,7 @@ class DataSetPDS3(DataSet):
         }
         active_filter_flags = [name for name, value in results_filter_flags.items() if value]
         if active_filter_flags:
-            logger.info(f'*** Results filters:    {", ".join(active_filter_flags)}')
+            logger.info('*** Results filters:    %s', ', '.join(active_filter_flags))
         if img_name_list:
             logger.info('*** Explicit image names:')
             for explicit_img_name in img_name_list:

--- a/src/spindoctor/dataset/dataset_pds3.py
+++ b/src/spindoctor/dataset/dataset_pds3.py
@@ -30,6 +30,24 @@ _LABEL_IMAGE_POINTER_RE = re.compile(
 )
 
 
+def _positive_int(value: str) -> int:
+    """Parses an argparse value as a strictly positive integer.
+
+    Parameters:
+        value: The raw command-line string.
+
+    Returns:
+        The parsed integer.
+
+    Raises:
+        argparse.ArgumentTypeError: If the value is not a positive integer.
+    """
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError(f'must be a positive integer, got {value!r}')
+    return ivalue
+
+
 class DataSetPDS3(DataSet):
     """Parent class for PDS3 datasets.
 
@@ -413,10 +431,10 @@ class DataSetPDS3(DataSet):
         #     help='Expression to evaluate to decide whether to reprocess an offset')
         group.add_argument(
             '--choose-random-images',
-            type=int,
+            type=_positive_int,
             default=None,
             metavar='N',
-            help='Choose N random images to process within other constraints',
+            help='Choose N random images to process within other constraints (N must be positive)',
         )
         # group.add_argument(
         #     '--show-image-list-only', action='store_true', default=False,
@@ -679,6 +697,10 @@ class DataSetPDS3(DataSet):
         has_offset_nonspice_error: bool = kwargs.pop('has_offset_nonspice_error', False)
         nav_results_root: str | Path | FCPath | None = kwargs.pop('nav_results_root', None)
         choose_random_images: int | None = kwargs.pop('choose_random_images', None)
+        if choose_random_images is not None and choose_random_images <= 0:
+            raise ValueError(
+                f'choose_random_images must be a positive integer, got {choose_random_images}'
+            )
         max_filenames: int | None = kwargs.pop('max_filenames', None)
         arguments: argparse.Namespace | None = kwargs.pop('arguments', None)
         additional_index_columns: tuple[str, ...] = kwargs.pop('additional_index_columns', ())

--- a/src/spindoctor/dataset/dataset_pds3.py
+++ b/src/spindoctor/dataset/dataset_pds3.py
@@ -670,7 +670,10 @@ class DataSetPDS3(DataSet):
             nav_results_root: str | Path | FCPath | None = None,
                 Results root for the filters above.  None resolves via the
                 arguments, configuration, or NAV_RESULTS_ROOT environment variable.
-            choose_random_images: int | None = False,
+            choose_random_images: int | None = None,
+                When set, a positive count of images to sample uniformly at
+                random across the selected volumes.  Must be a positive
+                integer; non-positive values raise ValueError.
             max_filenames: Optional[int] = None,
             suffix: Optional[str] = None,
             planets: Optional[str] = None

--- a/src/spindoctor/dataset/dataset_pds3.py
+++ b/src/spindoctor/dataset/dataset_pds3.py
@@ -792,14 +792,10 @@ class DataSetPDS3(DataSet):
                 nav_results_root = get_nav_results_root(
                     arguments if arguments is not None else argparse.Namespace(), self.config
                 )
-            if isinstance(nav_results_root, FCPath):
-                results_root = nav_results_root
-            else:
-                # Results are not shared with other processes and may change between
-                # runs, so use a private temporary cache like the writers do.
-                results_root = FileCache(None).new_path(nav_results_root)
+            # ResultsFilter accepts the str | Path | FCPath union and normalizes
+            # at its boundary, preserving an existing FCPath's file cache.
             results_filter = ResultsFilter(
-                valid_volumes, results_root, logger=logger, **results_filter_flags
+                valid_volumes, nav_results_root, logger=logger, **results_filter_flags
             )
 
         # URLs to the volume raw directory and index directory

--- a/src/spindoctor/dataset/results_filter.py
+++ b/src/spindoctor/dataset/results_filter.py
@@ -168,11 +168,18 @@ class ResultsFilter:
                             self._offset_rel_paths.add(rel_path)
                         elif file_name.endswith(SUMMARY_PNG_SUFFIX):
                             self._png_rel_paths.add(rel_path)
-            except OSError:
+            except (FileNotFoundError, NotADirectoryError):
+                # A volume with no results directory (or whose results path is
+                # not a directory) simply has no result files. Any other OSError
+                # (permission denied, network or cloud-backend failure) is a real
+                # scan failure that would silently corrupt the filter result, so
+                # it is allowed to propagate.
                 continue
         self._logger.info(
-            f'*** Results scan found {len(self._offset_rel_paths)} offset metadata and '
-            f'{len(self._png_rel_paths)} summary PNG files under {self._nav_results_root}'
+            '*** Results scan found %d offset metadata and %d summary PNG files under %s',
+            len(self._offset_rel_paths),
+            len(self._png_rel_paths),
+            self._nav_results_root,
         )
 
     def passes_presence(self, results_path_stub: str) -> bool:
@@ -260,20 +267,30 @@ class ResultsFilter:
     def _metadata_matches(self, image_file: ImageFile, local_path: Path) -> bool:
         """True if the image's metadata file satisfies the error filters.
 
-        A metadata file that cannot be read or parsed excludes its image with
-        a logged warning rather than aborting the enumeration.
+        A metadata file that cannot be read, cannot be decoded as UTF-8, does
+        not parse as JSON, or does not parse to a JSON object excludes its image
+        with a logged warning rather than aborting the enumeration.
 
         Parameters:
             image_file: The candidate image (for the warning message only).
             local_path: Local path of the retrieved metadata JSON file.
         """
         try:
-            metadata: dict[str, Any] = json.loads(local_path.read_text(encoding='utf-8'))
-        except (OSError, json.JSONDecodeError) as exc:
+            parsed: Any = json.loads(local_path.read_text(encoding='utf-8'))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
             self._logger.warning(
-                f'Excluding {image_file.results_path_stub}: unreadable metadata file: {exc}'
+                'Excluding %s: unreadable metadata file: %s',
+                image_file.results_path_stub,
+                exc,
             )
             return False
+        if not isinstance(parsed, dict):
+            self._logger.warning(
+                'Excluding %s: metadata JSON is not an object',
+                image_file.results_path_stub,
+            )
+            return False
+        metadata: dict[str, Any] = parsed
         if metadata.get('status') != 'error':
             return False
         status_error = metadata.get('status_error')

--- a/src/spindoctor/dataset/results_filter.py
+++ b/src/spindoctor/dataset/results_filter.py
@@ -21,7 +21,7 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, cast
 
-from filecache import FCPath
+from filecache import FCPath, FileCache
 from pdslogger import PdsLogger
 
 from .dataset import ImageFile
@@ -59,7 +59,7 @@ class ResultsFilter:
     def __init__(
         self,
         volumes: Iterable[str],
-        nav_results_root: FCPath,
+        nav_results_root: str | Path | FCPath,
         *,
         has_offset_file: bool = False,
         has_no_offset_file: bool = False,
@@ -76,7 +76,9 @@ class ResultsFilter:
             volumes: Volume names selected by the other constraints; only these
                 subdirectories of the results root are walked.
             nav_results_root: Root of the navigation results tree; may be a
-                cloud URL.
+                cloud URL.  A ``str`` or ``Path`` is normalized to an
+                :class:`FCPath` at construction; an existing :class:`FCPath` is
+                used as given so its file cache is preserved.
             has_offset_file: Only keep images whose offset metadata file exists.
             has_no_offset_file: Only keep images whose offset metadata file does
                 not exist.
@@ -120,7 +122,12 @@ class ResultsFilter:
         self._needs_offset_presence = has_offset_file or needs_metadata_read
         self._needs_png_presence = has_png_file
         self._needs_metadata_read = needs_metadata_read
-        self._nav_results_root = nav_results_root
+        if isinstance(nav_results_root, FCPath):
+            self._nav_results_root = nav_results_root
+        else:
+            # Results are not shared with other processes and may change between
+            # runs, so use a private temporary cache like the writers do.
+            self._nav_results_root = FileCache(None).new_path(nav_results_root)
         self._logger = logger
         self._offset_rel_paths: set[str] = set()
         self._png_rel_paths: set[str] = set()

--- a/tests/spindoctor/dataset/test_dataset_pds3.py
+++ b/tests/spindoctor/dataset/test_dataset_pds3.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+import pdslogger
 import pytest
 from filecache import FCPath
 
@@ -15,6 +16,7 @@ from spindoctor.dataset.dataset_pds3_cassini_iss import DataSetPDS3CassiniISS
 from spindoctor.dataset.dataset_pds3_galileo_ssi import DataSetPDS3GalileoSSI
 from spindoctor.dataset.dataset_pds3_newhorizons_lorri import DataSetPDS3NewHorizonsLORRI
 from spindoctor.dataset.dataset_pds3_voyager_iss import DataSetPDS3VoyagerISS
+from spindoctor.dataset.results_filter import ResultsFilter
 
 
 @pytest.fixture
@@ -314,6 +316,81 @@ def test_has_offset_nonspice_error_matches_only_nonspice(
     )
 
     assert _yielded_names(groups) == ['N1000000102']
+
+
+def _write_result_file_bytes(
+    results_root: Path,
+    volume: str,
+    numbers: list[int],
+    camera: str,
+    num: int,
+    suffix: str,
+    content: bytes,
+) -> None:
+    """Write one synthetic result file with raw byte content (e.g. bad UTF-8)."""
+    range_dir = f'{numbers[0]:010d}_{numbers[-1]:010d}'
+    path = results_root / volume / 'data' / range_dir / f'{camera}{num:010d}_1_CALIB{suffix}'
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+@pytest.mark.parametrize(
+    'bad_content',
+    [
+        pytest.param(b'[1, 2, 3]', id='json-list'),
+        pytest.param(b'null', id='json-null'),
+        pytest.param(b'\xff\xfe not valid utf-8', id='invalid-utf8'),
+    ],
+)
+def test_has_offset_error_excludes_malformed_metadata(
+    ds: DataSetPDS3CassiniISS,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    bad_content: bytes,
+) -> None:
+    # A metadata file that is valid JSON but not an object, or is not decodable
+    # UTF-8, must exclude only its own image without crashing enumeration.
+    _install_two_camera_index(ds, monkeypatch)
+    _write_result_file(
+        tmp_path,
+        'COISS_2001',
+        _FILTER_NUMS,
+        'N',
+        1000000100,
+        '_metadata.json',
+        json.dumps({'status': 'error'}),
+    )
+    _write_result_file_bytes(
+        tmp_path, 'COISS_2001', _FILTER_NUMS, 'N', 1000000101, '_metadata.json', bad_content
+    )
+
+    groups = list(
+        ds.yield_image_files_index(
+            volumes=['COISS_2001'], has_offset_error=True, nav_results_root=str(tmp_path)
+        )
+    )
+
+    assert _yielded_names(groups) == ['N1000000100']
+
+
+def test_results_scan_propagates_non_missing_oserror(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A missing results directory is expected and swallowed, but any other
+    # OSError (permission denied, cloud-backend failure) must surface rather
+    # than silently yielding an empty, incorrect filter result.
+    def boom(_self: FCPath) -> object:
+        raise PermissionError('results scan denied')
+
+    monkeypatch.setattr(FCPath, 'walk', boom)
+
+    with pytest.raises(PermissionError, match='results scan denied'):
+        ResultsFilter(
+            ['COISS_2001'],
+            str(tmp_path),
+            has_offset_file=True,
+            logger=pdslogger.NullLogger(),
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/spindoctor/dataset/test_dataset_pds3.py
+++ b/tests/spindoctor/dataset/test_dataset_pds3.py
@@ -419,6 +419,36 @@ def test_choose_random_images_with_offset_filter(
     assert sorted(_yielded_names(groups)) == ['N1000000101', 'N1000000201']
 
 
+@pytest.mark.parametrize('bad', [0, -1, -5])
+def test_choose_random_images_rejects_non_positive_programmatic(
+    ds: DataSetPDS3CassiniISS, monkeypatch: pytest.MonkeyPatch, bad: int
+) -> None:
+    # 0 would silently disable sampling (yielding everything) and a negative
+    # value would yield exactly one frame; both are rejected at the boundary.
+    _install_two_camera_index(ds, monkeypatch)
+
+    with pytest.raises(ValueError, match='positive integer'):
+        list(ds.yield_image_files_index(volumes=['COISS_2001'], choose_random_images=bad))
+
+
+@pytest.mark.parametrize('bad', ['0', '-3'])
+def test_choose_random_images_argparse_rejects_non_positive(bad: str) -> None:
+    parser = argparse.ArgumentParser()
+    DataSetPDS3CassiniISS.add_selection_arguments(parser)
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(['--choose-random-images', bad])
+
+
+def test_choose_random_images_argparse_accepts_positive() -> None:
+    parser = argparse.ArgumentParser()
+    DataSetPDS3CassiniISS.add_selection_arguments(parser)
+
+    arguments = parser.parse_args(['--choose-random-images', '5'])
+
+    assert arguments.choose_random_images == 5
+
+
 def test_selection_arguments_include_results_filters() -> None:
     parser = argparse.ArgumentParser()
     DataSetPDS3CassiniISS.add_selection_arguments(parser)

--- a/tests/spindoctor/dataset/test_dataset_pds3.py
+++ b/tests/spindoctor/dataset/test_dataset_pds3.py
@@ -509,12 +509,16 @@ def test_choose_random_images_rejects_non_positive_programmatic(
 
 
 @pytest.mark.parametrize('bad', ['0', '-3'])
-def test_choose_random_images_argparse_rejects_non_positive(bad: str) -> None:
+def test_choose_random_images_argparse_rejects_non_positive(
+    bad: str, capsys: pytest.CaptureFixture[str]
+) -> None:
     parser = argparse.ArgumentParser()
     DataSetPDS3CassiniISS.add_selection_arguments(parser)
 
     with pytest.raises(SystemExit):
         parser.parse_args(['--choose-random-images', bad])
+
+    assert 'positive integer' in capsys.readouterr().err
 
 
 def test_choose_random_images_argparse_accepts_positive() -> None:


### PR DESCRIPTION
Fixes the six code-review findings raised on #300 (results-file selection filters and uniform random sampling) that merged to `main` unaddressed. All six were verified still live at 3723ce3. Closes #348.

Three are correctness or robustness bugs; three are convention and documentation. Each is a small, contained change.

## Correctness and robustness

**Non-positive random sample sizes were silently wrong.** `--choose-random-images 0` is falsy, so the sampling branch was skipped and *every* matching image was yielded; a negative value set a negative yield limit and returned after exactly one image. Now rejected at the argument boundary by a `_positive_int` argparse type, with a matching guard on the programmatic `yield_image_files_*` path so a caller passing the kwarg directly is protected too.

**Every results-tree failure was treated as an empty volume.** The scan caught all `OSError` and continued, so a permission error, a network failure, or a cloud-backend error silently became "this volume has no results" and produced incorrect filter results rather than surfacing. Narrowed to `(FileNotFoundError, NotADirectoryError)` -- the genuinely expected missing-directory cases -- so any other failure propagates. This matters most for the cloud results roots the feature targets.

**Malformed metadata JSON crashed enumeration.** `json.loads` was consumed as a dict, but valid JSON may be a list, string, number, or `null`, and the following `.get()` raised `AttributeError`. Invalid UTF-8 raised `UnicodeDecodeError`, which the existing `(OSError, JSONDecodeError)` handler did not catch (it is a `ValueError` subclass). Both now warn, name the excluded image, and skip it, matching how the unreadable-file case was already handled.

## Convention and ergonomics

**Deferred logging.** The three log calls introduced by #300 used f-strings; converted to `%`-style deferred interpolation per the project rule. Pre-existing f-string log calls elsewhere in `dataset_pds3.py` were left alone as out of scope.

**Public path union.** `ResultsFilter.__init__` accepted only `FCPath`, where the repository standard for a public entry point (the class is in the API reference) is to accept `str | Path | FCPath` and normalize at the boundary, following the `pds3_holdings_root` precedent. The now-redundant normalization in the PDS3 caller was removed.

**Documentation.** The user guide said the filters answer existence questions "by walking the results tree once per selected volume". Pure `--has-no-*` absence filters do not walk; they use batched `exists()` calls. Rewritten to distinguish the three access patterns (presence and error filters walk; absence filters batch-check; error filters additionally batch-read metadata), verified against the code.

## Tests

New behavioral coverage for the three bugs, so they cannot silently regress: non-positive sample sizes (0, negative, valid) at both the argparse and programmatic layers; a non-missing `OSError` (permission error) propagating from the scan; and malformed metadata (JSON list, JSON null, invalid UTF-8) being excluded without a crash.

`test_dataset_pds3.py` 59 passed; `ruff check`, `ruff format --check`, `mypy --strict` clean on touched files; `sphinx-build -W` succeeds.

## Process note

These findings existed on #300 before it merged and were not dispositioned either way -- not fixed, not declined. #348 tracks the follow-through gap independently of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HoCUAeNeMz5bFmGk2iVBf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation requiring `--choose-random-images` to be a positive integer.
  * Results filtering now supports local and cloud-based results locations with improved caching behavior.

* **Bug Fixes**
  * Missing results directories no longer interrupt filtering.
  * Malformed or unreadable metadata is safely excluded instead of stopping image selection.
  * Other results-access errors continue to be reported.

* **Documentation**
  * Expanded guidance on how presence, absence, and error filters evaluate results files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->