### PR TITLE
fix: trim ring-annulus template for planet occlusion (#378)

### DIFF
--- a/docs/dev_guide/dev_guide_navigation_models_ring.rst
+++ b/docs/dev_guide/dev_guide_navigation_models_ring.rst
@@ -37,6 +37,8 @@ For each catalog-defined ring edge the model:
 4. Walks the pixel set to produce a polyline of vertices, each with an outward radial
    normal estimated from the local radius gradient.
 
+.. _ring-planet-occlusion:
+
 Planet occlusion
 ----------------
 
@@ -48,8 +50,14 @@ Both the emitted
 :data:`~spindoctor.feature.feature_type.NavFeatureType.RING_EDGE` features and the summary
 overlay read the same masks, so an edge segment behind the disc is neither fitted by
 :doc:`dev_guide_techniques_ring_edge` nor drawn across the planet, while a near-side edge
-crossing in front of the disc is kept. When the backplane cannot be evaluated the model
-keeps every edge rather than aborting.
+crossing in front of the disc is kept. The same backplane clears the annulus correlation
+template: the full-feature render that feeds the
+:data:`~spindoctor.feature.feature_type.NavFeatureType.RING_ANNULUS` path is trimmed against
+it before the per-ring renderings are composited, so the template carries no ring brightness
+from behind the disc and
+:doc:`dev_guide_techniques_ring_annulus` correlates only visible ring material. When the
+backplane cannot be evaluated the model keeps every edge and the full template rather than
+aborting.
 
 Per-edge feature filtering
 --------------------------
@@ -141,8 +149,10 @@ Annulus template
 When the per-planet km/px scale exceeds the configured threshold (or any single ring edge
 compresses below the per-polyline radial-pixel threshold), the model emits a single
 :attr:`~spindoctor.feature.feature_type.NavFeatureType.RING_ANNULUS` feature carrying a rendered
-template image of the entire ring system
-(every ring radius painted at the catalog brightness contrast) plus the matching mask.
+template image of the visible ring system
+(every ring radius painted at the catalog brightness contrast, with pixels behind the
+planet disc cleared as described under :ref:`ring-planet-occlusion`) plus the matching
+mask.
 The template's bounding box is the union of the per-edge bounding boxes; the template
 brightness at each pixel is the sum of the per-ring-edge contributions.
 

--- a/src/spindoctor/nav_model/nav_model_rings.py
+++ b/src/spindoctor/nav_model/nav_model_rings.py
@@ -693,6 +693,15 @@ class NavModelRings(NavModelRingsBase):
             ) in self._render_results:
                 if not edge_info_list:
                     continue
