### PR TITLE
fix: fuse correlated ensemble witnesses as one (#222, #317, #339)

### DIFF
--- a/docs/api_reference/api_nav_orchestrator.rst
+++ b/docs/api_reference/api_nav_orchestrator.rst
@@ -53,6 +53,11 @@ spindoctor.nav_orchestrator
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: spindoctor.nav_orchestrator.ensemble_independence
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: spindoctor.nav_orchestrator.ensemble_observability
    :members:
    :undoc-members:

--- a/docs/api_reference/api_support.rst
+++ b/docs/api_reference/api_support.rst
@@ -8,6 +8,11 @@ spindoctor.support
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: spindoctor.support.background_gradient
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: spindoctor.support.constants
    :members:
    :undoc-members:

--- a/docs/dev_guide/dev_guide_orchestrator_ensemble.rst
+++ b/docs/dev_guide/dev_guide_orchestrator_ensemble.rst
@@ -18,7 +18,7 @@ fused via precision-weighted (Kalman-style) merging.
 Theory
 ======
 
-The ensemble's reconciliation is a seven-step pipeline.
+The ensemble's reconciliation is an eight-step pipeline.
 
 Step 1 — drop spurious
 ----------------------
@@ -64,10 +64,10 @@ rank-1 fit, or a rotation-unobservable star result) carries meaningless values a
 the axis it cannot observe; differencing those against a result that *does* observe
 that axis would manufacture disagreement out of nothing. Restricting the comparison to
 the directions both results genuinely constrain lets a rank-1 ring edge and a full-rank
-blob that agree radially group — and Step 5 then fuses the ring's radial precision with
+blob that agree radially group — and Step 6 then fuses the ring's radial precision with
 the blob's along-edge constraint. Two results with no shared observable direction have
 nothing to disagree on and are treated as agreeing, so their complementary constraints
-combine. The pseudo-inverse used here and in Step 5 quarantines the huge
+combine. The pseudo-inverse used here and in Step 6 quarantines the huge
 unobservable-axis sentinel variances (the ``1e15`` rotation sentinel and the
 ``1e12``-scale translation sentinels) and inverts them separately from the genuine
 block, so a sentinel axis cannot raise the eigenvalue cutoff and silently zero the
@@ -90,9 +90,11 @@ searches a small window around the pass-1 prior — is conditionally dependent o
 techniques that set that prior. The orchestrator records those techniques on the
 result's :attr:`~spindoctor.nav_technique.technique_result.NavTechniqueResult.prior_source_techniques`;
 when such a technique sits in the same subset, the descendant re-observed its own seed
-and casts **no independent vote** (it may still refine the fused offset in Step 5, just
-not corroborate its prior). This stops a marginal refine seeded by a wrong pass-1
-answer from "confirming" that answer and inflating consensus.
+and casts **no independent vote**. A multi-star refine may still lend its precision to
+the fused offset in Step 6; a *single*-star refine adds no independent constraint at all
+and is dropped from the combine entirely in Step 5 (below). This stops a marginal refine
+seeded by a wrong pass-1 answer from "confirming" that answer and inflating consensus, or
+from dragging the fused offset off the pass-1 techniques that agree at the truth.
 
 Exclusion forces the conflicted branch only when the excluded results constitute a
 genuine alternative answer: the strongest consensus formable among the excluded
@@ -110,10 +112,52 @@ summed-confidence gap test that then decides a conflict is applied in two regime
   not a conflict.
 
 A lone dissenter against a multi-technique consensus is outlier-rejected: the consensus
-is fused normally (with the Step 6 disagreement penalty) and the dissenter appears only
+is fused normally (with the Step 7 disagreement penalty) and the dissenter appears only
 in ``excluded_from_consensus`` and ``per_technique``.
 
-Step 5 — precision-weighted merge
+Step 5 — resolve independent estimators
+---------------------------------------
+
+The precision-weighted merge and the agreement boost both assume the members they fuse are
+*independent* measurements: their information matrices add (so two agreeing witnesses fuse
+to a tighter covariance than either alone), and their mutual agreement multiplies the
+confidence. That assumption is false whenever two members draw on the same underlying
+error source, and fusing them anyway over-tightens the covariance (inflating the tier),
+spuriously boosts the confidence, and lets a redundant member drag the offset. Before the
+merge, :func:`~spindoctor.nav_orchestrator.ensemble_independence.resolve_independent_estimators`
+resolves the winning subset into the set of estimators the merge may treat as independent,
+correcting three known correlations:
+
+- **Seeded single-star refine.** A one-inlier
+  :class:`~spindoctor.nav_technique.nav_technique_star_refine.StarRefineNav` seeded by a
+  technique in the subset (Step 4) re-observes its own prior near the predicted position
+  and adds no independent constraint, so it is dropped from the combine entirely. A
+  multi-star refine carries genuine catalog matches and is kept (it still casts no
+  corroboration vote).
+- **Two ring techniques on one catalog.**
+  :class:`~spindoctor.nav_technique.nav_technique_ring_edge.RingEdgeNav` and
+  :class:`~spindoctor.nav_technique.nav_technique_ring_annulus.RingAnnulusNav` read the
+  same predicted ring geometry from the same catalog model; a radially misplaced catalog
+  puts both wrong by the same amount, so they are collapsed to a single representative
+  witness rather than fused as two.
+- **Disc and limb on one scattered-light gradient.** On a frame whose
+  :attr:`~spindoctor.nav_orchestrator.image_classifier_result.NavImageClassifierResult.background_gradient_score`
+  clears ``scattered_light_gradient_score`` (default 5.0), a large-scale veiling ramp
+  crosses the sensor and both
+  :class:`~spindoctor.nav_technique.nav_technique_body_disc.BodyDiscCorrelateNav` and
+  :class:`~spindoctor.nav_technique.nav_technique_body_limb.BodyLimbNav` lock onto the ramp
+  rather than the body, correlating their errors; the disc and limb results on one body are
+  then collapsed to a single representative. On a clean frame (score below the threshold)
+  they remain two independent witnesses.
+
+The representative of a collapsed set is its highest-positional-precision member (with a
+deterministic tie-break), so the fused offset is the single best view of the shared
+measurement, not a spuriously tightened average of two. The full consensus membership is
+still reported on
+:attr:`~spindoctor.nav_orchestrator.nav_result.NavResult.consensus_techniques` for
+transparency; only the fusion math sees the resolved set.
+
+Step 6 — precision-weighted merge
 ---------------------------------
 
 Inside the winning group, fuse the per-technique offsets into one estimate via
@@ -124,7 +168,7 @@ pseudo-inverse of the summed information matrix. The pseudoinverse handles rank-
 inputs (e.g. a flat-ring-only result) gracefully — the unobservable axis carries an
 unbounded marginal sigma.
 
-Step 6 — disagreement and conflict penalties
+Step 7 — disagreement and conflict penalties
 --------------------------------------------
 
 When any result was excluded from the consensus, the fused confidence is multiplied
@@ -133,7 +177,7 @@ by ``disagreement_penalty`` (default 0.7). When the conflict branch fired in Ste
 ``conflicted_confidence_multiplier`` (default 0.3) applied to the winning group's
 combined confidence so the JSON sidecar reflects the conflict's severity.
 
-Step 7 — confidence-rank assignment
+Step 8 — confidence-rank assignment
 -----------------------------------
 
 The fused confidence and the per-axis sigma are mapped to a five-bucket rank
@@ -183,14 +227,17 @@ scene (``tests/integration/sim_scenes/ring_system/orbit_error_ringlet.yaml``)
 both ring techniques widen their reported covariance by the declared 2.5 px
 catalog error bar along the translation each would absorb such a displacement
 into -- the edge fit from its fit vertices, the annulus correlation from the
-same edge normals painted into its composite template. The fused radial sigma
-grows past the high tier's cap and the biased offset demotes to ``medium``.
-Because both members price the same hazard rather than one carrying an
-un-widened radial axis, the fused sigma covers the residual bias (a measured
-~2.3 px error against a ~1.8 px fused sigma, about 1.3 sigma, where widening the
-edge fit alone left ~2.8 sigma). The channel prices the hazard; it cannot
-remove the bias, so the scene keeps its measured-error pin. The shared DT
-fit-quality gates
+same edge normals painted into its composite template. Because the two ring
+techniques read one catalog model, the Step 5 independence resolution collapses
+them to a single representative witness before the merge, so the fused radial
+sigma is that one witness's honest ~2.5 px rather than the value a
+two-independent-witness fuse would shrink it to. The biased offset then demotes
+to ``low`` (a measured confidence around 0.89 against a ~2.5 px sigma that
+covers the residual bias), and the scene keeps its measured-error pin: the
+channel prices the hazard, but it cannot remove the bias. Collapsing the ring
+pair is what stops the spurious alternative -- treating the two correlated
+views as independent, which shrank the sigma below the hazard and let the
+agreement boost re-inflate the confidence. The shared DT fit-quality gates
 (:doc:`dev_guide_techniques_dt_fitting`) close the adjacent
 unverified-fit family before results reach the ensemble at all.
 
@@ -316,7 +363,7 @@ constructor accepts an :class:`~spindoctor.nav_orchestrator.ensemble.EnsembleCon
   most of the discrimination, so the ``'medium'`` and ``'low'`` confidence floors rest
   at the same value as the final ``min_confidence`` gate. A structural consequence:
   the two-star and one-star confidence caps (0.8 / 0.7) sit below the high boundary,
-  so capped star locks top out at medium regardless of quality. The Step 7 tier caps
+  so capped star locks top out at medium regardless of quality. The Step 8 tier caps
   apply on top of these thresholds.
 
 Implementation

--- a/docs/dev_guide/dev_guide_orchestrator_ensemble.rst
+++ b/docs/dev_guide/dev_guide_orchestrator_ensemble.rst
@@ -153,9 +153,10 @@ correcting three known correlations:
 The representative of a collapsed set is its highest-positional-precision member (with a
 deterministic tie-break), so the fused offset is the single best view of the shared
 measurement, not a spuriously tightened average of two. The full consensus membership is
-still reported on
+reported on
 :attr:`~spindoctor.nav_orchestrator.nav_result.NavResult.consensus_techniques` for
-transparency; only the fusion math sees the resolved set.
+transparency, while the resolved set of independent witnesses drives the precision-weighted
+fusion, the agreement boost, the quorum count, and the vote mass.
 
 Step 6 — precision-weighted merge
 ---------------------------------
@@ -261,15 +262,17 @@ CI. A high tier on a frame with plausible *undeclared* systematic error is
 not evidence against that error.
 
 A related honesty caveat survives inside the confidence scalar itself: the
-two-member agreement boost assumes the members' errors are independent, so
-two techniques observing the same displaced feature (the ring-edge fit and
-the ring-annulus correlation on one misplaced ringlet) can fuse to a high
-scalar confidence even as the sigma-gated tier demotes the result. The
-planted-orbit-error scene above is exactly this case: once both ring
-techniques widen isotropically their radial weights re-couple, the agreement
-boost engages, and the scene reports a ~0.99 scalar at ``medium`` tier and
-~2.3 px error. On such frames the tier is the trustworthy verdict and the
-scalar is not.
+two-member agreement boost assumes the members' errors are independent, so two
+techniques observing the same displaced feature can fuse to a high scalar
+confidence even as the sigma-gated tier demotes the result. The Step 5
+independence resolution collapses the correlations it models -- the two ring
+techniques on one catalog, disc and limb on one veiling gradient -- to a single
+witness before the merge, so those pairs do not earn the boost; the
+planted-orbit-error scene above accordingly lands at ``low`` on its honest
+~2.5 px sigma rather than at a boosted near-cap scalar. The caveat is that any
+correlation the resolution does not model still couples two members while the
+boost treats them as independent, and on such frames the tier is the
+trustworthy verdict and the scalar is not.
 
 That scalar is **not** inert, and it must not be dismissed as documentation.
 The tier boundaries are themselves fitted *from* it: the calibration tooling
@@ -284,9 +287,9 @@ Two consequences worth stating plainly:
   the calibration cohort (it is generated independently by the campaign's
   own randomized scene generator), so no scene-level exclusion is needed
   and none is applied.
-- The cohort's own ring family *does* plant orbit errors with declared
-  sigmas, so it generates rows with this same coupling. The next
-  recalibration has to treat them deliberately -- by pricing the
+- Any correlation the independence resolution does not model still generates
+  cohort rows that pair a near-cap confidence with a multi-pixel error. The
+  next recalibration has to treat them deliberately -- by pricing the
   correlated-error discount, or by fitting the boundary against fused sigma
   rather than the boosted scalar -- rather than absorbing them as evidence
   that high confidence at multi-pixel error is normal.
@@ -369,7 +372,7 @@ constructor accepts an :class:`~spindoctor.nav_orchestrator.ensemble.EnsembleCon
 Implementation
 ==============
 
-The ensemble is split across three modules under ``src/spindoctor/nav_orchestrator/``:
+The ensemble is split across four modules under ``src/spindoctor/nav_orchestrator/``:
 
 - ``ensemble.py`` — the reconciler itself:
   :func:`~spindoctor.nav_orchestrator.ensemble.ensemble`,
@@ -380,6 +383,11 @@ The ensemble is split across three modules under ``src/spindoctor/nav_orchestrat
   :func:`~spindoctor.nav_orchestrator.ensemble_consensus.corroborating_members`,
   :func:`~spindoctor.nav_orchestrator.ensemble_consensus.corroborating_confidence`, and
   :func:`~spindoctor.nav_orchestrator.ensemble_consensus.result_param_vector`.
+- ``ensemble_independence.py`` — the independence-resolution step that collapses
+  correlated witnesses before the merge:
+  :func:`~spindoctor.nav_orchestrator.ensemble_independence.resolve_independent_estimators`,
+  :func:`~spindoctor.nav_orchestrator.ensemble_independence.is_single_star_result`, and
+  :class:`~spindoctor.nav_orchestrator.ensemble_independence.IndependenceResolution`.
 - ``ensemble_observability.py`` — observable-subspace linear algebra:
   :func:`~spindoctor.nav_orchestrator.ensemble_observability.mixed_scale_pinvh`,
   :func:`~spindoctor.nav_orchestrator.ensemble_observability.observable_basis`,

--- a/plans/ENGINEERING_PLAN.md
+++ b/plans/ENGINEERING_PLAN.md
@@ -21,10 +21,10 @@ fields to match current behavior.
 
 ## Track B — Navigation correctness
 
