### PR TITLE
fix: make campaign worker thread pinning effective under fork (#287)

### DIFF
--- a/util/agreement/collect.py
+++ b/util/agreement/collect.py
@@ -56,11 +56,29 @@ import argparse
 import json
 import math
 import multiprocessing
+import os
 import random
 import sys
 import time
 from pathlib import Path
 from typing import Any
+
+# Pin native (BLAS/OpenMP) thread pools to one thread per process before the
+# first numpy import, which happens transitively through ``scene_gen`` below.
+# The worker pool uses the default fork start method, so each worker inherits
+# the parent's already-initialized threading runtime: setting these variables
+# in the pool initializer runs after that runtime is configured and has no
+# effect.  Setting them here, ahead of numpy's first import, makes the parent
+# (and therefore every forked worker it inherits from) single-threaded, which
+# is what keeps the pool from oversubscribing the machine.  ``setdefault``
+# leaves an explicit operator override in place.
+for _thread_var in (
+    'OMP_NUM_THREADS',
+    'OPENBLAS_NUM_THREADS',
+    'MKL_NUM_THREADS',
+    'NUMEXPR_NUM_THREADS',
+):
+    os.environ.setdefault(_thread_var, '1')
 
 HERE = Path(__file__).parent
 REPO = HERE.parent.parent
@@ -369,21 +387,14 @@ def _navigate_one(
 
 
 def _init_worker() -> None:
-    """Pin per-worker threading and silence the per-image logger.
+    """Silence the per-image logger in a freshly forked pool worker.
 
-    One BLAS/OpenMP thread per worker: the pool already saturates the
-    cores.  The env vars must be set before the worker's first numpy
-    import, which is why this runs in the pool initializer.
+    Thread pinning is handled at module import (one BLAS/OpenMP thread per
+    process, set before the first numpy import and inherited by every forked
+    worker), not here: under the default fork start method a worker inherits
+    the parent's already-initialized threading runtime, so setting the thread
+    variables in this initializer would be too late to take effect.
     """
-    import os
-
-    for var in (
-        'OMP_NUM_THREADS',
-        'OPENBLAS_NUM_THREADS',
-        'MKL_NUM_THREADS',
-        'NUMEXPR_NUM_THREADS',
-    ):
-        os.environ[var] = '1'
     import pdslogger
 
     from spindoctor.config.logger import IMAGE_LOGGER, MAIN_LOGGER

--- a/util/agreement/collect.py
+++ b/util/agreement/collect.py
@@ -387,9 +387,11 @@ def _navigate_one(
 
 
 def _init_worker() -> None:
-    """Silence the per-image logger in a freshly forked pool worker.
+    """Silence the per-image and main loggers in a pool worker.
 
-    Thread pinning is handled at module import (one BLAS/OpenMP thread per
+    Runs once per worker: at fork when the pool starts, and again after each
+    ``maxtasksperchild`` respawn.  Native thread-pool pinning is handled at
+    module import (the BLAS/OpenMP/NumExpr pools are capped to one thread per
     process, set before the first numpy import and inherited by every forked
     worker), not here: under the default fork start method a worker inherits
     the parent's already-initialized threading runtime, so setting the thread

--- a/util/calibration/README.md
+++ b/util/calibration/README.md
@@ -129,14 +129,14 @@ Notes on reproducing the measurement:
 
 - Worker thread pinning is automatic: `collect.py` sets the
   `*_NUM_THREADS=1` variables at module import, ahead of the first numpy
-  import, so the parent process starts single-threaded and every forked
-  worker inherits that.  No shell-level exports are needed.  (Setting the
-  variables in the pool initializer would be too late under the fork start
-  method, since workers inherit the parent's already-initialized BLAS
-  thread pools.)  To let workers use multiple BLAS threads for a
-  deliberately-different measurement, export the variables with higher
-  values before running -- `collect.py` uses `setdefault`, so an explicit
-  value wins.
+  import, so the parent's native BLAS/OpenMP/NumExpr thread pools are
+  capped to one thread and every forked worker inherits that.  No
+  shell-level exports are needed.  (Setting the variables in the pool
+  initializer would be too late under the fork start method, since workers
+  inherit the parent's already-initialized BLAS thread pools.)  To let
+  workers use multiple BLAS threads for a deliberately-different
+  measurement, export the variables with higher values before running --
+  `collect.py` uses `setdefault`, so an explicit value wins.
 - Worker CPU affinity on this machine is load-bearing, not cosmetic:
   always `source setup.sh` first so the excluded cores stay excluded.
 

--- a/util/calibration/README.md
+++ b/util/calibration/README.md
@@ -115,9 +115,7 @@ disc-texture slice):
 
 ```bash
 source setup.sh
-OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
-    NUMEXPR_NUM_THREADS=1 \
-    python util/calibration/collect.py \
+python util/calibration/collect.py \
     --per-family 600 --workers 14 --out _work/calibration/rows.jsonl
 ```
 
@@ -129,11 +127,16 @@ well inside the 2x budget below.
 
 Notes on reproducing the measurement:
 
-- The shell-level `*_NUM_THREADS=1` exports are **required**: `collect.py`
-  sets the same variables inside each worker, but the workers inherit the
-  parent's already-initialized BLAS thread pools under the fork start
-  method, so the in-worker pinning does not take effect.  Unpinned
-  BLAS threads oversubscribe the 14 workers and distort the timing.
+- Worker thread pinning is automatic: `collect.py` sets the
+  `*_NUM_THREADS=1` variables at module import, ahead of the first numpy
+  import, so the parent process starts single-threaded and every forked
+  worker inherits that.  No shell-level exports are needed.  (Setting the
+  variables in the pool initializer would be too late under the fork start
+  method, since workers inherit the parent's already-initialized BLAS
+  thread pools.)  To let workers use multiple BLAS threads for a
+  deliberately-different measurement, export the variables with higher
+  values before running -- `collect.py` uses `setdefault`, so an explicit
+  value wins.
 - Worker CPU affinity on this machine is load-bearing, not cosmetic:
   always `source setup.sh` first so the excluded cores stay excluded.
 

--- a/util/calibration/collect.py
+++ b/util/calibration/collect.py
@@ -26,10 +26,29 @@ import dataclasses
 import json
 import math
 import multiprocessing
+import os
 import sys
 import time
 from pathlib import Path
 from typing import Any
+
+# Pin native (BLAS/OpenMP) thread pools to one thread per process before the
+# first numpy import, which happens transitively through ``scene_gen`` below.
+# The worker pool uses the default fork start method, so each worker inherits
+# the parent's already-initialized threading runtime: setting these variables
+# in the pool initializer runs after that runtime is configured and has no
+# effect.  Setting them here, ahead of numpy's first import, makes the parent
+# (and therefore every forked worker it inherits from) single-threaded, which
+# is what keeps the pool from oversubscribing the machine (~10x wall-clock
+# inflation otherwise).  ``setdefault`` leaves an explicit operator override in
+# place.
+for _thread_var in (
+    'OMP_NUM_THREADS',
+    'OPENBLAS_NUM_THREADS',
+    'MKL_NUM_THREADS',
+    'NUMEXPR_NUM_THREADS',
+):
+    os.environ.setdefault(_thread_var, '1')
 
 HERE = Path(__file__).parent
 REPO = HERE.parent.parent
@@ -128,23 +147,14 @@ def _navigate_one(task: tuple[str, str, dict[str, Any]]) -> dict[str, Any]:
 
 
 def _init_worker() -> None:
-    """Pin per-worker threading and silence the per-image logger.
+    """Silence the per-image logger in a freshly forked pool worker.
 
-    One BLAS/OpenMP thread per worker: the pool already saturates the
-    cores, and letting every worker spin a full thread team oversubscribes
-    the machine badly (measured ~10x wall-clock inflation).  The env vars
-    must be set before the worker's first numpy import, which is why this
-    runs in the pool initializer rather than at module import.
+    Thread pinning is handled at module import (one BLAS/OpenMP thread per
+    process, set before the first numpy import and inherited by every forked
+    worker), not here: under the default fork start method a worker inherits
+    the parent's already-initialized threading runtime, so setting the thread
+    variables in this initializer would be too late to take effect.
     """
-    import os
-
-    for var in (
-        'OMP_NUM_THREADS',
-        'OPENBLAS_NUM_THREADS',
-        'MKL_NUM_THREADS',
-        'NUMEXPR_NUM_THREADS',
-    ):
-        os.environ[var] = '1'
     import pdslogger
 
     from spindoctor.config.logger import IMAGE_LOGGER, MAIN_LOGGER

--- a/util/calibration/collect.py
+++ b/util/calibration/collect.py
@@ -147,9 +147,11 @@ def _navigate_one(task: tuple[str, str, dict[str, Any]]) -> dict[str, Any]:
 
 
 def _init_worker() -> None:
-    """Silence the per-image logger in a freshly forked pool worker.
+    """Silence the per-image and main loggers in a pool worker.
 
-    Thread pinning is handled at module import (one BLAS/OpenMP thread per
+    Runs once per worker: at fork when the pool starts, and again after each
+    ``maxtasksperchild`` respawn.  Native thread-pool pinning is handled at
+    module import (the BLAS/OpenMP/NumExpr pools are capped to one thread per
     process, set before the first numpy import and inherited by every forked
     worker), not here: under the default fork start method a worker inherits
     the parent's already-initialized threading runtime, so setting the thread


### PR DESCRIPTION
Closes #287.

## Problem
`util/calibration/collect.py` (and its twin `util/agreement/collect.py`) set `OMP_NUM_THREADS` / `OPENBLAS_NUM_THREADS` / `MKL_NUM_THREADS` / `NUMEXPR_NUM_THREADS` = 1 inside the pool initializer `_init_worker`. The pool is created with `multiprocessing.Pool(...)`, which defaults to the **fork** start method on Linux, so each worker inherits the parent's already-imported and already-initialized numpy/OpenMP runtime. The env vars are therefore set after the threading runtime is configured and have no effect. Measured impact: every worker runs a full BLAS thread team (NLWP ~30), load average ~250+ per campaign, ~10x wall-clock inflation — the exact regime the initializer's own docstring warned about.

## Fix
Set the four variables at **module import, before the first numpy import** (which happens transitively through the `scene_gen` import), using `os.environ.setdefault` so an explicit operator override still wins. The parent process then initializes numpy single-threaded, and every forked worker inherits that state; `maxtasksperchild` respawns fork from the same parent, so they inherit it too. `_init_worker` keeps only the logger silencing.

This is fix option 1 from the issue (dependency-free; keeps fork's fast startup). Applied to both campaign drivers since they share the identical bug.

## Verification
Importing either module with the shell thread vars unset now reports a single BLAS thread, where importing numpy first reports the full team:

```
control (numpy imported first):      max BLAS threads: 30
util/calibration/collect.py import:  max BLAS threads: 1
util/agreement/collect.py import:    max BLAS threads: 1
```

`ruff check` and `ruff format --check` clean on both files.

## Docs
`util/calibration/README.md` updated: the shell-level `*_NUM_THREADS=1` exports are no longer required (pinning is automatic at import); an explicit higher value can still be exported to opt into multi-threaded workers.

Note for the operator: `plans/OPERATOR_PLAYBOOK.md` §4 and `plans/SIM_REALISM_PLAN.md` §15.9 still tell sessions to export the thread vars "until #287 is fixed" — those references can be dropped once this merges (left untouched here to avoid churn in the operator-owned plan docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HoCUAeNeMz5bFmGk2iVBf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved campaign collection reliability by ensuring native computation libraries use a single thread per process from startup.
  * Prevented inconsistent thread configuration across worker processes.

* **Documentation**
  * Updated calibration instructions and reproduction notes to reflect the automatic thread configuration.
  * Clarified that explicitly configured thread counts override the default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->