### PR TITLE
test: re-ratchet library sidecars to the 20260718 recalibration

### DIFF
--- a/plans/OPERATOR_PLAYBOOK.md
+++ b/plans/OPERATOR_PLAYBOOK.md
@@ -9,7 +9,10 @@ Environment for every command below: `source /seti/newnav/setup.sh` from
 
 ## 0. Right now (operator-only, minutes)
 
-### 0.1 Merge the sim-realism program
+### 0.1 Merge the sim-realism program -- DONE
+
+Merged 2026-07-20: PR #313 squash-merged to `main` (f9c37f0). Commands
+kept for the record:
 
 ```bash
 gh pr view 313 --web      # final read if desired
@@ -23,25 +26,14 @@ the tip; the library-suite delta is 100% attributed in
 integration tier, so the green you rely on is the local battery recorded
 in those PRs.
 
-### 0.2 Clean up the investigation worktrees
+### 0.2 Clean up the investigation worktrees -- DONE
 
-The #288 evidence packet lives in the baseline worktree; keep the packet,
-drop the throwaway checkouts:
-
-```bash
-cp -r /seti/newnav/rms-nav-baseline/attr288 \
-      /seti/newnav/rms-nav/_work/attr288_packet
-cd /seti/newnav/rms-nav
-for wt in rms-nav-attr288-main rms-nav-attr288-352014d \
-          rms-nav-attr288-d694188 rms-nav-attr288-83583e9 \
-          rms-nav-attr288-1ab0395 rms-nav-attr288-a0a3040 \
-          rms-nav-attr288-27ada67 rms-nav-attr288-b3041dc \
-          rms-nav-288fix; do
-  git worktree remove --force /seti/newnav/$wt 2>/dev/null
-done
-git worktree prune
-# rms-nav-baseline: keep or remove after confirming the packet copy.
-```
+Done 2026-07-20: all investigation worktrees and their local branches were
+removed (the operator directed a full worktree cleanup, so the baseline
+worktree went too) and the checkout returned to `main`. The throwaway
+attr288 packet was therefore not copied to `_work/attr288_packet`; its
+failure taxonomy survives in the #288 issue body and is superseded by the
+Section 1 re-ratchet, which reduces #288 to the deliberately-red pins.
 
 ### 0.3 Two cheap decisions (comment on the issues)
 
@@ -55,7 +47,34 @@ gh issue comment 60  --body "Decision: <implement now | defer until X>"
 gh issue comment 188 --body "Decision: <ship | defer>"
 ```
 
-## 1. The sidecar re-ratchet (first agent session after the merge)
+## 1. The sidecar re-ratchet -- EXECUTED, PR #353 (unmerged)
+
+Done 2026-07-20; PR #353 targets `main` and is unmerged, per the "do not
+merge" instruction. The full library suite is `66 passed, 9 failed`
+(`pytest tests/integration/test_autonomous_nav.py -m '' -n auto
+--dist=loadfile`, 26 min on the canonical local machine), and the nine
+failures are exactly the deliberately-red pins below. 36 sidecars were
+re-ratcheted to measured behavior (23 tier flips under the 0.85 high
+boundary and the 2.61 px limb covariance floor, 11 primary flips to
+multi-star StarRefineNav and others, 3 conflicted->success recoveries)
+plus the C1205021_GEOMED adjudication (medium->high, which resolves #347).
+Ground-truth offsets were never touched. This clears the bulk of the #288
+library regression.
+
+Remaining red set, each owned by an open issue:
+
+| frame(s) | owner |
+|---|---|
+| N1492091163, N1867601758, N1867602424 (wrong ring-feature locks) | #346 |
+| N1853392805 (highly-irregular exclusion discards the terminator fit) | #338 |
+| N1572105349 (single-inlier refine offset-pull) | #222 (reopened) |
+| N1484593951, N1686349893 (resolved-body ~2 px offset misses) | #350 |
+| N1530185128 (recalibration-induced spurious conflict) | #351 |
+| W1444747627 (star gates spurious on a navigable small-offset field) | #352 |
+
+Filed for this task: #350, #351, #352; #222 reopened; #347 resolved by the
+adjudication. See the register in Section 3c. The original prompt and
+verify block are kept below for the record.
 
 The recalibration re-tiers real library frames; every flip is
 pre-attributed. Your role is to review the attribution table once and
@@ -80,11 +99,12 @@ table and the "Transfer watch (proposed)" section.
 > not merge it. Finish by re-running the suite and reporting the final
 > red set with the issue that owns each remaining red frame.
 
-**After the PR merges, adopt the transfer watch:** edit
-`util/calibration/CAMPAIGN_20260718.md`, change the "Transfer watch
-(proposed)" heading to "Transfer watch (adopted YYYY-MM-DD)", adjusting
-thresholds if you disagree with the proposal. That gives the calibration
-its falsification criterion.
+**Still pending -- after the PR merges, adopt the transfer watch**
+(tracked by #334): edit `util/calibration/CAMPAIGN_20260718.md`, change
+the "Transfer watch (proposed)" heading to "Transfer watch (adopted
+YYYY-MM-DD)", adjusting thresholds if you disagree with the proposal. That
+gives the calibration its falsification criterion. This is the one part of
+Section 1 not yet done.
 
 **Verify when done:**
 
@@ -295,6 +315,77 @@ else. Applied to the items above:
   growth, the agreement study's bulk execution (once WS-0 hands it a
   proven estimator), #229, #311, #284/#285, #130, #179, and the
   documentation/engineering items.
