### PR TITLE
feat: measure reliability-gate selection effect

### DIFF
--- a/util/agreement/CAMPAIGN_20260719.md
+++ b/util/agreement/CAMPAIGN_20260719.md
@@ -322,8 +322,11 @@ study builds cohorts.
 The third shared element named by the plan, the feature reliability
 gate, acts on feature admission (binary), not on offsets; its
 common-mode effect is the same selection-effect class as the
-noise-sigma channel and was not separately injected.  Recorded as an
-open question below.
+noise-sigma channel and was not separately injected here.  Recorded as
+an open question below and resolved in `CAMPAIGN_20260721.md` (the
+reliability-gate selection-effect campaign): the gate is a pure
+selection channel and its distortion is bounded by the survivorship
+model there.
 
 ### Pair verdicts (this sim, this regime)
 
@@ -431,7 +434,10 @@ open question below.
 - **Reliability-gate injection.**  The gate's common-mode effect is
   feature dropout; measuring it needs a selection-effect design
   (which frames survive under gate perturbation), not an offset
-  regression.  Not done in this campaign.
+  regression.  Not done in this campaign -- **resolved** in
+  `CAMPAIGN_20260721.md`, which adds the `reliability_gate` injection
+  channel, a survivorship-stratified analysis, and the `selection.py`
+  survivorship model that bounds the distortion.
 - **PSF-layer coupling for limb vs disc.**  This campaign's clean
   scenes render no PSF stage, so the shared-PSF-edge-bias suspicion
   against the limb/disc base pair is unprobed.  A follow-up injection

--- a/util/agreement/CAMPAIGN_20260721.md
+++ b/util/agreement/CAMPAIGN_20260721.md
@@ -140,14 +140,20 @@ survivorship distorts a covariance as a function of the survival fraction and of
 how the gate's admission depends on the scene.  Two mechanisms, each pinned by
 `tests/test_selection.py`:
 
