### PR TITLE
test: probe limb-disc pair for a shared PSF edge bias (#320)

### DIFF
--- a/util/agreement/CAMPAIGN_20260719.md
+++ b/util/agreement/CAMPAIGN_20260719.md
@@ -432,15 +432,163 @@ open question below.
   feature dropout; measuring it needs a selection-effect design
   (which frames survive under gate perturbation), not an offset
   regression.  Not done in this campaign.
-- **PSF-layer coupling for limb vs disc.**  This campaign's clean
-  scenes render no PSF stage, so the shared-PSF-edge-bias suspicion
-  against the limb/disc base pair is unprobed.  A follow-up injection
-  through a PSF-bearing render (the realism-validated chain) is the
-  next measurement the base pair needs before it is called clean on
-  real frames.
+- **PSF-layer coupling for limb vs disc.**  Probed by the PSF-layer
+  addendum below (measured 2026-07-21): a *symmetric* rendered PSF
+  mismatch opens no shared edge bias (the disc barely responds, bounding
+  the coupling magnitude).  The asymmetric-PSF mechanism the suspicion
+  names most directly is unrenderable by the simulator and left
+  explicitly unprobed; that and the disc's sub-pixel resolution floor are
+  carried as tracking issues, cited there.
 - **Clipped-body radial biases.**  The ~-2.1 px (limb) and ~-0.6 px
   (disc) inward mean biases of partial-body fits in this regime are
   technique-behavior observations from this campaign that deserve
   their own diagnosis (possible frame-edge contamination of the
   boundary polyline or coarse-seed asymmetry); they are recorded and
   absorbed by the estimator's rotating mean columns, not diagnosed.
+
+## Stage 0b addendum (PSF layer): the limb-disc base pair, 2026-07-21
+
+Follow-up to the Stage 0b bias-independence measurement above (issue
+#320).  The main campaign cleared limb-DT vs disc-NCC *for the shared
+gradient / distance-transform channel only*: the disc reads the image,
+not the DT products, so its response slope to the `dt_shift` injection
+was 0.000 by construction and the pair could not have coupled through
+that channel either way.  The mechanism that channel cannot reach is a
+shared PSF edge bias -- an NCC disc-template peak tracking the same
+PSF-blurred limb edge the DT fit tracks, so a render-vs-navigate PSF
+error moves both estimates together.  That coupling can appear only
+against a rendered blurred edge, which the main campaign's PSF-free
+scenes do not have.  This addendum renders the edge and injects at the
+PSF layer.
+
+### Method
+
+A PSF-bearing single-body family (`limb_disc_psf`) with the same
+geometry as `limb_disc` (fully-framed body, limb + disc, no ring,
+phase 10-45 deg so the body is partially lit).  The control render
+sets `optics.psf: {match_navigator: true}` -- the PSF self-consistency
+floor, where the rendered Gaussian equals the navigator's own
+`star_psf_sigma` (0.54 px for the emulated Cassini NAC), so there is no
+render-vs-navigate mismatch.  The injection replaces that block with a
+broadened kernel the navigator does not model, the only channel through
+which a shared PSF edge bias can reach both techniques:
+
+- `psf_broaden` -- core sigma scaled isotropically by a per-scene
+  log-uniform factor 1.4-3.0x (rendered sigma 0.76-1.62 px).  The
+  documented `psf_limb_mismatch` axis.
+- `psf_aniso` -- the factor (1.6-3.5x) applied to one image axis only,
+  a zero-mean elliptical kernel that softens the edge directionally
+  *without translating the image* (a whole-kernel centroid shift would
+  be degenerate with a true pointing offset and would couple every
+  technique trivially; it is deliberately not used).
+
+The injection is render-side only (the scene's `optics.psf` block); the
+navigator keeps its configured PSF.  Nothing under `src/` changes.  400
+scenes per pass, seed 20260719, 8 workers, 0 errors, ~1.4-2.7 min each.
+Feasibility is unchanged by the mismatch: limb non-spurious on
+395-397/400, disc on 400/400.
+
+### Result: no shared PSF edge bias from symmetric broadening; the coupling is magnitude-bounded by disc insensitivity
+
+The dangerous mode is a *positive* limb-disc cross-covariance: a shared
+bias raises `cov(limb, disc)`, cancels in `limb - disc`, and makes
+`Var(limb - disc)` blind to it.  It is not found -- but the robust form
+of that statement is a magnitude bound, not a sign claim (see below).
+
+The load-bearing, resample-stable fact is that the disc-NCC barely
+responds to the PSF mismatch while the limb-DT responds strongly.  Under
+`psf_broaden` the limb moves with median \|delta\| 0.13 px, p90 4.0 px,
+max 8.8 px (a heavy tail of unflagged re-locks as the softened curved
+edge approaches the navigability cliff), while the disc moves with
+median 0.008 px and p90 0.47 px -- ~16x less at the median, ~8x at p90 --
+because a symmetric broadening preserves the lit silhouette's NCC
+centroid.  A cross-covariance is bounded by
+`|cov| <= sqrt(Var_limb * Var_disc)`, so the disc's small PSF response
+caps the shared component at a small magnitude *whatever its sign*; the
+limb's large, heavy-tailed sensitivity is a *per-technique* variance that
+belongs in `C_limb` (it corroborates the ~2.6 px limb covariance floor
+the calibration campaign priced against unmodeled terrain and the
+`psf_limb_mismatch` cliff), not a bias shared with the disc.
+
+Truth-based limb-disc coupling (scalar summary, per-axis mean):
+
+| condition | n | cross-covariance (px^2) | correlation |
+|---|---|---|---|
+| control (matched PSF) | 397 | -0.016 | -0.244 |
+| psf_broaden | 395 | -0.091 | -0.248 |
+| psf_aniso | 397 | -0.045 | -0.189 |
+
+Paired per-scene response (same scene with and without the mismatch;
+the injection's *own* induced coupling, isolated from the intrinsic
+control coupling):
+
+| injection | limb RMS \|delta\| | disc RMS \|delta\| | delta coupling corr (image / illum-proj) |
+|---|---|---|---|
+| psf_broaden | 2.16 px | 0.26 px | -0.056 / -0.099 |
+| psf_aniso | 1.87 px | 0.18 px | -0.004 / +0.020 |
+
+Every measured limb-disc coupling is small, correlation magnitude at or
+below ~0.25 (the intrinsic term) and ~0.1 for the injection-induced term.
+The induced term's *sign is not robust*: an independent 30-scene resample
+put the image-frame induced correlation at +0.14 (the hazard sign) with
+the illumination-projected value at ~0, while the 400-scene cohort put it
+at -0.06.  Both are within sampling noise of zero at these counts, so the
+honest statement is "consistent with zero, magnitude-bounded by disc
+insensitivity", not "reliably negative / safe direction".  The intrinsic
+(control) limb-disc correlation is a more stable -0.24 and the injection
+does not drive it materially more positive, but nothing here licenses
+treating the sign as a guarantee.
+
+### Consequence for the #225 per-technique covariance claim
+
+The base limb-disc pair survives the PSF channel *for the PSF error the
+simulator can honestly render*: a symmetric (isotropic or axis-aligned
+elliptical, zero-mean) broadening mismatch does not open a shared edge
+bias, because the disc barely responds and so caps the coupling
+magnitude regardless of sign.  `Var(limb - disc)` is not silently blind
+to a common bias of that class, so limb-disc remains a usable
+independence anchor against it, in the Cassini-NAC regime.  This is
+narrower than "limb-disc does not couple through the PSF channel", and
+three qualifications ride the verdict and are neither cleared nor buried:
+
+1. **The most direct #320 mechanism is untested, by design.**  The
+   suspicion in #320 is an NCC disc peak tracking a *shifted* blurred
+   limb edge; the PSF error that shifts an edge by a geometry-dependent
+   amount (without being degenerate with a global pointing offset) is an
+   *asymmetric / coma* kernel.  The simulator's whole-scene PSF is a
+   symmetric Gaussian core plus an isotropic Moffat wing and cannot
+   render that; both injections here are deliberately zero-mean, so they
+   probe softening, not a systematic edge shift.  Rather than fabricate
+   an asymmetric kernel the realism match does not vouch for, the
+   asymmetric-PSF mechanism is left explicitly unprobed and tracked as
+   issue #359.  The symmetric result bounds one channel; it does not
+   close the one the issue named most directly.
+2. **A mild intrinsic negative coupling is real but not a safe sign.**
+   The control limb-disc correlation is -0.24 (cov -0.016 px^2, -0.09
+   px^2 under broadening); a solve assuming `S = 0` on PSF-bearing frames
+   would misattribute at the ~1-2%-of-limb-variance level.  The sign is
+   not something to lean on -- resamples of the injection-induced term
+   land on either side of zero -- so carry a declared limb-disc pair
+   covariance if that precision matters, rather than trusting the
+   difference to inflate safely.
+3. **Floor and instrument limits.**  The probe is floor-limited by the
+   disc's coarse sub-pixel NCC resolution -- a shared bias below the
+   disc's response quantum (~0.1-0.2 px) is invisible -- and, per the
+   simulator's capability envelope, PSF accuracy is realism-supported for
+   the Cassini NAC only; elsewhere these are reproducibility statements.
+   The disc-resolution floor is tracked as issue #361.
+
+Reproduce (row files under `_work/agreement/psf/`, gitignored):
+
+```bash
+for kind in ctrl psf_broaden psf_aniso; do
+  inj=$( [ "$kind" = ctrl ] && echo "" || echo "--injection $kind" )
+  venv/bin/python util/agreement/collect.py --per-family 400 \
+      --families limb_disc_psf $inj --workers 8 --seed 20260719 \
+      --out _work/agreement/psf/rows_${kind}.jsonl
+done
+venv/bin/python util/agreement/analyze.py _work/agreement/psf/rows_ctrl.jsonl \
+    --psf-broaden-rows _work/agreement/psf/rows_psf_broaden.jsonl \
+    --psf-aniso-rows _work/agreement/psf/rows_psf_aniso.jsonl \
+    --out _work/agreement/psf/report.md
+```

--- a/util/agreement/README.md
+++ b/util/agreement/README.md
@@ -28,12 +28,14 @@ preserves the numbers and conclusions that outlive them.
    ring edges), shared parameter groups (same technique on two bodies),
    and declared suspect-pair cross-covariances.
 2. **`scene_gen.py`** — seeded scene families whose *estimator
-   composition* is the controlled variable: `limb_disc`,
-   `limb_disc_ring_fixed` / `_diverse` (frozen vs drawn ring radial
-   direction), `limb_ring_aniso_fixed` / `_diverse` (clipped body,
-   genuinely anisotropic limb covariance), `multi_body`.  Scenes are
-   deliberately clean (smooth ellipsoids, moderate noise): the campaign
-   validates the estimator's mathematics, not technique robustness.
+   composition* is the controlled variable: `limb_disc`, `limb_disc_psf`
+   (the same body rendered through an active whole-scene PSF, for the
+   PSF-layer coupling probe below), `limb_disc_ring_fixed` / `_diverse`
+   (frozen vs drawn ring radial direction), `limb_ring_aniso_fixed` /
+   `_diverse` (clipped body, genuinely anisotropic limb covariance),
+   `multi_body`.  Scenes are deliberately clean (smooth ellipsoids,
+   moderate noise): the campaign validates the estimator's mathematics,
+   not technique robustness.
 3. **`collect.py`** — navigates every scene in-process and writes one
    JSONL row per scene: planted truth, geometry angles, and every
    per-technique result from each configured run (multi-body scenes run
@@ -49,14 +51,26 @@ preserves the numbers and conclusions that outlive them.
    products translated by a per-scene random bias, and
    `--injection noise_scale` with the shared noise-sigma estimate
    scaled — both as harness-level monkeypatches of the orchestrator
-   module (no production seam).  Injected values are drawn from the
-   campaign seed and recorded per row.
+   module (no production seam).  `--injection psf_broaden` /
+   `--injection psf_aniso` instead perturb the *render*: they overwrite
+   the scene's `optics.psf` block with a broadened (isotropic) or
+   axis-broadened (zero-mean elliptical) kernel the navigator does not
+   model, the only channel through which a shared PSF edge bias can
+   reach both the limb (distance-transform) and disc (correlation)
+   estimators — so they require the `limb_disc_psf` family, whose control
+   render matches the navigator (no mismatch).  Injected values are
+   drawn from the campaign seed and recorded per row.
 
    ```bash
    venv/bin/python util/agreement/collect.py \
        --per-family 400 --families limb_disc_ring_diverse \
        --injection dt_shift --workers 8 \
        --out _work/agreement/rows_dt.jsonl
+
+   venv/bin/python util/agreement/collect.py \
+       --per-family 400 --families limb_disc_psf \
+       --injection psf_broaden --workers 8 \
+       --out _work/agreement/psf/rows_psf_broaden.jsonl
    ```
 
 4. **`analyze.py`** — produces the Markdown report: per composition, the
@@ -65,12 +79,18 @@ preserves the numbers and conclusions that outlive them.
    degenerate compositions, and — when injected row files are supplied —
    the bias-independence tables (truth-based pair coupling per
    condition, paired per-scene injection response, solve-side detection
-   with a declared pair covariance).
+   with a declared pair covariance).  `--psf-broaden-rows` /
+   `--psf-aniso-rows` add the PSF-layer section: the limb-disc coupling
+   under a rendered PSF mismatch (control vs injected), the paired
+   per-scene limb/disc response, and the deltas decomposed onto each
+   scene's illumination axis.
 
    ```bash
    venv/bin/python util/agreement/analyze.py _work/agreement/rows.jsonl \
        --dt-rows _work/agreement/rows_dt.jsonl \
        --noise-rows _work/agreement/rows_noise.jsonl \
+       --psf-broaden-rows _work/agreement/psf/rows_psf_broaden.jsonl \
+       --psf-aniso-rows _work/agreement/psf/rows_psf_aniso.jsonl \
        --out _work/agreement/report.md
    ```
 

--- a/util/agreement/analyze.py
+++ b/util/agreement/analyze.py
@@ -447,6 +447,100 @@ def report_injection_response(
     out.append('')
 
 
+def report_psf_coupling(
+    out: list[str],
+    control: list[dict[str, Any]],
+    injected: list[dict[str, Any]],
+    label: str,
+    *,
+    family: str = 'limb_disc_psf',
+) -> None:
+    """Paired per-scene limb/disc response to a PSF-layer render mismatch.
+
+    For every scene where both the limb and the disc are non-spurious in the
+    control (navigator-matched PSF) and the injected (broadened PSF) pass, the
+    offset delta between the two passes is the render-vs-navigate PSF mismatch's
+    effect on that technique.  The load-bearing quantity is whether the limb
+    and disc deltas move *together*: a positive cross-covariance means the base
+    pair shares a PSF edge bias, which would make ``Var(limb - disc)`` blind to
+    it exactly as the DT-layer coupling made ``Var(limb - ring)`` blind to the
+    shared gradient shift.  Because the body is partially lit, a symmetric
+    broadening biases the edge along the illumination direction, so the deltas
+    are also decomposed onto each scene's illumination axis to test whether the
+    coupling is locked to that (unmodeled) geometry.
+
+    Parameters:
+        out: Markdown accumulator.
+        control: Control rows (navigator-matched PSF).
+        injected: Injected rows (broadened PSF).
+        label: Injection label for the section heading.
+        family: PSF-bearing family to pair on.
+    """
+    ctrl_by_id = {r['scene_id']: r for r in control if r['family'] == family and 'error' not in r}
+    limb_d: list[np.ndarray] = []
+    disc_d: list[np.ndarray] = []
+    illum: list[float] = []
+    for row in injected:
+        if row['family'] != family or 'error' in row:
+            continue
+        ctrl = ctrl_by_id.get(row['scene_id'])
+        if ctrl is None or not row['injection'].get('kind', '').startswith('psf_'):
+            continue
+        inj_off = _instance_offsets(row)
+        ctl_off = _instance_offsets(ctrl)
+        if not ({'limb', 'disc'} <= set(inj_off) and {'limb', 'disc'} <= set(ctl_off)):
+            continue
+        limb_d.append(np.array(inj_off['limb']) - np.array(ctl_off['limb']))
+        disc_d.append(np.array(inj_off['disc']) - np.array(ctl_off['disc']))
+        illum.append(math.radians(float(row['geometry'].get('illumination_deg', 0.0))))
+    out.append(f'#### {label}: paired limb/disc response to the PSF mismatch')
+    out.append('')
+    if len(limb_d) < 5:
+        out.append(f'Fewer than 5 paired scenes ({len(limb_d)}); no response measured.')
+        out.append('')
+        return
+    limb = np.asarray(limb_d)
+    disc = np.asarray(disc_d)
+    n_dir = np.stack([np.cos(illum), np.sin(illum)], axis=1)
+    limb_proj = np.sum(limb * n_dir, axis=1)
+    disc_proj = np.sum(disc * n_dir, axis=1)
+    n = limb.shape[0]
+
+    def _axis_cov(a: np.ndarray, b: np.ndarray) -> tuple[float, float]:
+        covs = [float(np.cov(a[:, k], b[:, k], ddof=1)[0, 1]) for k in range(a.shape[1])]
+        corrs = []
+        for k in range(a.shape[1]):
+            sa = float(a[:, k].std(ddof=1))
+            sb = float(b[:, k].std(ddof=1))
+            corrs.append(covs[k] / (sa * sb) if sa > 0 and sb > 0 else 0.0)
+        return float(np.mean(covs)), float(np.mean(corrs))
+
+    raw_cov, raw_corr = _axis_cov(limb, disc)
+    proj_cov = float(np.cov(limb_proj, disc_proj, ddof=1)[0, 1])
+    sp_l = float(limb_proj.std(ddof=1))
+    sp_d = float(disc_proj.std(ddof=1))
+    proj_corr = proj_cov / (sp_l * sp_d) if sp_l > 0 and sp_d > 0 else 0.0
+    out.append(f'{n} paired scenes.')
+    out.append('')
+    out.append('| quantity | limb | disc |')
+    out.append('|---|---|---|')
+    out.append(
+        f'| mean delta (dv, du) px | ({limb[:, 0].mean():+.4f}, {limb[:, 1].mean():+.4f}) '
+        f'| ({disc[:, 0].mean():+.4f}, {disc[:, 1].mean():+.4f}) |'
+    )
+    out.append(
+        f'| RMS \\|delta\\| px | {float(np.sqrt(np.mean(np.sum(limb**2, axis=1)))):.4f} '
+        f'| {float(np.sqrt(np.mean(np.sum(disc**2, axis=1)))):.4f} |'
+    )
+    out.append(f'| mean delta . illum px | {limb_proj.mean():+.4f} | {disc_proj.mean():+.4f} |')
+    out.append('')
+    out.append('| coupling of the paired deltas | cross-covariance (px^2) | correlation |')
+    out.append('|---|---|---|')
+    out.append(f'| image-frame (per-axis mean) | {raw_cov:+.5f} | {raw_corr:+.3f} |')
+    out.append(f'| projected on illumination axis | {proj_cov:+.5f} | {proj_corr:+.3f} |')
+    out.append('')
+
+
 def report_noise_response(
     out: list[str],
     control: list[dict[str, Any]],
@@ -515,7 +609,10 @@ def _specs_for_family(
     ring = EstimatorSpec('ring', 'rank1')
     blob = EstimatorSpec('blob', 'full')
     no_pairs: list[tuple[str, str]] = []
-    if family == 'limb_disc':
+    if family in ('limb_disc', 'limb_disc_psf'):
+        # limb+disc alone is degenerate (the split is unidentifiable); the
+        # PSF family carries the same composition and is analyzed for coupling,
+        # not for a per-technique split.
         return [([limb_img, disc], no_pairs)]
     if family in ('limb_disc_ring_fixed', 'limb_disc_ring_diverse'):
         return [([limb_img, disc, ring], no_pairs), ([limb_img, disc, ring, blob], no_pairs)]
@@ -550,6 +647,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument('rows', type=Path, help='control (no-injection) rows file')
     parser.add_argument('--dt-rows', type=Path, default=None)
     parser.add_argument('--noise-rows', type=Path, default=None)
+    parser.add_argument('--psf-broaden-rows', type=Path, default=None)
+    parser.add_argument('--psf-aniso-rows', type=Path, default=None)
     parser.add_argument('--out', type=Path, default=None)
     args = parser.parse_args(argv)
 
@@ -650,6 +749,35 @@ def main(argv: list[str] | None = None) -> int:
                     pair_covariances=[('limb', 'ring')],
                 )
                 report_truth_reference(out, usable, specs)
+
+    psf_sources = [('psf_broaden', args.psf_broaden_rows), ('psf_aniso', args.psf_aniso_rows)]
+    if any(path is not None for _, path in psf_sources):
+        out.append('## Stage 0b (PSF layer): limb-disc coupling through a PSF mismatch')
+        out.append('')
+        psf_family = 'limb_disc_psf'
+        control_psf = build_cohort(rows, psf_family)
+        report_pair_truth(
+            out,
+            control_psf,
+            [('limb', 'disc')],
+            'Control (navigator-matched PSF): truth-based limb-disc coupling',
+        )
+        for label, path in psf_sources:
+            if path is None:
+                continue
+            inj_manifest, inj_rows = load_rows(path)
+            cohort = build_cohort(inj_rows, psf_family)
+            out.append(f'### Injection: {label} (`{path}`)')
+            out.append('')
+            out.append(
+                'Injection parameters: rendered PSF core sigma scaled per scene '
+                f'({inj_manifest.get("injection", label)}), navigator PSF unchanged.'
+            )
+            out.append('')
+            report_pair_truth(
+                out, cohort, [('limb', 'disc')], f'{label}: truth-based limb-disc coupling'
+            )
+            report_psf_coupling(out, rows, inj_rows, label)
 
     text = '\n'.join(out) + '\n'
     if args.out is not None:

--- a/util/agreement/collect.py
+++ b/util/agreement/collect.py
@@ -10,13 +10,26 @@ own limb/disc estimates; ring-bearing compositions add a blob-only run
 (``only_techniques=['BodyBlobNav']``) to supply an extra estimator that
 never touches the shared gradient/DT products.
 
-Shared-bias injection (the bias-independence stage) is harness-level only:
-``--injection dt_shift`` monkeypatches the orchestrator module's
-``compute_all_image_derivatives`` so every DT technique sees the shared
-gradient / edge-distance-transform products translated by a per-scene
-random bias, and ``--injection noise_scale`` monkeypatches
-``estimate_image_noise_sigma`` to scale the single shared noise estimate.
-Nothing under ``src/`` changes; the injected values are recorded per row.
+Shared-bias injection (the bias-independence stage) is harness-level only.
+Two families of injection exist, both recorded per row and neither touching
+``src/``:
+
+- Shared preprocessing layer (nav-side monkeypatch of the orchestrator
+  module): ``--injection dt_shift`` translates the shared gradient /
+  edge-distance-transform products by a per-scene random bias, and
+  ``--injection noise_scale`` scales the single shared noise estimate.  Only
+  the distance-transform techniques read those products, so a
+  correlation/centroid technique (disc, blob) is decoupled by construction.
+- PSF layer (render-side, via the scene's ``optics.psf`` block):
+  ``--injection psf_broaden`` renders the whole-scene PSF with its core sigma
+  scaled up by a per-scene factor, and ``--injection psf_aniso`` renders it
+  broadened along one axis only (a zero-mean elliptical kernel, so no global
+  translation).  The navigator keeps its own modeled PSF sigma, so the
+  rendered blurred edge no longer matches the template edge -- the only
+  channel through which a shared PSF edge bias can reach both the limb
+  (distance-transform) and disc (normalized cross-correlation) estimators.
+  These require a PSF-bearing scene family (``limb_disc_psf``), whose control
+  render matches the navigator (``optics.psf: {match_navigator: true}``).
 
 Run (from an activated project venv; ``source /seti/newnav/setup.sh``):
 
@@ -49,7 +62,15 @@ from scene_gen import FAMILIES, generate_scenes  # noqa: E402
 DEFAULT_SEED = 20260719
 DEFAULT_OUT = REPO / '_work/agreement/rows.jsonl'
 
-INJECTION_KINDS = ('none', 'dt_shift', 'noise_scale')
+INJECTION_KINDS = ('none', 'dt_shift', 'noise_scale', 'psf_broaden', 'psf_aniso')
+
+# PSF-layer injection: per-scene multiplicative broadening of the rendered PSF
+# core sigma above the navigator's modeled sigma (log-uniform draw).  The
+# anisotropic variant applies the factor to one axis only.  The ranges start
+# above 1 (a genuine mismatch) and stay inside the sim's resolvable,
+# realism-supported PSF regime for the Cassini NAC.
+_PSF_BROADEN_RANGE = (1.4, 3.0)
+_PSF_ANISO_RANGE = (1.6, 3.5)
 
 
 def _runs_for_family(family: str) -> list[dict[str, Any]]:
@@ -96,9 +117,22 @@ def _draw_injection(kind: str, scene_id: str, seed: int, sigma_px: float) -> dic
             'bias_v': rng.gauss(0.0, sigma_px),
             'bias_u': rng.gauss(0.0, sigma_px),
         }
+    if kind == 'noise_scale':
+        return {
+            'kind': 'noise_scale',
+            'factor': math.exp(rng.uniform(math.log(2.0), math.log(8.0))),
+        }
+    if kind == 'psf_broaden':
+        lo, hi = _PSF_BROADEN_RANGE
+        return {
+            'kind': 'psf_broaden',
+            'factor': math.exp(rng.uniform(math.log(lo), math.log(hi))),
+        }
+    lo, hi = _PSF_ANISO_RANGE
     return {
-        'kind': 'noise_scale',
-        'factor': math.exp(rng.uniform(math.log(2.0), math.log(8.0))),
+        'kind': 'psf_aniso',
+        'factor': math.exp(rng.uniform(math.log(lo), math.log(hi))),
+        'axis': rng.choice(('v', 'u')),
     }
 
 
@@ -165,6 +199,63 @@ def _restore(patched: list[tuple[Any, str, Any]]) -> None:
         setattr(module, attribute, original)
 
 
+def _inject_sim_params(
+    sim_params: dict[str, Any], injection: dict[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return the render-side sim_params for a PSF-layer injection.
+
+    The PSF injections act on the *rendered* scene rather than on the
+    navigator: they overwrite the scene's ``optics.psf`` block with an
+    explicit kernel broadened above the navigator's modeled sigma, while the
+    navigator's belief (its ``star_psf_sigma`` config) is untouched, so the
+    rendered blurred edge no longer matches the template edge.  ``psf_broaden``
+    scales both core sigmas by the drawn factor (isotropic); ``psf_aniso``
+    scales one axis only (a zero-mean elliptical kernel that softens the edge
+    directionally without translating the image).  Non-PSF injections leave the
+    scene unchanged (they act on the nav side; see :func:`_apply_injection`).
+
+    Parameters:
+        sim_params: The generated (validated) scene parameters.
+        injection: Draw from :func:`_draw_injection`.
+
+    Returns:
+        ``(render_params, applied)`` where ``applied`` records the resolved
+        kernel sigmas (empty for non-PSF injections).
+    """
+    kind = injection['kind']
+    if not kind.startswith('psf_'):
+        return sim_params, {}
+
+    import copy as _copy
+
+    from spindoctor.config import DEFAULT_CONFIG
+    from spindoctor.sim.instruments import navigator_matched_psf
+    from spindoctor.sim.scene import validate_sim_params
+
+    params = _copy.deepcopy(dict(sim_params))
+    base = navigator_matched_psf(
+        DEFAULT_CONFIG, params.get('instrument'), params.get('instrument_config')
+    )
+    base_sigma = float(base['sigma_v'])
+    factor = float(injection['factor'])
+    if kind == 'psf_broaden':
+        sigma_v = sigma_u = base_sigma * factor
+    elif injection.get('axis') == 'v':
+        sigma_v, sigma_u = base_sigma * factor, base_sigma
+    else:
+        sigma_v, sigma_u = base_sigma, base_sigma * factor
+    optics = dict(params.get('optics') or {})
+    optics['psf'] = {'sigma_v': sigma_v, 'sigma_u': sigma_u, 'w': 0.0, 'r0': 2.0, 'n': 3.0}
+    params['optics'] = optics
+    render_params = validate_sim_params(params, source='psf_inject')
+    applied = {
+        'base_sigma_px': base_sigma,
+        'sigma_v_px': sigma_v,
+        'sigma_u_px': sigma_u,
+    }
+    return render_params, applied
+
+
 def _navigate_one(
     task: tuple[str, str, dict[str, Any], dict[str, Any], dict[str, Any]],
 ) -> dict[str, Any]:
@@ -187,11 +278,14 @@ def _navigate_one(
         'injection': injection,
         'runs': {},
     }
+    render_params, applied = _inject_sim_params(sim_params, injection)
+    if applied:
+        row['injection'] = {**injection, **applied}
     patched = _apply_injection(injection)
     try:
         # The path is a label only (sim_params overrides the file read), but
         # FCPath resolves it, so it must sit under a real directory.
-        obs = ObsSim.from_file(f'/tmp/{scene_id}.json', sim_params=sim_params)
+        obs = ObsSim.from_file(f'/tmp/{scene_id}.json', sim_params=render_params)
         for run in _runs_for_family(family):
             orchestrator = NavOrchestrator(
                 build_models_for_obs(obs),

--- a/util/agreement/scene_gen.py
+++ b/util/agreement/scene_gen.py
@@ -7,6 +7,13 @@ needs:
 
 - limb_disc              : one resolved body, fully in frame; BodyLimbNav and
                            BodyDiscCorrelateNav both run (no ring).
+- limb_disc_psf          : identical geometry to limb_disc but rendered through
+                           an active whole-scene PSF, so the limb edge and the
+                           disc silhouette carry a sub-pixel-resolved blurred
+                           edge.  This is the scene family the base limb-disc
+                           pair needs to probe a shared PSF edge bias (the
+                           PSF-layer injection in collect.py); that bias cannot
+                           appear in the PSF-free families.
 - limb_disc_ring_fixed   : the same body plus a straight face-on ringlet whose
                            radial direction is FROZEN across the cohort (the
                            degenerate rank-1 regime the identifiability map
@@ -45,6 +52,7 @@ from typing import Any
 
 FAMILIES = (
     'limb_disc',
+    'limb_disc_psf',
     'limb_disc_ring_fixed',
     'limb_disc_ring_diverse',
     'limb_ring_aniso_fixed',
@@ -181,6 +189,37 @@ def _gen_limb_disc(rng: random.Random) -> tuple[dict[str, Any], dict[str, Any]]:
     body, _, _ = _framed_body(rng)
     params['bodies'] = [body]
     geometry = {'composition': 'limb_disc'}
+    return params, geometry
+
+
+def _gen_limb_disc_psf(rng: random.Random) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Fully-framed partially-lit body rendered through an active whole-scene PSF.
+
+    Identical geometry to :func:`_gen_limb_disc` (limb + disc, no ring), but the
+    scene carries ``optics.psf: {match_navigator: true}`` so the control render
+    equals the navigator's own Gaussian (the self-consistency floor: no
+    render-vs-navigate PSF mismatch).  The PSF-layer injection (see
+    ``collect.py``) replaces that block with a broadened or anisotropic kernel
+    the navigator does not model; a shared PSF edge bias between the limb
+    (distance-transform) and disc (normalized cross-correlation) estimators can
+    appear only against a rendered blurred edge, which the PSF-free families
+    lack.  The body is partially lit (phase 10-45 deg), so the illumination
+    direction breaks the silhouette's symmetry and a symmetric broadening can
+    still bias the edge; the illumination direction is recorded so the analysis
+    can test whether any induced coupling is locked to it.
+
+    Parameters:
+        rng: Scene-local random generator.
+    """
+    params = _base(rng)
+    body, _, _ = _framed_body(rng)
+    params['bodies'] = [body]
+    params['optics'] = {'psf': {'match_navigator': True}}
+    geometry = {
+        'composition': 'limb_disc_psf',
+        'illumination_deg': float(body['illumination_angle']),
+        'phase_deg': float(body['phase_angle']),
+    }
     return params, geometry
 
 
@@ -346,6 +385,7 @@ def _gen_multi_body(rng: random.Random) -> tuple[dict[str, Any], dict[str, Any]]
 
 _GENERATORS: dict[str, Callable[[random.Random], tuple[dict[str, Any], dict[str, Any]]]] = {
     'limb_disc': _gen_limb_disc,
+    'limb_disc_psf': _gen_limb_disc_psf,
     'limb_disc_ring_fixed': lambda rng: _gen_limb_disc_ring(rng, diverse=False),
     'limb_disc_ring_diverse': lambda rng: _gen_limb_disc_ring(rng, diverse=True),
     'limb_ring_aniso_fixed': lambda rng: _gen_limb_ring_aniso(rng, diverse=False),

--- a/util/agreement/tests/test_collect.py
+++ b/util/agreement/tests/test_collect.py
@@ -1,0 +1,123 @@
+"""Tests for the agreement collector's injection construction.
+
+Covers the per-scene injection draws and the PSF-layer sim_params rewrite
+without rendering a scene (rendering is exercised by the campaign itself).
+Requires the spindoctor package on the path; run from the repo checkout with
+``PYTHONPATH=src``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+sys.path.insert(0, str(_HERE.parent.parent.parent / 'src'))
+
+from collect import _apply_injection, _draw_injection, _inject_sim_params  # noqa: E402
+from scene_gen import generate_scenes  # noqa: E402
+
+_SEED = 20260719
+
+
+def _psf_scene() -> dict[str, object]:
+    """One validated limb_disc_psf scene's sim_params."""
+    _, params, _ = generate_scenes('limb_disc_psf', 1, campaign_seed=_SEED)[0]
+    return params
+
+
+def test_draw_none_is_disabled() -> None:
+    """The 'none' draw carries no bias."""
+    assert _draw_injection('none', 'scene', _SEED, 0.7) == {'kind': 'none'}
+
+
+def test_draw_psf_broaden_is_deterministic() -> None:
+    """The same scene/seed redraws the same broadening factor."""
+    a = _draw_injection('psf_broaden', 'limb_disc_psf_00000', _SEED, 0.7)
+    b = _draw_injection('psf_broaden', 'limb_disc_psf_00000', _SEED, 0.7)
+    assert a == b
+
+
+def test_draw_psf_broaden_factor_in_range() -> None:
+    """The broadening factor stays inside its declared log-uniform range."""
+    draw = _draw_injection('psf_broaden', 'limb_disc_psf_00003', _SEED, 0.7)
+    assert draw['kind'] == 'psf_broaden'
+    assert 1.4 <= draw['factor'] <= 3.0
+
+
+def test_draw_psf_aniso_carries_an_axis() -> None:
+    """The anisotropic draw names the broadened axis."""
+    draw = _draw_injection('psf_aniso', 'limb_disc_psf_00001', _SEED, 0.7)
+    assert draw['kind'] == 'psf_aniso'
+    assert draw['axis'] in ('v', 'u')
+    assert 1.6 <= draw['factor'] <= 3.5
+
+
+def test_inject_non_psf_passes_through() -> None:
+    """A DT-layer injection leaves the render params (and applied) untouched."""
+    params = _psf_scene()
+    draw = {'kind': 'dt_shift', 'bias_v': 0.1, 'bias_u': -0.2}
+    render_params, applied = _inject_sim_params(params, draw)
+    assert render_params is params
+    assert applied == {}
+
+
+def test_inject_psf_broaden_is_isotropic() -> None:
+    """psf_broaden scales both core sigmas by the factor above the matched sigma."""
+    params = _psf_scene()
+    draw = {'kind': 'psf_broaden', 'factor': 2.0}
+    render_params, applied = _inject_sim_params(params, draw)
+    psf = render_params['optics']['psf']
+    assert psf['sigma_v'] == pytest.approx(applied['base_sigma_px'] * 2.0)
+    assert psf['sigma_u'] == pytest.approx(applied['base_sigma_px'] * 2.0)
+    assert psf['w'] == 0.0
+
+
+def test_inject_psf_broaden_exceeds_matched_sigma() -> None:
+    """The rendered sigma is broader than the navigator's matched sigma."""
+    params = _psf_scene()
+    _, applied = _inject_sim_params(params, {'kind': 'psf_broaden', 'factor': 1.5})
+    assert applied['sigma_v_px'] > applied['base_sigma_px']
+
+
+def test_inject_psf_aniso_broadens_one_axis() -> None:
+    """psf_aniso broadens only the named axis (a zero-mean elliptical kernel)."""
+    params = _psf_scene()
+    render_params, applied = _inject_sim_params(
+        params, {'kind': 'psf_aniso', 'factor': 2.5, 'axis': 'v'}
+    )
+    psf = render_params['optics']['psf']
+    assert psf['sigma_v'] == pytest.approx(applied['base_sigma_px'] * 2.5)
+    assert psf['sigma_u'] == pytest.approx(applied['base_sigma_px'])
+
+
+def test_inject_psf_does_not_mutate_input() -> None:
+    """The injection deep-copies: the source scene keeps its matched-PSF block."""
+    params = _psf_scene()
+    _inject_sim_params(params, {'kind': 'psf_broaden', 'factor': 2.0})
+    assert params['optics']['psf'] == {'match_navigator': True}
+
+
+def test_inject_psf_base_is_the_navigator_nac_sigma() -> None:
+    """The broadening base is the emulated Cassini NAC's configured star_psf_sigma.
+
+    Pinned against the config value directly (not the code's own report) so a
+    wrong base -- e.g. the WAC 0.77 px or the sim-default 1.0 px instead of the
+    navigator's 0.54 px NAC belief -- would fail here rather than pass silently.
+    """
+    params = _psf_scene()
+    _, applied = _inject_sim_params(params, {'kind': 'psf_broaden', 'factor': 2.0})
+    assert applied['base_sigma_px'] == pytest.approx(0.54)
+
+
+def test_apply_injection_leaves_nav_side_unpatched_for_psf() -> None:
+    """A PSF injection acts on the render only; it adds no orchestrator patch."""
+    assert _apply_injection({'kind': 'psf_broaden', 'factor': 2.0}) == []
+
+
+def test_apply_injection_leaves_nav_side_unpatched_for_aniso() -> None:
+    """The anisotropic PSF injection also touches only the render side."""
+    assert _apply_injection({'kind': 'psf_aniso', 'factor': 2.0, 'axis': 'v'}) == []

--- a/util/agreement/tests/test_scene_gen.py
+++ b/util/agreement/tests/test_scene_gen.py
@@ -61,6 +61,34 @@ def test_limb_disc_body_fully_in_frame() -> None:
         assert body['axis1'] >= 104.0
 
 
+def test_limb_disc_psf_authors_matched_psf() -> None:
+    """The PSF family's control render matches the navigator (floor)."""
+    for _, params, geometry in generate_scenes('limb_disc_psf', 15, campaign_seed=_SEED):
+        assert params['optics']['psf'] == {'match_navigator': True}
+        assert geometry['composition'] == 'limb_disc_psf'
+        assert 0.0 <= geometry['illumination_deg'] <= 360.0
+
+
+def test_limb_disc_psf_body_fully_in_frame() -> None:
+    """The PSF family keeps the same fully-framed single-body geometry."""
+    for _, params, _ in generate_scenes('limb_disc_psf', 15, campaign_seed=_SEED):
+        assert len(params['bodies']) == 1
+        body = params['bodies'][0]
+        radius = body['axis1'] / 2.0
+        assert body['center_v'] - radius > 0.0
+        assert body['center_v'] + radius < FRAME_SIZE
+
+
+def test_limb_disc_psf_geometry_matches_limb_disc() -> None:
+    """PSF scenes differ from limb_disc only by the optics block, not geometry."""
+    plain = generate_scenes('limb_disc', 10, campaign_seed=_SEED)
+    psf = generate_scenes('limb_disc_psf', 10, campaign_seed=_SEED)
+    # Different families draw independent RNG streams, so the bodies differ;
+    # what must hold is that the PSF family adds optics and the plain one omits it.
+    assert all('optics' not in params for _, params, _ in plain)
+    assert all('optics' in params for _, params, _ in psf)
+
+
 def test_ring_line_clears_framed_body() -> None:
     """The ringlet mid-line keeps clear of the fully-framed body."""
     for _, params, geometry in generate_scenes('limb_disc_ring_diverse', 25, campaign_seed=_SEED):


### PR DESCRIPTION
## In plain terms

The navigator figures out where a spacecraft camera was really pointing by fitting several independent "techniques" to the same image -- for example, one fits the planet's lit limb (its curved edge against space), and one fits the planet's disc (its bright face) by sliding a template until it lines up. Each produces its own pointing offset. When two techniques disagree, that disagreement is our only handle on how accurate each one is -- but only if their mistakes are *independent*. If some shared piece of upstream processing makes them both wrong in the same direction, their disagreement shrinks and the pipeline fools itself into reporting better accuracy than it has. The "agreement study" (WS-0, #224) is the effort to prove when that independence holds.

The limb-plus-disc pair is the single most important case, because it is the *base* comparison the whole method is anchored on: if these two share a hidden mistake, the accuracy math is unreliable everywhere, not just in some corner. The earlier validation (PR #314) checked this pair and found no shared mistake -- but it checked through only one shared channel (an edge/gradient image) and, crucially, tested on images rendered with a perfectly sharp point of light. Real starlight and real edges are slightly blurred by the camera optics; that blur is called the point-spread function, or PSF. The specific way limb and disc could secretly move together runs *through* that blur: the disc-matching template can end up tracking the blurred limb edge, so if the blur is rendered or modeled slightly wrong, both techniques could drift the same way. A sharp-edge test can't see that mechanism at all. This PR re-runs the test with blur present.

## The bottom line

For the kind of blur error the simulator can faithfully reproduce, limb and disc do **not** develop a shared mistake -- so the base pair stays a usable anchor for the accuracy math in the Cassini narrow-angle-camera regime. The reason is concrete and stable: when the rendered blur is wrong, the limb fit moves a lot but the disc fit barely moves (about 16x less sensitive). Since two techniques can only "share" a mistake as large as the smaller of the two responses allows, the disc's near-indifference to blur caps how coupled they can be, whatever the direction.

Two honest limits, both filed as issues rather than papered over:

- This tests only *symmetric* blur error (the blur spreads evenly in all directions). The blur shape that most directly matches the feared mechanism is a *lopsided* (coma-like) blur that shifts the edge sideways -- and the simulator cannot render that faithfully, so it was left explicitly unprobed (#359) rather than faked.
- The disc template's coarse sub-pixel resolution sets a floor on the smallest coupling this test could have detected (#361).

So this is "no shared mistake for the blur error we can honestly render, bounded by the disc's insensitivity," not a blanket all-clear.

## What and why (technical)

Stage 0b of WS-0 (#224), follow-up to the agreement-estimator validation (PR #314). Closes the outstanding piece of #320: the main campaign measured limb-DT vs disc-NCC bias independence only through the shared gradient / edge-distance-transform channel, in a PSF-free regime. The disc reads the image (not the DT products), so its response to that channel was 0.000 by construction and the pair could not have coupled through it either way. The mechanism that channel cannot reach is a shared PSF edge bias, which can appear only against a rendered blurred edge.

## What this adds (all under `util/agreement/`, outside the shipped package)

- **`limb_disc_psf` scene family** (`scene_gen.py`): the same fully-framed, partially-lit body as `limb_disc`, rendered through an active whole-scene PSF. The control render uses `optics.psf: {match_navigator: true}` (the PSF self-consistency floor: the rendered Gaussian equals the navigator's own `star_psf_sigma`, so there is no render-vs-navigate mismatch).
- **Two render-side PSF-layer injections** (`collect.py`): `psf_broaden` scales the rendered PSF core sigma isotropically by a per-scene factor above the navigator's belief; `psf_aniso` scales one image axis only (a zero-mean elliptical kernel that softens the edge directionally without translating the image -- a whole-kernel centroid shift is degenerate with a pointing offset and is deliberately not used). Render-side only; nothing under `src/` changes; the navigator keeps its own modeled PSF.
- **Induced-coupling analysis** (`analyze.py`): truth-based limb-disc coupling control-vs-injected, the paired per-scene limb/disc response, and the deltas decomposed onto each scene's illumination axis (`--psf-broaden-rows` / `--psf-aniso-rows`).
- **Tests** for the scene family and the injection construction (draws, base sigma pinned against the NAC config value, render/nav-side separation, no input mutation).
- **Campaign record**: a dated `Stage 0b addendum (PSF layer)` section appended to `CAMPAIGN_20260719.md`.

## Finding (400 scenes/pass, seed 20260719, 0 errors)

A **symmetric** PSF-rendering mismatch opens **no shared limb-disc edge bias**. The robust, resample-stable fact is that the disc-NCC barely responds to the PSF mismatch (median |delta| 0.008 px, p90 0.47 px) while the limb-DT responds strongly (median 0.13 px, p90 4.0 px, ~16x). Because `|cov| <= sqrt(Var_limb * Var_disc)`, the disc's small response caps the coupling magnitude whatever its sign. The induced coupling is small and consistent with zero (400-scene induced correlation -0.06; an independent 30-scene resample landed at +0.14 -- the sign is not robust, so the claim is "magnitude-bounded / consistent with zero", not "safely negative"). The limb's large, heavy-tailed PSF sensitivity is a per-technique variance for `C_limb` (it corroborates the ~2.6 px limb covariance floor and the documented `psf_limb_mismatch` navigability cliff), not a bias shared with the disc.

**Scope, stated honestly (not a blanket verdict).** This probes only the PSF errors the simulator can honestly render (symmetric Gaussian core + isotropic Moffat wing). The asymmetric / coma kernel that most directly matches the #320 mechanism -- an NCC disc peak tracking a *shifted* blurred edge -- is unrenderable, so rather than fabricate an error model the realism match does not vouch for, it is left explicitly unprobed and tracked in **#359**. The disc's coarse sub-pixel NCC resolution floors the smallest detectable coupling (**#361**). Per the simulator capability envelope, PSF accuracy is realism-supported for the Cassini NAC only; elsewhere these are reproducibility statements.

## Consequence for #225

The base limb-disc pair stays a usable independence anchor for the covariance solve **against symmetric PSF error, in the Cassini-NAC regime** -- the shared-PSF-edge-bias hazard that motivated #320 does not materialize for that class. It is not a clean-on-all-PSF verdict: a mild intrinsic negative coupling is real (control corr -0.24) with an unreliable sign, so carry a declared limb-disc pair covariance where precision demands, and the asymmetric-PSF channel remains open (#359).

## Follow-ups filed

- #359 -- probe limb-disc PSF coupling under PSF error forms the sim cannot render (asymmetric / coma / field-varying).
- #361 -- disc NCC sub-pixel resolution floors the smallest detectable coupling.

## Validation

- `util/agreement` focused: `ruff check`, `ruff format --check`, `mypy --strict`, and `pytest util/agreement/tests` (58 passed) all clean.
- Full `scripts/run-all-checks.sh` (non-integration: ruff/format/mypy on src+tests, unit pytest, `sphinx -W`, pymarkdown) passes. The diff touches only `util/agreement/` (outside the repo's ruff/mypy/pytest/sphinx scope) and one `util/` markdown doc (outside pymarkdown's scanned roots), so the integration suite is identical to `main`; integration collection is clean.
- Independent fresh-context review completed; its two framing corrections (bound on coupling magnitude rather than a "safe negative sign"; scope the headline to symmetric PSF error) are folded into the campaign record, the tests, and this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HoCUAeNeMz5bFmGk2iVBf