+
+## 3c. Tracking-issue register (2026-07-20 audit + re-ratchet)
+
+The 2026-07-20 sim-program audit filed #325-#347 and the Section 1
+re-ratchet filed #350-#352 (and reopened #222). All are open and carry
+A/B/Priority/Effort labels with assignee rfrenchseti. Listed here so none
+is lost to a PR body; the sequencing hooks reference the sections above.
+
+**Confident-wrong / ensemble honesty (sequence with #230/WS-5 and the
+#301/#291 channel in Section 3):**
+
+- **#328** high-phase haze crescent returns a gate-passing success ~30 px
+  wrong and nothing vetoes it (Essential; the family that had no owner)
+- **#339** scattered-light correlated disc/limb errors fused as independent
+  at the 0.99 confidence cap
+- **#346** three library frames lock confidently onto the wrong ring feature
+  (owns the N1492091163 / N1867601758 / N1867602424 red pins)
+- **#326** BODY_DISC correlation template ignores body-body occlusion at deep
+  mutual-event overlap
+- **#327** NavModelBody reports full visible_arc_fraction for limbs occluded
+  by a nearer body
+
+**Simulator fidelity gaps (feed #309 and the sim follow-ups in Section 3):**
+
+- **#325** simulated stars shine through dark limbs; star-technique success is
+  optimistic
+- **#329** simulated calibrated products floor at 1 LSB; real products dither
+  below it (WAC diverges 8x)
+- **#330** instrument chains render cosmic-ray transients at zero
+- **#331** simulated hot pixels are per-scene, not per-detector
+- **#332** PSF catalog has one kernel per instrument; binned/summed readout
+  modes are inexpressible
+- **#333** four physical error axes are unmodeled
+- **#341** the campaign's scene mixture is authored, unvalidated against real
+  frames
+- **#342** star_psf_sigma is a 3.0 placeholder on Galileo, Voyager, LORRI
+- **#343** the tuned NAC PSF wing may be absorbing operator registration error
+- **#344** haze brightness is a module constant
+- **#345** a scene can echo truth-side noise into instrument_config with no
+  validator warning
+
+**Calibration governance / CI (gate WS-5 and the CI tier in Section 2.5):**
+
+- **#334** calibration has no armed falsification criterion and its real-frame
+  gate is suspended (owns the Section 1 "adopt the transfer watch" step)
+- **#335** no canonical environment for committed sim baselines (0.99 vs
+  0.81-0.84 across machines)
+- **#336** data-independent simulator integration suites never run in Actions
+  (relates to #229/WS-4)
+- **#340** library_crosscheck records only a yes/no primary-technique flag,
+  not the winning technique
+
+**Star navigation:**
+
+- **#337** star-field matcher triplet canonicalization is a seed lottery on
+  equal-brightness fields
+
+**Library-frame reds and decisions (from the Section 1 re-ratchet):**
+
+- **#338** highly-irregular exclusion discards the ground-truth terminator fit
+  on N1853392805 (decision)
+- **#347** C1205021_GEOMED medium-vs-high provenance mismatch -- resolved by
+  the re-ratchet adjudication in PR #353
+- **#350** two resolved-body frames miss offset tolerance by ~2 px
+  (N1484593951, N1686349893)
+- **#351** recalibration turns an operator-verified success into a spurious
+  conflict (N1530185128)
+- **#352** star gates self-flag spurious on a navigable small-offset WAC frame
+  (W1444747627)
+- **#222** (reopened) single-inlier pass-2 refine pulls the fused offset off a
+  correct body fix (N1572105349)
 
 ## 4. Standing practices for every session you dispatch
 

--- a/tests/integration/image_library/images/below_resolution_body/N1777325846_1_CALIB.yaml
+++ b/tests/integration/image_library/images/below_resolution_body/N1777325846_1_CALIB.yaml
@@ -23,9 +23,11 @@ ground_truth:
     Small Mimas ~20 px diameter in lower left corner.
     Slightly overexposed, 72 degree phase angle.
 
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/medium/BodyBlobNav -> measured success/low/BodyLimbNav. Tier medium->low under the model-error covariance floors, dominated by the 2.61 px BodyLimbNav limb floor: a body-led fuse reports fused sigma above the medium tier 2.0 px cap, so the confident body fix is honestly low-tier. Offset unchanged and within slack. Primary also moves to BodyLimbNav with the recalibrated confidences. BodyBlobNav no longer emits a result; techniques_must_run updated to BodyLimbNav.
+
 expected:
   status: success                           # success | failed | conflicted
-  confidence_tier: medium                # high | medium | low | failed
-  primary_technique: BodyBlobNav  # e.g. BodyLimbNav
-  techniques_must_run: [BodyBlobNav]
+  confidence_tier: low                # high | medium | low | failed
+  primary_technique: BodyLimbNav  # e.g. BodyLimbNav
+  techniques_must_run: [BodyLimbNav]
   techniques_must_skip: []

--- a/tests/integration/image_library/images/body_full_fov/N1634226853_1_CALIB.yaml
+++ b/tests/integration/image_library/images/body_full_fov/N1634226853_1_CALIB.yaml
@@ -20,9 +20,11 @@ ground_truth:
     Selection: TETHYS | <30; {"apparent_diameter_px": 764.9, "center_phase_deg": 1.532, "filter": "CL1", "lat_coverage_deg": 165.2, "target": "TETHYS", "year": "2009"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.381, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav'], per-technique offsets={"BodyDiscCorrelateNav": [3.7812, 32.5], "BodyLimbNav": [3.5133, 32.3413]}.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/medium/BodyDiscCorrelateNav -> measured success/low/BodyDiscCorrelateNav. Tier medium->low under the model-error covariance floors, dominated by the 2.61 px BodyLimbNav limb floor: a body-led fuse reports fused sigma above the medium tier 2.0 px cap, so the confident body fix is honestly low-tier. Offset unchanged and within slack.
 expected:
   status: success
-  confidence_tier: medium
+  confidence_tier: low
   primary_technique: BodyDiscCorrelateNav
   techniques_must_run:
   - BodyDiscCorrelateNav

--- a/tests/integration/image_library/images/body_full_fov/N1637475277_1_CALIB.yaml
+++ b/tests/integration/image_library/images/body_full_fov/N1637475277_1_CALIB.yaml
@@ -20,9 +20,11 @@ ground_truth:
     Selection: ENCELADUS | 30-60; {"apparent_diameter_px": 868.5, "center_phase_deg": 40.377, "filter": "CL1", "lat_coverage_deg": 171.5, "target": "ENCELADUS", "year": "2009"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.394, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyDiscCorrelateNav": [10.875, -3.5], "BodyLimbNav": [10.9955, -3.4627], "StarUniqueMatchNav": [0.0, 0.0], "StarRefineNav": [0.0, 0.0]}.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/medium/BodyDiscCorrelateNav -> measured success/low/BodyDiscCorrelateNav. Tier medium->low under the model-error covariance floors, dominated by the 2.61 px BodyLimbNav limb floor: a body-led fuse reports fused sigma above the medium tier 2.0 px cap, so the confident body fix is honestly low-tier. Offset unchanged and within slack.
 expected:
   status: success
-  confidence_tier: medium
+  confidence_tier: low
   primary_technique: BodyDiscCorrelateNav
   techniques_must_run:
   - BodyDiscCorrelateNav

--- a/tests/integration/image_library/images/body_full_fov/N1699263827_1_CALIB.yaml
+++ b/tests/integration/image_library/images/body_full_fov/N1699263827_1_CALIB.yaml
@@ -21,10 +21,12 @@ ground_truth:
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.377, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav'], per-technique offsets={"BodyDiscCorrelateNav": [17.5, -19.3281], "BodyLimbNav": [18.2049, -19.6064]}.
     Primary ratchet 2026-07-16: after the 2026-07-14 NCC-covariance rederivation BodyLimbNav is the highest-confidence technique; disc and limb still agree at the operator-verified offset and the navigation is unchanged. Ratcheted BodyDiscCorrelateNav -> BodyLimbNav.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/medium/BodyLimbNav -> measured success/low/BodyDiscCorrelateNav. Tier medium->low under the model-error covariance floors, dominated by the 2.61 px BodyLimbNav limb floor: a body-led fuse reports fused sigma above the medium tier 2.0 px cap, so the confident body fix is honestly low-tier. Offset unchanged and within slack. Primary also moves to BodyDiscCorrelateNav with the recalibrated confidences.
 expected:
   status: success
-  confidence_tier: medium
-  primary_technique: BodyLimbNav
+  confidence_tier: low
+  primary_technique: BodyDiscCorrelateNav
   techniques_must_run:
   - BodyDiscCorrelateNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/body_full_fov/W1637520502_1_CALIB.yaml
+++ b/tests/integration/image_library/images/body_full_fov/W1637520502_1_CALIB.yaml
@@ -20,10 +20,12 @@ ground_truth:
     Selection: RHEA | <30; {"apparent_diameter_px": 868.1, "center_phase_deg": 26.787, "filter": "CL1", "lat_coverage_deg": 169.1, "target": "RHEA", "year": "2009"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.395, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav'], per-technique offsets={"BodyDiscCorrelateNav": [2.0156, 0.5], "BodyLimbNav": [2.1392, 0.0022]}.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/medium/BodyDiscCorrelateNav -> measured success/low/BodyLimbNav. Tier medium->low under the model-error covariance floors, dominated by the 2.61 px BodyLimbNav limb floor: a body-led fuse reports fused sigma above the medium tier 2.0 px cap, so the confident body fix is honestly low-tier. Offset unchanged and within slack. Primary also moves to BodyLimbNav with the recalibrated confidences.
 expected:
   status: success
-  confidence_tier: medium
-  primary_technique: BodyDiscCorrelateNav
+  confidence_tier: low
+  primary_technique: BodyLimbNav
   techniques_must_run:
   - BodyDiscCorrelateNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/body_irregular/N1560303384_1_CALIB.yaml
+++ b/tests/integration/image_library/images/body_irregular/N1560303384_1_CALIB.yaml
@@ -20,10 +20,12 @@ ground_truth:
     Selection: ATLAS | 90-120; {"apparent_diameter_px": 182.6, "center_phase_deg": 90.755, "filter": "CL1", "target": "ATLAS", "year": "2007"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.4, rank=low, techniques=['BodyBlobNav', 'BodyTerminatorNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [0.0, 0.0], "BodyBlobNav": [8.4286, -16.6754], "BodyTerminatorNav": [13.3809, 4.4969], "StarRefineNav": [9.5654, -16.0876]}.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/medium/BodyBlobNav -> measured success/low/StarRefineNav. Tier medium->low under the model-error covariance floors, dominated by the 2.61 px BodyLimbNav limb floor: a body-led fuse reports fused sigma above the medium tier 2.0 px cap, so the confident body fix is honestly low-tier. Offset unchanged and within slack. Primary also moves to StarRefineNav: a multi-star refine (uncapped, confidence >0.50) is the highest-confidence contributor; this retires the Track-B marker that withheld refine-as-primary, whose fix shipped as the single-inlier 0.50 cap and does not apply to multi-star refines.
 expected:
   status: success
-  confidence_tier: medium
-  primary_technique: BodyBlobNav
+  confidence_tier: low
+  primary_technique: StarRefineNav
   techniques_must_run:
   - BodyBlobNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/body_partial_overflow/N1481737141_2_CALIB.yaml
+++ b/tests/integration/image_library/images/body_partial_overflow/N1481737141_2_CALIB.yaml
@@ -20,9 +20,11 @@ ground_truth:
     Selection: DIONE | 30-60; {"apparent_diameter_px": 1161.5, "center_phase_deg": 33.843, "filter": "RED", "lat_coverage_deg": 139.5, "target": "DIONE", "year": "2004"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.392, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyDiscCorrelateNav": [-4.5, 6.9219], "BodyLimbNav": [-5.3883, 6.4939], "StarUniqueMatchNav": [-11.3827, 25.4959], "StarRefineNav": [0.0, 0.0]}.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/medium/BodyDiscCorrelateNav -> measured success/low/BodyDiscCorrelateNav. Tier medium->low under the model-error covariance floors, dominated by the 2.61 px BodyLimbNav limb floor: a body-led fuse reports fused sigma above the medium tier 2.0 px cap, so the confident body fix is honestly low-tier. Offset unchanged and within slack.
 expected:
   status: success
-  confidence_tier: medium
+  confidence_tier: low
   primary_technique: BodyDiscCorrelateNav
   techniques_must_run:
   - BodyDiscCorrelateNav

--- a/tests/integration/image_library/images/body_partial_overflow/N1816644691_1_CALIB.yaml
+++ b/tests/integration/image_library/images/body_partial_overflow/N1816644691_1_CALIB.yaml
@@ -21,10 +21,12 @@ ground_truth:
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.375, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav'], per-technique offsets={"BodyDiscCorrelateNav": [4.5, 11.5], "BodyLimbNav": [3.9629, 11.7921]}.
     Primary ratchet 2026-07-16: after the 2026-07-14 NCC-covariance rederivation BodyLimbNav is the highest-confidence technique; disc and limb still agree at the operator-verified offset and the navigation is unchanged. Ratcheted BodyDiscCorrelateNav -> BodyLimbNav.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/medium/BodyLimbNav -> measured success/low/BodyDiscCorrelateNav. Tier medium->low under the model-error covariance floors, dominated by the 2.61 px BodyLimbNav limb floor: a body-led fuse reports fused sigma above the medium tier 2.0 px cap, so the confident body fix is honestly low-tier. Offset unchanged and within slack. Primary also moves to BodyDiscCorrelateNav with the recalibrated confidences.
 expected:
   status: success
-  confidence_tier: medium
-  primary_technique: BodyLimbNav
+  confidence_tier: low
+  primary_technique: BodyDiscCorrelateNav
   techniques_must_run:
   - BodyDiscCorrelateNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/high_phase_terminator/N1489256001_1_CALIB.yaml
+++ b/tests/integration/image_library/images/high_phase_terminator/N1489256001_1_CALIB.yaml
@@ -20,10 +20,12 @@ ground_truth:
     Selection: DIONE | 90-120; {"apparent_diameter_px": 160.4, "center_phase_deg": 106.863, "filter": "P120", "lat_coverage_deg": 119.1, "target": "DIONE", "year": "2005"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.841, rank=high, techniques=['BodyLimbNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyLimbNav": [5.5269, -0.8399], "StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [0.0, 0.0], "StarRefineNav": [4.8156, -0.4015]}.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/medium/BodyTerminatorNav -> measured success/medium/BodyLimbNav. Primary re-ratcheted BodyTerminatorNav->BodyLimbNav: BodyTerminatorNav no longer emits a result after the terminator refit; BodyLimbNav carries the frame and techniques_must_run is updated to it. Tier and offset unchanged.
 expected:
   status: success
   confidence_tier: medium
-  primary_technique: BodyTerminatorNav
+  primary_technique: BodyLimbNav
   techniques_must_run:
-  - BodyTerminatorNav
+  - BodyLimbNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/high_phase_terminator/N1597846115_2_CALIB.yaml
+++ b/tests/integration/image_library/images/high_phase_terminator/N1597846115_2_CALIB.yaml
@@ -21,9 +21,11 @@ ground_truth:
 
     Phase-4 status: BodyLimbNav and BodyTerminatorNav both fire and BodyLimbNav's offset (6.09, 1.19) lands within ~1 px of the operator's ground truth. The ensemble flags the result conflicted because the summed-confidence gap between the two techniques (0.045) falls below the agreement_gap threshold (0.5), even though the techniques' offsets agree closely. The headline answer is correct; only the ok-vs-conflicted status decision is wrong. Phase 10 calibration target: lower agreement_gap (or replace it with a per-axis disagreement-in-pixels test) so near-agreeing techniques don't trip the conflict detector.
 
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected conflicted/conflicted/BodyLimbNav -> measured success/low/BodyLimbNav. Status conflicted->success/low: the sim-anchored BodyTerminatorNav refit drops the ~0.05-confidence terminator vote that previously tripped the agreement-gap conflict detector; with only BodyLimbNav voting the frame resolves to a clean low-tier success on the operator offset. BodyTerminatorNav no longer emits a result here and is removed from techniques_must_run.
+
 expected:
-  status: conflicted
-  confidence_tier: conflicted
+  status: success
+  confidence_tier: low
   primary_technique: BodyLimbNav
-  techniques_must_run: [BodyLimbNav, BodyTerminatorNav]
+  techniques_must_run: [BodyLimbNav]
   techniques_must_skip: []

--- a/tests/integration/image_library/images/high_phase_terminator/N1858933303_1_CALIB.yaml
+++ b/tests/integration/image_library/images/high_phase_terminator/N1858933303_1_CALIB.yaml
@@ -20,10 +20,12 @@ ground_truth:
     Selection: ENCELADUS | 90-120; {"apparent_diameter_px": 650.5, "center_phase_deg": 117.033, "filter": "CL1", "lat_coverage_deg": 84.3, "target": "ENCELADUS", "year": "2016"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.465, rank=low, techniques=['BodyLimbNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyLimbNav": [14.6187, -17.0685], "StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [0.0, 0.0], "StarRefineNav": [14.0751, -15.655]}.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/BodyTerminatorNav -> measured success/medium/BodyLimbNav. Tier high->medium under the recalibrated 0.85 high-tier boundary: fused confidence sits in the 0.55-0.85 band that the campaign's planted ring-orbit-error failure mass moved out of the high tier; the confidence did not move materially, the boundary did. Offset unchanged and within slack. Primary also moves to BodyLimbNav with the recalibrated confidences.
 expected:
   status: success
-  confidence_tier: high
-  primary_technique: BodyTerminatorNav
+  confidence_tier: medium
+  primary_technique: BodyLimbNav
   techniques_must_run:
-  - BodyTerminatorNav
+  - BodyLimbNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/multi_body/N1487595731_1_CALIB.yaml
+++ b/tests/integration/image_library/images/multi_body/N1487595731_1_CALIB.yaml
@@ -50,14 +50,16 @@ ground_truth:
     weighs more strongly against an isolated wrong-answer
     high-confidence runner-up.
 
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected conflicted/conflicted/BodyTerminatorNav -> measured success/medium/BodyDiscCorrelateNav. Status conflicted->success/medium: BodyTerminatorNav no longer latches its wrong high-confidence local minimum (it emits no result after the terminator refit), so the agreeing BodyDiscCorrelateNav + BodyLimbNav pair carries the fuse to the operator offset. BodyTerminatorNav removed from techniques_must_run.
+
 expected:
-  status: conflicted
-  confidence_tier: conflicted
-  primary_technique: BodyTerminatorNav  # highest-confidence
+  status: success
+  confidence_tier: medium
+  primary_technique: BodyDiscCorrelateNav  # highest-confidence
                                         # per-technique result, even
                                         # though wrong — the test's
                                         # primary_technique rule is
                                         # max-confidence with
                                         # tie-break by name
-  techniques_must_run: [BodyDiscCorrelateNav, BodyLimbNav, BodyTerminatorNav]
+  techniques_must_run: [BodyDiscCorrelateNav, BodyLimbNav]
   techniques_must_skip: []

--- a/tests/integration/image_library/images/multi_body/N1487595731_1_CALIB.yaml
+++ b/tests/integration/image_library/images/multi_body/N1487595731_1_CALIB.yaml
@@ -55,11 +55,6 @@ ground_truth:
 expected:
   status: success
   confidence_tier: medium
-  primary_technique: BodyDiscCorrelateNav  # highest-confidence
-                                        # per-technique result, even
-                                        # though wrong — the test's
-                                        # primary_technique rule is
-                                        # max-confidence with
-                                        # tie-break by name
+  primary_technique: BodyDiscCorrelateNav
   techniques_must_run: [BodyDiscCorrelateNav, BodyLimbNav]
   techniques_must_skip: []

--- a/tests/integration/image_library/images/multi_body/N1489603610_2_CALIB.yaml
+++ b/tests/integration/image_library/images/multi_body/N1489603610_2_CALIB.yaml
@@ -19,10 +19,12 @@ ground_truth:
     Selection: DIONE+MIMAS+RHEA; {"filter": "BL1", "largest_px": 87.5, "targets_px": {"DIONE": 67.9, "MIMAS": 27.0, "RHEA": 87.5}, "year": "2005"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.402, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'RingAnnulusNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyDiscCorrelateNav": [6.7891, -45.4375], "BodyLimbNav": [7.0108, -45.1008], "RingAnnulusNav": [-24.5, -101.5], "StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [0.0, 0.0], "StarRefineNav": [6.5631, -45.5973]}.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/BodyLimbNav -> measured success/high/StarRefineNav. Primary also moves to StarRefineNav: a multi-star refine (uncapped, confidence >0.50) is the highest-confidence contributor; this retires the Track-B marker that withheld refine-as-primary, whose fix shipped as the single-inlier 0.50 cap and does not apply to multi-star refines.
 expected:
   status: success
   confidence_tier: high
-  primary_technique: BodyLimbNav
+  primary_technique: StarRefineNav
   techniques_must_run:
   - BodyLimbNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/one_bright_star_no_body/N1555145539_1_CALIB.yaml
+++ b/tests/integration/image_library/images/one_bright_star_no_body/N1555145539_1_CALIB.yaml
@@ -28,10 +28,12 @@ ground_truth:
     Pipeline at review and at sidecar time: status=success, confidence=0.50,
     rank=medium, StarUniqueMatchNav (4.0251, -12.46) conf 0.429 and
     StarRefineNav (4.0251, -12.46) conf 0.50 (single-inlier refine cap).
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/medium/StarRefineNav -> measured success/medium/StarUniqueMatchNav. Primary re-ratcheted StarRefineNav->StarUniqueMatchNav: the star refit softened residual_px so the one-star match rides its 0.70 cap above the single-inlier refine 0.50 cap. Status/tier/offset unchanged.
 expected:
   status: success
   confidence_tier: medium
-  primary_technique: StarRefineNav
+  primary_technique: StarUniqueMatchNav
   techniques_must_run:
   - StarUniqueMatchNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_only_curved/N1447064164_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_only_curved/N1447064164_1_CALIB.yaml
@@ -31,9 +31,11 @@ ground_truth:
     coefficients are placeholders pending Phase 10 calibration; the
     expected.confidence_tier below pins today's behavior.
 
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected conflicted/conflicted/RingAnnulusNav -> measured success/medium/BodyDiscCorrelateNav. Status conflicted->success/medium: the recalibrated per-technique confidences dissolve the prior standoff; the dissenting vote falls below the ensemble veto weight and RingAnnulusNav carries the fuse within slack.
+
 expected:
-  status: conflicted                           # success | failed | conflicted
-  confidence_tier: conflicted              # high | medium | low | failed
-  primary_technique: RingAnnulusNav  # e.g. BodyLimbNav
+  status: success                           # success | failed | conflicted
+  confidence_tier: medium              # high | medium | low | failed
+  primary_technique: BodyDiscCorrelateNav  # e.g. BodyLimbNav
   techniques_must_run: [RingAnnulusNav]
   techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_only_curved/N1447064164_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_only_curved/N1447064164_1_CALIB.yaml
@@ -31,7 +31,7 @@ ground_truth:
     coefficients are placeholders pending Phase 10 calibration; the
     expected.confidence_tier below pins today's behavior.
 
-    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected conflicted/conflicted/RingAnnulusNav -> measured success/medium/BodyDiscCorrelateNav. Status conflicted->success/medium: the recalibrated per-technique confidences dissolve the prior standoff; the dissenting vote falls below the ensemble veto weight and RingAnnulusNav carries the fuse within slack.
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected conflicted/conflicted/RingAnnulusNav -> measured success/medium/BodyDiscCorrelateNav. Status conflicted->success/medium: the recalibrated per-technique confidences dissolve the prior standoff (the dissenting vote falls below the ensemble veto weight); the Saturn disc and limb, RingAnnulusNav, and the star techniques now agree and fuse to 0.990 within slack, with BodyDiscCorrelateNav the highest-confidence contributor.
 
 expected:
   status: success                           # success | failed | conflicted

--- a/tests/integration/image_library/images/ring_plus_body/N1486991973_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_plus_body/N1486991973_1_CALIB.yaml
@@ -20,10 +20,12 @@ ground_truth:
     Selection: ENCELADUS | 30-60 | -0.0; {"apparent_diameter_px": 51.0, "center_phase_deg": 42.235, "filter": "CL1", "ring_edges_in_frame": ["keeler_a_ring_oe_2005_05_01_2005_08_01.inner", "keeler_a_ring_oe_2005_05_01_2005_08_01.outer", "keeler_a_ring_oe_2006_01_01_2009_07_01.inner", "keeler_a_ring_oe_2006_01_01_2009_07_01.outer", "keeler_a_ring_oe_2010_01_01_2013_08_01.inner", "keeler_a_ring_oe_2010_01_01_2013_08_01.outer"], "ring_opening_deg": -1.766, "target": "ENCELADUS", "year": "2005"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.771, rank=medium, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'RingEdgeNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyDiscCorrelateNav": [-29.5, 27.5], "BodyLimbNav": [8.8129, 8.4537], "RingEdgeNav": [-49.9978, 95.0056], "StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [6.3535, 8.9801], "StarRefineNav": [6.3885, 8.9523]}.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/BodyLimbNav -> measured success/medium/StarRefineNav. Tier high->medium under the recalibrated 0.85 high-tier boundary: fused confidence sits in the 0.55-0.85 band that the campaign's planted ring-orbit-error failure mass moved out of the high tier; the confidence did not move materially, the boundary did. Offset unchanged and within slack. Primary also moves to StarRefineNav: a multi-star refine (uncapped, confidence >0.50) is the highest-confidence contributor; this retires the Track-B marker that withheld refine-as-primary, whose fix shipped as the single-inlier 0.50 cap and does not apply to multi-star refines.
 expected:
   status: success
-  confidence_tier: high
-  primary_technique: BodyLimbNav
+  confidence_tier: medium
+  primary_technique: StarRefineNav
   techniques_must_run:
   - BodyLimbNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_plus_body/N1503576135_2_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_plus_body/N1503576135_2_CALIB.yaml
@@ -22,10 +22,12 @@ ground_truth:
     Pipeline: status=success, confidence=0.39, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'RingEdgeNav'], per-technique offsets={"BodyDiscCorrelateNav": [10.3047, -6.1016], "BodyLimbNav": [10.0362, -5.974], "RingEdgeNav": [-9.9986, 57.0368]}.
     Primary ratchet 2026-07-16: RingEdgeNav is the highest-confidence technique and the ring edge is the legitimate primary for this ring_plus_body scene; applies the 2026-07-13 D6 reconciliation decision, which was documented at the time but never committed. Ratcheted BodyDiscCorrelateNav -> RingEdgeNav.
     Tier ratchet 2026-07-16: the fused tier is now high with the navigation itself unchanged, consistent with the 2026-07-14 NCC-covariance rederivation tightening the fused sigma. Ratcheted medium -> high to the measured tier.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/RingEdgeNav -> measured success/medium/BodyDiscCorrelateNav. Tier high->medium: pre-boundary demotion carried from the refit (fused sigma above the 0.5 px high-tier cap / mid-band fused confidence). Offset unchanged and within slack. Primary also moves to BodyDiscCorrelateNav with the recalibrated confidences.
 expected:
   status: success
-  confidence_tier: high
-  primary_technique: RingEdgeNav
+  confidence_tier: medium
+  primary_technique: BodyDiscCorrelateNav
   techniques_must_run:
   - BodyLimbNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_plus_body/N1572472169_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_plus_body/N1572472169_1_CALIB.yaml
@@ -21,10 +21,12 @@ ground_truth:
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.367, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'RingEdgeNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyDiscCorrelateNav": [0.2422, 15.5], "BodyLimbNav": [0.1807, 15.6359], "RingEdgeNav": [10.9977, 38.9643], "StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [-0.4354, 14.7186], "StarRefineNav": [-0.4209, 14.7127]}.
     Primary ratchet 2026-07-16: RingEdgeNav is the highest-confidence technique and the ring edge is the legitimate primary for this ring_plus_body scene; applies the 2026-07-13 D6 reconciliation decision, which was documented at the time but never committed. Ratcheted BodyLimbNav -> RingEdgeNav.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/RingEdgeNav -> measured success/medium/StarRefineNav. Tier high->medium under the recalibrated 0.85 high-tier boundary: fused confidence sits in the 0.55-0.85 band that the campaign's planted ring-orbit-error failure mass moved out of the high tier; the confidence did not move materially, the boundary did. Offset unchanged and within slack. Primary also moves to StarRefineNav: a multi-star refine (uncapped, confidence >0.50) is the highest-confidence contributor; this retires the Track-B marker that withheld refine-as-primary, whose fix shipped as the single-inlier 0.50 cap and does not apply to multi-star refines.
 expected:
   status: success
-  confidence_tier: high
-  primary_technique: RingEdgeNav
+  confidence_tier: medium
+  primary_technique: StarRefineNav
   techniques_must_run:
   - BodyLimbNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_plus_body/N1598065103_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_plus_body/N1598065103_1_CALIB.yaml
@@ -21,10 +21,12 @@ ground_truth:
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.388, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'RingEdgeNav'], per-technique offsets={"BodyDiscCorrelateNav": [6.5703, 17.1875], "BodyLimbNav": [6.7784, 17.1911], "RingEdgeNav": [42.9999, 16.047]}.
     Primary ratchet 2026-07-16: RingEdgeNav is the highest-confidence technique and the ring edge is the legitimate primary for this ring_plus_body scene; applies the 2026-07-13 D6 reconciliation decision, which was documented at the time but never committed. Ratcheted BodyDiscCorrelateNav -> RingEdgeNav.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/medium/RingEdgeNav -> measured success/medium/BodyDiscCorrelateNav. Primary re-ratcheted RingEdgeNav->BodyDiscCorrelateNav: the ring-vocabulary refit re-ordered the per-technique confidences and the disc fix is now highest-confidence. Tier and offset unchanged.
 expected:
   status: success
   confidence_tier: medium
-  primary_technique: RingEdgeNav
+  primary_technique: BodyDiscCorrelateNav
   techniques_must_run:
   - BodyLimbNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_plus_body/N1598093741_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_plus_body/N1598093741_1_CALIB.yaml
@@ -22,10 +22,12 @@ ground_truth:
     Pipeline: status=success, confidence=0.383, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'RingEdgeNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyDiscCorrelateNav": [10.2422, -13.6328], "BodyLimbNav": [9.9672, -13.7982], "RingEdgeNav": [-14.0018, -29.9983], "StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [0.0, 0.0], "StarRefineNav": [12.8436, -14.3323]}.
     Primary ratchet 2026-07-16: RingEdgeNav is the highest-confidence technique and the ring edge is the legitimate primary for this ring_plus_body scene; applies the 2026-07-13 D6 reconciliation decision, which was documented at the time but never committed. Ratcheted BodyDiscCorrelateNav -> RingEdgeNav.
     Tier ratchet 2026-07-16: the fused tier is now high with the navigation itself unchanged, consistent with the 2026-07-14 NCC-covariance rederivation tightening the fused sigma. Ratcheted medium -> high to the measured tier.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/RingEdgeNav -> measured success/medium/BodyDiscCorrelateNav. Tier high->medium under the recalibrated 0.85 high-tier boundary: fused confidence sits in the 0.55-0.85 band that the campaign's planted ring-orbit-error failure mass moved out of the high tier; the confidence did not move materially, the boundary did. Offset unchanged and within slack. Primary also moves to BodyDiscCorrelateNav with the recalibrated confidences.
 expected:
   status: success
-  confidence_tier: high
-  primary_technique: RingEdgeNav
+  confidence_tier: medium
+  primary_technique: BodyDiscCorrelateNav
   techniques_must_run:
   - BodyLimbNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_plus_body/N1633925572_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_plus_body/N1633925572_1_CALIB.yaml
@@ -24,10 +24,12 @@ ground_truth:
     Operator comment: appended: batch-1 candidate rescued by relaxed gates (was not in the batch-1 review selection)
     A later clean run of the default pipeline (2026-07-13) navigates this frame at high/0.50 after the confidence recalibration that followed first curation; expected.confidence_tier reflects that current behavior. The frame no longer needs the relaxed-gate rescue its earlier snapshot was taken under.
     Primary ratchet 2026-07-16: RingEdgeNav is the highest-confidence technique and the ring edge is the legitimate primary for this ring_plus_body scene; applies the 2026-07-13 D6 reconciliation decision, which was documented at the time but never committed. Ratcheted StarRefineNav -> RingEdgeNav.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/RingEdgeNav -> measured success/medium/BodyLimbNav. Tier high->medium: pre-boundary demotion carried from the refit (fused sigma above the 0.5 px high-tier cap / mid-band fused confidence). Offset unchanged and within slack. Primary also moves to BodyLimbNav with the recalibrated confidences.
 expected:
   status: success
-  confidence_tier: high
-  primary_technique: RingEdgeNav
+  confidence_tier: medium
+  primary_technique: BodyLimbNav
   techniques_must_run:
   - StarRefineNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/ring_plus_body/N1747232897_1_CALIB.yaml
+++ b/tests/integration/image_library/images/ring_plus_body/N1747232897_1_CALIB.yaml
@@ -22,10 +22,12 @@ ground_truth:
     Pipeline: status=success, confidence=0.426, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'RingEdgeNav'], per-technique offsets={"BodyDiscCorrelateNav": [3.9688, -20.7891], "BodyLimbNav": [3.9904, -21.095], "RingEdgeNav": [-2.8987, -16.9884]}.
     Primary ratchet 2026-07-16: RingEdgeNav is the highest-confidence technique and the ring edge is the legitimate primary for this ring_plus_body scene; applies the 2026-07-13 D6 reconciliation decision, which was documented at the time but never committed. Ratcheted BodyDiscCorrelateNav -> RingEdgeNav.
     Tier ratchet 2026-07-16: the fused tier is now high with the navigation itself unchanged, consistent with the 2026-07-14 NCC-covariance rederivation tightening the fused sigma. Ratcheted medium -> high to the measured tier.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/RingEdgeNav -> measured success/medium/BodyDiscCorrelateNav. Tier high->medium under the recalibrated 0.85 high-tier boundary: fused confidence sits in the 0.55-0.85 band that the campaign's planted ring-orbit-error failure mass moved out of the high tier; the confidence did not move materially, the boundary did. Offset unchanged and within slack. Primary also moves to BodyDiscCorrelateNav with the recalibrated confidences.
 expected:
   status: success
-  confidence_tier: high
-  primary_technique: RingEdgeNav
+  confidence_tier: medium
+  primary_technique: BodyDiscCorrelateNav
   techniques_must_run:
   - BodyLimbNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/scattered_light/C3446143_GEOMED.yaml
+++ b/tests/integration/image_library/images/scattered_light/C3446143_GEOMED.yaml
@@ -21,9 +21,11 @@ ground_truth:
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.399, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyDiscCorrelateNav": [-28.2578, -5.75], "BodyLimbNav": [-28.2054, -5.8645], "StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [0.0, 0.0], "StarRefineNav": [-30.7778, -2.8347]}.
     Tier ratchet 2026-07-16: the 2026-07-14 NCC-covariance rederivation tightens the fused sigma past the high-tier gate and the fused confidence sits at the 0.99 combined-confidence cap via the two-technique agreement boost; per-technique results are essentially unchanged. Pinned as measured behavior with a caveat recorded in the reconcile decisions file: a tier increase produced by a covariance rescale alone, with disc and limb errors likely correlated, may overstate the fused certainty. Ratcheted medium -> high.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/BodyDiscCorrelateNav -> measured success/medium/BodyDiscCorrelateNav. Tier high->medium under the recalibrated 0.85 high-tier boundary: fused confidence sits in the 0.55-0.85 band that the campaign's planted ring-orbit-error failure mass moved out of the high tier; the confidence did not move materially, the boundary did. Offset unchanged and within slack.
 expected:
   status: success
-  confidence_tier: high
+  confidence_tier: medium
   primary_technique: BodyDiscCorrelateNav
   techniques_must_run:
   - BodyLimbNav

--- a/tests/integration/image_library/images/scattered_light/C3448723_GEOMED.yaml
+++ b/tests/integration/image_library/images/scattered_light/C3448723_GEOMED.yaml
@@ -22,9 +22,11 @@ ground_truth:
     First-curation pipeline snapshot (2026-07): status=success, confidence=0.401, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyDiscCorrelateNav": [-28.9297, -16.7656], "BodyLimbNav": [-28.8277, -17.0884], "StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [0.0, 0.0], "StarRefineNav": [-27.4357, -17.1837]}.
     A later clean run of the default pipeline (2026-07-13) navigates this frame at medium/0.99 after the confidence recalibration that followed first curation; expected.confidence_tier reflects that current behavior. The frame no longer needs the relaxed-gate rescue its earlier snapshot was taken under.
     Tier ratchet 2026-07-16: the 2026-07-14 NCC-covariance rederivation tightens the fused sigma past the high-tier gate (the fused confidence already sat at the 0.99 combined-confidence cap); per-technique results are essentially unchanged. Pinned as measured behavior with a caveat recorded in the reconcile decisions file: a tier increase produced by a covariance rescale alone, with disc and limb errors likely correlated, may overstate the fused certainty. Ratcheted medium -> high.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/BodyDiscCorrelateNav -> measured success/medium/BodyDiscCorrelateNav. Tier high->medium under the recalibrated 0.85 high-tier boundary: fused confidence sits in the 0.55-0.85 band that the campaign's planted ring-orbit-error failure mass moved out of the high tier; the confidence did not move materially, the boundary did. Offset unchanged and within slack.
 expected:
   status: success
-  confidence_tier: high
+  confidence_tier: medium
   primary_technique: BodyDiscCorrelateNav
   techniques_must_run:
   - BodyLimbNav

--- a/tests/integration/image_library/images/star_dominated/C1205021_GEOMED.yaml
+++ b/tests/integration/image_library/images/star_dominated/C1205021_GEOMED.yaml
@@ -20,10 +20,12 @@ ground_truth:
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.936, rank=high, techniques=['StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"StarFieldFromCatalogNav": [-49.0337, -1.8331], "StarUniqueMatchNav": [0.0, 0.0], "StarRefineNav": [-49.2965, -1.7568]}.
     Operator comment: many stars
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/medium/StarFieldFromCatalogNav -> measured success/high/StarRefineNav. Tier medium->high adjudicated per provenance: the cautious operator medium pin contradicted this frame's own recorded rank=high from the batch-006 curation run; the recalibrated star-field lock scores high. Offset unchanged and within slack. Primary also moves to StarRefineNav: a multi-star refine (uncapped, confidence >0.50) is the highest-confidence contributor; this retires the Track-B marker that withheld refine-as-primary, whose fix shipped as the single-inlier 0.50 cap and does not apply to multi-star refines.
 expected:
   status: success
-  confidence_tier: medium
-  primary_technique: StarFieldFromCatalogNav
+  confidence_tier: high
+  primary_technique: StarRefineNav
   techniques_must_run:
   - StarFieldFromCatalogNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/star_dominated/N1459552012_1_CALIB.yaml
+++ b/tests/integration/image_library/images/star_dominated/N1459552012_1_CALIB.yaml
@@ -19,10 +19,12 @@ ground_truth:
     Selection: 2004 | 6; {"filter": "HAL", "maglim": 11.54, "n_detectable": 6, "star_vmags": [6.83, 6.88, 7.89, 9.41, 9.99], "texp_s": 2.6, "year": "2004"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.263, rank=low, techniques=['StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [3.3482, -33.6334], "StarRefineNav": [2.9437, -34.1868]}.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/StarFieldFromCatalogNav -> measured success/high/StarRefineNav. Primary also moves to StarRefineNav: a multi-star refine (uncapped, confidence >0.50) is the highest-confidence contributor; this retires the Track-B marker that withheld refine-as-primary, whose fix shipped as the single-inlier 0.50 cap and does not apply to multi-star refines.
 expected:
   status: success
   confidence_tier: high
-  primary_technique: StarFieldFromCatalogNav
+  primary_technique: StarRefineNav
   techniques_must_run:
   - StarFieldFromCatalogNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/star_dominated/N1461997416_1_CALIB.yaml
+++ b/tests/integration/image_library/images/star_dominated/N1461997416_1_CALIB.yaml
@@ -22,10 +22,12 @@ ground_truth:
     First-curation pipeline snapshot (2026-07): status=success, confidence=0.343, rank=low, techniques=['StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"StarUniqueMatchNav": [1.5485, -7.4586], "StarRefineNav": [1.5558, -7.4517]}.
     Operator comment: re-vote: rescued with relaxed gates (previous vote: None)
     A later clean run of the default pipeline (2026-07-13) navigates this frame at high/0.686 after the confidence recalibration that followed first curation; expected.confidence_tier reflects that current behavior. The frame no longer needs the relaxed-gate rescue its earlier snapshot was taken under.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/StarFieldFromCatalogNav -> measured success/medium/StarUniqueMatchNav. Tier high->medium under the recalibrated 0.85 high-tier boundary: fused confidence sits in the 0.55-0.85 band that the campaign's planted ring-orbit-error failure mass moved out of the high tier; the confidence did not move materially, the boundary did. Offset unchanged and within slack. Primary also moves to StarUniqueMatchNav with the recalibrated confidences. StarFieldFromCatalogNav no longer emits a result (below the RANSAC inlier floor after the refit); techniques_must_run updated to the carrying technique.
 expected:
   status: success
-  confidence_tier: high
-  primary_technique: StarFieldFromCatalogNav
+  confidence_tier: medium
+  primary_technique: StarUniqueMatchNav
   techniques_must_run:
-  - StarFieldFromCatalogNav
+  - StarUniqueMatchNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/star_dominated/N1483174087_1_CALIB.yaml
+++ b/tests/integration/image_library/images/star_dominated/N1483174087_1_CALIB.yaml
@@ -19,10 +19,12 @@ ground_truth:
     Selection: 2004 | 5; {"filter": "CL1", "maglim": 10.7, "n_detectable": 5, "star_vmags": [8.84, 9.31, 10.02, 10.53, 10.66], "texp_s": 1.2, "year": "2004"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.745, rank=medium, techniques=['BodyBlobNav', 'BodyTerminatorNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [-1.6686, 15.4814], "BodyBlobNav": [63.7862, -98.9428], "BodyTerminatorNav": [-50.9389, -130.2657], "StarRefineNav": [-1.6467, 15.4914]}.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/StarFieldFromCatalogNav -> measured success/medium/StarRefineNav. Tier high->medium under the recalibrated 0.85 high-tier boundary: fused confidence sits in the 0.55-0.85 band that the campaign's planted ring-orbit-error failure mass moved out of the high tier; the confidence did not move materially, the boundary did. Offset unchanged and within slack. Primary also moves to StarRefineNav: a multi-star refine (uncapped, confidence >0.50) is the highest-confidence contributor; this retires the Track-B marker that withheld refine-as-primary, whose fix shipped as the single-inlier 0.50 cap and does not apply to multi-star refines.
 expected:
   status: success
-  confidence_tier: high
-  primary_technique: StarFieldFromCatalogNav
+  confidence_tier: medium
+  primary_technique: StarRefineNav
   techniques_must_run:
   - StarFieldFromCatalogNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/star_dominated/N1506004925_1_CALIB.yaml
+++ b/tests/integration/image_library/images/star_dominated/N1506004925_1_CALIB.yaml
@@ -20,10 +20,12 @@ ground_truth:
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.759, rank=medium, techniques=['StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"StarUniqueMatchNav": [5.6767, -22.9518], "StarRefineNav": [5.6778, -22.952]}.
     Operator comment: this actually has two stars
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/StarFieldFromCatalogNav -> measured success/medium/StarRefineNav. Tier high->medium under the recalibrated 0.85 high-tier boundary: fused confidence sits in the 0.55-0.85 band that the campaign's planted ring-orbit-error failure mass moved out of the high tier; the confidence did not move materially, the boundary did. Offset unchanged and within slack. Primary also moves to StarRefineNav: a multi-star refine (uncapped, confidence >0.50) is the highest-confidence contributor; this retires the Track-B marker that withheld refine-as-primary, whose fix shipped as the single-inlier 0.50 cap and does not apply to multi-star refines. StarFieldFromCatalogNav no longer emits a result (below the RANSAC inlier floor after the refit); techniques_must_run updated to the carrying technique.
 expected:
   status: success
-  confidence_tier: high
-  primary_technique: StarFieldFromCatalogNav
+  confidence_tier: medium
+  primary_technique: StarRefineNav
   techniques_must_run:
-  - StarFieldFromCatalogNav
+  - StarRefineNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/star_dominated/W1580760393_1_CALIB.yaml
+++ b/tests/integration/image_library/images/star_dominated/W1580760393_1_CALIB.yaml
@@ -32,12 +32,14 @@ ground_truth:
     could not close the frame); ground truth and expected were re-saved
     to success/high.
 
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/StarFieldFromCatalogNav -> measured success/high/StarRefineNav. Primary re-ratcheted StarFieldFromCatalogNav->StarRefineNav: the refit re-balanced the star-field terms so the 95-star refine (0.9513) edges the field matcher 0.95 hard cap. A multi-star refine legitimately carries the pick; status/tier/offset unchanged.
+
 expected:
   # success | failed | conflicted
   status: success
   # high | medium | low | failed
   confidence_tier: high
   # e.g. BodyLimbNav
-  primary_technique: StarFieldFromCatalogNav
+  primary_technique: StarRefineNav
   techniques_must_run: [StarFieldFromCatalogNav]
   techniques_must_skip: []

--- a/tests/integration/image_library/images/stars_plus_body/N1488823805_1_CALIB.yaml
+++ b/tests/integration/image_library/images/stars_plus_body/N1488823805_1_CALIB.yaml
@@ -20,10 +20,12 @@ ground_truth:
     Selection: DIONE | 30-60; {"apparent_diameter_px": 138.7, "center_phase_deg": 50.515, "filter": "P60", "maglim": 10.7, "n_detectable_stars": 10, "star_vmags": [8.37, 9.02, 9.82, 9.85, 9.87, 10.13, 10.14, 10.2], "target": "DIONE", "texp_s": 1.2, "year": "2005"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.361, rank=low, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyDiscCorrelateNav": [-1.0625, 5.5], "BodyLimbNav": [-0.7074, 5.0762], "StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [-1.5095, 4.8689], "StarRefineNav": [-1.4165, 4.7348]}.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/BodyLimbNav -> measured success/high/StarRefineNav. Primary also moves to StarRefineNav: a multi-star refine (uncapped, confidence >0.50) is the highest-confidence contributor; this retires the Track-B marker that withheld refine-as-primary, whose fix shipped as the single-inlier 0.50 cap and does not apply to multi-star refines.
 expected:
   status: success
   confidence_tier: high
-  primary_technique: BodyLimbNav
+  primary_technique: StarRefineNav
   techniques_must_run:
   - BodyLimbNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/stars_plus_body/N1550270436_1_CALIB.yaml
+++ b/tests/integration/image_library/images/stars_plus_body/N1550270436_1_CALIB.yaml
@@ -20,10 +20,12 @@ ground_truth:
     Selection: HYPERION | 60-90; {"apparent_diameter_px": 244.0, "center_phase_deg": 73.676, "filter": "P120", "maglim": 10.5, "n_detectable_stars": 4, "star_vmags": [9.19, 9.38, 9.79, 10.03], "target": "HYPERION", "texp_s": 1.0, "year": "2007"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=conflicted, confidence=0.13, rank=conflicted, techniques=['BodyBlobNav', 'BodyTerminatorNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"StarUniqueMatchNav": [-1.0316, -8.7157], "BodyBlobNav": [3.4608, -23.0015], "BodyTerminatorNav": [-3.2845, 32.46], "StarRefineNav": [0.0, 0.0]}.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/medium/StarUniqueMatchNav -> measured success/medium/StarRefineNav. Primary re-ratcheted StarUniqueMatchNav->StarRefineNav: the refit zeroed the residual_scatter_px penalty so this two-star refine (0.809) rises above the two-star match 0.80 cap. Multi-star refine; status/tier/offset unchanged.
 expected:
   status: success
   confidence_tier: medium
-  primary_technique: StarUniqueMatchNav
+  primary_technique: StarRefineNav
   techniques_must_run:
   - StarUniqueMatchNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/stars_plus_body/N1806609736_1_CALIB.yaml
+++ b/tests/integration/image_library/images/stars_plus_body/N1806609736_1_CALIB.yaml
@@ -20,10 +20,12 @@ ground_truth:
     Selection: IAPETUS | 30-60; {"apparent_diameter_px": 243.5, "center_phase_deg": 58.029, "filter": "IR2", "maglim": 12.16, "n_detectable_stars": 31, "star_vmags": [9.35, 9.71, 10.18, 10.61, 10.84, 10.9, 10.99, 11.07], "target": "IAPETUS", "texp_s": 4.6, "year": "2015"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.99, rank=high, techniques=['BodyDiscCorrelateNav', 'BodyLimbNav', 'StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"BodyDiscCorrelateNav": [-48.5, 61.5], "BodyLimbNav": [1.4644, 12.8465], "StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [1.5275, 11.3323], "StarRefineNav": [1.4887, 11.3878]}.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/BodyLimbNav -> measured success/medium/StarRefineNav. Tier high->medium under the recalibrated 0.85 high-tier boundary: fused confidence sits in the 0.55-0.85 band that the campaign's planted ring-orbit-error failure mass moved out of the high tier; the confidence did not move materially, the boundary did. Offset unchanged and within slack. Primary also moves to StarRefineNav: a multi-star refine (uncapped, confidence >0.50) is the highest-confidence contributor; this retires the Track-B marker that withheld refine-as-primary, whose fix shipped as the single-inlier 0.50 cap and does not apply to multi-star refines.
 expected:
   status: success
-  confidence_tier: high
-  primary_technique: BodyLimbNav
+  confidence_tier: medium
+  primary_technique: StarRefineNav
   techniques_must_run:
   - BodyLimbNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/two_bright_stars_no_body/N1459509270_1_CALIB.yaml
+++ b/tests/integration/image_library/images/two_bright_stars_no_body/N1459509270_1_CALIB.yaml
@@ -20,10 +20,12 @@ ground_truth:
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.771, rank=medium, techniques=['StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"StarUniqueMatchNav": [3.6862, 5.7972], "StarRefineNav": [3.6961, 5.8105]}.
     Operator comment: this actually has two stars
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/StarUniqueMatchNav -> measured success/medium/StarRefineNav. Tier high->medium under the recalibrated 0.85 high-tier boundary: fused confidence sits in the 0.55-0.85 band that the campaign's planted ring-orbit-error failure mass moved out of the high tier; the confidence did not move materially, the boundary did. Offset unchanged and within slack. Primary also moves to StarRefineNav: a multi-star refine (uncapped, confidence >0.50) is the highest-confidence contributor; this retires the Track-B marker that withheld refine-as-primary, whose fix shipped as the single-inlier 0.50 cap and does not apply to multi-star refines.
 expected:
   status: success
-  confidence_tier: high
-  primary_technique: StarUniqueMatchNav
+  confidence_tier: medium
+  primary_technique: StarRefineNav
   techniques_must_run:
   - StarUniqueMatchNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/two_bright_stars_no_body/N1548432342_1_CALIB.yaml
+++ b/tests/integration/image_library/images/two_bright_stars_no_body/N1548432342_1_CALIB.yaml
@@ -19,10 +19,12 @@ ground_truth:
     Selection: 2007; {"filter": "CL1", "maglim": 8.44, "n_detectable": 2, "star_vmags": [6.83, 6.88, 9.41, 10.18], "texp_s": 0.15, "year": "2007"}.
     Operator verified the pipeline overlay alignment at the proposed offset during batch review (summary PNG plus, for star classes, a hard-stretch star-check PNG with circled catalog positions).
     Pipeline: status=success, confidence=0.231, rank=low, techniques=['StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [7.59, 2.0633], "StarRefineNav": [7.7446, 1.5441]}.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/StarUniqueMatchNav -> measured success/high/StarRefineNav. Primary also moves to StarRefineNav: a multi-star refine (uncapped, confidence >0.50) is the highest-confidence contributor; this retires the Track-B marker that withheld refine-as-primary, whose fix shipped as the single-inlier 0.50 cap and does not apply to multi-star refines.
 expected:
   status: success
   confidence_tier: high
-  primary_technique: StarUniqueMatchNav
+  primary_technique: StarRefineNav
   techniques_must_run:
   - StarUniqueMatchNav
   techniques_must_skip: []

--- a/tests/integration/image_library/images/two_bright_stars_no_body/N1622628483_1_CALIB.yaml
+++ b/tests/integration/image_library/images/two_bright_stars_no_body/N1622628483_1_CALIB.yaml
@@ -22,10 +22,12 @@ ground_truth:
     First-curation pipeline snapshot (2026-07): status=success, confidence=0.604, rank=medium, techniques=['StarFieldFromCatalogNav', 'StarRefineNav', 'StarUniqueMatchNav'], per-technique offsets={"StarFieldFromCatalogNav": [0.0, 0.0], "StarUniqueMatchNav": [9.6145, 8.5501], "StarRefineNav": [9.542, 7.9076]}.
     Operator comment: re-vote: rescued with relaxed gates (previous vote: None)
     A later clean run of the default pipeline (2026-07-13) navigates this frame at high/0.99 after the confidence recalibration that followed first curation; expected.confidence_tier reflects that current behavior. The frame no longer needs the relaxed-gate rescue its earlier snapshot was taken under.
+
+    Re-ratchet 2026-07-20 (sidecar reconciled to the seed-20260718 recalibration; attribution basis util/calibration/CAMPAIGN_20260718.md). Expected success/high/StarUniqueMatchNav -> measured success/high/StarRefineNav. Primary also moves to StarRefineNav: a multi-star refine (uncapped, confidence >0.50) is the highest-confidence contributor; this retires the Track-B marker that withheld refine-as-primary, whose fix shipped as the single-inlier 0.50 cap and does not apply to multi-star refines.
 expected:
   status: success
   confidence_tier: high
-  primary_technique: StarUniqueMatchNav
+  primary_technique: StarRefineNav
   techniques_must_run:
   - StarUniqueMatchNav
   techniques_must_skip: []


### PR DESCRIPTION
## What

Reconciles 36 image-library sidecar expectations to the seed-20260718 sim-anchored recalibration (`util/calibration/CAMPAIGN_20260718.md` is the per-frame attribution basis), and leaves 9 frames deliberately red, each owned by an open issue. After this change the full library suite is `66 passed, 9 failed`, and the 9 failures are exactly the pinned frames below. This resolves the bulk of the #288 library reconciliation.

Verification (canonical local integration machine, real PDS3 holdings):

```
pytest tests/integration/test_autonomous_nav.py -m '' -n auto --dist=loadfile
=> 9 failed, 66 passed in 26:01
```

The failing set equals the pinned set exactly (no unexplained deltas). GitHub Actions does not run the integration tier, so this green rests on the local run recorded here.

## Re-ratcheted frames (36)

Each frame's `expected` status / tier / primary (and `techniques_must_run` where the recalibration changed the technique composition) was set to the measured behavior of the recalibrated pipeline, with a dated note in the sidecar naming the attribution. Ground-truth offsets were not touched. Categories:

- **Tier medium -> low (8)** under the model-error covariance floors (dominated by the 2.61 px BodyLimbNav limb floor): a body-led fuse reports sigma above the medium tier's 2.0 px cap. N1777325846, N1634226853, N1637475277, N1699263827, W1637520502, N1560303384, N1481737141, N1816644691.
- **Tier high -> medium (14)** under the recalibrated 0.85 high-tier boundary (the campaign's planted ring-orbit-error failure mass moved this confidence band out of high) or, for two, a pre-boundary demotion carried from the refit. N1858933303, N1486991973, N1572472169, N1598093741, N1747232897, C3446143, C3448723, N1461997416, N1483174087, N1506004925, N1806609736, N1459509270, N1503576135, N1633925572.
- **Primary technique flips (11)** to multi-star StarRefineNav and other techniques. These retire the Track-B standing marker that withheld refine-as-primary: that defect's fix shipped as the single-inlier 0.50 confidence cap, which does not apply to the multi-star (2-95 inlier, confidence >0.50) refines that legitimately carry these picks. Verified per-frame that the winning refine is multi-star. Includes the three campaign-attributed star-refit flips (N1555145539, W1580760393, N1550270436).
- **Status conflicted -> success (3)**: N1597846115 and N1487595731 recover because a weak/wrong BodyTerminatorNav vote no longer fires after the terminator refit (it emits no result and is dropped from `techniques_must_run`); N1447064164 recovers as the dissenting vote falls below the ensemble veto weight.
- **C1205021_GEOMED adjudication (medium -> high)**: its cautious `medium` pin contradicted the frame's own recorded `rank=high` from batch-006 curation from the start. Set to `high` per that provenance and the recalibrated 0.94 star-field lock. Resolves #347.

## Deliberately-red pins left untouched (9) — owner per frame

Ground-truth offsets and pinned outcomes are operator truth; these stay red until their owning issue is fixed, at which point the test flips and prompts re-verification.

| frame | failure | owning issue |
|---|---|---|
| N1492091163_1_CALIB | RingEdgeNav locks a confident high-tier success ~93 px off truth; operator pinned `failed` | #346 |
| N1867601758_1_CALIB | wrong ring-feature lock, dv 2.96 px breach | #346 |
| N1867602424_1_CALIB | wrong ring-feature lock, tier + offset breach | #346 |
| N1853392805_1_CALIB | highly-irregular exclusion discards the terminator fit; blob fallback du 1.82 px | #338 |
| N1572105349_1_CALIB | single-inlier StarRefine pulls the fused offset 1.53 px off an otherwise-correct body fix | #222 (reopened) |
| N1484593951_2_CALIB | partial-overflow limb fix, dv 2.69 px breach | #350 |
| N1686349893_1_CALIB | resolved-body disc/limb fix, du 1.87 px breach | #350 |
| N1530185128_1_CALIB | recalibration turns an operator-verified success into a spurious ensemble conflict | #351 |
| W1444747627_1_CALIB | both star techniques self-flag spurious on a navigable small-offset field | #352 |

New issues filed for the previously-unowned reds: #350, #351, #352 (and #347 resolved by the adjudication above). #222 was reopened because its single-inlier residual persists on N1572105349 on the recalibrated pipeline (the multi-star refines it also described are now correct to carry the pick).

## Not done here

Per the operator playbook, adopting the campaign's "Transfer watch (proposed)" as an armed falsification criterion is a separate follow-up (tracked by #334) and is not part of this re-ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HoCUAeNeMz5bFmGk2iVBf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated image calibration sidecar expectations after the 2026-07-20 recalibration.
  * Adjusted confidence tiers, primary techniques, and required techniques across body, ring, and star scenarios (including several conflict cases now marked successful).
  * Added/expanded “re-ratchet” reconciliation notes while keeping offset/expected behavior consistent where applicable.
* **Documentation**
  * Refreshed the operator playbook status, test summary, and tracking register with the latest re-ratchet audit details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->