-- **Separate per-technique gates do not manufacture cross-covariance.**  When two
-  techniques have independent errors and each is admitted by its *own* gate, the
-  joint-survival event factorizes across the two, so the survivor cross-covariance
-  stays at its population value (zero).  Measured at n = 400000, independent
-  errors: survivor cross-covariance stays within +/-0.003 of zero at every
-  survival fraction from 0.90 down to 0.25.  This matters because the real gate is
-  exactly this configuration -- each feature has its own per-type threshold -- so
-  the gate cannot invent a coupling between two genuinely independent techniques.
+- **Separately-gated independent errors are not coupled by survival (in the
+  model).**  When two techniques have independent errors and each is admitted by
+  a gate on its *own* error, the joint-survival event factorizes across the two,
+  so the survivor cross-covariance stays at its population value (zero).  Measured
+  at n = 400000, independent errors: survivor cross-covariance stays within
+  +/-0.003 of zero at every survival fraction from 0.90 down to 0.25.  This result
+  is conditional on the model's separable admission structure.  The real gate uses
+  a separate per-type threshold per feature, which is *necessary* for that
+  structure but not *sufficient*: the reliability scores that feed those
+  thresholds could still share an error dependence (both falling with a common
+  image-quality factor) or depend inversely on error, either of which would couple
+  admission and induce conditional covariance.  Whether the real scores are
+  separable in error space is a real-frame measurement (#358), not something
+  per-type thresholds alone establish.
 - **What separate gating does do is attenuate each marginal variance, and a
   shared scene latent attenuates the shared covariance.**  When survival tracks a
   technique's own error, survivors are the low-error frames and the marginal
@@ -198,42 +204,54 @@ neither manufactured nor attenuated.
 ## What the sim cannot establish
 
 Per the capability envelope, planted-truth recovery is the axis on which the
-simulator's word is final; real-frame accuracy is not.  The bound above is exact
-*given the gate regime and survival fraction*.  The one input it cannot supply is
-the real one: how strongly a feature's reliability score tracks its technique's
-error on real photons, which sets where a real cohort sits between the
-"separate-gate" and "shared-latent" rows.  In the clean sim that coupling is
-near-zero by construction (reliability is flat), so the sim can bound the effect
-but cannot place a real cohort on the grid.  Measuring that coupling on the #225
-cohorts, and running the stratified estimator there against the fixed production
-gate, is filed as #358; whether a selection-aware correction is then warranted is
-#360.
+simulator's word is final; real-frame accuracy is not.  The grid is exact *for
+the model's admission structure, gate regime, and survival fraction* -- it is a
+scenario result, not a universal bound on a real cohort.  Two real-frame inputs
+it cannot supply set where a real cohort lands: (1) how strongly each feature's
+reliability score tracks its technique's error on real photons, which sets the
+magnitude of the attenuation; and (2) whether the two scores' error-dependence
+is genuinely *separable* -- i.e. each score falls only with its own technique's
+error -- or is shared (both falling with a common image-quality factor) or
+inverse, which is what decides whether survival can induce a coupling at all.
+Per-type thresholds make the gates separate functions but do not establish that
+separability in error space.  In the clean sim both inputs are degenerate by
+construction (reliability is flat), so the sim can characterize the effect under
+an assumed admission model but cannot place a real cohort on the grid or confirm
+its separability.  Measuring the score-error coupling and separability on the
+#225 cohorts, and running the stratified estimator there against the fixed
+production gate, is filed as #358; whether a selection-aware correction is then
+warranted is #360.
 
 ## Consequence for the #225 cohorts (the selection-effect statement)
 
-The reliability-gate selection effect on the agreement study's covariances is
-**bounded, one-signed, and (for the pairwise base pairs) provably absent from the
-manufacturing direction**:
+The reliability-gate selection effect on the agreement study's covariances is,
+**under a separable and monotonic admission model** (whose real-frame validity
+is #358's job to check), **one-signed and free of manufactured coupling on
+independent pairs**:
 
-1. **The gate cannot manufacture cross-technique coupling.**  Each feature type
-   has its own per-type threshold, so two techniques with independent errors are
-   admitted by separate gates and their survivor cross-covariance stays at zero
-   (measured to within +/-0.003 at n = 400000, every survival fraction).  A
-   pairwise agreement that looks clean cannot be an artifact the gate invented;
-   the gate only ever *attenuates* an already-shared coupling.
-2. **Every per-technique sigma the study reports is a lower bound under
-   survivorship.**  Because survivors are the frames whose features passed, the
-   per-technique covariance measured on a cohort is attenuated *toward zero*
-   relative to the full population whenever admission tracks the technique's own
-   error.  The magnitude of that attenuation is set by how strongly reliability
-   tracks error -- a coupling the simulator cannot fix -- so the grid gives
-   representative, not universal, factors: at 50% survival the retained marginal
-   variance runs from ~0.32 (independent errors, admission gated on the whole
-   error) through ~0.40 (mixed) to ~0.57 (admission gated on only the shared
-   half of the variance), i.e. the population sigma is roughly 1.3x to 1.8x the
-   survivor sigma at that dropout; a stronger coupling attenuates more.  The
-   reported sigma is therefore optimistic by a factor that #358 must measure on
-   the real cohorts.
+1. **Under separable admission the gate does not manufacture cross-technique
+   coupling.**  When two techniques with independent errors are each admitted by
+   a gate on their own error, their survivor cross-covariance stays at zero
+   (measured to within +/-0.003 at n = 400000, every survival fraction), so a
+   pairwise agreement that looks clean is not an artifact the gate invented, and
+   the gate only *attenuates* an already-shared coupling.  The real gate's
+   per-type thresholds are necessary for this separability but not sufficient:
+   if the reliability scores share or invert their error-dependence the survival
+   conditioning *can* induce a coupling, so this benign result must be validated
+   on real frames (#358) before it is relied on.
+2. **If admission is monotonic in a technique's own error, its per-technique
+   sigma measured on survivors is a lower bound.**  Survivors are then the
+   low-error frames, so the per-technique covariance is attenuated *toward zero*
+   relative to the full population.  The magnitude of that attenuation is set by
+   how strongly reliability tracks error -- which the simulator cannot fix -- so
+   the grid gives representative, not universal, factors: at 50% survival the
+   retained marginal variance runs from ~0.32 (independent errors, admission
+   gated on the whole error) through ~0.40 (mixed) to ~0.57 (admission gated on
+   only the shared half of the variance), i.e. the population sigma is roughly
+   1.3x to 1.8x the survivor sigma at that dropout; a stronger coupling
+   attenuates more.  The reported sigma is optimistic by a factor #358 must
+   measure on the real cohorts; a non-monotonic score-error relation could break
+   even the lower-bound direction, which is a further reason for the #358 check.
 3. **Pairwise agreement on the filtered cohort is likewise optimistic** to the
    extent a shared scene latent drives both the shared error and the joint
    admission: the shared cross-covariance retains as little as ~14% at 50% joint
@@ -241,13 +259,13 @@ manufacturing direction**:
    study must report this as a caveat, not fold the attenuated covariance into a
    sigma as if it were the population value.
 
-In one line: on the #225 cohorts the reliability gate can only make the
-agreement look *better* than it is, never worse -- the direction is provably
-one-signed (attenuation toward zero, and no manufactured coupling on independent
-pairs) -- so the per-technique and pairwise covariances it yields are lower
-bounds; the *size* of the attenuation is characterized by the survivorship grid
-but set by the real reliability-vs-error coupling, which the simulator cannot
-establish and #358 must measure.
+In one line: *under a separable, monotonic admission model* the reliability gate
+can only make the #225 agreement look better than it is, never worse -- one-signed
+attenuation toward zero, and no manufactured coupling on independent pairs -- so
+its per-technique and pairwise covariances are lower bounds; the *size* of the
+attenuation is characterized (not universally bounded) by the survivorship grid,
+and both the size and the validity of the separable/monotonic assumption itself
+are real-frame properties the simulator cannot establish and #358 must measure.
 
 ## Open questions
 

--- a/util/agreement/CAMPAIGN_20260721.md
+++ b/util/agreement/CAMPAIGN_20260721.md
@@ -1,0 +1,261 @@
+# Reliability-gate selection-effect campaign 20260721
+
+Tracked record of the seed-20260721 campaign that closes the third shared
+element of the bias-independence stage (issue #224 Stage 0b; the
+agreement-estimator validation stage of
+`plans/VALIDATION_AND_CALIBRATION_PLAN.md`): the feature **reliability
+gate**.  The first two shared elements (the gradient / edge-distance-transform
+products and the single noise-sigma estimate) were injected through in the
+seed-20260719 campaign (`CAMPAIGN_20260719.md`).  The gate was left there as an
+open question because it does not fit the bias channel the other two use.  This
+campaign resolves it.  Generated artifacts (row files, the generated report)
+live under `_work/agreement/` (gitignored); this file preserves the numbers and
+conclusions that outlive them.
+
+## The design problem: a filter is not a bias
+
+The estimator's bias-independence machinery injects a shared bias and checks
+that the solve detects the induced *offset* correlation.  That works for the
+gradient/DT products and the noise-sigma estimate because both **shift** a
+surviving technique's offset.  The reliability gate does not shift anything: it
+admits or drops a feature, and a technique whose feature survives produces
+exactly the offset it would have without the gate.  Verified directly this
+campaign -- across the injected passes, the maximum offset change of any
+surviving technique relative to its control-pass offset is **0.0 px** (the gate
+patch only moves features between the kept and dropped lists).
+
+So the gate's common-mode effect is not a bias at all.  It is a **selection
+effect**.  Every real agreement cohort is assembled *downstream* of this gate:
+a frame enters #225 only if the techniques it needs produced results, i.e. only
+if their features survived.  The covariances measured on such a cohort describe
+the survivor population, not the population -- and if survival correlates with
+error, the survivor covariances are a filtered, biased view.  The noise-sigma
+channel already exposed this class (it made the limb spurious on 153/400 scenes
+without coherently shifting offsets); the gate does it more directly, since
+dropping features is its entire job.
+
+## Chosen approach and why
+
+The issue named four candidate designs: (1) condition the solve on
+survivorship; (2) model the gate threshold explicitly; (3) compare recovered
+covariances across matched survivor / non-survivor strata; (4) measure coupling
+only within scenes where every technique survives at every injection level.
+
+This campaign takes **(3), the survivor-vs-full stratified comparison, as the
+measurement**, and adds a **survivorship model that bounds the effect** for the
+regime the sim cannot reach directly.  The reasons:
+
+- **(3) is a measurement; (1) and (2) are corrections.**  Conditioning the solve
+  on survivorship and modelling the threshold are ways to *undo* the selection
+  effect (a Heckman-style correction), which is a heavier commitment that needs a
+  defensible selection model and would collide with the estimator's
+  negative-variance rejection diagnostic.  The deliverable is to *quantify* the
+  effect, so the direct stratum comparison is the right instrument.  The
+  correction path is deferred to a tracking issue.
+- **(4) is the control, not the answer.**  Restricting to scenes where everyone
+  survives removes the selection effect by construction, so it cannot measure it;
+  it is the reference the stratum comparison is taken against.
+- The stratum comparison is **truth-based** and therefore exact on the axis the
+  simulator's word is final on (planted-truth recovery, per the capability
+  envelope in `docs/dev_guide/dev_guide_simulator.rst`): it states precisely how
+  much the act of gating changes a recovered covariance on these scenes.
+
+The stratum comparison is added to `analyze.py` (`--gate-rows`) and the gate
+injection to `collect.py` (`--injection reliability_gate`).  The
+survivorship-bound model is `selection.py`, validated by `tests/test_selection.py`.
+
+## What the gate does in the clean sim: a cliff, not a selector
+
+The stratified comparison needs a graded survivor stratum -- some scenes kept,
+some dropped, with survival correlated to error -- to show a nonzero selection
+effect.  The clean cohort does not provide one.  The load-bearing feature
+reliabilities are near-degenerate across scenes (measured over the
+`limb_disc_ring_diverse` family):
+
+| feature | gate threshold | reliability across the cohort |
+|---|---|---|
+| BODY_DISC | 0.30 | 1.000 (saturated, flat) |
+| RING_EDGE | 0.30 | 1.000 (saturated, flat) |
+| LIMB_ARC | 0.30 | 0.816-0.817 (flat, range 0.001) |
+| BODY_BLOB | 0.20 | 0.400 (flat) |
+
+Because each feature type's reliability is essentially constant across scenes,
+raising its threshold by a depression `d` drops **either every scene's feature
+or none** -- an all-or-nothing cliff at `d = reliability - threshold`, never a
+scene-selective filter.  The survival sweep confirms the cliffs (400 scenes per
+pass, seed 20260721; surviving-technique counts, dropout vs the control pass in
+parentheses):
+
+| depression | limb | disc | ring | blob | cliff crossed |
+|---|---|---|---|---|---|
+| +0.15 | 398 (0%) | 400 (0%) | 400 (0%) | 400 (0%) | none |
+| +0.25 | 398 (0%) | 400 (0%) | 400 (0%) | 0 (100%) | blob (reliability 0.400, threshold 0.20) |
+| +0.55 | 0 (100%) | 400 (0%) | 400 (0%) | 0 (100%) | blob and limb (limb reliability 0.817, threshold 0.30) |
+
+Every crossing is 0% or 100% -- no depression produces a partial (graded)
+dropout of any technique, because no technique's reliability varies enough
+across the cohort to split it.  (The control-pass limb count is 398 of 400:
+two scenes have a spurious or at-edge limb independent of the gate.)  The disc
+and ring never drop within the swept range; their cliffs sit at depression 0.70.
+
+There is therefore no graded survivor stratum for the load-bearing techniques in
+this regime: at every depression below a technique's cliff the survivor subset
+equals the full population, and above it the subset is empty.  The
+survivorship-stratified selection effect measured on the featured pass
+(depression +0.25, which clears the blob cliff and no other) is
+correspondingly a floor:
+
+| instance | n control | n survivor | dropout | covariance control -> survivor |
+|---|---|---|---|---|
+| blob | 400 | 0 | 100.0% | [+0.029 -0.004; -0.004 +0.040] -> n/a |
+| disc | 400 | 400 | 0.0% | [+0.0009 -0.0001; -0.0001 +0.0010] (unchanged) |
+| limb | 398 | 398 | 0.0% | [+1.714 -0.065; -0.065 +1.479] (unchanged) |
+| ring | 400 | 400 | 0.0% | s2 = 0.0035 (unchanged) |
+
+| pair | cross-cov full | cross-cov survivor | correlation full -> survivor |
+|---|---|---|---|
+| limb vs disc | -0.00248 | -0.00248 | -0.064 -> -0.064 |
+| limb vs ring | +0.00274 | +0.00274 | +0.036 -> +0.036 |
+| disc vs ring | -0.00003 | -0.00003 | -0.014 -> -0.014 |
+| limb vs blob | n/a (blob dropped) | n/a | n/a |
+
+The blob feature drops on every scene (its flat 0.400 reliability is below the
+0.20 + 0.25 elevated threshold); the load-bearing limb / disc / ring features
+drop on none, so their survivor stratum equals the full population and every
+recovered covariance -- marginal and pairwise -- is identical to control.  The
+in-sim selection effect on the load-bearing covariances is exactly zero, not
+because selection is harmless but because the clean cohort admits no graded
+selection.
+
+This is the honest in-sim result: the clean-scene reliability scores carry
+almost no per-scene information, so the gate cannot induce a correlated
+selection here.  It is exactly the configuration in which a direct injection
+*cannot* measure the real effect -- which is why the bound below, not the
+in-sim number, is the load-bearing product.
+
+## The bound: the survivorship model (`selection.py`)
+
+`selection.py` measures, on planted error arrays (truth-based, so exact), how
+survivorship distorts a covariance as a function of the survival fraction and of
+how the gate's admission depends on the scene.  Two mechanisms, each pinned by
+`tests/test_selection.py`:
+
+- **Separate per-technique gates do not manufacture cross-covariance.**  When two
+  techniques have independent errors and each is admitted by its *own* gate, the
+  joint-survival event factorizes across the two, so the survivor cross-covariance
+  stays at its population value (zero).  Measured at n = 400000, independent
+  errors: survivor cross-covariance stays within +/-0.003 of zero at every
+  survival fraction from 0.90 down to 0.25.  This matters because the real gate is
+  exactly this configuration -- each feature has its own per-type threshold -- so
+  the gate cannot invent a coupling between two genuinely independent techniques.
+- **What separate gating does do is attenuate each marginal variance, and a
+  shared scene latent attenuates the shared covariance.**  When survival tracks a
+  technique's own error, survivors are the low-error frames and the marginal
+  variance shrinks; when a common scene factor drives both the errors and the
+  admission, conditioning on survival truncates that factor's variance and pulls
+  the shared covariance toward zero.  The attenuation is always *toward zero* --
+  the gate can only make the covariances the solve ingests look smaller
+  (agreement look better), never larger.  (The cross-*correlation* coefficient
+  can rise as the marginals shrink faster than the covariance, but the estimator
+  consumes covariances, not correlations, so the one-signed conclusion holds for
+  what it actually solves.)
+
+Bound grid (n = 400000; ratios are survivor / full).  Each regime is quoted at
+its own population moments, because in the model the variance and covariance are
+locked (`cov = common_gain**2`, `var = common_gain**2 + 1`): a genuinely
+*independent*-error regime has population variance 1.0 and covariance 0.0, while
+a *shared-coupling* regime has population variance 2.0 and covariance 1.0.
+
+| gate regime | survival | marginal var ratio | cross-cov ratio |
+|---|---|---|---|
+| independent errors, self-gated (var 1.0, cov 0.0) | 0.90 | 0.75 | ~0 (stays 0) |
+| independent errors, self-gated (var 1.0, cov 0.0) | 0.75 | 0.55 | ~0 |
+| independent errors, self-gated (var 1.0, cov 0.0) | 0.50 | 0.32 | ~0 |
+| independent errors, self-gated (var 1.0, cov 0.0) | 0.25 | 0.14 | ~0 |
+| shared coupling, gated on the shared latent (var 2.0, cov 1.0) | 0.90 | 0.81 | 0.62 |
+| shared coupling, gated on the shared latent (var 2.0, cov 1.0) | 0.75 | 0.69 | 0.37 |
+| shared coupling, gated on the shared latent (var 2.0, cov 1.0) | 0.50 | 0.57 | 0.14 |
+| shared coupling, gated on the shared latent (var 2.0, cov 1.0) | 0.25 | 0.52 | 0.037 |
+| shared coupling, gated on both (var 2.0, cov 1.0) | 0.90 | 0.79 | 0.77 |
+| shared coupling, gated on both (var 2.0, cov 1.0) | 0.75 | 0.62 | 0.58 |
+| shared coupling, gated on both (var 2.0, cov 1.0) | 0.50 | 0.40 | 0.37 |
+| shared coupling, gated on both (var 2.0, cov 1.0) | 0.25 | 0.22 | 0.20 |
+
+Read the grid at a given survival fraction.  The cross-covariance is either left
+alone (independent errors -- the gate cannot invent a coupling) or attenuated
+toward zero (a shared latent driving admission retains only ~14% of the shared
+cross-covariance at 50% survival).  The marginal variance always attenuates when
+survival tracks the error, and *how much* depends on how much of the variance the
+gate's admission variable actually truncates: at 50% survival the retained
+marginal variance runs from ~0.32 (independent errors self-gated -- the gate
+truncates all of the variance) to ~0.57 (a shared latent gates only its own
+half of the variance), with the mixed case at ~0.40.  A separate check (not
+tabulated) confirms the benign direction of the no-manufacture result: when
+errors *are* coupled but admission is gated on each technique's own independent
+noise, the shared cross-covariance is left essentially unchanged (ratio ~1.0),
+neither manufactured nor attenuated.
+
+## What the sim cannot establish
+
+Per the capability envelope, planted-truth recovery is the axis on which the
+simulator's word is final; real-frame accuracy is not.  The bound above is exact
+*given the gate regime and survival fraction*.  The one input it cannot supply is
+the real one: how strongly a feature's reliability score tracks its technique's
+error on real photons, which sets where a real cohort sits between the
+"separate-gate" and "shared-latent" rows.  In the clean sim that coupling is
+near-zero by construction (reliability is flat), so the sim can bound the effect
+but cannot place a real cohort on the grid.  Measuring that coupling on the #225
+cohorts, and running the stratified estimator there against the fixed production
+gate, is filed as #358; whether a selection-aware correction is then warranted is
+#360.
+
+## Consequence for the #225 cohorts (the selection-effect statement)
+
+The reliability-gate selection effect on the agreement study's covariances is
+**bounded, one-signed, and (for the pairwise base pairs) provably absent from the
+manufacturing direction**:
+
+1. **The gate cannot manufacture cross-technique coupling.**  Each feature type
+   has its own per-type threshold, so two techniques with independent errors are
+   admitted by separate gates and their survivor cross-covariance stays at zero
+   (measured to within +/-0.003 at n = 400000, every survival fraction).  A
+   pairwise agreement that looks clean cannot be an artifact the gate invented;
+   the gate only ever *attenuates* an already-shared coupling.
+2. **Every per-technique sigma the study reports is a lower bound under
+   survivorship.**  Because survivors are the frames whose features passed, the
+   per-technique covariance measured on a cohort is attenuated *toward zero*
+   relative to the full population whenever admission tracks the technique's own
+   error.  The magnitude of that attenuation is set by how strongly reliability
+   tracks error -- a coupling the simulator cannot fix -- so the grid gives
+   representative, not universal, factors: at 50% survival the retained marginal
+   variance runs from ~0.32 (independent errors, admission gated on the whole
+   error) through ~0.40 (mixed) to ~0.57 (admission gated on only the shared
+   half of the variance), i.e. the population sigma is roughly 1.3x to 1.8x the
+   survivor sigma at that dropout; a stronger coupling attenuates more.  The
+   reported sigma is therefore optimistic by a factor that #358 must measure on
+   the real cohorts.
+3. **Pairwise agreement on the filtered cohort is likewise optimistic** to the
+   extent a shared scene latent drives both the shared error and the joint
+   admission: the shared cross-covariance retains as little as ~14% at 50% joint
+   survival in the worst (purely shared-latent) case in the grid.  The agreement
+   study must report this as a caveat, not fold the attenuated covariance into a
+   sigma as if it were the population value.
+
+In one line: on the #225 cohorts the reliability gate can only make the
+agreement look *better* than it is, never worse -- the direction is provably
+one-signed (attenuation toward zero, and no manufactured coupling on independent
+pairs) -- so the per-technique and pairwise covariances it yields are lower
+bounds; the *size* of the attenuation is characterized by the survivorship grid
+but set by the real reliability-vs-error coupling, which the simulator cannot
+establish and #358 must measure.
+
+## Open questions
+
+- **Real-cohort coupling and stratified measurement (#358).**  The sim bounds the
+  effect but cannot place a real cohort on the grid; #358 measures the
+  reliability-vs-error coupling and runs the stratified estimator on the real
+  #225 cohorts against the fixed production gate.
+- **Selection-aware correction (#360).**  Whether to correct (condition the solve
+  on survivorship / model the threshold) rather than only caveat, decided after
+  #358; deferred here because a correction needs a defensible selection model and
+  would collide with the negative-variance rejection diagnostic.

--- a/util/agreement/README.md
+++ b/util/agreement/README.md
@@ -68,12 +68,17 @@ preserves the numbers and conclusions that outlive them.
    gate never moves a surviving offset, so its common-mode effect is a
    selection on the cohort, not a bias; a covariance measured downstream
    of it describes the survivor population.  This module quantifies the
-   distortion on planted error arrays (truth-based, so exact): it makes
-   precise that separate per-technique gates on independent errors do
-   not manufacture cross-covariance (joint survival factorizes) and only
-   attenuate each marginal variance, while a shared scene latent driving
-   both error and admission attenuates the shared cross-covariance toward
-   zero.  Its `main` prints the bound grid the campaign record quotes:
+   distortion on planted error arrays (truth-based, so exact) *under a
+   separable, monotonic admission model*: under that structure separately
+   gated independent errors are not coupled by survival (joint survival
+   factorizes) and gating only attenuates each marginal variance, while a
+   shared scene latent driving both error and admission attenuates the
+   shared cross-covariance toward zero.  The grid is a scenario result
+   conditional on that model, not a universal real-cohort bound: per-type
+   thresholds make the gates separate functions but do not by themselves
+   establish separability in error space (the real score-error structure
+   is #358's to measure).  Its `main` prints the grid the campaign record
+   quotes:
 
    ```bash
    venv/bin/python util/agreement/selection.py --n 200000

--- a/util/agreement/README.md
+++ b/util/agreement/README.md
@@ -46,11 +46,15 @@ preserves the numbers and conclusions that outlive them.
    ```
 
    `--injection dt_shift` re-runs with the shared gradient / edge-DT
-   products translated by a per-scene random bias, and
+   products translated by a per-scene random bias,
    `--injection noise_scale` with the shared noise-sigma estimate
-   scaled — both as harness-level monkeypatches of the orchestrator
-   module (no production seam).  Injected values are drawn from the
-   campaign seed and recorded per row.
+   scaled, and `--injection reliability_gate` with every per-type
+   reliability threshold raised by `--gate-depression` — all as
+   harness-level monkeypatches of the orchestrator module (no
+   production seam).  The first two shift a surviving technique's
+   offset; the gate only admits or drops, so it is the pure selection
+   channel (a surviving technique's offset is byte-identical to the
+   control pass).  Injected values are recorded per row.
 
    ```bash
    venv/bin/python util/agreement/collect.py \
@@ -59,33 +63,54 @@ preserves the numbers and conclusions that outlive them.
        --out _work/agreement/rows_dt.jsonl
    ```
 
-4. **`analyze.py`** — produces the Markdown report: per composition, the
+4. **`selection.py`** — the survivorship (selection-effect) model for a
+   shared layer that *filters* rather than *shifts*.  The reliability
+   gate never moves a surviving offset, so its common-mode effect is a
+   selection on the cohort, not a bias; a covariance measured downstream
+   of it describes the survivor population.  This module quantifies the
+   distortion on planted error arrays (truth-based, so exact): it makes
+   precise that separate per-technique gates on independent errors do
+   not manufacture cross-covariance (joint survival factorizes) and only
+   attenuate each marginal variance, while a shared scene latent driving
+   both error and admission attenuates the shared cross-covariance toward
+   zero.  Its `main` prints the bound grid the campaign record quotes:
+
+   ```bash
+   venv/bin/python util/agreement/selection.py --n 200000
+   ```
+
+5. **`analyze.py`** — produces the Markdown report: per composition, the
    truth-free solve next to the truth-based reference (empirical error
    covariance against planted offsets), the null-space demonstration for
    degenerate compositions, and — when injected row files are supplied —
    the bias-independence tables (truth-based pair coupling per
    condition, paired per-scene injection response, solve-side detection
-   with a declared pair covariance).
+   with a declared pair covariance).  `--gate-rows` adds the
+   survivorship-stratified selection-effect table (full population vs
+   survivor subset), the procedure the agreement study runs on its own
+   real cohorts.
 
    ```bash
    venv/bin/python util/agreement/analyze.py _work/agreement/rows.jsonl \
        --dt-rows _work/agreement/rows_dt.jsonl \
        --noise-rows _work/agreement/rows_noise.jsonl \
+       --gate-rows _work/agreement/rows_gate.jsonl \
        --out _work/agreement/report.md
    ```
 
-5. **`tests/`** — pytest suite for the estimator (synthetic-Gaussian
-   recovery and degeneracy demonstrations for every composition regime)
-   and the scene generator (determinism, schema validity, geometry
-   invariants).  `util/` is outside the repo's CI pytest/ruff/mypy
-   scope; run them directly:
+6. **`tests/`** — pytest suite for the estimator (synthetic-Gaussian
+   recovery and degeneracy demonstrations for every composition regime),
+   the scene generator (determinism, schema validity, geometry
+   invariants), and the selection model (the factorization and
+   attenuation facts above).  `util/` is outside the repo's CI
+   pytest/ruff/mypy scope; run them directly:
 
    ```bash
    venv/bin/python -m pytest util/agreement/tests -q
    ruff check util/agreement && ruff format --check util/agreement
    MYPYPATH=src mypy --strict util/agreement/estimator.py \
        util/agreement/scene_gen.py util/agreement/analyze.py \
-       util/agreement/collect.py
+       util/agreement/collect.py util/agreement/selection.py
    ```
 
 ## Reading the estimator output
@@ -135,3 +160,13 @@ preserves the numbers and conclusions that outlive them.
   measured per-technique covariances are near-floor values specific to
   this validation cohort — inputs for checking the solve, not shippable
   technique accuracy numbers.
+- **Selection effect is bounded, not measured, in-sim.**  The gate's
+  distortion of a covariance depends on how strongly feature reliability
+  tracks technique error.  In the clean cohort the load-bearing feature
+  reliabilities are near-degenerate across scenes, so the gate acts as an
+  all-or-nothing cliff rather than a scene-selective filter, and the
+  direct in-sim selection effect on the load-bearing covariances is a
+  floor value.  The `selection.py` model supplies the bound for the
+  error-correlated case the real cohorts may sit in; the actual coupling
+  strength is a property of the real reliability scores, outside the
+  simulator's envelope.

--- a/util/agreement/analyze.py
+++ b/util/agreement/analyze.py
@@ -94,12 +94,51 @@ def _instance_offsets(row: dict[str, Any]) -> dict[str, tuple[float, float]]:
     return offsets
 
 
-def build_cohort(rows: list[dict[str, Any]], family: str) -> list[CohortFrame]:
-    """Assemble estimator frames for one family's rows.
+def _frame_from_row(
+    row: dict[str, Any], offsets: dict[str, tuple[float, float]]
+) -> CohortFrame | None:
+    """Build one cohort frame from a row and a chosen instance-offset set.
 
     Ring instances take their per-frame radial axis, and the clipped-limb
     families take the limb's rotating basis angle, from the row geometry
-    (derived from the idealized scene parameters, not truth keys).
+    (derived from the idealized scene parameters, not truth keys).  The
+    ``offsets`` argument lets a caller substitute a filtered or alternate-source
+    offset set (e.g. control-pass offsets under a gate survival mask) while
+    keeping the row's geometry and planted truth.
+
+    Parameters:
+        row: One collection row (supplies geometry and planted truth).
+        offsets: The per-instance offsets to place on the frame.
+
+    Returns:
+        The cohort frame, or ``None`` when fewer than two instances are given.
+    """
+    if len(offsets) < 2:
+        return None
+    geometry = row['geometry']
+    basis: dict[str, float] = {}
+    axis: dict[str, float] = {}
+    if 'ring_radial_deg' in geometry and 'ring' in offsets:
+        axis['ring'] = math.radians(float(geometry['ring_radial_deg']))
+    if 'limb_arc_outward_deg' in geometry:
+        # The arc direction is the rotating basis for every technique
+        # navigating the clipped body: the limb (anisotropic covariance)
+        # and the disc (its inward pull toward the body center is a
+        # geometry-locked bias the solve's rotating mean columns must
+        # be able to absorb).
+        arc = math.radians(float(geometry['limb_arc_outward_deg']))
+        for name in ('limb', 'disc'):
+            if name in offsets:
+                basis[name] = arc
+    return CohortFrame(
+        scene_id=row['scene_id'],
+        sample=FrameSample(offsets=offsets, basis_angle_rad=basis, axis_angle_rad=axis),
+        truth=(float(row['planted']['dv']), float(row['planted']['du'])),
+    )
+
+
+def build_cohort(rows: list[dict[str, Any]], family: str) -> list[CohortFrame]:
+    """Assemble estimator frames for one family's rows.
 
     Parameters:
         rows: All rows from a collection pass.
@@ -113,31 +152,51 @@ def build_cohort(rows: list[dict[str, Any]], family: str) -> list[CohortFrame]:
     for row in rows:
         if row['family'] != family or 'error' in row:
             continue
-        offsets = _instance_offsets(row)
-        if len(offsets) < 2:
+        frame = _frame_from_row(row, _instance_offsets(row))
+        if frame is not None:
+            frames.append(frame)
+    return frames
+
+
+def build_survivor_cohort(
+    control: list[dict[str, Any]], gate: list[dict[str, Any]], family: str
+) -> list[CohortFrame]:
+    """Control-offset cohort masked to the instances that survived the gate.
+
+    Survivorship membership comes from the gate pass (which instances still
+    produced a result on each scene), but the offset *values* come from the
+    matched control row.  This isolates the selection effect from any offset
+    change: even if a future gate perturbation shifted a surviving offset,
+    the comparison would still measure only which scenes and instances the
+    gate removed, never an offset difference.  (The reliability_gate channel
+    is a pure selection channel -- surviving offsets are byte-identical to
+    control -- so on these rows the result equals ``build_cohort(gate, ...)``;
+    the substitution is a hardening, not a correction.)
+
+    Parameters:
+        control: Control (no-injection) rows.
+        gate: Reliability-gate injection rows (survivor membership).
+        family: Family to select.
+
+    Returns:
+        The survivor cohort frames, control offsets under the gate mask.
+    """
+    survivors = {
+        row['scene_id']: set(_instance_offsets(row))
+        for row in gate
+        if row['family'] == family and 'error' not in row
+    }
+    frames: list[CohortFrame] = []
+    for row in control:
+        if row['family'] != family or 'error' in row:
             continue
-        geometry = row['geometry']
-        basis: dict[str, float] = {}
-        axis: dict[str, float] = {}
-        if 'ring_radial_deg' in geometry and 'ring' in offsets:
-            axis['ring'] = math.radians(float(geometry['ring_radial_deg']))
-        if 'limb_arc_outward_deg' in geometry:
-            # The arc direction is the rotating basis for every technique
-            # navigating the clipped body: the limb (anisotropic covariance)
-            # and the disc (its inward pull toward the body center is a
-            # geometry-locked bias the solve's rotating mean columns must
-            # be able to absorb).
-            arc = math.radians(float(geometry['limb_arc_outward_deg']))
-            for name in ('limb', 'disc'):
-                if name in offsets:
-                    basis[name] = arc
-        frames.append(
-            CohortFrame(
-                scene_id=row['scene_id'],
-                sample=FrameSample(offsets=offsets, basis_angle_rad=basis, axis_angle_rad=axis),
-                truth=(float(row['planted']['dv']), float(row['planted']['du'])),
-            )
-        )
+        kept = survivors.get(row['scene_id'])
+        if kept is None:
+            continue
+        offsets = {name: off for name, off in _instance_offsets(row).items() if name in kept}
+        frame = _frame_from_row(row, offsets)
+        if frame is not None:
+            frames.append(frame)
     return frames
 
 
@@ -502,7 +561,15 @@ def report_noise_response(
 
 
 def _survival_counts(rows: list[dict[str, Any]], family: str) -> dict[str, int]:
-    """Per-instance count of scenes on which the instance produced a result."""
+    """Per-instance count of scenes on which the instance produced a result.
+
+    Parameters:
+        rows: All rows from a collection pass.
+        family: Family to select.
+
+    Returns:
+        Mapping of instance name to the number of scenes it survived on.
+    """
     counts: dict[str, int] = {}
     for row in rows:
         if row['family'] != family or 'error' in row:
@@ -521,23 +588,24 @@ def report_selection_effect(
 ) -> None:
     """Survivorship-stratified truth comparison for the reliability-gate channel.
 
-    The gate only admits or drops features, so a surviving technique's offset
-    equals its control offset exactly; the selection effect is therefore the
-    difference between the truth-based covariance on the full (control)
-    population and on the survivor subset (the scenes the gate keeps).  This
-    is the procedure the agreement study must run on its own real cohorts,
-    where feature reliability is not degenerate; on these clean scenes it
-    reports the in-sim floor.
+    The selection effect is the difference between the truth-based covariance on
+    the full (control) population and on the survivor subset (the scenes and
+    instances the gate keeps).  Survivor membership comes from the gate pass but
+    the offset values come from the matched control rows (see
+    :func:`build_survivor_cohort`), so the comparison isolates selection from any
+    offset change.  This is the procedure the agreement study must run on its own
+    real cohorts, where feature reliability is not degenerate; on these clean
+    scenes it reports the in-sim floor.
 
     Parameters:
         out: Markdown accumulator.
         control: Control (no-injection) rows.
-        gate: Reliability-gate injection rows (survivor subset).
+        gate: Reliability-gate injection rows (survivor membership).
         family: Family to compare on.
         depression: Threshold depression the gate pass used.
     """
     full_cohort = build_cohort(control, family)
-    survivor_cohort = build_cohort(gate, family)
+    survivor_cohort = build_survivor_cohort(control, gate, family)
     ctrl_counts = _survival_counts(control, family)
     gate_counts = _survival_counts(gate, family)
     out.append(f'Threshold depression: +{depression:.3f} on every per-type reliability gate.')
@@ -734,6 +802,21 @@ def main(argv: list[str] | None = None) -> int:
 
         if args.gate_rows is not None:
             gate_manifest, gate_rows = load_rows(args.gate_rows)
+            gate_kind = gate_manifest.get('injection')
+            if gate_kind != 'reliability_gate':
+                raise ValueError(
+                    f'--gate-rows manifest injection is {gate_kind!r}, expected '
+                    "'reliability_gate'; the selection-effect comparison is only "
+                    'valid for a reliability_gate pass'
+                )
+            gate_seed = gate_manifest.get('campaign_seed')
+            ctrl_seed = manifest.get('campaign_seed')
+            if gate_seed != ctrl_seed:
+                raise ValueError(
+                    f'--gate-rows campaign_seed {gate_seed!r} does not match the '
+                    f'control seed {ctrl_seed!r}; the passes must share scenes to '
+                    'pair by scene id'
+                )
             out.append(f'### Injection: reliability_gate (`{args.gate_rows}`)')
             out.append('')
             out.append(

--- a/util/agreement/analyze.py
+++ b/util/agreement/analyze.py
@@ -501,6 +501,86 @@ def report_noise_response(
     out.append('')
 
 
+def _survival_counts(rows: list[dict[str, Any]], family: str) -> dict[str, int]:
+    """Per-instance count of scenes on which the instance produced a result."""
+    counts: dict[str, int] = {}
+    for row in rows:
+        if row['family'] != family or 'error' in row:
+            continue
+        for name in _instance_offsets(row):
+            counts[name] = counts.get(name, 0) + 1
+    return counts
+
+
+def report_selection_effect(
+    out: list[str],
+    control: list[dict[str, Any]],
+    gate: list[dict[str, Any]],
+    family: str,
+    depression: float,
+) -> None:
+    """Survivorship-stratified truth comparison for the reliability-gate channel.
+
+    The gate only admits or drops features, so a surviving technique's offset
+    equals its control offset exactly; the selection effect is therefore the
+    difference between the truth-based covariance on the full (control)
+    population and on the survivor subset (the scenes the gate keeps).  This
+    is the procedure the agreement study must run on its own real cohorts,
+    where feature reliability is not degenerate; on these clean scenes it
+    reports the in-sim floor.
+
+    Parameters:
+        out: Markdown accumulator.
+        control: Control (no-injection) rows.
+        gate: Reliability-gate injection rows (survivor subset).
+        family: Family to compare on.
+        depression: Threshold depression the gate pass used.
+    """
+    full_cohort = build_cohort(control, family)
+    survivor_cohort = build_cohort(gate, family)
+    ctrl_counts = _survival_counts(control, family)
+    gate_counts = _survival_counts(gate, family)
+    out.append(f'Threshold depression: +{depression:.3f} on every per-type reliability gate.')
+    out.append('')
+    out.append('Per-instance survival (control -> gate) and marginal covariance shift:')
+    out.append('')
+    out.append('| instance | n control | n survivor | dropout | cov control -> survivor |')
+    out.append('|---|---|---|---|---|')
+    instances = sorted(set(ctrl_counts) | set(gate_counts))
+    for name in instances:
+        n_ctrl = ctrl_counts.get(name, 0)
+        n_surv = gate_counts.get(name, 0)
+        dropout = 1.0 - (n_surv / n_ctrl) if n_ctrl else 0.0
+        if name == 'ring':
+            full_radial = truth_radial_variance(full_cohort, name)
+            surv_radial = truth_radial_variance(survivor_cohort, name)
+            full_str = f's2={full_radial[1]:.4f}' if full_radial else 'n/a'
+            surv_str = f's2={surv_radial[1]:.4f}' if surv_radial else 'n/a'
+        else:
+            full_cov = truth_covariance(full_cohort, name)
+            surv_cov = truth_covariance(survivor_cohort, name)
+            full_str = _fmt_matrix(full_cov[1]) if full_cov else 'n/a'
+            surv_str = _fmt_matrix(surv_cov[1]) if surv_cov else 'n/a'
+        out.append(f'| {name} | {n_ctrl} | {n_surv} | {dropout:.1%} | {full_str} -> {surv_str} |')
+    out.append('')
+    pivotal = [('limb', 'disc'), ('limb', 'ring'), ('disc', 'ring'), ('limb', 'blob')]
+    out.append('Pairwise cross-covariance, full population -> survivor subset:')
+    out.append('')
+    out.append('| pair | cov full | cov survivor | corr full -> survivor |')
+    out.append('|---|---|---|---|')
+    for a, b in pivotal:
+        full_pair = truth_cross_covariance(full_cohort, a, b)
+        surv_pair = truth_cross_covariance(survivor_cohort, a, b)
+        if full_pair is None or surv_pair is None:
+            out.append(f'| {a} vs {b} | n/a | n/a | n/a |')
+            continue
+        out.append(
+            f'| {a} vs {b} | {full_pair[0]:+.5f} | {surv_pair[0]:+.5f} '
+            f'| {full_pair[1]:+.3f} -> {surv_pair[1]:+.3f} |'
+        )
+    out.append('')
+
+
 def _specs_for_family(
     family: str,
 ) -> list[tuple[list[EstimatorSpec], list[tuple[str, str]]]]:
@@ -550,6 +630,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument('rows', type=Path, help='control (no-injection) rows file')
     parser.add_argument('--dt-rows', type=Path, default=None)
     parser.add_argument('--noise-rows', type=Path, default=None)
+    parser.add_argument('--gate-rows', type=Path, default=None)
     parser.add_argument('--out', type=Path, default=None)
     args = parser.parse_args(argv)
 
@@ -595,7 +676,7 @@ def main(argv: list[str] | None = None) -> int:
         pairs = [(a, b) for i, a in enumerate(all_instances) for b in all_instances[i + 1 :]]
         report_pair_truth(out, cohort, pairs, f'{family}: truth-based pair coupling (no injection)')
 
-    if args.dt_rows is not None or args.noise_rows is not None:
+    if args.dt_rows is not None or args.noise_rows is not None or args.gate_rows is not None:
         out.append('## Stage 0b: bias independence through the shared layer')
         out.append('')
         family = 'limb_disc_ring_diverse'
@@ -650,6 +731,26 @@ def main(argv: list[str] | None = None) -> int:
                     pair_covariances=[('limb', 'ring')],
                 )
                 report_truth_reference(out, usable, specs)
+
+        if args.gate_rows is not None:
+            gate_manifest, gate_rows = load_rows(args.gate_rows)
+            out.append(f'### Injection: reliability_gate (`{args.gate_rows}`)')
+            out.append('')
+            out.append(
+                'The reliability gate filters rather than shifts: it admits or '
+                'drops features, never moving a surviving technique offset. Its '
+                'common-mode effect is a survivorship selection on the cohort, '
+                'measured by comparing the truth-based covariance on the full '
+                'population against the survivor subset.'
+            )
+            out.append('')
+            report_selection_effect(
+                out,
+                rows,
+                gate_rows,
+                family,
+                float(gate_manifest.get('gate_depression', 0.0)),
+            )
 
     text = '\n'.join(out) + '\n'
     if args.out is not None:

--- a/util/agreement/collect.py
+++ b/util/agreement/collect.py
@@ -16,7 +16,16 @@ Shared-bias injection (the bias-independence stage) is harness-level only:
 gradient / edge-distance-transform products translated by a per-scene
 random bias, and ``--injection noise_scale`` monkeypatches
 ``estimate_image_noise_sigma`` to scale the single shared noise estimate.
-Nothing under ``src/`` changes; the injected values are recorded per row.
+``--injection reliability_gate`` is the third shared element: it
+monkeypatches ``FeatureReliabilityGate.apply`` to tighten every per-type
+threshold by a fixed depression (``--gate-depression``), so more features
+are dropped and whole techniques stop reporting on the lower-reliability
+scenes.  Unlike the other two channels the gate never shifts a surviving
+technique's offset -- it only admits or drops -- so it is the pure
+*selection* channel: pairing a gate pass with the control pass by scene id
+recovers, for every scene, both the technique's true (unperturbed) error
+and whether it survived.  Nothing under ``src/`` changes; the injected
+values are recorded per row.
 
 Run (from an activated project venv; ``source /seti/newnav/setup.sh``):
 
@@ -49,7 +58,7 @@ from scene_gen import FAMILIES, generate_scenes  # noqa: E402
 DEFAULT_SEED = 20260719
 DEFAULT_OUT = REPO / '_work/agreement/rows.jsonl'
 
-INJECTION_KINDS = ('none', 'dt_shift', 'noise_scale')
+INJECTION_KINDS = ('none', 'dt_shift', 'noise_scale', 'reliability_gate')
 
 
 def _runs_for_family(family: str) -> list[dict[str, Any]]:
@@ -75,7 +84,9 @@ def _runs_for_family(family: str) -> list[dict[str, Any]]:
     return runs
 
 
-def _draw_injection(kind: str, scene_id: str, seed: int, sigma_px: float) -> dict[str, Any]:
+def _draw_injection(
+    kind: str, scene_id: str, seed: int, sigma_px: float, gate_depression: float
+) -> dict[str, Any]:
     """Draw the per-scene injection values (recorded in the row).
 
     Parameters:
@@ -83,12 +94,18 @@ def _draw_injection(kind: str, scene_id: str, seed: int, sigma_px: float) -> dic
         scene_id: Scene identifier (part of the draw key).
         seed: Campaign seed (part of the draw key).
         sigma_px: Per-axis standard deviation of the dt_shift bias draw.
+        gate_depression: Fixed amount every reliability threshold is raised
+            by in the ``reliability_gate`` channel (constant across the
+            pass, so the per-scene dropout is set by the scene's own feature
+            reliabilities rather than a per-scene draw).
 
     Returns:
         Dict describing the injection (``{'kind': 'none'}`` when disabled).
     """
     if kind == 'none':
         return {'kind': 'none'}
+    if kind == 'reliability_gate':
+        return {'kind': 'reliability_gate', 'depression': gate_depression}
     rng = random.Random(f'{seed}/{scene_id}/inject')
     if kind == 'dt_shift':
         return {
@@ -156,6 +173,34 @@ def _apply_injection(injection: dict[str, Any]) -> list[tuple[Any, str, Any]]:
 
         patched.append((orch_mod, 'estimate_image_noise_sigma', real_noise))
         orch_mod.estimate_image_noise_sigma = injected_noise  # type: ignore[attr-defined,assignment]
+    elif injection['kind'] == 'reliability_gate':
+        from spindoctor.feature.reliability import FeatureReliabilityGate, GatedFeatureRecord
+
+        depression = float(injection['depression'])
+        real_apply = FeatureReliabilityGate.apply
+
+        def injected_apply(self: Any, features: list[Any]) -> tuple[list[Any], list[Any]]:
+            # Reproduce the real gate logic with every threshold raised by
+            # ``depression``; at depression 0 this is byte-for-byte the
+            # production admission rule.  Dropping features is all the gate
+            # does, so a surviving technique's offset is unchanged.
+            kept: list[Any] = []
+            gated: list[Any] = []
+            for feature in features:
+                threshold = self.thresholds.get(feature.feature_type, 0.0) + depression
+                if feature.reliability < threshold:
+                    gated.append(
+                        GatedFeatureRecord(
+                            feature=feature,
+                            reason=f'reliability_gate_injection_depression_{depression:.3f}',
+                        )
+                    )
+                else:
+                    kept.append(feature)
+            return kept, gated
+
+        patched.append((FeatureReliabilityGate, 'apply', real_apply))
+        FeatureReliabilityGate.apply = injected_apply  # type: ignore[method-assign]
     return patched
 
 
@@ -261,6 +306,12 @@ def main(argv: list[str] | None = None) -> int:
         default=0.7,
         help='per-axis sigma of the dt_shift bias draw',
     )
+    parser.add_argument(
+        '--gate-depression',
+        type=float,
+        default=0.15,
+        help='amount every reliability threshold is raised in the reliability_gate channel',
+    )
     parser.add_argument('--out', type=Path, default=DEFAULT_OUT)
     args = parser.parse_args(argv)
 
@@ -271,7 +322,11 @@ def main(argv: list[str] | None = None) -> int:
             family, args.per_family, campaign_seed=args.seed
         ):
             injection = _draw_injection(
-                args.injection, scene_id, args.seed, args.injection_sigma_px
+                args.injection,
+                scene_id,
+                args.seed,
+                args.injection_sigma_px,
+                args.gate_depression,
             )
             tasks.append((scene_id, family, sim_params, geometry, injection))
 
@@ -289,6 +344,7 @@ def main(argv: list[str] | None = None) -> int:
                     'families': families,
                     'injection': args.injection,
                     'injection_sigma_px': args.injection_sigma_px,
+                    'gate_depression': args.gate_depression,
                     'n_scenes': len(tasks),
                 }
             )

--- a/util/agreement/collect.py
+++ b/util/agreement/collect.py
@@ -315,6 +315,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument('--out', type=Path, default=DEFAULT_OUT)
     args = parser.parse_args(argv)
 
+    if not math.isfinite(args.gate_depression) or args.gate_depression < 0.0:
+        parser.error('--gate-depression must be a non-negative finite number')
+
     families = [f.strip() for f in args.families.split(',') if f.strip()]
     tasks = []
     for family in families:

--- a/util/agreement/selection.py
+++ b/util/agreement/selection.py
@@ -1,0 +1,273 @@
+"""Survivorship (selection-effect) model for a filtering shared layer.
+
+The reliability gate differs in kind from the gradient / edge-distance-transform
+and noise-sigma channels the bias-independence stage injects through: those
+*shift* a surviving technique's offset, so their coupling is an offset
+regression.  The gate only *admits or drops* a feature -- a surviving
+technique's offset is unchanged -- so its common-mode effect is a **selection
+effect**, not a bias.  A cohort assembled downstream of the gate (every real
+agreement cohort is) is the set of scenes whose techniques survived, and the
+covariances measured on it describe that survivor population rather than the
+whole population.
+
+This module is the truth-based instrument for that effect.  It works on planted
+error arrays (never on real frames), so every number it returns is an exact
+statement about how survivorship distorts a covariance -- the axis on which the
+simulator's word is final.  Two facts it makes precise:
+
+- **Separate per-technique gates do not manufacture cross-covariance.**  When
+  two techniques have independent errors and each is admitted by its own gate,
+  the joint-survival event factorizes across the two, so the survivor
+  cross-covariance stays at its (zero) population value.  What separate gating
+  *does* do is attenuate each technique's *marginal* covariance when survival
+  tracks that technique's own error -- survivors are the low-error frames, so a
+  per-technique sigma measured on survivors understates the population sigma.
+- **A shared scene latent is the only channel that distorts the pairwise
+  covariance.**  When a common scene-quality factor drives both techniques'
+  errors *and* their admission, conditioning on survival truncates that
+  latent's variance and so attenuates the shared (cross) covariance toward zero.
+
+The model plants ``e_i = common_gain * q + eps_i`` with a shared scene latent
+``q`` and independent per-technique noise ``eps_i``, then admits a scene when
+both techniques' "badness" (a weighted sum of the shared-latent and own-error
+magnitudes) is small enough to hit a target survival fraction.  Sweeping the
+gate weights and the survival fraction bounds the distortion: at a given real
+per-technique dropout fraction and a given strength of the reliability-vs-error
+coupling, the induced change in any recovered covariance element is at most what
+this model reports.  What the model cannot supply -- the actual strength of that
+coupling on real frames -- is a property of the real reliability scores, outside
+the simulator's envelope.
+
+All statistics are per-axis scalars (variance and covariance along one image
+axis): the agreement solve reduces every rank-1 (ring) pair to a per-axis
+projection, and the per-axis form is where the bound is cleanest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+__all__ = [
+    'SelectionTrial',
+    'StratumStats',
+    'stratum_stats',
+    'synthetic_selection_trial',
+]
+
+
+@dataclass(frozen=True)
+class StratumStats:
+    """Per-axis second moments of one stratum's two error series.
+
+    Parameters:
+        n: Number of samples in the stratum.
+        var_a: Variance of instance A's error.
+        var_b: Variance of instance B's error.
+        cov_ab: Cross-covariance of the two errors.
+        corr_ab: Cross-correlation (``0`` when either variance is zero).
+    """
+
+    n: int
+    var_a: float
+    var_b: float
+    cov_ab: float
+    corr_ab: float
+
+
+@dataclass(frozen=True)
+class SelectionTrial:
+    """Full-population vs survivor statistics for one synthetic trial.
+
+    Parameters:
+        keep_frac_target: Requested scene survival fraction.
+        keep_frac_actual: Achieved survival fraction (both techniques kept).
+        full: Statistics over every planted scene.
+        survivor: Statistics over the survivor stratum only.
+    """
+
+    keep_frac_target: float
+    keep_frac_actual: float
+    full: StratumStats
+    survivor: StratumStats
+
+
+def stratum_stats(err_a: NDArray[np.float64], err_b: NDArray[np.float64]) -> StratumStats:
+    """Second moments of a paired error stratum.
+
+    Parameters:
+        err_a: Instance A errors (1-D).
+        err_b: Instance B errors (1-D), aligned with ``err_a``.
+
+    Returns:
+        The stratum statistics.  Variances and covariance use ``ddof=1``;
+        below two samples they are reported as zero.
+
+    Raises:
+        ValueError: if the two arrays differ in length.
+    """
+    if err_a.shape != err_b.shape:
+        raise ValueError(f'err_a and err_b must align; got {err_a.shape} and {err_b.shape}')
+    n = int(err_a.shape[0])
+    if n < 2:
+        return StratumStats(n=n, var_a=0.0, var_b=0.0, cov_ab=0.0, corr_ab=0.0)
+    var_a = float(np.var(err_a, ddof=1))
+    var_b = float(np.var(err_b, ddof=1))
+    cov_ab = float(np.cov(err_a, err_b, ddof=1)[0, 1])
+    denom = math.sqrt(var_a * var_b) if var_a > 0.0 and var_b > 0.0 else 0.0
+    corr_ab = cov_ab / denom if denom > 0.0 else 0.0
+    return StratumStats(n=n, var_a=var_a, var_b=var_b, cov_ab=cov_ab, corr_ab=corr_ab)
+
+
+def _threshold_for_keep(
+    badness_a: NDArray[np.float64], badness_b: NDArray[np.float64], keep_frac: float
+) -> float:
+    """Bisection for the badness cutoff that admits ``keep_frac`` of scenes.
+
+    A scene is admitted when both techniques' badness is at or below the
+    returned cutoff; badness is admitted-low, so the kept fraction rises
+    monotonically with the cutoff.
+
+    Parameters:
+        badness_a: Instance A per-scene badness (admitted when low).
+        badness_b: Instance B per-scene badness.
+        keep_frac: Target joint survival fraction in (0, 1).
+
+    Returns:
+        The cutoff value.
+    """
+    lo = 0.0
+    hi = float(max(badness_a.max(), badness_b.max()))
+    for _ in range(60):
+        mid = 0.5 * (lo + hi)
+        kept = float(np.mean((badness_a <= mid) & (badness_b <= mid)))
+        if kept < keep_frac:
+            lo = mid
+        else:
+            hi = mid
+    return 0.5 * (lo + hi)
+
+
+def synthetic_selection_trial(
+    rng: np.random.Generator,
+    n: int,
+    *,
+    common_gain: float,
+    common_gate: float,
+    self_gate: float,
+    keep_frac: float,
+) -> SelectionTrial:
+    """Plant paired errors, admit a survivor stratum, return both strata's moments.
+
+    The two techniques share a scene latent ``q ~ N(0, 1)`` scaled by
+    ``common_gain`` (the only source of population cross-covariance) plus
+    independent unit noise.  A scene's per-technique badness is
+    ``common_gate * q**2 + self_gate * eps_i**2`` -- large when the shared
+    latent is unfavorable (common-mode admission pressure) or when the
+    technique's own error is large (self-selection).  A scene survives when
+    both techniques' badness clears the cutoff chosen to hit ``keep_frac``.
+
+    Parameters:
+        rng: Seeded generator (determinism is the caller's).
+        n: Number of planted scenes.
+        common_gain: Shared-latent gain into each error (sets population
+            cross-covariance ``common_gain**2``).
+        common_gate: Weight of the shared latent in the admission badness
+            (the channel that attenuates the shared covariance).
+        self_gate: Weight of each technique's own error in its admission
+            badness (the channel that attenuates the marginal variance).
+        keep_frac: Target scene survival fraction in (0, 1).
+
+    Returns:
+        The trial's full-population and survivor statistics.
+
+    Raises:
+        ValueError: if ``n`` is below 2 or ``keep_frac`` is not in (0, 1).
+    """
+    if n < 2:
+        raise ValueError(f'n must be at least 2; got {n}')
+    if not 0.0 < keep_frac < 1.0:
+        raise ValueError(f'keep_frac must lie in (0, 1); got {keep_frac}')
+    q = rng.standard_normal(n)
+    eps_a = rng.standard_normal(n)
+    eps_b = rng.standard_normal(n)
+    err_a = common_gain * q + eps_a
+    err_b = common_gain * q + eps_b
+    badness_a = common_gate * q**2 + self_gate * eps_a**2
+    badness_b = common_gate * q**2 + self_gate * eps_b**2
+    cutoff = _threshold_for_keep(badness_a, badness_b, keep_frac)
+    survive = (badness_a <= cutoff) & (badness_b <= cutoff)
+    full = stratum_stats(err_a, err_b)
+    survivor = stratum_stats(err_a[survive], err_b[survive])
+    return SelectionTrial(
+        keep_frac_target=keep_frac,
+        keep_frac_actual=float(np.mean(survive)),
+        full=full,
+        survivor=survivor,
+    )
+
+
+def _fmt(stats: StratumStats) -> str:
+    """One-line rendering of a stratum's moments."""
+    return (
+        f'n={stats.n:5d} var_a={stats.var_a:6.3f} var_b={stats.var_b:6.3f} '
+        f'cov={stats.cov_ab:+.3f} corr={stats.corr_ab:+.3f}'
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Print the selection-effect bound grid for a range of gate strengths.
+
+    Sweeps the survival fraction and the two gate channels and reports, for
+    each cell, the survivor-vs-full change in the marginal variance and the
+    cross-covariance -- the bound the campaign record quotes.
+    """
+    parser = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+    parser.add_argument('--n', type=int, default=200000)
+    parser.add_argument('--seed', type=int, default=20260721)
+    parser.add_argument(
+        '--common-gain',
+        type=float,
+        default=1.0,
+        help='shared-latent gain (population cross-covariance is its square)',
+    )
+    args = parser.parse_args(argv)
+    rng = np.random.default_rng(args.seed)
+    print(f'# Selection-effect bound grid (n={args.n}, common_gain={args.common_gain})')
+    print('# marginal attenuation = survivor var_a / full var_a;')
+    print('# cross attenuation     = survivor cov / full cov.')
+    print('# Read each regime at the right common_gain: the no-manufacture result')
+    print('# (independent errors -> survivor cov stays 0) needs --common-gain 0.0;')
+    print('# at common_gain > 0 the separate self-gate row instead shows an existing')
+    print('# shared covariance left ~unchanged (cov ratio ~1.0), not attenuated.')
+    for label, common_gate, self_gate in (
+        ('separate self-gate (independent errors)', 0.0, 1.0),
+        ('shared-latent gate', 1.0, 0.0),
+        ('mixed gate', 1.0, 1.0),
+    ):
+        print(f'\n## {label}: common_gate={common_gate} self_gate={self_gate}')
+        for keep in (0.9, 0.75, 0.5, 0.25):
+            trial = synthetic_selection_trial(
+                rng,
+                args.n,
+                common_gain=args.common_gain,
+                common_gate=common_gate,
+                self_gate=self_gate,
+                keep_frac=keep,
+            )
+            var_ratio = trial.survivor.var_a / trial.full.var_a if trial.full.var_a else 0.0
+            cov_ratio = trial.survivor.cov_ab / trial.full.cov_ab if trial.full.cov_ab else 0.0
+            print(
+                f'keep={keep:.2f} (actual {trial.keep_frac_actual:.2f}): '
+                f'var_a x{var_ratio:.3f}  cov x{cov_ratio:.3f}  | '
+                f'full[{_fmt(trial.full)}] surv[{_fmt(trial.survivor)}]'
+            )
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/util/agreement/selection.py
+++ b/util/agreement/selection.py
@@ -12,17 +12,22 @@ whole population.
 
 This module is the truth-based instrument for that effect.  It works on planted
 error arrays (never on real frames), so every number it returns is an exact
-statement about how survivorship distorts a covariance -- the axis on which the
-simulator's word is final.  Two facts it makes precise:
+statement about how survivorship distorts a covariance *in this model* -- the
+axis on which the simulator's word is final.  The results below are scenario
+results conditional on the model's admission being **separable** (each
+technique admitted by a gate on its own error plus a shared latent, never on
+the other technique's error) and **monotonic** (larger error magnitude, lower
+chance of admission).  Under that structure:
 
-- **Separate per-technique gates do not manufacture cross-covariance.**  When
-  two techniques have independent errors and each is admitted by its own gate,
-  the joint-survival event factorizes across the two, so the survivor
-  cross-covariance stays at its (zero) population value.  What separate gating
-  *does* do is attenuate each technique's *marginal* covariance when survival
-  tracks that technique's own error -- survivors are the low-error frames, so a
-  per-technique sigma measured on survivors understates the population sigma.
-- **A shared scene latent is the only channel that distorts the pairwise
+- **Separately-gated independent errors are not coupled by survival.**  When
+  two techniques have independent errors and each is admitted by a gate on its
+  own error, the joint-survival event factorizes across the two, so the
+  survivor cross-covariance stays at its (zero) population value.  What separate
+  gating *does* do is attenuate each technique's *marginal* covariance when
+  survival tracks that technique's own error -- survivors are the low-error
+  frames, so a per-technique sigma measured on survivors understates the
+  population sigma.
+- **A shared scene latent is the channel that distorts the pairwise
   covariance.**  When a common scene-quality factor drives both techniques'
   errors *and* their admission, conditioning on survival truncates that
   latent's variance and so attenuates the shared (cross) covariance toward zero.
@@ -31,12 +36,15 @@ The model plants ``e_i = common_gain * q + eps_i`` with a shared scene latent
 ``q`` and independent per-technique noise ``eps_i``, then admits a scene when
 both techniques' "badness" (a weighted sum of the shared-latent and own-error
 magnitudes) is small enough to hit a target survival fraction.  Sweeping the
-gate weights and the survival fraction bounds the distortion: at a given real
-per-technique dropout fraction and a given strength of the reliability-vs-error
-coupling, the induced change in any recovered covariance element is at most what
-this model reports.  What the model cannot supply -- the actual strength of that
-coupling on real frames -- is a property of the real reliability scores, outside
-the simulator's envelope.
+gate weights and the survival fraction *characterizes* the distortion under that
+admission model -- it is not a universal bound on a real cohort.  Two real-frame
+properties the model cannot supply set where a real cohort lands: how strongly
+each reliability score tracks its own technique's error, and whether the two
+scores' error-dependence is genuinely separable or is shared (both scores
+falling with a common image-quality factor) or inverse.  Per-type thresholds
+make the gates separate *functions* but do not by themselves establish that
+separability in error space; that check is a real-frame measurement outside the
+simulator's envelope.
 
 All statistics are per-axis scalars (variance and covariance along one image
 axis): the agreement solve reduces every rank-1 (ring) pair to a per-axis
@@ -108,8 +116,10 @@ def stratum_stats(err_a: NDArray[np.float64], err_b: NDArray[np.float64]) -> Str
         below two samples they are reported as zero.
 
     Raises:
-        ValueError: if the two arrays differ in length.
+        ValueError: if either array is not 1-D, or the two differ in length.
     """
+    if err_a.ndim != 1 or err_b.ndim != 1:
+        raise ValueError(f'err_a and err_b must be 1-D; got ndim {err_a.ndim} and {err_b.ndim}')
     if err_a.shape != err_b.shape:
         raise ValueError(f'err_a and err_b must align; got {err_a.shape} and {err_b.shape}')
     n = int(err_a.shape[0])
@@ -212,7 +222,14 @@ def synthetic_selection_trial(
 
 
 def _fmt(stats: StratumStats) -> str:
-    """One-line rendering of a stratum's moments."""
+    """One-line rendering of a stratum's moments.
+
+    Parameters:
+        stats: The stratum statistics to render.
+
+    Returns:
+        A compact single-line string of the counts and moments.
+    """
     return (
         f'n={stats.n:5d} var_a={stats.var_a:6.3f} var_b={stats.var_b:6.3f} '
         f'cov={stats.cov_ab:+.3f} corr={stats.corr_ab:+.3f}'

--- a/util/agreement/tests/test_selection.py
+++ b/util/agreement/tests/test_selection.py
@@ -57,6 +57,12 @@ def test_stratum_stats_rejects_misaligned() -> None:
         stratum_stats(np.zeros(3), np.zeros(4))
 
 
+def test_stratum_stats_rejects_non_1d() -> None:
+    """A 2-D error array raises ValueError before the shape-match check."""
+    with pytest.raises(ValueError, match='must be 1-D'):
+        stratum_stats(np.zeros((3, 2)), np.zeros((3, 2)))
+
+
 def test_trial_rejects_bad_n() -> None:
     """A trial with fewer than two scenes raises."""
     rng = np.random.default_rng(0)

--- a/util/agreement/tests/test_selection.py
+++ b/util/agreement/tests/test_selection.py
@@ -1,0 +1,132 @@
+"""Tests for the survivorship (selection-effect) model.
+
+Pin the three facts the reliability-gate finding leans on: a gate with no
+dependence on the scene keeps everyone; separate per-technique gates on
+independent errors do not manufacture cross-covariance (they only attenuate
+each marginal variance); and a shared-latent gate attenuates the shared
+cross-covariance toward zero, more so as the survival fraction falls.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from selection import (
+    SelectionTrial,
+    StratumStats,
+    stratum_stats,
+    synthetic_selection_trial,
+)
+
+
+def _trial(
+    *,
+    common_gain: float,
+    common_gate: float,
+    self_gate: float,
+    keep_frac: float,
+    n: int = 40000,
+) -> SelectionTrial:
+    """Run one trial with a fixed generator and a default size."""
+    rng = np.random.default_rng(20260721)
+    return synthetic_selection_trial(
+        rng,
+        n,
+        common_gain=common_gain,
+        common_gate=common_gate,
+        self_gate=self_gate,
+        keep_frac=keep_frac,
+    )
+
+
+def test_stratum_stats_below_two_samples_is_zero() -> None:
+    """A one-sample stratum reports zero moments rather than raising."""
+    stats = stratum_stats(np.array([1.0]), np.array([2.0]))
+    assert stats == StratumStats(n=1, var_a=0.0, var_b=0.0, cov_ab=0.0, corr_ab=0.0)
+
+
+def test_stratum_stats_rejects_misaligned() -> None:
+    """Mismatched array lengths raise ValueError."""
+    with pytest.raises(ValueError, match='must align'):
+        stratum_stats(np.zeros(3), np.zeros(4))
+
+
+def test_trial_rejects_bad_n() -> None:
+    """A trial with fewer than two scenes raises."""
+    rng = np.random.default_rng(0)
+    with pytest.raises(ValueError, match='n must be at least 2'):
+        synthetic_selection_trial(
+            rng, 1, common_gain=0.0, common_gate=0.0, self_gate=1.0, keep_frac=0.5
+        )
+
+
+def test_trial_rejects_bad_keep_frac() -> None:
+    """A survival fraction outside (0, 1) raises."""
+    rng = np.random.default_rng(0)
+    with pytest.raises(ValueError, match='keep_frac'):
+        synthetic_selection_trial(
+            rng, 100, common_gain=0.0, common_gate=0.0, self_gate=1.0, keep_frac=1.0
+        )
+
+
+def test_determinism() -> None:
+    """Two trials with the same seed produce identical survivor covariance."""
+    a = _trial(common_gain=1.0, common_gate=1.0, self_gate=0.0, keep_frac=0.5)
+    b = _trial(common_gain=1.0, common_gate=1.0, self_gate=0.0, keep_frac=0.5)
+    assert a.survivor.cov_ab == b.survivor.cov_ab
+
+
+def test_inert_gate_keeps_everyone() -> None:
+    """A gate that depends on neither the latent nor the error selects nobody out."""
+    trial = _trial(common_gain=1.0, common_gate=0.0, self_gate=0.0, keep_frac=0.5)
+    assert trial.keep_frac_actual == 1.0
+
+
+def test_inert_gate_survivor_equals_full() -> None:
+    """With nobody dropped the survivor covariance equals the full covariance."""
+    trial = _trial(common_gain=1.0, common_gate=0.0, self_gate=0.0, keep_frac=0.5)
+    assert trial.survivor.cov_ab == trial.full.cov_ab
+
+
+def test_separate_gate_does_not_manufacture_covariance() -> None:
+    """Independent errors, self-gated separately: survivor cross-cov stays ~0."""
+    trial = _trial(common_gain=0.0, common_gate=0.0, self_gate=1.0, keep_frac=0.5)
+    assert abs(trial.survivor.cov_ab) < 0.05
+
+
+def test_separate_gate_attenuates_marginal_variance() -> None:
+    """Self-gating still shrinks each marginal variance (survivors are easy frames)."""
+    trial = _trial(common_gain=0.0, common_gate=0.0, self_gate=1.0, keep_frac=0.5)
+    assert trial.survivor.var_a < 0.6 * trial.full.var_a
+
+
+def test_shared_latent_gate_attenuates_cross_covariance() -> None:
+    """A shared-latent gate drives the survivor cross-cov below the full value."""
+    trial = _trial(common_gain=1.0, common_gate=1.0, self_gate=0.0, keep_frac=0.5)
+    assert trial.survivor.cov_ab < 0.5 * trial.full.cov_ab
+
+
+def test_shared_latent_gate_keeps_cross_covariance_positive() -> None:
+    """The attenuated shared covariance stays on the same (positive) side of zero."""
+    trial = _trial(common_gain=1.0, common_gate=1.0, self_gate=0.0, keep_frac=0.5)
+    assert trial.survivor.cov_ab > 0.0
+
+
+def test_shared_latent_attenuation_grows_with_dropout() -> None:
+    """Heavier dropout attenuates the shared cross-covariance further."""
+    light = _trial(common_gain=1.0, common_gate=1.0, self_gate=0.0, keep_frac=0.9)
+    heavy = _trial(common_gain=1.0, common_gate=1.0, self_gate=0.0, keep_frac=0.5)
+    assert heavy.survivor.cov_ab < light.survivor.cov_ab
+
+
+def test_marginal_attenuation_grows_with_dropout() -> None:
+    """Heavier dropout shrinks the marginal variance further."""
+    light = _trial(common_gain=0.0, common_gate=0.0, self_gate=1.0, keep_frac=0.9)
+    heavy = _trial(common_gain=0.0, common_gate=0.0, self_gate=1.0, keep_frac=0.5)
+    assert heavy.survivor.var_a < light.survivor.var_a


### PR DESCRIPTION
## What and why

Stage 0b of WS-0 (#224), resolving #323: the agreement estimator's bias-independence stage injected a shared bias through two of the three shared preprocessing products (gradient / edge-DT, and the single noise-sigma estimate) but not the third named in the plan, the reliability gate. That gap was a genuine design problem, not an oversight: the gate does not *shift* offsets, it *filters* features, so its common-mode effect is a survivorship selection effect, not a bias, and the estimator's offset-regression machinery does not fit it. This PR designs and implements the measurement for a filtering shared layer, and ends with a bounded statement of the reliability-gate selection effect on the downstream #225 cohorts.

## Chosen approach

Of the four candidate designs in #323, this takes the survivor-vs-full stratified comparison (#3) as the measurement, and adds a survivorship model that bounds the effect for the regime the sim cannot reach directly. Conditioning the solve on survivorship (#1) and modelling the threshold (#2) are corrections, not measurements, and would collide with the estimator's negative-variance rejection diagnostic; they are deferred to #360. Restricting to the always-survive subset (#4) is the control the stratum comparison is taken against, not the answer. The stratum comparison is truth-based, so it is exact on the axis the simulator's word is final on (planted-truth recovery).

## What is implemented

`util/agreement/collect.py` gains `--injection reliability_gate`, a harness monkeypatch of `FeatureReliabilityGate.apply` that raises every per-type threshold by a fixed depression. It is verified to be a pure selection channel: a surviving technique's offset is byte-identical to the control pass (max delta 0.0 px), so pairing a gate pass with the control pass by scene id recovers, for every scene, both the technique's true error and whether it survived.

`util/agreement/selection.py` (new) is the truth-based survivorship model, with `tests/test_selection.py`. Under a separable, monotonic admission model it pins two results: separately-gated independent errors are not coupled by survival (joint survival factorizes; survivor cross-cov stays within +/-0.003 of zero at every survival fraction, n = 400000), and a shared scene latent driving both error and admission attenuates the shared cross-covariance and each marginal variance toward zero. Within that model the attenuation is always toward zero -- the gate can only make a covariance look smaller, never larger. The grid is a scenario result conditional on that admission structure, not a universal real-cohort bound (see the bounded statement below).

`util/agreement/analyze.py` gains `--gate-rows`, the survivorship-stratified selection-effect report (full population vs survivor subset), which is the procedure the agreement study runs on its own real cohorts.

## Campaign result (seed 20260721, `util/agreement/CAMPAIGN_20260721.md`)

In the clean sim the load-bearing feature reliabilities are near-degenerate across scenes (disc and ring saturate at 1.000, limb clusters at 0.816-0.817, blob flat at 0.400), so the gate acts as an all-or-nothing cliff, not a scene-selective filter: raising the threshold drops either every scene's feature or none. The measured survival sweep confirms this (blob drops 100% at depression +0.25, limb drops 100% at +0.55, disc and ring never drop), and the survivorship-stratified selection effect on the load-bearing covariances is correspondingly exactly zero -- not because selection is harmless but because the clean cohort admits no graded selection. That is exactly the configuration in which a direct in-sim injection cannot measure the real effect, which is why the bound, not the in-sim number, is the load-bearing product.

## The bounded statement for #225

The synthetic survivorship model is a scenario result conditional on a separable, monotonic admission structure (each technique admitted by a gate on its own error plus a shared latent; larger error, lower admission), not a universal real-cohort bound. Under that structure: separately-gated independent errors are not coupled by survival (survivor cross-covariance stays at zero, within +/-0.003 at n=400000), so the gate does not manufacture coupling on independent pairs; every per-technique sigma measured on survivors is a lower bound (survivors are the low-error frames), optimistic by a factor set by how strongly reliability tracks error (representative grid: at 50% survival the marginal variance retains ~0.32-0.57, i.e. population sigma ~1.3x-1.8x the survivor sigma); and pairwise agreement is likewise optimistic to the extent a shared scene latent drives both the shared error and the joint admission (the shared cross-covariance retains as little as ~14% at 50% joint survival). In one line: under a separable, monotonic admission model the gate can only make #225 agreement look better than it is, never worse.

Crucially, the real gate's per-type thresholds are necessary for that separable structure but not sufficient -- the reliability scores that feed them could share or invert their error-dependence, which would let survival induce a coupling. So both the size of the attenuation and the validity of the separable/monotonic assumption itself are real-frame properties the simulator cannot establish: they are filed as #358 (measure the score-error coupling and separability, and run the stratified estimator on the real cohorts), and whether a selection-aware correction is then warranted is #360. The in-sim measurements (the cliff-structured survival sweep and the exactly-zero load-bearing selection effect in the clean cohort) stand on their own; only the extrapolation to real cohorts is conditional.

## Follow-ups filed

- #358 -- measure the reliability-vs-error coupling and run the stratified estimator on the real #225 cohorts (the one piece the sim cannot establish).
- #360 -- decide, after #358, whether the agreement solve needs a selection-aware correction.

This completes the Stage 0b coverage of #224 alongside #320 (the PSF-layer probe, still open).

## Validation

`util/` is outside the repo's CI pytest/ruff/mypy scope, so it was checked directly: `ruff check` and `ruff format --check` clean on `util/agreement/`; `mypy --strict` clean on the five modules; `pytest util/agreement/tests` 54 passed (13 new). No `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HoCUAeNeMz5bFmGk2iVBf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reliability-gate injection option that filters lower-reliability features (no offset shifting for survivors).
  - Added survivor-versus-full reporting for variance, covariance, and agreement changes, including a gate-driven analysis mode.
- **Documentation**
  - Expanded README and campaign notes with reliability-gate behavior, measurement approach, and selection-effect bounds/limitations.
- **Tests**
  - Added selection-effect model tests covering validation, determinism, covariance preservation, and attenuation trends under different gating configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->