+                # The annulus correlation template is built from these full-feature
+                # renders, so it must be cleared of ring brightness hidden behind
+                # the planet globe just as the per-edge masks already are (see
+                # _visible_edge_info).  Trim the render against the same occlusion
+                # mask before it can enter annulus_renderings; a backplane failure
+                # left the mask None and degrades to no trimming.
+                if self._ring_occluded_ext is not None:
+                    model_img = np.where(self._ring_occluded_ext, 0.0, model_img)
+                    model_mask = model_mask & ~self._ring_occluded_ext
                 for edge_mask, label_text, edge_label in edge_info_list:
                     edge_orbit_rms_km = ring_feat.edge_uncertainty(edge_label)
                     vertices_vu, normals_vu = _polyline_from_edge_mask(

--- a/tests/spindoctor/nav_model/test_nav_model_rings.py
+++ b/tests/spindoctor/nav_model/test_nav_model_rings.py
@@ -14,6 +14,7 @@ import pytest
 
 from spindoctor.config.config import Config
 from spindoctor.feature import NavFeatureType, RingEdgePolyline
+from spindoctor.feature.geometry import RingAnnulusGeometry
 from spindoctor.nav_model.nav_model_rings import (
     NavModelRings,
     _require_positive_finite_planet_scalar,
@@ -531,7 +532,7 @@ def _rings_model_for_to_features(
     edge_info = model._visible_edge_info(raw_edge_info)
     zeros = np.zeros((v_size, u_size), dtype=np.float64)
     model._render_results = [
-        (_StubRingFeature('b_ring'), zeros, zeros.astype(bool), 1.0, edge_info)  # type: ignore[list-item]
+        (_StubRingFeature('b_ring'), zeros, zeros.astype(bool), 1.0, edge_info)  # type: ignore[list-item]  # structural stub; supplies only key/edge_uncertainty
     ]
     return model
 
@@ -577,3 +578,157 @@ def test_emitted_edge_features_keep_all_vertices_without_mask() -> None:
     geometry = edge_features[0].geometry
     assert isinstance(geometry, RingEdgePolyline)
     assert geometry.vertices_vu.shape[0] == 20
+
+
+###############################################################################
+#
+# Occlusion carries through to the emitted RING_ANNULUS template -- the same
+# guarantee for the correlation-side technique that RingEdgeNav gets per edge:
+# the annulus template carries no ring brightness from behind the planet globe.
+#
+###############################################################################
+
+
+def _rings_model_for_annulus(
+    occluded: np.ndarray | None,
+    model_img: np.ndarray,
+    model_mask: np.ndarray,
+    edge_mask: np.ndarray,
+) -> NavModelRings:
+    """Build a NavModelRings wired to emit a RING_ANNULUS from stub render state.
+
+    A large radial km/px forces the system-level annulus gate on, so the single
+    surviving edge routes to the annulus-template path rather than the per-edge
+    path.  The template is composited from ``model_img`` / ``model_mask``, which
+    ``to_features`` trims against the occlusion mask before compositing -- the
+    behaviour under test.  As in ``_render``, the edge mask is passed through
+    ``_visible_edge_info`` before it lands on ``_render_results`` while the
+    full-feature render is stored untrimmed.
+
+    Parameters:
+        occluded: Ext-FOV occlusion mask (or None for "no signal").
+        model_img: Ext-FOV full-feature render brightness.
+        model_mask: Ext-FOV full-feature render mask.
+        edge_mask: Ext-FOV edge mask routing the feature to the annulus path.
+
+    Returns:
+        A NavModelRings ready for a ``to_features`` call.
+    """
+    v_size, u_size = model_img.shape
+    model = NavModelRings('rings:SATURN', None, config=Config())
+    model._ring_occluded_ext = occluded
+    model._planet = 'SATURN'
+    # Large radial scale exceeds the SATURN kmpp_threshold, forcing the
+    # system-level annulus gate so the annulus template path is exercised.
+    model._km_per_pixel_radial = 5000.0
+    model._radial_resolution_ext = np.ones((v_size, u_size), dtype=np.float64)
+    model._ring_radius_ext = None
+    model._extfov_v_size = v_size
+    model._extfov_u_size = u_size
+    model._predicted_center_vu = (v_size / 2.0, u_size / 2.0)
+    model._subject_range_km = 1.0e6
+    edge_info = model._visible_edge_info([(edge_mask, 'B ring', 'b_outer')])
+    model._render_results = [
+        (_StubRingFeature('b_ring'), model_img, model_mask, 1.0, edge_info)  # type: ignore[list-item]  # structural stub; supplies only key/edge_uncertainty
+    ]
+    return model
+
+
+def _occluded_right_half(size: int) -> np.ndarray:
+    """Return an ext-FOV occlusion mask hiding the right half of the frame.
+
+    Parameters:
+        size: Side length of the square ext-FOV.
+
+    Returns:
+        A boolean mask True at every column at or past the midline.
+    """
+    occluded = np.zeros((size, size), dtype=bool)
+    occluded[:, size // 2 :] = True
+    return occluded
+
+
+def _straddling_render(size: int) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return a full-feature render + edge straddling the occlusion midline.
+
+    The render band spans columns 5 through ``size - 6``, crossing the
+    right-half occlusion midline so part of it lies behind the planet disc.
+
+    Parameters:
+        size: Side length of the square ext-FOV.
+
+    Returns:
+        ``(model_img, model_mask, edge_mask)`` all shaped ``(size, size)``.
+    """
+    model_mask = np.zeros((size, size), dtype=bool)
+    model_mask[10:12, 5 : size - 5] = True
+    model_img = np.where(model_mask, 1.0, 0.0)
+    edge_mask = np.zeros((size, size), dtype=bool)
+    edge_mask[10, 5 : size - 5] = True
+    return model_img, model_mask, edge_mask
+
+
+def test_annulus_template_excludes_pixels_behind_planet_disc() -> None:
+    """No annulus-template pixel maps to an ext-FOV pixel behind the planet."""
+    occluded = _occluded_right_half(30)
+    model_img, model_mask, edge_mask = _straddling_render(30)
+    model = _rings_model_for_annulus(occluded, model_img, model_mask, edge_mask)
+    features = model.to_features(None)  # type: ignore[arg-type]
+    annulus = [f for f in features if f.feature_type == NavFeatureType.RING_ANNULUS]
+    assert len(annulus) == 1
+    geometry = annulus[0].geometry
+    assert isinstance(geometry, RingAnnulusGeometry)
+    bbox = geometry.bbox_extfov_vu
+    template_mask = annulus[0].template_mask
+    assert template_mask is not None
+    occluded_hits = [
+        bool(occluded[bbox[0] + int(i), bbox[1] + int(j)])
+        for i, j in zip(*np.nonzero(template_mask), strict=True)
+    ]
+    assert not any(occluded_hits)
+
+
+def test_annulus_template_retains_visible_ring_pixels() -> None:
+    """Trimming keeps every visible ring pixel; it removes only the occluded ones.
+
+    Complements the excludes test: together they pin the trim exactly (nothing
+    behind the disc survives, nothing in front is dropped), so the guard catches
+    over-trimming as well as under-trimming.
+    """
+    occluded = _occluded_right_half(30)
+    model_img, model_mask, edge_mask = _straddling_render(30)
+    model = _rings_model_for_annulus(occluded, model_img, model_mask, edge_mask)
+    features = model.to_features(None)  # type: ignore[arg-type]
+    annulus = [f for f in features if f.feature_type == NavFeatureType.RING_ANNULUS]
+    bbox = annulus[0].geometry.bbox_extfov_vu
+    template_mask = annulus[0].template_mask
+    assert template_mask is not None
+    covered = {
+        (bbox[0] + int(i), bbox[1] + int(j))
+        for i, j in zip(*np.nonzero(template_mask), strict=True)
+    }
+    visible_ring = {
+        (int(r), int(c)) for r, c in zip(*np.nonzero(model_mask & ~occluded), strict=True)
+    }
+    assert visible_ring <= covered
+
+
+def test_annulus_template_bbox_stops_at_the_planet_limb() -> None:
+    """The trimmed template bbox no longer spans into the occluded columns."""
+    occluded = _occluded_right_half(30)
+    model_img, model_mask, edge_mask = _straddling_render(30)
+    model = _rings_model_for_annulus(occluded, model_img, model_mask, edge_mask)
+    features = model.to_features(None)  # type: ignore[arg-type]
+    annulus = [f for f in features if f.feature_type == NavFeatureType.RING_ANNULUS]
+    bbox = annulus[0].geometry.bbox_extfov_vu
+    assert bbox[3] <= 15
+
+
+def test_annulus_template_without_mask_keeps_pixels_behind_disc() -> None:
+    """A backplane failure (None mask) degrades to an untrimmed template."""
+    model_img, model_mask, edge_mask = _straddling_render(30)
+    model = _rings_model_for_annulus(None, model_img, model_mask, edge_mask)
+    features = model.to_features(None)  # type: ignore[arg-type]
+    annulus = [f for f in features if f.feature_type == NavFeatureType.RING_ANNULUS]
+    bbox = annulus[0].geometry.bbox_extfov_vu
+    assert bbox[3] == 25

--- a/tests/spindoctor/nav_model/test_nav_model_rings.py
+++ b/tests/spindoctor/nav_model/test_nav_model_rings.py
@@ -721,7 +721,7 @@ def test_annulus_template_bbox_stops_at_the_planet_limb() -> None:
     features = model.to_features(None)  # type: ignore[arg-type]
     annulus = [f for f in features if f.feature_type == NavFeatureType.RING_ANNULUS]
     bbox = annulus[0].geometry.bbox_extfov_vu
-    assert bbox[3] <= 15
+    assert bbox[3] == 15
 
 
 def test_annulus_template_without_mask_keeps_pixels_behind_disc() -> None:


### PR DESCRIPTION
## Purpose

Closes #378.

`NavModelRings.to_features` built the RING_ANNULUS correlation template from the full-feature `model_img` / `model_mask` without trimming them against the planet-occlusion mask. On low-resolution frames where the planet disc covers part of the ring, the annulus correlation template could carry ring brightness from *behind* the globe. This is the annulus-side analog of the ring-edge occlusion trim, which already drops occluded vertices via `_visible_edge_info`. It is a correctness/cleanliness gap with no observed navigation failure today (RingAnnulusNav's NCC is robust to the stray pixels), filed so the annulus template matches the edge path.

## Changes

- Trim `model_img` / `model_mask` against the same `self._ring_occluded_ext` occlusion backplane the ring-edge path uses, once per render result, before the arrays can enter `annulus_renderings` / `_composite_ring_renderings` (`src/spindoctor/nav_model/nav_model_rings.py`). Reuses the existing mask rather than duplicating occlusion logic.
- A backplane failure leaves the mask `None` and degrades to no trimming, exactly matching the edge path. The orbit-uncertainty channel is untouched (its normals derive from the already-trimmed edge masks).
- Developer guide (`docs/dev_guide/dev_guide_navigation_models_ring.rst`): the planet-occlusion and annulus-template sections now state the annulus template is trimmed by the same backplane.

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that alters existing behavior or public API)
- [ ] Refactor (no functional or API changes)
- [x] Documentation
- [x] Tests only (no production code change)
- [ ] CI / Build / Dependencies

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] End-to-end tests pass (if applicable)
- [x] New or updated tests for changed code
- [x] Tested manually (describe below if applicable)

Four new tests in `tests/spindoctor/nav_model/test_nav_model_rings.py`: no template pixel maps behind the planet disc (fails before the fix); the trimmed bbox stops at the planet limb (fails before the fix); every *visible* ring pixel is retained while occluded ones are dropped (pins the trim exactly, catching over- and under-trimming); and a `None` mask degrades to an untrimmed template. Full file green (44 passed); `ruff`, `ruff format --check`, `mypy` clean.

No navigation-output change: the simulated ring model (`NavModelRingsSimulated`) has its own `to_features` and never calls this path, and RingAnnulusNav's NCC is robust to the removed behind-disc pixels; the ring sim baselines are unaffected (verified). This changes only the real-frame template *contents*.

## Potential Impacts

- **Public API:** none.
- **Behavior:** no change to navigation output. The real-frame annulus correlation template no longer includes ring pixels behind the planet disc; RingAnnulusNav's offset is unchanged. The curated-image-library re-ratchet for the annulus template contents is an operator batch-run concern, deferred per the issue.

## Checklist

- [x] Code follows project style (`ruff check`, `ruff format`)
- [x] Type annotations present and `mypy` passes
- [x] Docstrings and Sphinx docs updated (ring-model dev guide)
- [ ] CHANGES.md updated (no CHANGES.md in this repo)
- [x] No temporary or debug code left in
- [x] Breaking changes flagged in Type of Change above

## Notes

Adversarially reviewed by a separate agent (clean; one LOW test-strengthening suggestion applied — the visible-pixel-retention assertion). The occlusion mask is the same `where_in_front` backplane the edge path consumes, so shadow (applied earlier in `_render`) and occlusion are now both reflected in the annulus template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HoCUAeNeMz5bFmGk2iVBf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ring-edge features and annulus templates now omit parts hidden behind the planet disc while preserving visible near-side crossings.
  * When occlusion data can’t be evaluated, annulus rendering falls back to the untrimmed template.
* **Documentation**
  * Updated the ring navigation guide to clarify consistent occlusion handling and that annulus-template imagery shows only the visible ring system.
* **Tests**
  * Expanded coverage to validate pixel exclusion, retained visible pixels, template bounding limits, and the no-occlusion fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->