-Ordering within the track: the confidently-wrong defects first (#328, #346,
-#291, #326, #327, #350, #351, #352), because the agreement study consumes
-ensemble output at scale and several curated library frames pin these as
-standing red regressions. Then the coarse-lock calibration (#373) and the
+Ordering within the track: the confidently-wrong defects first
+(#328, #346, #291, #326, #327, #350, #351, #352), because the agreement study
+consumes ensemble output at scale and several curated library frames pin these
+as standing red regressions. Then the coarse-lock calibration (#373) and the
 star-matcher robustness items (#337, #376, #367), then the
 investigation/design items (#25, #128/#150), with the smaller decision items
 (#130, #239, #338) as fill.

--- a/plans/ENGINEERING_PLAN.md
+++ b/plans/ENGINEERING_PLAN.md
@@ -21,55 +21,30 @@ fields to match current behavior.
 
 ## Track B — Navigation correctness
 
-Ordering within the track: the confidently-wrong and ensemble-honesty
-defects first (#222, #317, #328, #339, #346, #291, #326, #327, #350, #351,
-#352), because the agreement study consumes ensemble output at scale and
-several curated library frames pin these as standing red regressions. Then
-the coarse-lock calibration (#373) and the star-matcher robustness items
-(#337, #376, #367), then the investigation/design items (#25, #128/#150),
-with the smaller decision items (#130, #239, #338) as fill.
+Ordering within the track: the confidently-wrong defects first (#328, #346,
+#291, #326, #327, #350, #351, #352), because the agreement study consumes
+ensemble output at scale and several curated library frames pin these as
+standing red regressions. Then the coarse-lock calibration (#373) and the
+star-matcher robustness items (#337, #376, #367), then the
+investigation/design items (#25, #128/#150), with the smaller decision items
+(#130, #239, #338) as fill.
 
-### #222 — Second-pass refinement votes as an independent opinion (reopened)
-
-**Symptom:** `StarRefineNav` in pass 2 runs from the pass-1 consensus prior,
-lands near it (as it must — it is a local refinement), and is then counted
-as independent corroboration. On N1572105349 (body_full_fov) disc and limb
-agree at the operator truth but the single-inlier StarRefine (capped to 0.5)
-sits ~2 px off and pulls the fused answer to ~1.8 px error, still reported at
-high tier. The failure mode is not just inflated confidence on failed frames
-— it degrades accurate answers while keeping the tier. The frame carries a
-library sidecar pinned to that navigable truth, so its autonomous regression
-stays red until this lands.
-
-**Where:** the two-pass flow in
-`src/spindoctor/nav_orchestrator/orchestrator.py` plus the ensemble's
-membership rules in `ensemble.py`.
-
-**Fix direction:** results seeded from a prior are correlated with that
-prior; either exclude them from the agreement/consensus vote (use them
-only to polish the winning group's estimate) or carry an explicit
-provenance flag (`seeded_from_prior`) that the ensemble treats as
-non-independent. The metadata should record the distinction either way.
-
-**Acceptance:** a test where pass-1 produces a deliberately wrong prior
-asserts the pass-2 refinement cannot raise the consensus confidence;
-N1572105349 returns to its navigable truth at an honest tier.
-
-### #317 — Ring witnesses of one catalog fused as independent
-
-**Symptom:** `RingEdgeNav` and `RingAnnulusNav` observe the same ring
-catalog model and, once both price an identical annulus geometry, their
-weights re-couple; on a widened-radial scene the correlated-witness scalar
-reaches 0.99, so two views of one model are fused as if independent.
-
-**Where:** `src/spindoctor/nav_orchestrator/ensemble.py` (agreement/fusion
-of the two ring techniques), documented at the `orbit_error_ringlet` scene
-pin and in the ensemble guide.
-
-**Fix direction:** treat the two ring techniques as correlated witnesses of
-one catalog model when combining them; **sequence before #230** so the
-recalibration does not fit tier boundaries against high-confidence/large-
-error correlated rows.
+The ensemble-independence family (#222 seeded single-star refine, #317 two
+ring techniques on one catalog, #339 scattered-light disc/limb) is closed by
+`src/spindoctor/nav_orchestrator/ensemble_independence.py`
+(`resolve_independent_estimators`), which resolves the winning consensus group
+into mutually independent estimators before the merge: a seeded single-star
+refine is dropped when a stronger non-single-star witness is present; two ring
+techniques and (on a scattered-light frame) disc and limb are each collapsed to
+a single representative. The scattered-light signal is a runtime
+background-gradient score
+(`src/spindoctor/support/background_gradient.py`, surfaced on
+`NavImageClassifierResult`) ported from the cohort-curation prescan. See the
+"resolve independent estimators" step in the ensemble dev guide. The collapse
+uses the conservative rho=1 (fully-correlated) model; #380 tracks the
+follow-up to fit an explicit per-family cross-covariance from the agreement
+study and recover the partially-correlated precision, gated on real-frame rho
+measurements (#225).
 
 ### #328 — High-phase haze crescent, gate-passing but ~30 px wrong
 
@@ -81,11 +56,8 @@ currently owns; Essential.
 veto that recognizes the haze-crescent failure signature. Coordinate with
 the #60 Titan / haze-limb work, since the substrate overlaps.
 
-### #339 / #346 / #291 / #326 / #327 — the remaining confident-wrong set
+### #346 / #291 / #326 / #327 — the remaining confident-wrong set
 
-- **#339** — scattered-light frames fuse correlated disc and limb errors as
-  independent at the 0.99 confidence cap; the correlation must be priced
-  before the fusion.
 - **#346** — three library frames (N1492091163, N1867601758, N1867602424)
   lock confidently onto the wrong ring feature; standing library reds, tied
   to the coarse-lock calibration (#373).
@@ -333,8 +305,11 @@ asserts the generated half matches the registries.
   xfails for #251, #252, #253, ready to flip when each fix lands.
 - **#288** — image-library regression reconciliation: the standing red set
   is now reduced to the deliberately-pinned frames, each owned by an open
-  navigation issue (#222, #338, #346, #350, #351, #352). Keep the pins
-  accurate as those issues close and re-ratchet only what they authorize.
+  navigation issue (#338, #346, #350, #351, #352). N1572105349's pin was
+  owned by #222 (now closed by the independence resolution); its autonomous
+  regression should flip green on the next integration run against real
+  holdings (that suite does not run in PR CI). Keep the pins accurate as
+  issues close and re-ratchet only what they authorize.
 - **#243** — direct tests for `nav_model/stars/conflicts.py`
   (`_check_one_star`, `mark_body_and_ring_conflicts`) with synthetic
   geometry; the existing per-pixel occlusion tests cover only the

--- a/plans/PROGRAM_PLAN.md
+++ b/plans/PROGRAM_PLAN.md
@@ -173,10 +173,11 @@ its section names):
    canonical environment for the committed sim baselines (#335).
 7. **Re-anchor confidence on real evidence** (#230; WS-5) — re-run the
    existing calibration tooling against the agreement study's
-   measurements; retire the provisional marker. Sequence the correlated-
-   ring-witness fix (#317) and the ring orbit-uncertainty severity decision
-   (#316) before it, since both push tier boundaries the wrong way, and
-   adopt the calibration's armed falsification criterion (#334).
+   measurements; retire the provisional marker. The correlated-ring-witness
+   fix (#317) is done, so the recalibration no longer trains against those
+   rows; the ring orbit-uncertainty severity decision (#316) still sequences
+   before it, since it pushes tier boundaries the wrong way, and adopt the
+   calibration's armed falsification criterion (#334).
 8. **Close the accuracy tail** (#233 measured star SNR and constant
    sensitivity, WS-9; #150/#128 the known ~0.1 px limb bias, WS-10; #234
    realistic noise for calibrated images, WS-13; #232 end-product
@@ -185,11 +186,13 @@ its section names):
 **Confident-wrong families that poison the validation data** (they belong to
 Track B but gate the study, because it consumes navigator output at scale):
 the high-phase haze crescent that returns a gate-passing success ~30 px wrong
-(#328), scattered-light disc/limb errors fused as independent (#339), the
-three frames that lock onto the wrong ring feature (#346), body-body
+(#328), the three frames that lock onto the wrong ring feature (#346), body-body
 occlusion ignored by the disc template (#326) and by the visible-arc report
-(#327), correlated ring witnesses fused as independent (#317), and the disc
-technique locking on at extreme shape mismatch (#291).
+(#327), and the disc technique locking on at extreme shape mismatch (#291). The
+ensemble-independence family -- a seeded single-star refine dragging a body fix
+(#222), two ring techniques fused as independent witnesses (#317), and
+scattered-light disc/limb errors fused as independent (#339) -- is closed by the
+consensus independence resolution.
 
 **Operator's role:** batch votes on library candidates (ongoing); bless the
 realism verdict; approve agreement-study frame selection; make the ring
@@ -209,16 +212,8 @@ answer or fails on a navigable scene.
 navigator's output at scale) and are exactly what a user hits first.
 The known open defects:
 
-- **#222** (reopened) — a single-inlier pass-2 star refinement, seeded from
-  the pass-1 prior, votes as an independent opinion and pulls an otherwise-
-  correct body fix to ~1.8 px error while keeping a high tier
-  (N1572105349). A tier-honesty / ensemble-independence defect.
-- **#317** — ring techniques observing one catalog model are fused as
-  independent witnesses; sequence before the #230 recalibration.
 - **#328** — a high-phase haze crescent returns a gate-passing success about
   30 px wrong and nothing vetoes it. Essential; a confident-wrong family.
-- **#339** — scattered-light frames fuse correlated disc and limb errors as
-  independent at the 0.99 confidence cap.
 - **#346** — three library frames (N1492091163, N1867601758, N1867602424)
   lock confidently onto the wrong ring feature. Standing library reds.
 - **#291** — `BodyDiscCorrelateNav` locks on confidently at extreme shape
@@ -427,17 +422,16 @@ Every open issue, listed once by the track that owns it.
 
 | Track | Issues |
 |---|---|
-| A — validation & calibration | #84, #150, #153, #172, #174, #176, #223, #225, #226, #227, #229, #230, #232, #233, #234, #235, #290, #309, #310, #311, #316, #319, #321, #322, #324, #325, #329, #330, #331, #332, #333, #334, #335, #336, #340, #341, #342, #343, #344, #345, #355, #358, #359, #360, #361, #377 |
-| B — navigation correctness | #25, #128, #130, #150, #222, #239, #281, #282, #283, #291, #317, #326, #327, #328, #337, #338, #339, #346, #350, #351, #352, #367, #373, #376, #378 |
+| A — validation & calibration | #84, #150, #153, #172, #174, #176, #223, #225, #226, #227, #229, #230, #232, #233, #234, #235, #290, #309, #310, #311, #316, #319, #321, #322, #324, #325, #329, #330, #331, #332, #333, #334, #335, #336, #340, #341, #342, #343, #344, #345, #355, #358, #359, #360, #361, #377, #380 |
+| B — navigation correctness | #25, #128, #130, #150, #239, #281, #282, #283, #291, #326, #327, #328, #337, #338, #346, #350, #351, #352, #367, #373, #376, #378 |
 | C — statistics & QA | #240 (plus the standing cross-check and campaign-report practice) |
 | D — capability completion | #28, #30, #47, #50, #53, #54, #55, #57, #60, #63, #66, #67, #69, #70, #71, #72, #73, #74, #75, #76, #77, #79, #93, #108, #118, #126, #141, #142, #188, #231, #236, #251, #252, #253, #265 |
 | E — test & docs debt | #122, #129, #177, #178, #241, #242, #243, #244, #245, #288, #379 |
 | F — instruments, features, hardening | #2, #13, #15, #17, #18, #19, #21, #22, #23, #27, #33, #34, #38, #39, #43, #65, #78, #81, #82, #83, #92, #96, #97, #98, #99, #100, #101, #102, #103, #104, #105, #107, #109, #110, #119, #134, #135, #137, #138, #140, #143, #144, #147, #151, #152, #155, #157, #158, #181, #182, #183, #184, #185, #186, #187, #212 |
 
 Cross-listed items (listed once above, noted here): #150/#128 serve both
-Track A's limb-bias workstream and Track B's redesign; #317 serves both
-Track A's confidence re-anchoring and Track B's ensemble honesty; the
-confident-wrong families (#328, #339, #346, #326, #327, #291) sit in Track B
+Track A's limb-bias workstream and Track B's redesign; the
+confident-wrong families (#328, #346, #326, #327, #291) sit in Track B
 but gate the Track A study; #103/#134/#126 serve both Track D performance and
 Track F hardening; #93 is written in Track D, extended per instrument in
 Track F; #174 baselines are Track A infrastructure delivered as Track E test

--- a/src/spindoctor/config_files/config_540_orchestrator.yaml
+++ b/src/spindoctor/config_files/config_540_orchestrator.yaml
@@ -67,6 +67,11 @@ orchestrator:
     pinvh_rcond: 1.0e-9
     # Maximum |rotation| (deg) a 3-DoF result may take before rejection.
     max_allowed_rotation_deg: 5.0
+    # Background-gradient score at or above which a frame is treated as
+    # scattered-light, so the disc and limb techniques on one body are fused
+    # as a single correlated witness rather than two independent ones.
+    # Matches the cohort-curation scattered-light prescan threshold.
+    scattered_light_gradient_score: 5.0
     # Confidence/sigma requirements per confidence tier; max_sigma_px
     # null means no sigma requirement for that tier.
     tier_thresholds:

--- a/src/spindoctor/nav_orchestrator/curator.py
+++ b/src/spindoctor/nav_orchestrator/curator.py
@@ -162,6 +162,11 @@ def _curate_image_classifier(classifier: NavImageClassifierResult) -> dict[str, 
         'missing_frac': _round_float(classifier.missing_frac, CONFIDENCE_DECIMALS),
         'noise_sigma': _round_float(classifier.noise_sigma, CONFIDENCE_DECIMALS),
         'max_dn': _round_float(classifier.max_dn, CONFIDENCE_DECIMALS),
+        'background_gradient_score': (
+            None
+            if classifier.background_gradient_score is None
+            else _round_float(classifier.background_gradient_score, CONFIDENCE_DECIMALS)
+        ),
         'flags': list(classifier.flags),
     }
 

--- a/src/spindoctor/nav_orchestrator/ensemble.py
+++ b/src/spindoctor/nav_orchestrator/ensemble.py
@@ -23,16 +23,24 @@ estimates become one offset.  Every step is honest:
    members: a pass-2 result whose prior was seeded by a technique in the
    same subset re-observed its own seed, so it refines the offset but
    casts no independent vote.
-5. Combine offsets within the winning subset via precision-weighted
+5. Resolve the winning subset into mutually independent estimators before
+   fusing (``resolve_independent_estimators``): drop a seeded single-star
+   refine that only re-observes its own prior, and collapse correlated
+   witnesses that share one error source (two ring techniques on one
+   catalog; disc and limb on one scattered-light gradient) to a single
+   representative.  The information-form merge assumes independence, so
+   fusing correlated members would over-tighten the covariance, inflate the
+   tier, and let a redundant member drag the offset.
+6. Combine offsets within the resolved subset via precision-weighted
    (Kalman-style) merging.
-6. Apply optional disagreement / conflict penalties.
-7. Cap the confidence tier at ``medium`` when the fused covariance is
+7. Apply optional disagreement / conflict penalties.
+8. Cap the confidence tier at ``medium`` when the fused covariance is
    rank-deficient (one translation axis unobservable) or when every
    combined member is a single-star solution (a one-star unique match
    or one-inlier refine) — neither an assumed axis nor an
    un-cross-checked star is ``high``-tier evidence, however tight the
    localization sigma.
-8. Emit a NavResult carrying the excluded technique names.
+9. Emit a NavResult carrying the excluded technique names.
 
 The ensemble is tested in isolation against synthetic per-technique results;
 correctness here is what makes the rest of the pipeline trustworthy.
@@ -58,6 +66,10 @@ from spindoctor.nav_orchestrator.ensemble_consensus import (
     corroborating_members,
     result_param_vector,
 )
+from spindoctor.nav_orchestrator.ensemble_independence import (
+    is_single_star_result,
+    resolve_independent_estimators,
+)
 from spindoctor.nav_orchestrator.ensemble_observability import (
     mixed_scale_pinvh,
     observable_basis,
@@ -66,10 +78,6 @@ from spindoctor.nav_orchestrator.feature_summary import NavFeatureSummary
 from spindoctor.nav_orchestrator.image_classifier_result import NavImageClassifierResult
 from spindoctor.nav_orchestrator.nav_result import ConfidenceRank, NavResult
 from spindoctor.nav_orchestrator.provenance import Provenance
-from spindoctor.nav_technique.diagnostics import (
-    StarRefineDiagnostics,
-    StarUniqueMatchDiagnostics,
-)
 from spindoctor.nav_technique.nav_technique import technique_tier
 from spindoctor.nav_technique.technique_result import NavTechniqueResult
 from spindoctor.support.exceptions import NavContractError
@@ -92,6 +100,11 @@ DEFAULT_CONFLICTED_CONFIDENCE_MULTIPLIER = 0.3
 DEFAULT_MIN_CONFIDENCE = 0.35
 DEFAULT_PINVH_RCOND = 1.0e-9
 DEFAULT_MAX_ALLOWED_ROTATION_DEG = 5.0
+# Background-gradient score at or above which a frame is treated as
+# scattered-light: the disc and limb techniques then measure the same veiling
+# ramp, so they are collapsed to one witness before the combine (issue #339).
+# Matches the cohort-curation scattered-light prescan threshold.
+DEFAULT_SCATTERED_LIGHT_GRADIENT_SCORE = 5.0
 # Tier confidence boundaries are sim-anchored (fitted 2026-07-18 on the
 # recalibrated simulated-scene campaign, with the #210 covariance
 # floors live and the ring truth vocabulary in the scene cohort): the
@@ -154,6 +167,11 @@ class EnsembleConfig:
             ``+-max_rotation_deg``, default 5 deg).  A 3-DoF result
             arriving with ``abs(rotation_rad)`` at or above this bound is a
             programming error upstream and raises ``NavContractError``.
+        scattered_light_gradient_score: Background-gradient score at or
+            above which the frame is treated as scattered-light, so the disc
+            and limb techniques on one body are fused as a single correlated
+            witness rather than two independent ones (see
+            ``resolve_independent_estimators``).
         tier_thresholds: Mapping ``rank -> {min_confidence, max_sigma_px}``;
             see ``derive_confidence_rank``.
     """
@@ -166,6 +184,7 @@ class EnsembleConfig:
     min_confidence: float = DEFAULT_MIN_CONFIDENCE
     pinvh_rcond: float = DEFAULT_PINVH_RCOND
     max_allowed_rotation_deg: float = DEFAULT_MAX_ALLOWED_ROTATION_DEG
+    scattered_light_gradient_score: float = DEFAULT_SCATTERED_LIGHT_GRADIENT_SCORE
     tier_thresholds: dict[str, dict[str, float | None]] = field(
         default_factory=lambda: copy.deepcopy(DEFAULT_TIER_THRESHOLDS)
     )
@@ -505,24 +524,6 @@ def _combine_confidence(
     return combined
 
 
-def _is_single_star_result(res: NavTechniqueResult) -> bool:
-    """Return True when a result rests on a single star with no cross-check.
-
-    A one-star ``StarUniqueMatchNav`` match and a one-inlier
-    ``StarRefineNav`` refine each localize the offset from a single
-    detection: nothing in the solution corroborates the identification
-    itself.  The ensemble caps the tier of a consensus built solely from
-    such results (see :func:`ensemble`).  Multi-star solutions and every
-    non-star technique return False.
-    """
-    diag = res.diagnostics
-    if isinstance(diag, StarUniqueMatchDiagnostics):
-        return diag.mode == 'one_star'
-    if isinstance(diag, StarRefineDiagnostics):
-        return diag.n_stars_used <= 1
-    return False
-
-
 def derive_confidence_rank(
     *,
     confidence: float,
@@ -647,20 +648,55 @@ def ensemble(
     excluded = selection.excluded
     excluded_names = [r.technique_name for r in excluded]
     consensus_names = [r.technique_name for r in best_group]
-    # Vote mass and quorum count only corroborating members: a pass-2
-    # prior-descendant refines the offset but casts no independent vote
-    # (issue #222).
-    best_summed_conf = corroborating_confidence(best_group)
-    best_has_quorum = len(corroborating_members(best_group)) >= 2
+    # Resolve the winning group into mutually independent estimators before
+    # any fusion: drop a seeded single-star refine that only re-observes its
+    # own prior (issue #222), and collapse correlated witnesses that share one
+    # error source -- two ring techniques reading one catalog (issue #317), or
+    # disc and limb on one scattered-light gradient (issue #339) -- to a single
+    # representative.  The information-form combine assumes independence, so
+    # fusing correlated members would over-tighten the covariance and inflate
+    # the tier, and a redundant member would drag the fused offset.
+    resolution = resolve_independent_estimators(
+        best_group,
+        image_classifier=image_classifier,
+        scattered_light_gradient_score=cfg.scattered_light_gradient_score,
+        rcond=cfg.pinvh_rcond,
+    )
+    combine_set = resolution.estimators
+    for dropped in resolution.dropped_descendants:
+        IMAGE_LOGGER.info(
+            'Dropping seeded single-star refine %s from the combine: it '
+            're-observes its own pass-1 prior and adds no independent '
+            'constraint',
+            dropped.technique_name,
+        )
+    for collapsed in resolution.collapsed_groups:
+        IMAGE_LOGGER.info(
+            'Collapsing correlated witnesses to %s: %s share one error '
+            'source and are fused as a single witness, not independent ones',
+            collapsed[0].technique_name,
+            ', '.join(r.technique_name for r in collapsed),
+        )
+    # Vote mass and quorum count independent witnesses only, so they are
+    # measured over the resolved ``combine_set`` -- the same set the merge
+    # fuses -- not the raw consensus.  This keeps the conflict logic consistent
+    # with the merge: a collapsed correlated pair (two ring techniques, or
+    # scattered-light disc/limb) counts as the one witness it is, so it cannot
+    # claim a spurious quorum that would suppress a genuine lone-vs-lone
+    # conflict.  ``corroborating_members`` additionally drops any surviving
+    # multi-star prior-descendant, which refines the offset but casts no
+    # independent vote (issue #222).
+    best_summed_conf = corroborating_confidence(combine_set)
+    best_has_quorum = len(corroborating_members(combine_set)) >= 2
     apply_disagreement_penalty = bool(excluded)
     try:
         combined = _combine_precision_weighted(
-            best_group,
+            combine_set,
             rcond=cfg.pinvh_rcond,
             max_allowed_rotation_deg=cfg.max_allowed_rotation_deg,
         )
         combined_confidence = _combine_confidence(
-            best_group,
+            combine_set,
             rcond=cfg.pinvh_rcond,
             disagreement_penalty=cfg.disagreement_penalty,
             apply_disagreement_penalty=apply_disagreement_penalty,
@@ -783,17 +819,19 @@ def ensemble(
             '(one translation axis unobservable)'
         )
         rank = 'medium'
-    if rank == 'high' and all(_is_single_star_result(r) for r in best_group):
+    if rank == 'high' and all(is_single_star_result(r) for r in combine_set):
         # A single-star solution's confidence is deliberately capped to say
         # "weak, no cross-check" (the one-inlier refine caps at exactly the
         # high tier's confidence boundary), and its localization sigma is
         # CRLB-tight, so it would otherwise clear the high gates.  A result
         # whose every combined member rests on one star tops out at medium
-        # (issue #263).
+        # (issue #263).  Judged over the independent estimators, so a dropped
+        # seeded single-star refine does not force the cap on an otherwise
+        # multi-star consensus.
         IMAGE_LOGGER.info(
             'Tier capped at medium: every consensus member is a single-star '
             'solution with no independent cross-check (%s)',
-            ', '.join(r.technique_name for r in best_group),
+            ', '.join(r.technique_name for r in combine_set),
         )
         rank = 'medium'
     if rank == 'failed':

--- a/src/spindoctor/nav_orchestrator/ensemble.py
+++ b/src/spindoctor/nav_orchestrator/ensemble.py
@@ -73,6 +73,7 @@ from spindoctor.nav_orchestrator.ensemble_independence import (
 from spindoctor.nav_orchestrator.ensemble_observability import (
     mixed_scale_pinvh,
     observable_basis,
+    positional_precision,
 )
 from spindoctor.nav_orchestrator.feature_summary import NavFeatureSummary
 from spindoctor.nav_orchestrator.image_classifier_result import NavImageClassifierResult
@@ -483,20 +484,16 @@ def _combine_confidence(
             (W = 0); the orchestrator's caller routes this to
             ``unobservable_offset`` failure.
     """
-    weights = []
-    for res in group:
-        cov = np.asarray(res.covariance_px2, np.float64)
-        # Weight by the *positional* precision only.  Taking trace(pinvh(cov))
-        # over a full 3-DoF covariance would add the v, u precisions (px^-2) to
-        # the rotation precision (rad^-2), so a star-field result whose rotation
-        # is tightly pinned would dominate the confidence average on an
-        # arbitrary, unit-mixed scale.  Marginalising rotation out and tracing
-        # the 2x2 translation block keeps every weight in px^-2; the additive
-        # trace (rather than det(info)^(1/p)) stays well-defined for the rank-1
-        # ring-edge covariances whose unobservable axis carries zero precision.
-        # The 2-DoF path is unchanged: cov[:2, :2] is then the whole matrix.
-        info_xy = mixed_scale_pinvh(np.ascontiguousarray(cov[:2, :2]), rcond=rcond)
-        weights.append(float(np.trace(info_xy)))
+    # Weight by the *positional* precision only.  Taking trace(pinvh(cov)) over
+    # a full 3-DoF covariance would add the v, u precisions (px^-2) to the
+    # rotation precision (rad^-2), so a star-field result whose rotation is
+    # tightly pinned would dominate the confidence average on an arbitrary,
+    # unit-mixed scale.  Marginalising rotation out and tracing the 2x2
+    # translation block keeps every weight in px^-2; the additive trace (rather
+    # than det(info)^(1/p)) stays well-defined for the rank-1 ring-edge
+    # covariances whose unobservable axis carries zero precision.  The 2-DoF
+    # path is unchanged: cov[:2, :2] is then the whole matrix.
+    weights = [positional_precision(res.covariance_px2, rcond=rcond) for res in group]
     w_total = sum(weights)
     if w_total <= 0.0:
         raise ValueError('precision-weighted combine: total weight is zero; offset is unobservable')

--- a/src/spindoctor/nav_orchestrator/ensemble_independence.py
+++ b/src/spindoctor/nav_orchestrator/ensemble_independence.py
@@ -49,9 +49,7 @@ the shared measurement rather than a spuriously tightened average of two.
 
 from dataclasses import dataclass
 
-import numpy as np
-
-from spindoctor.nav_orchestrator.ensemble_observability import mixed_scale_pinvh
+from spindoctor.nav_orchestrator.ensemble_observability import positional_precision
 from spindoctor.nav_orchestrator.image_classifier_result import NavImageClassifierResult
 from spindoctor.nav_technique.diagnostics import (
     StarRefineDiagnostics,
@@ -67,11 +65,11 @@ __all__ = [
 
 #: Ring techniques that read one shared ``NavModelRings`` catalog per frame.
 #: Any two of these observing the same frame are correlated witnesses of one
-#: model (issue #317).
+#: model.
 _RING_TECHNIQUES = frozenset({'RingEdgeNav', 'RingAnnulusNav'})
 
 #: Intensity-based body techniques that both measure a scattered-light veiling
-#: gradient when one is present, correlating their errors (issue #339).
+#: gradient when one is present, correlating their errors.
 _SCATTER_SENSITIVE_BODY_TECHNIQUES = frozenset({'BodyDiscCorrelateNav', 'BodyLimbNav'})
 
 
@@ -82,6 +80,15 @@ def is_single_star_result(res: NavTechniqueResult) -> bool:
     ``StarRefineNav`` refine each localize the offset from a single
     detection: nothing in the solution corroborates the identification
     itself.  Multi-star solutions and every non-star technique return False.
+
+    Parameters:
+        res: The per-technique result to classify.
+
+    Returns:
+        True when ``res`` is a ``StarUniqueMatchNav`` result whose match mode
+        is ``'one_star'`` or a ``StarRefineNav`` result that used at most one
+        star; False for every other result, including multi-star star results
+        and all non-star techniques.
     """
     diag = res.diagnostics
     if isinstance(diag, StarUniqueMatchDiagnostics):
@@ -112,15 +119,24 @@ class IndependenceResolution:
     collapsed_groups: list[list[NavTechniqueResult]]
 
 
-def _positional_precision(res: NavTechniqueResult, *, rcond: float) -> float:
-    """Scalar positional precision ``trace(pinvh(Sigma[:2, :2]))`` in px^-2."""
-    cov = np.asarray(res.covariance_px2, np.float64)
-    info_xy = mixed_scale_pinvh(np.ascontiguousarray(cov[:2, :2]), rcond=rcond)
-    return float(np.trace(info_xy))
-
-
 def _is_seeded_descendant(res: NavTechniqueResult, group_names: set[str]) -> bool:
-    """True when a result was seeded by another technique present in the group."""
+    """Return True when a result was seeded by another technique in the group.
+
+    A result is a seeded descendant when at least one of its
+    ``prior_source_techniques`` (the techniques whose pass-1 offset seeded its
+    search prior) is also present in the group, other than the result's own
+    technique.  A result seeded only by itself, or only by techniques absent
+    from the group, is not a descendant.
+
+    Parameters:
+        res: The result whose seeding provenance is examined.
+        group_names: The technique names of every member of the group ``res``
+            belongs to.
+
+    Returns:
+        True when ``res.prior_source_techniques`` intersects ``group_names``
+        after removing ``res``'s own technique name; False otherwise.
+    """
     return bool(res.prior_source_techniques & (group_names - {res.technique_name}))
 
 
@@ -129,10 +145,24 @@ def _correlation_adjacency(
     *,
     scattered_light: bool,
 ) -> list[set[int]]:
-    """Undirected correlation edges among group indices (R2 and R3).
+    """Return undirected correlation edges among group indices (R2 and R3).
 
-    Returns an adjacency list; index ``i`` is adjacent to ``j`` when the two
-    results are correlated witnesses of one shared error source.
+    Two results are joined by an edge when they are correlated witnesses of
+    one shared error source: R2 joins any two ring techniques (both in
+    ``_RING_TECHNIQUES``), which read one shared catalog model; R3 joins the
+    disc and limb techniques (``_SCATTER_SENSITIVE_BODY_TECHNIQUES``) observing
+    a shared body, but only when ``scattered_light`` is True.
+
+    Parameters:
+        group: The results to test pairwise, indexed positionally.
+        scattered_light: Whether the frame carries a scattered-light veiling
+            gradient; gates the R3 disc/limb edge.
+
+    Returns:
+        An adjacency list of length ``len(group)``; entry ``i`` is the set of
+        indices ``j`` correlated with result ``i``.  The relation is symmetric,
+        so ``j in adj[i]`` iff ``i in adj[j]``, and no index is adjacent to
+        itself.
     """
     n = len(group)
     adj: list[set[int]] = [set() for _ in range(n)]
@@ -159,7 +189,18 @@ def _correlation_adjacency(
 
 
 def _connected_components(adj: list[set[int]]) -> list[list[int]]:
-    """Connected components of an adjacency list, each in ascending index order."""
+    """Return the connected components of an undirected adjacency list.
+
+    Parameters:
+        adj: A symmetric adjacency list; ``adj[i]`` holds the indices adjacent
+            to ``i``.
+
+    Returns:
+        A list of components covering every index ``0 .. len(adj) - 1`` exactly
+        once.  Each component is sorted in ascending index order, and an index
+        with no edges forms its own singleton component.  The components
+        themselves are ordered by their smallest member.
+    """
     n = len(adj)
     seen = [False] * n
     components: list[list[int]] = []
@@ -252,7 +293,7 @@ def resolve_independent_estimators(
         rep_idx = max(
             comp,
             key=lambda i: (
-                _positional_precision(survivors[i], rcond=rcond),
+                positional_precision(survivors[i].covariance_px2, rcond=rcond),
                 survivors[i].technique_name,
                 survivors[i].feature_ids,
             ),

--- a/src/spindoctor/nav_orchestrator/ensemble_independence.py
+++ b/src/spindoctor/nav_orchestrator/ensemble_independence.py
@@ -1,0 +1,270 @@
+"""Resolve a consensus group into mutually independent estimators.
+
+The ensemble fuses agreeing per-technique results with an information-form
+(Kalman-style) merge whose every step assumes the inputs are *independent*
+measurements: their precisions add, and their mutual agreement earns a
+confidence boost.  That assumption is false whenever two results draw on the
+same underlying error source.  Fusing correlated results as independent both
+over-tightens the combined covariance (so the reported sigma is too small and
+the tier too high) and lets a redundant member drag the fused offset.
+
+This module resolves a winning consensus group into the set of estimators the
+combine may treat as independent, correcting three known correlations:
+
+* **Seeded second-pass refine (R1).**  A pass-2 ``StarRefineNav`` searches a
+  small window around the pass-1 prior, so its offset is conditionally
+  dependent on whichever techniques seeded that prior
+  (``prior_source_techniques``).  A refine that rests on a *single* star adds
+  no independent constraint of its own -- it merely re-observes its seed near
+  the predicted position -- and its CRLB-tight covariance would otherwise let
+  it dominate the precision-weighted merge.  So a seeded single-star refine is
+  dropped from the combine when the group also holds a stronger, non-single-
+  star witness (a body or ring fix, or a multi-star result) that it would
+  otherwise drag off; a genuine single-star lock, where the refine is the
+  only refinement of a legitimately weak fix and no stronger witness is
+  present, keeps it.  A multi-star refine always carries independent
+  information and is kept (the ensemble separately denies it a corroboration
+  vote).
+
+* **Two ring techniques on one catalog (R2).**  ``RingEdgeNav`` and
+  ``RingAnnulusNav`` observe the same predicted ring geometry from the same
+  catalog model, so a radially misplaced catalog puts both wrong in the same
+  direction by the same amount.  They are collapsed to a single representative
+  witness.
+
+* **Disc and limb on one veiling gradient (R3).**  On a scattered-light frame
+  ``BodyDiscCorrelateNav`` and ``BodyLimbNav`` both lock onto the same
+  large-scale brightness ramp rather than the body, so their errors correlate.
+  When the image's background-gradient score exceeds the scattered-light
+  threshold, the disc and limb results on the same body are collapsed to a
+  single representative.
+
+R1 is a directional drop (the descendant is subordinate to its seeds, which
+remain independent of one another); R2 and R3 are symmetric collapses (neither
+member is subordinate, so the pair is replaced by one representative).  The
+representative of a collapsed set is its highest-positional-precision member,
+with a deterministic tie-break, so the fused offset is the single best view of
+the shared measurement rather than a spuriously tightened average of two.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from spindoctor.nav_orchestrator.ensemble_observability import mixed_scale_pinvh
+from spindoctor.nav_orchestrator.image_classifier_result import NavImageClassifierResult
+from spindoctor.nav_technique.diagnostics import (
+    StarRefineDiagnostics,
+    StarUniqueMatchDiagnostics,
+)
+from spindoctor.nav_technique.technique_result import NavTechniqueResult
+
+__all__ = [
+    'IndependenceResolution',
+    'is_single_star_result',
+    'resolve_independent_estimators',
+]
+
+#: Ring techniques that read one shared ``NavModelRings`` catalog per frame.
+#: Any two of these observing the same frame are correlated witnesses of one
+#: model (issue #317).
+_RING_TECHNIQUES = frozenset({'RingEdgeNav', 'RingAnnulusNav'})
+
+#: Intensity-based body techniques that both measure a scattered-light veiling
+#: gradient when one is present, correlating their errors (issue #339).
+_SCATTER_SENSITIVE_BODY_TECHNIQUES = frozenset({'BodyDiscCorrelateNav', 'BodyLimbNav'})
+
+
+def is_single_star_result(res: NavTechniqueResult) -> bool:
+    """Return True when a result rests on a single star with no cross-check.
+
+    A one-star ``StarUniqueMatchNav`` match and a one-inlier
+    ``StarRefineNav`` refine each localize the offset from a single
+    detection: nothing in the solution corroborates the identification
+    itself.  Multi-star solutions and every non-star technique return False.
+    """
+    diag = res.diagnostics
+    if isinstance(diag, StarUniqueMatchDiagnostics):
+        return diag.mode == 'one_star'
+    if isinstance(diag, StarRefineDiagnostics):
+        return diag.n_stars_used <= 1
+    return False
+
+
+@dataclass(frozen=True)
+class IndependenceResolution:
+    """Outcome of resolving a consensus group into independent estimators.
+
+    Parameters:
+        estimators: The results the combine may treat as independent, in the
+            input group's order.  One member per independence class: seeded
+            single-star refines removed, each correlated peer set replaced by
+            its representative.  Never empty when the input group is non-empty.
+        dropped_descendants: Seeded single-star refines removed by R1 (kept for
+            logging / provenance; they cast no vote and lend no precision).
+        collapsed_groups: One entry per correlated peer set that was collapsed
+            (R2 / R3), representative first, then the members it stood in for.
+            Singletons are not listed.
+    """
+
+    estimators: list[NavTechniqueResult]
+    dropped_descendants: list[NavTechniqueResult]
+    collapsed_groups: list[list[NavTechniqueResult]]
+
+
+def _positional_precision(res: NavTechniqueResult, *, rcond: float) -> float:
+    """Scalar positional precision ``trace(pinvh(Sigma[:2, :2]))`` in px^-2."""
+    cov = np.asarray(res.covariance_px2, np.float64)
+    info_xy = mixed_scale_pinvh(np.ascontiguousarray(cov[:2, :2]), rcond=rcond)
+    return float(np.trace(info_xy))
+
+
+def _is_seeded_descendant(res: NavTechniqueResult, group_names: set[str]) -> bool:
+    """True when a result was seeded by another technique present in the group."""
+    return bool(res.prior_source_techniques & (group_names - {res.technique_name}))
+
+
+def _correlation_adjacency(
+    group: list[NavTechniqueResult],
+    *,
+    scattered_light: bool,
+) -> list[set[int]]:
+    """Undirected correlation edges among group indices (R2 and R3).
+
+    Returns an adjacency list; index ``i`` is adjacent to ``j`` when the two
+    results are correlated witnesses of one shared error source.
+    """
+    n = len(group)
+    adj: list[set[int]] = [set() for _ in range(n)]
+    for i in range(n):
+        for j in range(i + 1, n):
+            ri, rj = group[i], group[j]
+            names = {ri.technique_name, rj.technique_name}
+            # R2: two ring techniques share one catalog model.
+            ring_pair = ri.technique_name in _RING_TECHNIQUES and (
+                rj.technique_name in _RING_TECHNIQUES
+            )
+            # R3: disc and limb on the same body share a veiling gradient when
+            # the frame carries a scattered-light ramp.
+            scatter_pair = (
+                scattered_light
+                and names <= _SCATTER_SENSITIVE_BODY_TECHNIQUES
+                and ri.technique_name != rj.technique_name
+                and bool(ri.source_bodies & rj.source_bodies)
+            )
+            if ring_pair or scatter_pair:
+                adj[i].add(j)
+                adj[j].add(i)
+    return adj
+
+
+def _connected_components(adj: list[set[int]]) -> list[list[int]]:
+    """Connected components of an adjacency list, each in ascending index order."""
+    n = len(adj)
+    seen = [False] * n
+    components: list[list[int]] = []
+    for start in range(n):
+        if seen[start]:
+            continue
+        stack = [start]
+        seen[start] = True
+        comp: list[int] = []
+        while stack:
+            node = stack.pop()
+            comp.append(node)
+            for nbr in adj[node]:
+                if not seen[nbr]:
+                    seen[nbr] = True
+                    stack.append(nbr)
+        components.append(sorted(comp))
+    return components
+
+
+def resolve_independent_estimators(
+    group: list[NavTechniqueResult],
+    *,
+    image_classifier: NavImageClassifierResult,
+    scattered_light_gradient_score: float,
+    rcond: float,
+) -> IndependenceResolution:
+    """Resolve a consensus group into mutually independent estimators.
+
+    Parameters:
+        group: The winning consensus subset (non-empty).
+        image_classifier: The image-quality verdict; its
+            ``background_gradient_score`` gates the R3 scattered-light rule.
+        scattered_light_gradient_score: Background-gradient score at or above
+            which a frame is treated as scattered-light for R3.
+        rcond: rcond for the pseudo-inverse used to weigh precision.
+
+    Returns:
+        An :class:`IndependenceResolution`.  ``estimators`` is the deduplicated,
+        correlation-collapsed set the combine treats as independent; it is
+        never empty when ``group`` is non-empty.
+
+    Raises:
+        ValueError: if ``group`` is empty.
+    """
+    if not group:
+        raise ValueError('empty group passed to resolve_independent_estimators')
+
+    # R1: drop a seeded single-star refine, but only when a stronger,
+    # non-single-star witness is present for it to override.  A pure
+    # single-star lock (no stronger witness) keeps its refine, which is then
+    # the only refinement of a legitimately weak fix rather than a redundant
+    # vote against a body or multi-star consensus.  Guard against emptying the
+    # set defensively (the strong-witness condition already prevents it).
+    # Exclusion is by index, not value: NavTechniqueResult equality keys only
+    # on (technique_name, feature_ids), so a value-membership test could drop a
+    # distinct result that happened to share those.
+    group_names = {r.technique_name for r in group}
+    strong_witness_present = any(not is_single_star_result(r) for r in group)
+    dropped_idx: set[int] = set()
+    if strong_witness_present:
+        dropped_idx = {
+            i
+            for i, r in enumerate(group)
+            if _is_seeded_descendant(r, group_names) and is_single_star_result(r)
+        }
+    survivors = [r for i, r in enumerate(group) if i not in dropped_idx]
+    if not survivors:
+        # Defensive: strong_witness_present already guarantees a non-single-star
+        # survivor, so this cannot fire; kept so the combine never sees an empty
+        # set even if the drop rule changes.
+        dropped_idx = set()
+        survivors = list(group)
+    dropped = [group[i] for i in sorted(dropped_idx)]
+
+    # R2 / R3: collapse each correlated peer set to a single representative.
+    score = image_classifier.background_gradient_score
+    scattered_light = score is not None and score >= scattered_light_gradient_score
+    adj = _correlation_adjacency(survivors, scattered_light=scattered_light)
+    components = _connected_components(adj)
+
+    keep: set[int] = set()
+    collapsed_groups: list[list[NavTechniqueResult]] = []
+    for comp in components:
+        if len(comp) == 1:
+            keep.add(comp[0])
+            continue
+        # Representative: highest positional precision, then a deterministic
+        # tie-break so the choice never depends on input order or hashing.
+        rep_idx = max(
+            comp,
+            key=lambda i: (
+                _positional_precision(survivors[i], rcond=rcond),
+                survivors[i].technique_name,
+                survivors[i].feature_ids,
+            ),
+        )
+        keep.add(rep_idx)
+        rep = survivors[rep_idx]
+        others = [survivors[i] for i in comp if i != rep_idx]
+        collapsed_groups.append([rep, *others])
+
+    estimators = [survivors[i] for i in range(len(survivors)) if i in keep]
+    return IndependenceResolution(
+        estimators=estimators,
+        dropped_descendants=dropped,
+        collapsed_groups=collapsed_groups,
+    )

--- a/src/spindoctor/nav_orchestrator/ensemble_observability.py
+++ b/src/spindoctor/nav_orchestrator/ensemble_observability.py
@@ -25,6 +25,7 @@ __all__ = [
     'mixed_scale_pinvh',
     'observable_basis',
     'observable_intersection_basis',
+    'positional_precision',
 ]
 
 # The floor separates genuine uncertainty from sentinels: 1e10 px^2 is a
@@ -76,6 +77,34 @@ def mixed_scale_pinvh(mat: NDArrayFloatType, *, rcond: float) -> NDArrayFloatTyp
         block = np.ascontiguousarray(mat[np.ix_(regular, regular)])
         out[np.ix_(regular, regular)] = pinvh(block, rtol=rcond)
     return out
+
+
+def positional_precision(cov: NDArrayFloatType, *, rcond: float) -> float:
+    """Return the scalar positional precision of a covariance in ``px^-2``.
+
+    The positional (v, u) translation block ``cov[:2, :2]`` is pseudo-inverted
+    with :func:`mixed_scale_pinvh` (so an unobservable sentinel axis is
+    quarantined rather than truncating the well-constrained axes) and its trace
+    is returned.  Any rotation axis is marginalised out first, so the value is
+    purely the translation precision and is never skewed by a 3-DoF result's
+    unrelated ``rad^-2`` rotation precision.  The additive trace stays
+    well-defined for a rank-1 covariance whose unobservable axis carries zero
+    precision, contributing zero from that axis rather than diverging.
+
+    Parameters:
+        cov: Per-technique covariance, ``(2, 2)`` or ``(3, 3)``, in mixed
+            px / rad units.  Only the leading ``2 x 2`` translation block is
+            read.
+        rcond: Relative eigenvalue cutoff for the pseudo-inverse of the
+            translation block.
+
+    Returns:
+        ``trace(pinvh(cov[:2, :2]))``, the positional precision in ``px^-2``;
+        zero when the translation block is entirely unobservable.
+    """
+    cov = np.asarray(cov, np.float64)
+    info_xy = mixed_scale_pinvh(np.ascontiguousarray(cov[:2, :2]), rcond=rcond)
+    return float(np.trace(info_xy))
 
 
 def observable_basis(cov: NDArrayFloatType) -> NDArrayFloatType:

--- a/src/spindoctor/nav_orchestrator/image_classifier.py
+++ b/src/spindoctor/nav_orchestrator/image_classifier.py
@@ -24,6 +24,7 @@ from spindoctor.nav_orchestrator.image_classifier_result import (
     ImageFlag,
     NavImageClassifierResult,
 )
+from spindoctor.support.background_gradient import background_gradient_score
 from spindoctor.support.noise_estimate import estimate_image_noise_sigma
 from spindoctor.support.types import NDArrayBoolType, NDArrayFloatType
 
@@ -151,6 +152,14 @@ class NavImageClassifier:
             max_dn = float(np.nanmax(sensor))
         else:
             max_dn = 0.0
+        # Low-order brightness-ramp score over the 2-D frame (the block-median
+        # affine fit needs spatial structure, so it runs on the image array
+        # rather than the flattened sensor selection).  The sensor mask keeps
+        # extfov padding out of the plane fit -- otherwise the zero-filled
+        # border biases the score and can suppress it below the ensemble's
+        # scattered-light threshold on full-frame images.  Recorded on every
+        # verdict; the ensemble reads it when resolving disc/limb correlations.
+        background_gradient = background_gradient_score(image, sensor_mask)
         flags: list[ImageFlag] = []
         # Outcome decision: blank check runs first so a near-zero image with
         # missing-data marker == 0 isn't mis-classified as "mostly_missing".
@@ -161,6 +170,7 @@ class NavImageClassifier:
                 missing_frac=missing_frac,
                 noise_sigma=noise_sigma,
                 max_dn=max_dn,
+                background_gradient_score=background_gradient,
                 flags=flags,
             )
         if saturation_frac > self.thresholds.max_saturation_frac_clean:
@@ -170,6 +180,7 @@ class NavImageClassifier:
                 missing_frac=missing_frac,
                 noise_sigma=noise_sigma,
                 max_dn=max_dn,
+                background_gradient_score=background_gradient,
                 flags=flags,
             )
         if missing_frac > self.thresholds.max_missing_frac_clean:
@@ -179,6 +190,7 @@ class NavImageClassifier:
                 missing_frac=missing_frac,
                 noise_sigma=noise_sigma,
                 max_dn=max_dn,
+                background_gradient_score=background_gradient,
                 flags=flags,
             )
         # Otherwise the image is clean (with optional advisory flags).
@@ -192,5 +204,6 @@ class NavImageClassifier:
             missing_frac=missing_frac,
             noise_sigma=noise_sigma,
             max_dn=max_dn,
+            background_gradient_score=background_gradient,
             flags=flags,
         )

--- a/src/spindoctor/nav_orchestrator/image_classifier_result.py
+++ b/src/spindoctor/nav_orchestrator/image_classifier_result.py
@@ -59,8 +59,12 @@ class NavImageClassifierResult:
             residual MAD-sigma; see
             :func:`spindoctor.support.background_gradient.background_gradient_score`).
             A flat field scores near zero; a scattered-light veiling gradient
-            scores well above five.  ``None`` when the image is too small for
-            the measure or the downsample is perfectly planar.
+            scores well above five.  A non-constant image whose downsample fits
+            an affine plane with exactly zero residual (a perfectly noiseless
+            ramp) saturates to
+            :data:`~spindoctor.support.background_gradient.SATURATED_GRADIENT_SCORE`,
+            a large finite sentinel.  ``None`` when the image is too small for
+            the measure or the downsample is perfectly constant.
         flags: Additional flags caveats (independent of ``image_class``).
     """
 

--- a/src/spindoctor/nav_orchestrator/image_classifier_result.py
+++ b/src/spindoctor/nav_orchestrator/image_classifier_result.py
@@ -54,6 +54,13 @@ class NavImageClassifierResult:
         missing_frac: Fraction of pixels equal to the missing-data marker.
         noise_sigma: Per-image MAD-based noise sigma (DN units).
         max_dn: Maximum DN observed in the image.
+        background_gradient_score: Dimensionless score of the low-order
+            brightness ramp across the sensor (affine-plane peak-to-peak over
+            residual MAD-sigma; see
+            :func:`spindoctor.support.background_gradient.background_gradient_score`).
+            A flat field scores near zero; a scattered-light veiling gradient
+            scores well above five.  ``None`` when the image is too small for
+            the measure or the downsample is perfectly planar.
         flags: Additional flags caveats (independent of ``image_class``).
     """
 
@@ -62,4 +69,5 @@ class NavImageClassifierResult:
     missing_frac: float
     noise_sigma: float
     max_dn: float
+    background_gradient_score: float | None = None
     flags: list[ImageFlag] = field(default_factory=list)

--- a/src/spindoctor/support/background_gradient.py
+++ b/src/spindoctor/support/background_gradient.py
@@ -24,6 +24,7 @@ from spindoctor.support.types import NDArrayBoolType, NDArrayFloatType
 
 __all__ = [
     'BLOCK_SIZE',
+    'SATURATED_GRADIENT_SCORE',
     'background_gradient_score',
 ]
 
@@ -31,6 +32,13 @@ __all__ = [
 #: into before the affine-plane fit.  The image must span at least four blocks
 #: on each axis for the score to be defined.
 BLOCK_SIZE = 16
+
+#: Score returned for a non-constant downsample whose affine-plane fit leaves
+#: exactly zero residual (an idealized, perfectly noiseless veiling ramp).  The
+#: amplitude-over-sigma ratio saturates to infinity there, so a large finite
+#: sentinel stands in for it.  It sits far above any scattered-light threshold,
+#: so such a frame is unambiguously classified as carrying a gradient.
+SATURATED_GRADIENT_SCORE = 1.0e6
 
 
 def background_gradient_score(
@@ -47,7 +55,7 @@ def background_gradient_score(
         image: 2-D float image array in any physical units.  Non-finite
             pixels (for example calibrated-I/F ``NaN`` markers) are treated
             as missing and excluded from every block median.
-        sensor_mask: Optional boolean mask, same shape as ``image``, selecting
+        sensor_mask: Optional boolean mask, exactly ``image.shape``, selecting
             true sensor pixels.  When given, non-sensor pixels (extfov padding,
             which the orchestrator fills with zeros) are excluded from the
             block medians, so the padded border does not bias the plane fit.
@@ -55,11 +63,29 @@ def background_gradient_score(
     Returns:
         The gradient score, or ``None`` when the image spans fewer than four
         blocks on either axis, when no block has a finite median, or when the
-        residual sigma is zero (a perfectly planar or constant downsample,
-        where the ratio is undefined).
+        downsample is perfectly constant (no brightness gradient at all).  A
+        non-constant downsample whose affine-plane fit leaves exactly zero
+        residual returns :data:`SATURATED_GRADIENT_SCORE`, a large finite
+        sentinel well above any scattered-light threshold: the ramp is real
+        and maximally clean, not absent.
+
+    Raises:
+        TypeError: if ``image`` is not 2-D, or ``sensor_mask`` is given but is
+            not a boolean ndarray.
+        ValueError: if ``sensor_mask`` is given but its shape differs from
+            ``image.shape``.
     """
-    h, w = image.shape
+    if image.ndim != 2:
+        raise TypeError(f'image must be 2-D, got a {image.ndim}-D array')
     b = BLOCK_SIZE
+    if sensor_mask is not None:
+        if not isinstance(sensor_mask, np.ndarray) or sensor_mask.dtype != np.bool_:
+            raise TypeError('sensor_mask must be a boolean ndarray')
+        if sensor_mask.shape != image.shape:
+            raise ValueError(
+                f'sensor_mask shape {sensor_mask.shape} must equal image shape {image.shape}'
+            )
+    h, w = image.shape
     if h < 4 * b or w < 4 * b:
         return None
     if sensor_mask is not None:
@@ -96,5 +122,9 @@ def background_gradient_score(
     sigma = 1.4826 * float(np.median(np.abs(resid - np.median(resid))))
     amp = float(plane.max() - plane.min())
     if sigma <= 0:
-        return None
+        # The block medians lie exactly on the fitted plane (zero residual).
+        # The constant case already returned above, so the values are
+        # non-constant and the plane carries a genuine, maximally clean ramp:
+        # the amp/sigma ratio saturates, so report the finite sentinel.
+        return SATURATED_GRADIENT_SCORE
     return amp / sigma

--- a/src/spindoctor/support/background_gradient.py
+++ b/src/spindoctor/support/background_gradient.py
@@ -1,0 +1,100 @@
+"""Low-order background-brightness gradient score for an image.
+
+A scattered-light (veiling) frame carries a smooth, large-scale brightness
+ramp across the sensor that no navigable feature produces.  When such a ramp
+is present, the intensity-based body techniques
+(``BodyDiscCorrelateNav`` and ``BodyLimbNav``) both measure it rather than
+the body, so their pointing errors correlate and must not be fused as
+independent witnesses (the ensemble uses this score to detect that case).
+
+The score fits an affine plane to a block-median downsample of the image
+(medians are robust to stars and cosmic rays) and reports the plane's
+peak-to-peak amplitude divided by the MAD-sigma of the fit residuals.  A flat
+star field scores near zero; a frame with a real veiling gradient scores well
+above five.  This is the same measure the cohort-curation prescan uses to
+select scattered-light candidates, lifted into the library so the navigation
+runtime and the curation tooling share one definition.
+"""
+
+import warnings
+
+import numpy as np
+
+from spindoctor.support.types import NDArrayBoolType, NDArrayFloatType
+
+__all__ = [
+    'BLOCK_SIZE',
+    'background_gradient_score',
+]
+
+#: Side length in pixels of the square blocks the image is median-downsampled
+#: into before the affine-plane fit.  The image must span at least four blocks
+#: on each axis for the score to be defined.
+BLOCK_SIZE = 16
+
+
+def background_gradient_score(
+    image: NDArrayFloatType, sensor_mask: NDArrayBoolType | None = None
+) -> float | None:
+    """Return the low-order brightness-gradient score of an image.
+
+    The score is the peak-to-peak amplitude of an affine plane fitted to the
+    ``BLOCK_SIZE`` x ``BLOCK_SIZE`` block-median downsample of ``image``,
+    divided by the MAD-sigma of the fit residuals.  It is dimensionless and
+    scale-free: multiplying the image by a constant leaves it unchanged.
+
+    Parameters:
+        image: 2-D float image array in any physical units.  Non-finite
+            pixels (for example calibrated-I/F ``NaN`` markers) are treated
+            as missing and excluded from every block median.
+        sensor_mask: Optional boolean mask, same shape as ``image``, selecting
+            true sensor pixels.  When given, non-sensor pixels (extfov padding,
+            which the orchestrator fills with zeros) are excluded from the
+            block medians, so the padded border does not bias the plane fit.
+
+    Returns:
+        The gradient score, or ``None`` when the image spans fewer than four
+        blocks on either axis, when no block has a finite median, or when the
+        residual sigma is zero (a perfectly planar or constant downsample,
+        where the ratio is undefined).
+    """
+    h, w = image.shape
+    b = BLOCK_SIZE
+    if h < 4 * b or w < 4 * b:
+        return None
+    if sensor_mask is not None:
+        # Exclude non-sensor (extfov padding) pixels by making them NaN; the
+        # NaN-aware block median below then ignores them.
+        image = np.where(sensor_mask, image, np.nan)
+    hh, ww = h // b * b, w // b * b
+    blocks = image[:hh, :ww].reshape(hh // b, b, ww // b, b)
+    # Median over each block; NaN-aware so a partially-missing block still
+    # contributes its finite pixels and an all-missing block becomes NaN.  An
+    # all-missing block legitimately yields NaN (the ``finite`` mask below
+    # excludes it), so silence numpy's "All-NaN slice" warning rather than let
+    # it surface as an error under the test suite's warnings filter.
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
+        med = np.nanmedian(blocks, axis=(1, 3))
+    ny, nx = med.shape
+    yy, xx = np.mgrid[0:ny, 0:nx]
+    finite = np.isfinite(med)
+    if finite.sum() < 3:
+        # Fewer than three finite block medians cannot constrain the three
+        # affine-plane coefficients.
+        return None
+    design = np.column_stack([np.ones(med.size), xx.ravel(), yy.ravel()])[finite.ravel()]
+    values = med.ravel()[finite.ravel()]
+    if float(values.max()) == float(values.min()):
+        # A perfectly constant downsample has no brightness gradient; the
+        # affine fit would report only numerical rounding, whose amp/sigma
+        # ratio is meaningless.  Real (noisy) frames never hit this branch.
+        return None
+    coef, *_ = np.linalg.lstsq(design, values, rcond=None)
+    plane = design @ coef
+    resid = values - plane
+    sigma = 1.4826 * float(np.median(np.abs(resid - np.median(resid))))
+    amp = float(plane.max() - plane.min())
+    if sigma <= 0:
+        return None
+    return amp / sigma

--- a/tests/integration/sim_baselines/mmode_ringlet.json
+++ b/tests/integration/sim_baselines/mmode_ringlet.json
@@ -1,5 +1,5 @@
 {
-  "confidence": 0.99,
+  "confidence": 0.91,
   "offset_du_px": 0.8,
   "offset_dv_px": -1.7,
   "scene_name": "mmode_ringlet",

--- a/tests/integration/sim_baselines/moonlet_propeller.json
+++ b/tests/integration/sim_baselines/moonlet_propeller.json
@@ -1,7 +1,7 @@
 {
-  "confidence": 0.99,
+  "confidence": 0.91,
   "offset_du_px": -1.1,
-  "offset_dv_px": -0.81,
+  "offset_dv_px": -0.8,
   "scene_name": "moonlet_propeller",
   "status": "success"
 }

--- a/tests/integration/sim_baselines/orbit_error_ringlet.json
+++ b/tests/integration/sim_baselines/orbit_error_ringlet.json
@@ -1,7 +1,7 @@
 {
-  "confidence": 0.99,
-  "offset_du_px": -1.95,
-  "offset_dv_px": -1.26,
+  "confidence": 0.89,
+  "offset_du_px": -2.41,
+  "offset_dv_px": -2.03,
   "scene_name": "orbit_error_ringlet",
   "status": "success"
 }

--- a/tests/integration/sim_baselines/planted_offset_ring.json
+++ b/tests/integration/sim_baselines/planted_offset_ring.json
@@ -1,5 +1,5 @@
 {
-  "confidence": 0.99,
+  "confidence": 0.91,
   "offset_du_px": -0.62,
   "offset_dv_px": 1.42,
   "scene_name": "planted_offset_ring",

--- a/tests/integration/sim_baselines/relief_psf_stray_light.json
+++ b/tests/integration/sim_baselines/relief_psf_stray_light.json
@@ -1,7 +1,7 @@
 {
-  "confidence": 0.98,
-  "offset_du_px": -0.91,
-  "offset_dv_px": 2.35,
+  "confidence": 0.68,
+  "offset_du_px": -0.5,
+  "offset_dv_px": 2.5,
   "scene_name": "relief_psf_stray_light",
   "status": "success"
 }

--- a/tests/integration/sim_baselines/spoked_sheet.json
+++ b/tests/integration/sim_baselines/spoked_sheet.json
@@ -1,5 +1,5 @@
 {
-  "confidence": 0.99,
+  "confidence": 0.91,
   "offset_du_px": 1.39,
   "offset_dv_px": 0.9,
   "scene_name": "spoked_sheet",

--- a/tests/spindoctor/nav_orchestrator/test_ensemble.py
+++ b/tests/spindoctor/nav_orchestrator/test_ensemble.py
@@ -1,5 +1,7 @@
 """Tests for ``spindoctor.nav_orchestrator.ensemble.ensemble`` and helpers."""
 
+import dataclasses
+
 import numpy as np
 import pytest
 
@@ -14,8 +16,11 @@ from spindoctor.nav_orchestrator.ensemble import (
 from spindoctor.nav_orchestrator.image_classifier_result import NavImageClassifierResult
 from spindoctor.nav_orchestrator.provenance import Provenance
 from spindoctor.nav_technique.diagnostics import (
+    BodyDiscDiagnostics,
     BodyLimbDiagnostics,
     NavTechniqueDiagnostics,
+    RingAnnulusDiagnostics,
+    RingEdgeDiagnostics,
     StarRefineDiagnostics,
     StarUniqueMatchDiagnostics,
 )
@@ -27,13 +32,14 @@ from spindoctor.nav_technique.technique_result import NavTechniqueResult
 from spindoctor.support.exceptions import NavContractError
 
 
-def _classifier() -> NavImageClassifierResult:
+def _classifier(*, background_gradient_score: float | None = None) -> NavImageClassifierResult:
     return NavImageClassifierResult(
         image_class='clean',
         saturation_frac=0.0,
         missing_frac=0.0,
         noise_sigma=1.0,
         max_dn=10.0,
+        background_gradient_score=background_gradient_score,
     )
 
 
@@ -1274,6 +1280,7 @@ def _refine_result(
     confidence: float = 0.5,
     prior_sources: frozenset[str] = frozenset(),
     cov: np.ndarray | None = None,
+    n_stars_used: int = 1,
 ) -> NavTechniqueResult:
     """Build a pass-2 StarRefineNav result seeded by ``prior_sources``."""
     return NavTechniqueResult(
@@ -1284,18 +1291,20 @@ def _refine_result(
         confidence=confidence,
         spurious=False,
         at_edge=False,
-        diagnostics=StarRefineDiagnostics(n_stars_used=1),
+        diagnostics=StarRefineDiagnostics(n_stars_used=n_stars_used),
         prior_source_techniques=prior_sources,
     )
 
 
 def test_ensemble_prior_descendant_does_not_boost_confidence() -> None:
-    """A refine seeded by its groupmate adds no agreement boost.
+    """A single-star refine seeded by its groupmate adds no agreement boost.
 
     The N1492091163 anatomy: a wrong pass-1 result seeds the prior, the
     1-star refine locks onto whatever sits near the (wrong) predicted
     position, and the pair's 'agreement' must not raise the combined
-    confidence above what the pass-1 result carries alone.
+    confidence above what the pass-1 result carries alone.  The seeded
+    single-star refine is dropped from the combine entirely, so
+    the confidence is the pass-1 result's own, neither boosted nor diluted.
     """
     ring = _make_result(technique_name='RingEdgeNav', offset=(6.7, -118.6), confidence=0.9)
     tagged = _refine_result(offset=(6.8, -118.5), prior_sources=frozenset({'RingEdgeNav'}))
@@ -1314,16 +1323,51 @@ def test_ensemble_prior_descendant_does_not_boost_confidence() -> None:
     )
     assert with_tag.status == 'success'
     assert without_tag.confidence > with_tag.confidence
-    # The tagged pair collapses to the precision-weighted average with no
-    # 2-member agreement factor: (0.9 + 0.5) / 2 with equal covariances.
-    assert with_tag.confidence == pytest.approx(0.7)
+    # The seeded single-star refine is dropped, leaving the ring result alone:
+    # its own 0.9, with no 2-member agreement factor and no 0.5-dilution.
+    assert with_tag.confidence == pytest.approx(0.9)
     assert without_tag.confidence == pytest.approx(0.99)
 
 
-def test_ensemble_prior_descendant_still_refines_the_offset() -> None:
-    """A tagged refine keeps contributing its precision to the combined offset."""
+def test_ensemble_seeded_single_star_refine_does_not_drag_offset() -> None:
+    """A seeded single-star refine no longer pulls the fused offset.
+
+    The reopened N1572105349 anatomy: pass-1 techniques agree at the truth,
+    and a single-inlier StarRefine seeded from that prior sits off to one side.
+    Because it merely re-observes its own seed and adds no independent
+    constraint, it is dropped from the combine, so the fused offset stays on
+    the pass-1 result rather than being dragged toward the refine.
+    """
     ring = _make_result(technique_name='RingEdgeNav', offset=(6.0, -118.0), confidence=0.9)
     refine = _refine_result(offset=(7.0, -119.0), prior_sources=frozenset({'RingEdgeNav'}))
+    result = ensemble(
+        [ring, refine],
+        feature_inventory=[],
+        image_classifier=_classifier(),
+        provenance=_provenance(),
+    )
+    assert result.status == 'success'
+    assert result.offset_px is not None
+    # The refine is dropped: the offset is the ring result's, not the mean.
+    assert result.offset_px[0] == pytest.approx(6.0)
+    assert result.offset_px[1] == pytest.approx(-118.0)
+    # The full consensus membership is still reported for transparency.
+    assert result.consensus_techniques == ['RingEdgeNav', 'StarRefineNav']
+
+
+def test_ensemble_seeded_multi_star_refine_still_refines_the_offset() -> None:
+    """A seeded multi-star refine keeps contributing its precision.
+
+    Only a *single*-star seeded refine is dropped: a multi-star refine carries
+    independent catalog matches, so it still refines the fused offset even
+    though the ensemble denies it a corroboration vote.
+    """
+    ring = _make_result(technique_name='RingEdgeNav', offset=(6.0, -118.0), confidence=0.9)
+    refine = _refine_result(
+        offset=(7.0, -119.0),
+        prior_sources=frozenset({'RingEdgeNav'}),
+        n_stars_used=5,
+    )
     result = ensemble(
         [ring, refine],
         feature_inventory=[],
@@ -1335,7 +1379,147 @@ def test_ensemble_prior_descendant_still_refines_the_offset() -> None:
     # Equal covariances: the combined offset is the arithmetic mean.
     assert result.offset_px[0] == pytest.approx(6.5)
     assert result.offset_px[1] == pytest.approx(-118.5)
-    assert result.consensus_techniques == ['RingEdgeNav', 'StarRefineNav']
+
+
+def test_ensemble_two_ring_techniques_are_one_witness_not_two() -> None:
+    """RingEdge + RingAnnulus on one catalog earn no independence boost.
+
+    Two ring techniques read the same catalog model, so their agreement is not
+    independent corroboration.  Collapsing them to one witness must leave the
+    combined confidence at a single witness's level, well below the two-witness
+    boost an independent body+ring pair would earn on the same numbers.
+    """
+    tight = np.eye(2, dtype=np.float64) * 0.04
+    edge = _make_result(
+        technique_name='RingEdgeNav',
+        offset=(5.0, -6.0),
+        cov=tight,
+        confidence=0.8,
+        diagnostics=RingEdgeDiagnostics(),
+    )
+    annulus = _make_result(
+        technique_name='RingAnnulusNav',
+        offset=(5.05, -6.05),
+        cov=tight,
+        confidence=0.8,
+        diagnostics=RingAnnulusDiagnostics(),
+    )
+    ring_pair = ensemble(
+        [edge, annulus],
+        feature_inventory=[],
+        image_classifier=_classifier(),
+        provenance=_provenance(),
+    )
+    # Control: an independent body+ring pair on the same numbers does earn the
+    # two-witness boost, so it lands at the confidence cap.
+    body = _make_result(
+        technique_name='BodyLimbNav',
+        offset=(5.05, -6.05),
+        cov=tight,
+        confidence=0.8,
+        diagnostics=BodyLimbDiagnostics(),
+    )
+    independent_pair = ensemble(
+        [edge, body],
+        feature_inventory=[],
+        image_classifier=_classifier(),
+        provenance=_provenance(),
+    )
+    assert ring_pair.status == 'success'
+    # No agreement boost: the collapsed witness keeps its own 0.8, while the
+    # independent pair is boosted to the cap.
+    assert ring_pair.confidence == pytest.approx(0.8)
+    assert independent_pair.confidence > ring_pair.confidence
+    # And the collapsed covariance is not double-tightened: a single witness's
+    # sigma, larger than the fused two-witness sigma.
+    assert ring_pair.covariance_px2 is not None
+    assert independent_pair.covariance_px2 is not None
+    assert ring_pair.covariance_px2[0, 0] > independent_pair.covariance_px2[0, 0]
+
+
+def test_ensemble_collapsed_ring_pair_has_no_spurious_quorum() -> None:
+    """A collapsed ring pair counts as one witness in the conflict logic.
+
+    RingEdge + RingAnnulus agree (and collapse to one witness), and a lone
+    dissenter of comparable confidence is excluded. Because the collapsed pair
+    is one witness, this is a lone-vs-lone standoff and must go conflicted --
+    not be suppressed by the pair spuriously claiming a two-member quorum.
+    """
+    tight = np.eye(2, dtype=np.float64) * 0.04
+    loose = np.eye(2, dtype=np.float64) * 0.25
+    edge = _make_result(
+        technique_name='RingEdgeNav',
+        offset=(0.0, 0.0),
+        cov=tight,
+        confidence=0.6,
+        diagnostics=RingEdgeDiagnostics(),
+    )
+    annulus = _make_result(
+        technique_name='RingAnnulusNav',
+        offset=(0.05, 0.05),
+        cov=tight,
+        confidence=0.6,
+        diagnostics=RingAnnulusDiagnostics(),
+    )
+    dissenter = _make_result(
+        technique_name='TechniqueB', offset=(30.0, 30.0), cov=loose, confidence=0.55
+    )
+    result = ensemble(
+        [edge, annulus, dissenter],
+        feature_inventory=[],
+        image_classifier=_classifier(),
+        provenance=_provenance(),
+    )
+    assert result.status == 'conflicted'
+    assert result.excluded_from_consensus == ['TechniqueB']
+
+
+def test_ensemble_scattered_light_disc_limb_are_one_witness() -> None:
+    """Disc + limb on a scattered-light frame do not inflate the tier.
+
+    On a frame whose background-gradient score clears the scattered-light
+    threshold, disc and limb measure the same veiling ramp, so their agreement
+    is not independent.  Collapsing them must keep the tier honest, whereas the
+    identical numbers on a clean frame legitimately earn the two-witness boost
+    and a high tier.
+    """
+    tight = np.eye(2, dtype=np.float64) * 0.04
+    disc = _make_result(
+        technique_name='BodyDiscCorrelateNav',
+        offset=(5.0, -6.0),
+        cov=tight,
+        confidence=0.8,
+        diagnostics=BodyDiscDiagnostics(),
+    )
+    limb = _make_result(
+        technique_name='BodyLimbNav',
+        offset=(5.05, -6.05),
+        cov=tight,
+        confidence=0.8,
+        diagnostics=BodyLimbDiagnostics(),
+    )
+    disc = dataclasses.replace(disc, source_bodies=frozenset({'MIMAS'}))
+    limb = dataclasses.replace(limb, source_bodies=frozenset({'MIMAS'}))
+    scattered = ensemble(
+        [disc, limb],
+        feature_inventory=[],
+        image_classifier=_classifier(background_gradient_score=8.0),
+        provenance=_provenance(),
+    )
+    clean = ensemble(
+        [disc, limb],
+        feature_inventory=[],
+        image_classifier=_classifier(background_gradient_score=1.0),
+        provenance=_provenance(),
+    )
+    assert scattered.status == 'success'
+    assert clean.status == 'success'
+    # Scattered: one witness, no boost -> medium tier at its own 0.8.
+    assert scattered.confidence == pytest.approx(0.8)
+    assert scattered.confidence_rank != 'high'
+    # Clean: two independent witnesses, boosted to the cap and a high tier.
+    assert clean.confidence > scattered.confidence
+    assert clean.confidence_rank == 'high'
 
 
 def test_ensemble_descendant_backed_winner_is_singleton_in_standoff() -> None:

--- a/tests/spindoctor/nav_orchestrator/test_ensemble_independence.py
+++ b/tests/spindoctor/nav_orchestrator/test_ensemble_independence.py
@@ -1,0 +1,290 @@
+"""Tests for the consensus-group independence resolution.
+
+Covers the three correlations the resolution corrects: a seeded single-star
+refine (R1), two ring techniques on one catalog (R2), and disc/limb on one
+scattered-light gradient (R3).
+"""
+
+# R1 / R2 / R3 correspond to issues #222, #317, #339 respectively.
+
+import numpy as np
+import pytest
+
+from spindoctor.nav_orchestrator.ensemble_independence import (
+    IndependenceResolution,
+    is_single_star_result,
+    resolve_independent_estimators,
+)
+from spindoctor.nav_orchestrator.image_classifier_result import NavImageClassifierResult
+from spindoctor.nav_technique.diagnostics import (
+    BodyDiscDiagnostics,
+    BodyLimbDiagnostics,
+    NavTechniqueDiagnostics,
+    RingAnnulusDiagnostics,
+    RingEdgeDiagnostics,
+    StarRefineDiagnostics,
+    StarUniqueMatchDiagnostics,
+)
+from spindoctor.nav_technique.technique_result import NavTechniqueResult
+
+RCOND = 1.0e-9
+
+
+def _classifier(*, gradient: float | None = None) -> NavImageClassifierResult:
+    return NavImageClassifierResult(
+        image_class='clean',
+        saturation_frac=0.0,
+        missing_frac=0.0,
+        noise_sigma=1.0,
+        max_dn=10.0,
+        background_gradient_score=gradient,
+    )
+
+
+def _result(
+    *,
+    technique_name: str,
+    offset: tuple[float, float] = (0.0, 0.0),
+    cov: np.ndarray | None = None,
+    confidence: float = 0.8,
+    diagnostics: NavTechniqueDiagnostics | None = None,
+    source_bodies: frozenset[str] = frozenset(),
+    prior_sources: frozenset[str] = frozenset(),
+) -> NavTechniqueResult:
+    return NavTechniqueResult(
+        technique_name=technique_name,
+        feature_ids=(f'{technique_name}:f1',),
+        offset_px=offset,
+        covariance_px2=cov if cov is not None else np.eye(2, dtype=np.float64) * 0.25,
+        confidence=confidence,
+        spurious=False,
+        at_edge=False,
+        diagnostics=diagnostics if diagnostics is not None else BodyLimbDiagnostics(),
+        source_bodies=source_bodies,
+        prior_source_techniques=prior_sources,
+    )
+
+
+def _resolve(
+    group: list[NavTechniqueResult], *, gradient: float | None = None
+) -> IndependenceResolution:
+    return resolve_independent_estimators(
+        group,
+        image_classifier=_classifier(gradient=gradient),
+        scattered_light_gradient_score=5.0,
+        rcond=RCOND,
+    )
+
+
+def test_empty_group_raises() -> None:
+    """Resolving an empty group is a programming error."""
+    with pytest.raises(ValueError, match='empty group'):
+        _resolve([])
+
+
+def test_is_single_star_result_variants() -> None:
+    """One-star matches and one-inlier refines are single-star; others are not."""
+    one_star = _result(
+        technique_name='StarUniqueMatchNav',
+        diagnostics=StarUniqueMatchDiagnostics(mode='one_star'),
+    )
+    two_star = _result(
+        technique_name='StarUniqueMatchNav',
+        diagnostics=StarUniqueMatchDiagnostics(mode='two_star'),
+    )
+    one_inlier = _result(
+        technique_name='StarRefineNav',
+        diagnostics=StarRefineDiagnostics(n_stars_used=1),
+    )
+    many_inlier = _result(
+        technique_name='StarRefineNav',
+        diagnostics=StarRefineDiagnostics(n_stars_used=6),
+    )
+    body = _result(technique_name='BodyLimbNav')
+    assert is_single_star_result(one_star)
+    assert not is_single_star_result(two_star)
+    assert is_single_star_result(one_inlier)
+    assert not is_single_star_result(many_inlier)
+    assert not is_single_star_result(body)
+
+
+def test_r1_drops_seeded_single_star_refine() -> None:
+    """A single-star refine seeded by a groupmate is dropped from the combine."""
+    ring = _result(technique_name='RingEdgeNav', offset=(6.0, -118.0))
+    refine = _result(
+        technique_name='StarRefineNav',
+        offset=(7.0, -119.0),
+        diagnostics=StarRefineDiagnostics(n_stars_used=1),
+        prior_sources=frozenset({'RingEdgeNav'}),
+    )
+    res = _resolve([ring, refine])
+    assert res.estimators == [ring]
+    assert res.dropped_descendants == [refine]
+    assert res.collapsed_groups == []
+
+
+def test_r1_keeps_seeded_multi_star_refine() -> None:
+    """A multi-star refine carries independent information and is kept."""
+    ring = _result(technique_name='RingEdgeNav', offset=(6.0, -118.0))
+    refine = _result(
+        technique_name='StarRefineNav',
+        offset=(7.0, -119.0),
+        diagnostics=StarRefineDiagnostics(n_stars_used=6),
+        prior_sources=frozenset({'RingEdgeNav'}),
+    )
+    res = _resolve([ring, refine])
+    assert res.estimators == [ring, refine]
+    assert res.dropped_descendants == []
+
+
+def test_r1_keeps_single_star_refine_without_stronger_witness() -> None:
+    """A pure single-star lock keeps its refine: no stronger witness to override.
+
+    When the only other consensus member is itself single-star (a one-star
+    unique match), the seeded refine is the sole refinement of a legitimately
+    weak fix, not a redundant vote against a body or multi-star consensus, so
+    it is kept.
+    """
+    match = _result(
+        technique_name='StarUniqueMatchNav',
+        diagnostics=StarUniqueMatchDiagnostics(mode='one_star'),
+    )
+    refine = _result(
+        technique_name='StarRefineNav',
+        diagnostics=StarRefineDiagnostics(n_stars_used=1),
+        prior_sources=frozenset({'StarUniqueMatchNav'}),
+    )
+    res = _resolve([match, refine])
+    assert set(res.estimators) == {match, refine}
+    assert res.dropped_descendants == []
+
+
+def test_r1_keeps_unseeded_single_star_refine() -> None:
+    """A single-star refine whose seed is absent from the group is not a descendant."""
+    refine = _result(
+        technique_name='StarRefineNav',
+        offset=(7.0, -119.0),
+        diagnostics=StarRefineDiagnostics(n_stars_used=1),
+        prior_sources=frozenset({'BodyLimbNav'}),
+    )
+    other = _result(technique_name='RingEdgeNav', offset=(7.0, -119.0))
+    res = _resolve([refine, other])
+    assert set(res.estimators) == {refine, other}
+    assert res.dropped_descendants == []
+
+
+def test_r1_never_empties_the_group() -> None:
+    """If every member is a seeded single-star refine, none are dropped."""
+    a = _result(
+        technique_name='StarRefineNav',
+        diagnostics=StarRefineDiagnostics(n_stars_used=1),
+        prior_sources=frozenset({'StarRefineNav'}),
+    )
+    res = _resolve([a])
+    assert res.estimators == [a]
+    assert res.dropped_descendants == []
+
+
+def test_r2_collapses_two_ring_techniques() -> None:
+    """RingEdge and RingAnnulus collapse to one representative witness."""
+    tight = np.eye(2, dtype=np.float64) * 0.04
+    loose = np.eye(2, dtype=np.float64) * 0.25
+    edge = _result(
+        technique_name='RingEdgeNav',
+        cov=tight,
+        diagnostics=RingEdgeDiagnostics(),
+    )
+    annulus = _result(
+        technique_name='RingAnnulusNav',
+        cov=loose,
+        diagnostics=RingAnnulusDiagnostics(),
+    )
+    res = _resolve([edge, annulus])
+    # One estimator; the higher-precision (tighter) edge result represents it.
+    assert res.estimators == [edge]
+    assert res.collapsed_groups == [[edge, annulus]]
+
+
+def test_r3_collapses_disc_and_limb_only_when_scattered() -> None:
+    """Disc and limb on one body collapse only above the scatter threshold."""
+    disc = _result(
+        technique_name='BodyDiscCorrelateNav',
+        source_bodies=frozenset({'MIMAS'}),
+        diagnostics=BodyDiscDiagnostics(),
+    )
+    limb = _result(
+        technique_name='BodyLimbNav',
+        source_bodies=frozenset({'MIMAS'}),
+        diagnostics=BodyLimbDiagnostics(),
+    )
+    # Below threshold (clean frame): both survive as independent estimators.
+    clean = _resolve([disc, limb], gradient=1.0)
+    assert set(clean.estimators) == {disc, limb}
+    assert clean.collapsed_groups == []
+    # Above threshold (scattered-light frame): collapsed to one witness.  Equal
+    # precision, so the max() technique-name tie-break makes limb (the larger
+    # name) the representative.
+    scattered = _resolve([disc, limb], gradient=8.0)
+    assert scattered.estimators == [limb]
+    assert scattered.collapsed_groups == [[limb, disc]]
+
+
+def test_r3_does_not_collapse_different_bodies() -> None:
+    """Disc and limb on different bodies are independent even under scatter."""
+    disc = _result(
+        technique_name='BodyDiscCorrelateNav',
+        source_bodies=frozenset({'MIMAS'}),
+        diagnostics=BodyDiscDiagnostics(),
+    )
+    limb = _result(
+        technique_name='BodyLimbNav',
+        source_bodies=frozenset({'TETHYS'}),
+        diagnostics=BodyLimbDiagnostics(),
+    )
+    res = _resolve([disc, limb], gradient=8.0)
+    assert set(res.estimators) == {disc, limb}
+    assert res.collapsed_groups == []
+
+
+def test_no_gradient_score_never_collapses_disc_limb() -> None:
+    """A missing background-gradient score defaults to not-scattered."""
+    disc = _result(
+        technique_name='BodyDiscCorrelateNav',
+        source_bodies=frozenset({'MIMAS'}),
+        diagnostics=BodyDiscDiagnostics(),
+    )
+    limb = _result(
+        technique_name='BodyLimbNav',
+        source_bodies=frozenset({'MIMAS'}),
+        diagnostics=BodyLimbDiagnostics(),
+    )
+    res = _resolve([disc, limb], gradient=None)
+    assert set(res.estimators) == {disc, limb}
+
+
+def test_uncorrelated_group_passes_through_unchanged() -> None:
+    """A body and a star witness share no error source and both survive."""
+    body = _result(technique_name='BodyLimbNav', source_bodies=frozenset({'RHEA'}))
+    star = _result(
+        technique_name='StarFieldFromCatalogNav',
+        diagnostics=StarRefineDiagnostics(n_stars_used=8),
+    )
+    res = _resolve([body, star], gradient=8.0)
+    assert res.estimators == [body, star]
+    assert res.dropped_descendants == []
+    assert res.collapsed_groups == []
+
+
+def test_estimators_preserve_input_order() -> None:
+    """Surviving estimators keep the input group's order."""
+    star = _result(
+        technique_name='StarFieldFromCatalogNav',
+        offset=(1.0, 1.0),
+        diagnostics=StarRefineDiagnostics(n_stars_used=8),
+    )
+    edge = _result(technique_name='RingEdgeNav', diagnostics=RingEdgeDiagnostics())
+    annulus = _result(technique_name='RingAnnulusNav', diagnostics=RingAnnulusDiagnostics())
+    # Ring pair collapses to one; the star stays. Order: star (idx 0) then ring.
+    res = _resolve([star, edge, annulus])
+    assert res.estimators[0] == star
+    assert len(res.estimators) == 2

--- a/tests/spindoctor/nav_orchestrator/test_image_classifier.py
+++ b/tests/spindoctor/nav_orchestrator/test_image_classifier.py
@@ -19,6 +19,25 @@ def test_classifier_clean_image_no_flags() -> None:
     assert result.flags == []
 
 
+def test_classifier_reports_background_gradient_on_ramp() -> None:
+    """A large-scale brightness ramp populates a high background-gradient score."""
+    rng = np.random.default_rng(seed=7)
+    _yy, xx = np.mgrid[0:128, 0:128]
+    image = 100.0 + 3.0 * xx + rng.normal(0.0, 2.0, size=(128, 128))
+    result = NavImageClassifier().classify(image)
+    assert result.background_gradient_score is not None
+    assert result.background_gradient_score > 5.0
+
+
+def test_classifier_background_gradient_low_on_flat_noise() -> None:
+    """A flat noisy field scores well below the scattered-light threshold."""
+    rng = np.random.default_rng(seed=8)
+    image = 100.0 + rng.normal(0.0, 3.0, size=(128, 128))
+    result = NavImageClassifier().classify(image)
+    assert result.background_gradient_score is not None
+    assert result.background_gradient_score < 5.0
+
+
 def test_classifier_blank_image() -> None:
     """A near-zero image is classified as blank."""
     image = np.zeros((64, 64), np.float64)

--- a/tests/spindoctor/support/test_background_gradient.py
+++ b/tests/spindoctor/support/test_background_gradient.py
@@ -1,0 +1,96 @@
+"""Tests for the low-order background-gradient score."""
+
+import numpy as np
+
+from spindoctor.support.background_gradient import (
+    BLOCK_SIZE,
+    background_gradient_score,
+)
+
+
+def test_flat_field_scores_near_zero() -> None:
+    """A constant image has no plane amplitude, so it returns None or ~0."""
+    image = np.full((128, 128), 500.0, dtype=np.float64)
+    # A perfectly flat field has zero residual sigma -> undefined ratio.
+    assert background_gradient_score(image) is None
+
+
+def test_noise_only_field_scores_low() -> None:
+    """A flat field plus noise (no ramp) scores well below the scatter cutoff."""
+    rng = np.random.default_rng(1)
+    image = 500.0 + rng.normal(0.0, 5.0, size=(128, 128))
+    score = background_gradient_score(image)
+    assert score is not None
+    assert score < 5.0
+
+
+def test_strong_ramp_scores_high() -> None:
+    """A clean linear ramp scores far above the scatter cutoff."""
+    rng = np.random.default_rng(2)
+    _yy, xx = np.mgrid[0:256, 0:256]
+    image = 100.0 + 3.0 * xx + rng.normal(0.0, 2.0, size=(256, 256))
+    score = background_gradient_score(image)
+    assert score is not None
+    assert score > 5.0
+
+
+def test_score_is_scale_invariant() -> None:
+    """Multiplying the image by a constant leaves the score unchanged."""
+    rng = np.random.default_rng(3)
+    yy, _xx = np.mgrid[0:128, 0:128]
+    image = 50.0 + 2.0 * yy + rng.normal(0.0, 1.0, size=(128, 128))
+    base = background_gradient_score(image)
+    scaled = background_gradient_score(image * 7.0)
+    assert base is not None
+    assert scaled is not None
+    assert abs(scaled - base) < 1e-9
+
+
+def test_too_small_image_returns_none() -> None:
+    """An image spanning fewer than four blocks per axis is undefined."""
+    small = np.ones((2 * BLOCK_SIZE, 8 * BLOCK_SIZE), dtype=np.float64)
+    assert background_gradient_score(small) is None
+
+
+def test_nan_pixels_are_ignored() -> None:
+    """Non-finite pixels do not poison the score; a ramp still reads high."""
+    rng = np.random.default_rng(4)
+    _yy, xx = np.mgrid[0:256, 0:256]
+    image = 100.0 + 3.0 * xx + rng.normal(0.0, 2.0, size=(256, 256))
+    image[0:16, 0:16] = np.nan  # one fully-missing block
+    image[100, 100] = np.nan  # a scattered dropout
+    score = background_gradient_score(image)
+    assert score is not None
+    assert score > 5.0
+
+
+def test_all_nan_image_returns_none() -> None:
+    """An all-missing image yields too few finite block medians to fit."""
+    image = np.full((128, 128), np.nan, dtype=np.float64)
+    assert background_gradient_score(image) is None
+
+
+def test_sensor_mask_makes_score_independent_of_padding() -> None:
+    """With a sensor mask, the padding value cannot affect the score.
+
+    The orchestrator feeds the extfov-padded frame; the padding value must not
+    leak into the gradient score.  The same sensor content under two different
+    padding values yields the same masked score, and (in general) different
+    unmasked scores.
+    """
+    rng = np.random.default_rng(9)
+    interior = 100.0 + 3.0 * np.mgrid[0:128, 0:128][1] + rng.normal(0.0, 2.0, size=(128, 128))
+    mask = np.zeros((160, 160), dtype=bool)
+    mask[16:144, 16:144] = True
+    img_pad0 = np.zeros((160, 160), dtype=np.float64)
+    img_pad0[16:144, 16:144] = interior
+    img_pad1 = np.full((160, 160), 1000.0, dtype=np.float64)
+    img_pad1[16:144, 16:144] = interior
+    masked0 = background_gradient_score(img_pad0, mask)
+    masked1 = background_gradient_score(img_pad1, mask)
+    assert masked0 is not None
+    assert masked1 is not None
+    # Padding excluded: the score depends only on the sensor content.
+    assert abs(masked0 - masked1) < 1e-9
+    # Without the mask, the padding value does leak into the score.
+    assert background_gradient_score(img_pad0) != background_gradient_score(img_pad1)

--- a/tests/spindoctor/support/test_background_gradient.py
+++ b/tests/spindoctor/support/test_background_gradient.py
@@ -1,9 +1,11 @@
 """Tests for the low-order background-gradient score."""
 
 import numpy as np
+import pytest
 
 from spindoctor.support.background_gradient import (
     BLOCK_SIZE,
+    SATURATED_GRADIENT_SCORE,
     background_gradient_score,
 )
 
@@ -68,6 +70,53 @@ def test_all_nan_image_returns_none() -> None:
     """An all-missing image yields too few finite block medians to fit."""
     image = np.full((128, 128), np.nan, dtype=np.float64)
     assert background_gradient_score(image) is None
+
+
+def test_exact_plane_ramp_saturates_not_none() -> None:
+    """A noiseless ramp (zero residual sigma) returns the saturated sentinel.
+
+    The image is an exact integer affine ramp with only three non-collinear
+    blocks left finite.  Three block medians define the fitted affine plane
+    exactly, so the fit residual -- and hence the MAD-sigma -- is exactly zero.
+    A perfectly clean gradient is present, not absent, so the score must be the
+    finite saturated sentinel rather than ``None``.
+    """
+    _yy, xx = np.mgrid[0 : 6 * BLOCK_SIZE, 0 : 6 * BLOCK_SIZE]
+    image = (3 * xx + 2 * _yy).astype(np.float64)
+    finite = np.zeros(image.shape, dtype=bool)
+    for i, j in [(0, 0), (0, 1), (1, 0)]:
+        finite[i * BLOCK_SIZE : (i + 1) * BLOCK_SIZE, j * BLOCK_SIZE : (j + 1) * BLOCK_SIZE] = True
+    image[~finite] = np.nan
+    assert background_gradient_score(image) == SATURATED_GRADIENT_SCORE
+
+
+def test_constant_field_still_returns_none() -> None:
+    """A perfectly constant field has no gradient and returns None, not saturated."""
+    image = np.full((128, 128), 42.0, dtype=np.float64)
+    assert background_gradient_score(image) is None
+
+
+def test_non_2d_image_raises_type_error() -> None:
+    """A non-2-D image is rejected before any masking or downsampling."""
+    image = np.zeros((64,), dtype=np.float64)
+    with pytest.raises(TypeError, match='image must be 2-D'):
+        background_gradient_score(image)
+
+
+def test_non_boolean_mask_raises_type_error() -> None:
+    """A non-boolean sensor mask is rejected rather than silently coerced."""
+    image = np.zeros((64, 64), dtype=np.float64)
+    mask = np.ones((64, 64), dtype=np.float64)
+    with pytest.raises(TypeError, match='sensor_mask must be a boolean ndarray'):
+        background_gradient_score(image, mask)  # type: ignore[arg-type]  # wrong dtype on purpose
+
+
+def test_mismatched_mask_shape_raises_value_error() -> None:
+    """A mask whose shape differs from the image is rejected (no broadcasting)."""
+    image = np.zeros((64, 64), dtype=np.float64)
+    mask = np.ones((1, 64), dtype=bool)
+    with pytest.raises(ValueError, match='sensor_mask shape'):
+        background_gradient_score(image, mask)
 
 
 def test_sensor_mask_makes_score_independent_of_padding() -> None:


### PR DESCRIPTION
## Purpose

Closes #222. Closes #317. Closes #339.

**The problem, from scratch.** SpinDoctor figures out where a spacecraft camera was pointing by running several independent "techniques" on one image (fit a moon's limb, correlate its disc, match a star field, fit the ring edges). Each produces its own pointing estimate plus an uncertainty. A final step, the **ensemble**, reconciles them into one answer and one confidence number.

The ensemble rests on a classic statistical idea: **if two independent methods agree, that agreement is strong evidence both are right.** So when techniques agree, the ensemble (1) tightens the combined uncertainty — the way averaging independent noisy readings cancels noise — which raises the confidence tier, and (2) multiplies the confidence upward (an "agreement boost").

Both steps are only valid **if the measurements are actually independent.** In three situations they are not — two "witnesses" are really looking at the same thing, so they are wrong (or right) *together*. Fusing them as independent then shrinks the uncertainty that did not actually shrink and fires an agreement boost that was guaranteed, not earned. The result is the worst failure a measurement system can have: **confidently wrong.** Because these confidence numbers feed downstream calibration, a confidently-wrong answer poisons the statistics used to calibrate the whole pipeline — which is why these gate the validation program.

The three cases:

- **#222 — a star refinement that confirms its own guess.** Pass 2 runs a star refinement that *starts from the pass-1 answer* and searches nearby. It is almost guaranteed to land near where it started, and the ensemble counted that as an independent second opinion. On real frame `N1572105349`, limb and disc correctly agreed on the truth, but a single-star refinement seeded from that prior locked onto a star ~2 px away and, voting as independent, dragged the final answer ~1.8 px off the truth while still reporting a high tier. The echo corrupted a correct answer.

- **#317 — two ring techniques reading one catalog.** `RingEdgeNav` and `RingAnnulusNav` both get their prediction of where the rings should be from the *same catalog model*. If the catalog is off, both are wrong by the same amount in the same direction, so they agree perfectly. On a test scene with a deliberately-misplaced ring the ensemble reported 0.99 confidence at a ~3 px error.

- **#339 — disc and limb both fooled by stray light.** Some frames have a smooth "veiling" brightness gradient (stray light bouncing inside the camera). Disc-correlation and limb-fitting both lock onto that same spurious ramp rather than the moon, so their errors are correlated. The ensemble hit its 0.99 confidence cap on frames whose answer was ~1 px off.

## Changes

All three are the same disease — correlated measurements fused as independent — so they share one cure. A new step resolves the agreeing group into the set of estimates it may treat as independent **before** the merge (`nav_orchestrator/ensemble_independence.py::resolve_independent_estimators`):

- **#222:** a seeded single-star refinement is dropped from the merge, but only when a stronger, non-single-star witness (a body/ring fix or a multi-star result) is present for it to override. A genuine lone single-star lock keeps its refinement — nothing stronger is present to corrupt, and the refinement is the only refinement available.
- **#317:** the two ring techniques are collapsed to a single representative witness (the higher-precision one).
- **#339:** on a scattered-light frame, disc and limb on the same body are collapsed to a single representative witness.

Collapsing a correlated pair to one representative is the conservative choice: it treats the pair as perfectly correlated, so the fused answer is the single best view of the shared measurement rather than a falsely-tightened average. It never over-claims. #380 tracks the follow-up to recover the *partial* independence some pairs genuinely have, once it can be measured from real frames — a precision enhancement, not a correctness fix.

Supporting change — **detecting stray light at run time.** #339 needs the navigator to know while running whether a frame has a veiling gradient. The only such detector lived in offline curation tooling, so it is ported into the runtime:

- `support/background_gradient.py::background_gradient_score` fits a tilted plane to a coarse, star-robust downsample and reports the ramp strength relative to noise (flat field near zero; real veiling well above the 5.0 threshold). Computed by the image classifier and recorded on every result (`NavImageClassifierResult.background_gradient_score`).
- The classifier's image is padded with a zero-filled extfov border; measuring the gradient over that border corrupts the score (on a full-frame Cassini NAC it dragged a real score of ~300 down to ~3.75, below threshold — so R3 would never have fired on the exact frames it targets). The score therefore excludes non-sensor pixels via the sensor mask. The `relief_psf_stray_light` regression scene confirms R3 now correctly fires there.

Consistency fix in the merge: quorum and vote-mass in the conflict logic are now measured over the resolved witness set (the same set the merge fuses), so a collapsed pair cannot claim a spurious two-member quorum that would suppress a genuine lone-vs-lone conflict.

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (fix or feature that alters existing behavior or public API)
- [ ] Refactor (no functional or API changes)
- [x] Documentation
- [x] Tests only (no production code change)
- [ ] CI / Build / Dependencies

Note on "breaking": no API changes, but confidence/tier outputs deliberately change on frames containing a correlated pair (see Potential Impacts).

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] End-to-end tests pass (if applicable)
- [x] New or updated tests for changed code
- [x] Tested manually (describe below if applicable)

New unit tests: the independence resolution (each of the three rules, the "keep a genuine single-star lock" case, determinism, uncorrelated pass-through); the gradient score (ramp vs flat, scale-invariance, NaN handling, constant-frame guard, and padding-independence via the sensor mask); end-to-end ensemble (ring pair and scattered-light disc/limb earn no spurious boost, the reopened-#222 offset drag is gone, a multi-star refine still refines, and a collapsed pair does not suppress a real conflict).

Full unit suite green (`pytest -m "not integration"`, 3847 passed / 7 xfailed), plus `ruff check`, `ruff format --check`, `mypy` (strict), and the `-W` Sphinx build. Manually re-ran the integration sim-baseline suite: the 6 affected scenes (5 ring + `relief_psf_stray_light`) regenerate as described below; the two remaining sim-baseline failures (`mutual_deep`, `saturated_star`) also fail on `main` — pre-existing local-environment drift (tracked under #335), and this code is a no-op on them (their gradient scores are below the stray-light threshold).

This change was adversarially reviewed by a separate agent; all three findings (the extfov-padding gradient bug, the quorum/conflict inconsistency, and a value-vs-identity equality fragility) are addressed here.

## Potential Impacts

- **Public API:** none. New optional field `NavImageClassifierResult.background_gradient_score` (defaults to `None`); new config key `orchestrator.ensemble.scattered_light_gradient_score` (defaults to 5.0). No signatures removed or changed.
- **Behavior (intended):** confidence and tier drop on frames containing a correlated pair; the offset is unchanged except where the old answer was an illusion. Regenerated planted-truth sim baselines, all still `status: success`:

  | Scene | Before | After | Why |
  |---|---|---|---|
  | `mmode_ringlet`, `moonlet_propeller`, `planted_offset_ring`, `spoked_sheet` | 0.99 | 0.91, offset unchanged | two ring techniques no longer double-count; same answer, honest confidence |
  | `orbit_error_ringlet` | 0.99, ~2.3 px err | 0.89 (low tier), honest ~2.5 px sigma | deliberately-wrong catalog; one honest uncertain witness, not a falsely-confident average |
  | `relief_psf_stray_light` | 0.98 | 0.68 (medium tier) | disc+limb, both fooled by the stray-light gradient, collapse to one witness |

- **CI:** the real-frame image-library and sim-baseline tests are `integration`-marked and do not run in PR CI (they need PDS holdings + SPICE). The #222 fix for `N1572105349` will turn green on the next local/scheduled integration run; its library sidecar is left unedited.
- **Downstream:** the honest confidences are the correct input to the pending #230 recalibration; #317 was required before that recalibration and is cleared.

## Checklist

- [x] Code follows project style (`ruff check`, `ruff format`)
- [x] Type annotations present and `mypy` passes
- [x] Docstrings and Sphinx docs updated (ensemble dev guide gains a "resolve independent estimators" step)
- [ ] CHANGES.md updated (no CHANGES.md in this repo)
- [x] No temporary or debug code left in
- [x] Breaking changes flagged in Type of Change above

## Notes

- The conservative rho=1 collapse is deliberate; #380 tracks the explicit cross-covariance follow-up (fitted from the #225 agreement study). Not urgent — the shipped behavior never over-claims.
- The program and engineering plans are reconciled as if this merged (three issues closed, ordering notes and issue index updated, the #230 sequencing note cleared for #317).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HoCUAeNeMz5bFmGk2iVBf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added background-gradient scoring to image classification and diagnostic metadata.
  * Improved ensemble result handling by preventing correlated techniques from being counted as independent evidence.
  * Added clearer confidence and positioning behavior for seeded refinements, ring measurements, and scattered-light scenes.

* **Bug Fixes**
  * Reduced overstated confidence and corrected offsets in several integration scenarios.
  * Improved handling of scattered-light imagery by combining related disc and limb measurements.

* **Documentation**
  * Updated ensemble-processing guidance, pipeline steps, and project status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->