### PR TITLE
docs: document sd_consolidate_metadata in the user guide (#298)

### DIFF
--- a/docs/introduction_overview.rst
+++ b/docs/introduction_overview.rst
@@ -69,7 +69,8 @@ Navigation Phase
 
 * ``sd_consolidate_metadata`` - Copy each image's metadata JSON and/or summary
   PNG to a single flat directory so results are easy to browse without
-  descending the per-volume path hierarchy.
+  descending the per-volume path hierarchy (see
+  :doc:`/user_guide/user_guide_navigation`).
 
 * ``sd_stats_ingest`` - Ingest per-image navigation metadata JSON files into a
   SQLite database (see :doc:`/user_guide/user_guide_statistics`).

--- a/docs/user_guide/user_guide_navigation.rst
+++ b/docs/user_guide/user_guide_navigation.rst
@@ -928,6 +928,42 @@ to ``true`` has no effect in the current release.
    rings:
      remove_body_shadows: false   # default; not yet implemented
 
+Consolidating Navigation Outputs
+================================
+
+``sd_offset`` writes each image's results (the ``*_metadata.json`` offset file
+and the ``*_summary.png`` preview) under the navigation results root, mirroring
+the per-volume directory hierarchy of the input holdings. Browsing results
+across many volumes therefore means descending a deep path tree. The
+``sd_consolidate_metadata`` program copies the results for a selected set of
+images into a single flat directory so they are easy to review or hand off.
+
+It selects images with the same dataset arguments as ``sd_offset`` (positional
+image names, ``--volumes``, image-number and file-list filters, and so on), and
+for each selected image copies the requested product(s) out of the navigation
+results root into the destination directory:
+
+* ``--dest-dir PATH``: destination directory; every copied file lands directly
+  here with no subdirectories, and missing parents are created on first write.
+* ``--copy-metadata``: copy the per-image ``*_metadata.json`` files.
+* ``--copy-png``: copy the per-image ``*_summary.png`` files.
+* ``--copy-both``: copy both (equivalent to ``--copy-metadata --copy-png``).
+* ``--index-prefix``: prefix each destination filename with a six-digit
+  increasing index so the flat listing matches the iteration order.
+* ``--overwrite``: overwrite destination files that already exist.
+* ``--dry-run``: report what would be copied without copying anything.
+
+It reads (and never modifies) the navigation results; the source root comes
+from ``--nav-results-root``, the ``NAV_RESULTS_ROOT`` environment variable, or
+the ``nav_results_root`` configuration value, and holdings and configuration
+are resolved exactly as for ``sd_offset``.
+
+For example, to gather the summary PNGs for one Cassini volume into a single
+directory for a quick visual pass::
+
+   sd_consolidate_metadata coiss --volumes COISS_2xxx/COISS_2116 \
+       --copy-png --index-prefix --dest-dir /tmp/coiss_2116_summaries
+
 Troubleshooting
 ===============
 


### PR DESCRIPTION
Closes #298.

`sd_consolidate_metadata` appeared only in the introduction overview's program list — unlike its sibling post-navigation programs (`sd_stats_ingest`/`sd_stats_report`, `sd_backplanes`, `sd_create_bundle`, `sd_mosaic`), each of which has a dedicated user-guide chapter or section. This adds proper user documentation.

- New **Consolidating Navigation Outputs** section in `docs/user_guide/user_guide_navigation.rst`: what the program is for (flatten `*_metadata.json` / `*_summary.png` results out of the per-volume hierarchy into one directory), that it selects images with the same dataset arguments as `sd_offset`, the consolidation flags (`--dest-dir`, `--copy-metadata`, `--copy-png`, `--copy-both`, `--index-prefix`, `--overwrite`, `--dry-run`), how the results root / holdings / config resolve, and a worked example. Flags verified against `src/spindoctor/cli/sd_consolidate_metadata.py`.
- Cross-reference added from the overview entry to that section.

`sphinx-build -W` builds clean. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HoCUAeNeMz5bFmGk2iVBf