### PR TITLE
fix: make body model occlusion-aware at mutual-event overlap (#326, #327)

### DIFF
--- a/docs/dev_guide/dev_guide_navigation_models_body.rst
+++ b/docs/dev_guide/dev_guide_navigation_models_body.rst
@@ -175,6 +175,12 @@ would always score near unity for a fully-in-frame body and lose discriminating 
 disc gate. The overflow fraction measures the portion of the predicted disc that is outside
 the sensor FOV.
 
+A lit pixel a nearer body hides (see :ref:`body-body occlusion <body-occlusion>`) is not
+usable disc-template support, so it is excluded from the visible-lit numerator while the
+denominator stays the whole predicted disc. At deep mutual-event overlap the visible-lit
+fraction therefore falls toward the surviving crescent, which drops the disc reliability and,
+below the minimum, gates the disc feature out entirely.
+
 Lit-weighted predicted centroid
 -------------------------------
 
@@ -257,6 +263,38 @@ highly-irregular body whose predicted diameter exceeds that value drops its shap
 Below the threshold, and for bodies tagged merely ``irregular``, the shape features are
 unchanged — the continuous ellipsoid-residual widening in the per-vertex sigma budget already
 degrades an irregular body's limb reliability without dropping the feature outright.
+
+.. _body-occlusion:
+
+Body-body occlusion
+-------------------
+
+When two bodies overlap along the line of sight — a mutual event — the nearer body hides part
+of the farther one, and the image shows the occluder there, not the target. The model accounts
+for this so the features it emits describe the arcs and disc area the image actually carries.
+
+Each per-body model receives the other in-FOV bodies as siblings. A sibling occludes the target
+only when its inventory center range is strictly nearer; for each such sibling the model queries
+the SPICE backplane's ``where_in_front`` predicate over the target's bounding box, which is True
+at every pixel where the nearer body is intercepted in front of the target. The union of those
+predicates is the target's occluder mask.
+
+The occluder mask feeds three products:
+
+- **Limb and terminator polylines.** A ridge vertex the occluder hides is dropped from the
+  fitted polyline. It stays in the ridge total, so the ``visible_arc_fraction`` reports the loss:
+  a mutual-event limb scores like the partial arc it is rather than claiming a full limb the
+  distance-transform fit would then try to align against an arc the image does not show.
+- **The visible-lit fraction**, as described above, which drops the disc reliability with
+  occlusion depth.
+- **The disc template.** The occluded pixels are trimmed out of the correlation template (both
+  the brightness image and its mask), so the correlator scores only against disc brightness the
+  image carries. Correlating against the missing disc area would be a coherent mismatch the
+  robust machinery absorbs into the fit rather than discounting.
+
+A backplane failure on any occluder degrades to leaving that occluder's contribution untrimmed
+rather than aborting the render. The single-body case (no nearer sibling) computes no mask and
+costs nothing.
 
 Restrictions and assumptions
 ----------------------------

--- a/docs/dev_guide/dev_guide_simulator.rst
+++ b/docs/dev_guide/dev_guide_simulator.rst
@@ -1265,19 +1265,27 @@ records the outcome in the render truth (``body_occlusion``): each body's
 visible fraction and the angular extent of any hidden limb arc. This is
 bookkeeping the test can read, not something the navigator sees.
 
-The measured technique-level behavior is robust: the navigator predicts *both*
-full limbs (it does not know the hidden arc -- that arc is model error, and the
-occluded body's limb feature still reports full ``visible_arc_fraction``), the
-joint limb fit rejects the hidden arc through its Tukey biweight loss, and both
-techniques land within a fraction of a pixel and fuse to an accurate result. No
-confident-wrong result and no double-counting conflict was observed across
-grazing, half, and deep overlap.
+Both body models -- the simulated one and the SPICE-backed
+:class:`~spindoctor.nav_model.nav_model_body.NavModelBody` -- are occlusion-aware.
+Each per-body model knows the other bodies' idealized geometry and explicit
+nearer-or-farther depth order (``range_km`` in the sim; the inventory center
+range under SPICE), and from that it drops the hidden limb and terminator
+vertices from its predicted polylines, reports a ``visible_arc_fraction`` that
+falls with occlusion depth, and trims the hidden region out of the ``BODY_DISC``
+correlation template. So a mutual-event limb scores like the partial arc it is,
+and the disc correlator scores only against disc brightness the image carries.
+Nothing reads a truth key: the occlusion is derived from the same idealized
+sibling geometry both models already hold.
 
-The honest caveat, which the mutual-event scenes pin so a regression fails
-loudly: the occluded limb still *claims* full reliability. The technique
-succeeds because the robust loss discards the hidden arc, not because the model
-masks it -- the confidence a hidden-arc limb feature reports is optimistic, and
-a future change that made the fit trust that arc would move the answer.
+The measured technique-level behavior is accurate and honest across grazing,
+half, and deep overlap. On the deep scene the far body's disc is over 90 percent
+hidden, so its ``visible_lit_fraction`` collapses and the disc gate drops that
+feature; the near body's disc plus both visible limb arcs fuse to an accurate
+result. The joint limb fit runs on arcs the image actually shows -- the robust
+Tukey biweight loss is a second line of defense against a stray vertex, not the
+mechanism that carries the result -- and no confident-wrong result or
+double-counting conflict arises. The mutual-event scenes pin the arc fractions
+and offsets so a regression toward hidden-arc lock-on fails loudly.
 
 .. _sim-atmosphere:
 
@@ -1616,8 +1624,8 @@ The panels below are rendered by ``python -m tests.integration.sim_doc_images``
    :align: center
 
    A mutual event: the nearer body occludes part of the farther one. The
-   navigator still predicts both full limbs and the robust fit discards the
-   hidden arc.
+   navigator drops the hidden arc from the farther body's predicted limb and
+   trims its disc template, so each feature describes only what the image shows.
 
 .. figure:: _sim_images/rings.png
    :width: 45%

--- a/docs/simulator_report/simulator_report.rst
+++ b/docs/simulator_report/simulator_report.rst
@@ -473,7 +473,7 @@ same estimator on both sides (EE50 0.90 sim vs 0.91 real; EE80 1.72 vs
 calibrated-chain hot-pixel retune, while the transient (cosmic-ray)
 share stays unmodeled on every chain -- each catalog entry retains an
 explicit zero beside its measured rate and the chain-model reason (see
-known gap 7); limb rise widths agree in the like-for-like pool
+known gap 6); limb rise widths agree in the like-for-like pool
 (co-populated-strata medians 2.539 sim vs 2.539 px real, W1/IQR 0.16)
 with per-stratum divergences from 0.21 to 2.04 -- worst at high phase,
 where the simulated crescent limb measures *wider* than the real one
@@ -557,7 +557,7 @@ likewise (101), and the sky level above floor at 3.7e-5 vs 3.2e-4
 chain is a chain symptom, not a small-n artifact -- most plausibly the
 nominal DN-to-I/F calibration scale of the simulated chain (the
 per-filter CISSCAL scale is not modeled; the same family as known gap
-3), though the 4-frame cohort cannot close the attribution.  The
+2), though the 4-frame cohort cannot close the attribution.  The
 remaining WAC statistics rest on 1-2 frames per stratum and are
 reported in the summary JSON without distributional claims.
 
@@ -636,17 +636,7 @@ cannot close, it is recorded here rather than force-fitted:
    shines.  Simulated star-technique success on body-crossing fields is
    therefore optimistic: real frames lose stars behind dark limbs that
    simulated frames keep.
-2. **Disc templates ignore body-body occlusion.**  The simulated limb and
-   terminator arcs are occlusion-aware: vertices hidden behind an
-   explicitly nearer sibling body are dropped from the emitted polylines
-   and ``visible_arc_fraction`` reports the loss, so a mutual-event limb
-   scores like the partial arc it is.  The ``BODY_DISC`` correlation
-   template, however, still renders each body in isolation: at deep
-   overlap the far body's template contains disc area the image does not
-   show, a coherent mismatch the correlator's robust machinery absorbs
-   rather than discounts.  The mutual-event scenes pin the measured
-   (accurate) outcomes; an occlusion-aware disc template remains open.
-3. **Calibrated-product quantization scars.**  The sim's calibrated path
+2. **Calibrated-product quantization scars.**  The sim's calibrated path
    retains full LSB quantization texture: its measured sky-noise floor is
    ~1 DN-equivalent at every exposure (Cassini CALIB and Voyager GEOMED
    paths alike).  Real calibrated products sit *below* the LSB (NAC CALIB
@@ -664,24 +654,24 @@ cannot close, it is recorded here rather than force-fitted:
    uncertainty at full size: its simulated sky sigma undershoots the
    real cohort by roughly 8x one-sidedly (2.4e-5 vs 1.9e-4 I/F; see the
    WAC subsection).
-4. **Hot pixels are per-scene, not per-detector.**  The simulated
+3. **Hot pixels are per-scene, not per-detector.**  The simulated
    hot-pixel population is drawn from each scene's seeded stream, so it
    never recurs at fixed detector positions across frames the way real
    hot pixels do.  The FOM 6 stationary/transient split therefore cannot
    match by construction; only the total incidence is comparable (and now
    tuned).
-5. **No per-readout-mode PSF.**  The catalog carries one kernel per
+4. **No per-readout-mode PSF.**  The catalog carries one kernel per
    instrument; the LORRI cohort's 4x4-binned frames (and any summed
    Cassini modes that enter the library later) see a different effective
    kernel that the catalog cannot express.
-6. **Matched-frame content limits.**  Simulated ring edges are sharp
+5. **Matched-frame content limits.**  Simulated ring edges are sharp
    optical-depth steps and simulated matched bodies are relief-free
    ellipsoids, so residual FOM 3/4 width differences fold in real edge
    structure (ring radial profiles, limb topography) beyond the PSF that
    FOM 2 pins independently.  The Galileo negative frames carry an
    extended background glow (scattered light) that matched sky frames do
    not model, which dominates that cohort's FOM 5 comparison.
-7. **Measured transients exceed what the cosmic-ray stage can express.**
+6. **Measured transients exceed what the cosmic-ray stage can express.**
    Every cohort measures a nonzero transient spike fraction (NAC 2.75e-4,
    WAC 4.89e-4, Galileo 1.17e-4, LORRI 3.36e-4 per frame), yet no
    catalog entry adopts a ``cosmic_ray_rate_per_sec``: the Cassini
@@ -1501,7 +1491,7 @@ the dedicated sweep or the scene class that drives it:
      - sweep ``star_catalog_scatter``
    * - Mutual event
      - overlapping bodies
-     - occlusion-aware limb arcs; isolated disc templates
+     - occlusion-aware limb arcs and disc templates
      - ``mutual_event`` scene class
    * - Atmosphere
      - ``atmosphere`` ``tau_ref`` haze

--- a/src/spindoctor/nav_model/nav_model_body.py
+++ b/src/spindoctor/nav_model/nav_model_body.py
@@ -276,6 +276,10 @@ class NavModelBody(NavModelBodyBase):
         body_name: SPICE body name.
         inventory: Optional pre-computed inventory entry; pulled from
             ``obs.inventory`` on demand otherwise.
+        siblings: ``(body_name, range_km)`` for the other bodies in the FOV.
+            A sibling whose center range is strictly nearer occludes this
+            body's predicted limb / terminator arcs and disc template;
+            ``None`` (the common single-body case) means no sibling occludes.
         config: Optional ``Config`` override.
     """
 
@@ -288,11 +292,14 @@ class NavModelBody(NavModelBodyBase):
         body_name: str,
         *,
         inventory: dict[str, Any] | None = None,
+        siblings: list[tuple[str, float]] | None = None,
         config: Config | None = None,
     ) -> None:
         super().__init__(name, obs, config=config)
         self._body_name = body_name.upper()
         self._inventory = inventory
+        self._siblings: list[tuple[str, float]] = list(siblings or [])
+        self._occluder_mask: NDArrayBoolType | None = None
         self._model_img: NDArrayFloatType | None = None
         self._body_mask: NDArrayBoolType | None = None
         self._limb_mask: NDArrayBoolType | None = None
@@ -333,11 +340,33 @@ class NavModelBody(NavModelBodyBase):
             return []
         if config is None:
             config = DEFAULT_CONFIG
+        in_extfov = bodies_in_extfov(obs, config=config)
+        ranges = {
+            name.upper(): float(entry.get('range', float('inf'))) for name, entry in in_extfov
+        }
         out: list[NavModel] = []
-        for body_name, entry in bodies_in_extfov(obs, config=config):
+        for body_name, entry in in_extfov:
             if body_name.upper() == TITAN_BODY_NAME:
                 continue
-            out.append(cls(f'body:{body_name}', obs, body_name, inventory=entry, config=config))
+            # Every other in-FOV body is a candidate occluder (Titan included:
+            # it is not navigated as a shape, but a nearer Titan still hides a
+            # moon behind it).  The per-body render decides per pixel which are
+            # actually nearer via the backplane depth test.
+            siblings = [
+                (other.upper(), ranges[other.upper()])
+                for other, _ in in_extfov
+                if other.upper() != body_name.upper()
+            ]
+            out.append(
+                cls(
+                    f'body:{body_name}',
+                    obs,
+                    body_name,
+                    inventory=entry,
+                    siblings=siblings,
+                    config=config,
+                )
+            )
         return out
 
     def create_model(self) -> None:
@@ -637,11 +666,25 @@ class NavModelBody(NavModelBodyBase):
         else:
             km_per_pixel_local = np.zeros_like(body_mask_valid, dtype=np.float64)
 
+        # Body-body occlusion: every predicted pixel a nearer sibling body
+        # hides is dropped from the limb / terminator polylines (so the DT fit
+        # never chases an arc the image does not show) and, promoted to extfov
+        # coordinates, is trimmed out of the disc template (so the correlator
+        # does not score against disc brightness that is not there).
+        occluder_local = self._compute_occluder_local(
+            restr_bp, oversample_v=oversample_v, oversample_u=oversample_u
+        )
+        occluder_ext = obs.make_extfov_false()
+        if occluder_local is not None:
+            occluder_ext[v_slice, u_slice] = occluder_local & body_mask_valid
+        self._occluder_mask = occluder_ext
+
         limb_sampler = _build_polyline_sampler(
             local_mask=limb_mask_local,
             region_mask=body_mask_valid,
             incidence_local=incidence_vals,
             km_per_pixel_local=km_per_pixel_local,
+            occluder_local=occluder_local,
             ext_v0=ext_v0,
             ext_u0=ext_u0,
         )
@@ -650,6 +693,7 @@ class NavModelBody(NavModelBodyBase):
             region_mask=is_lit,
             incidence_local=incidence_vals,
             km_per_pixel_local=km_per_pixel_local,
+            occluder_local=occluder_local,
             ext_v0=ext_v0,
             ext_u0=ext_u0,
         )
@@ -678,7 +722,12 @@ class NavModelBody(NavModelBodyBase):
         # with partial framing.  Both regimes make the disc-correlation
         # template poor, which is exactly what the 0.4 gate screens out;
         # the phase coupling is intentional, not a normalisation bug.
-        lit_visible_in_fov = int(np.count_nonzero(lit_mask & in_sensor))
+        # A lit pixel a nearer sibling hides is not usable disc-template
+        # support, so it leaves the numerator while the denominator stays the
+        # whole predicted disc: at deep overlap ``visible_lit_fraction`` falls
+        # toward the surviving crescent, which is what the BODY_DISC gate and
+        # reliability consume.
+        lit_visible_in_fov = int(np.count_nonzero(lit_mask & in_sensor & ~occluder_ext))
         visible_lit_fraction = lit_visible_in_fov / max(body_total, 1)
         overflow_fraction = 1.0 - (body_visible / max(body_total, 1))
 
@@ -696,6 +745,54 @@ class NavModelBody(NavModelBodyBase):
             'overflow_fraction': overflow_fraction,
         }
         return model_img, limb_mask, terminator_mask, body_mask, info
+
+    def _compute_occluder_local(
+        self, restr_bp: Backplane, *, oversample_v: int, oversample_u: int
+    ) -> NDArrayBoolType | None:
+        """Union silhouette of nearer sibling bodies over the body's bbox grid.
+
+        A sibling occludes this body only when its inventory center range is
+        strictly nearer; the per-pixel depth test in
+        :meth:`oops.backplane.Backplane.where_in_front` then decides which
+        pixels the nearer body actually hides.  The result is downsampled to
+        the same discrete grid the limb / terminator masks live on.
+
+        A backplane failure on any occluder degrades to no occlusion for that
+        occluder (the arc / template stays untrimmed) rather than aborting the
+        render.
+
+        Parameters:
+            restr_bp: Backplane over the body's oversampled bbox meshgrid.
+            oversample_v: Vertical oversample factor of that meshgrid.
+            oversample_u: Horizontal oversample factor of that meshgrid.
+
+        Returns:
+            The bbox-local boolean occluder mask, or ``None`` when no sibling
+            is nearer or none hides any pixel (the common case costs nothing).
+        """
+        nearer = [name for name, rng in self._siblings if rng < self._subject_range_km]
+        if not nearer:
+            return None
+        occluder: NDArrayBoolType | None = None
+        for sibling_name in nearer:
+            try:
+                hidden = restr_bp.where_in_front(sibling_name, self._body_name)
+                hidden_over = hidden.mvals.filled(False).astype(bool)
+            except Exception:
+                self._logger.warning(
+                    'Body %s: failed to compute occlusion by %s; arc / template left untrimmed',
+                    self._body_name,
+                    sibling_name,
+                    exc_info=True,
+                )
+                continue
+            hidden_local = (
+                filter_downsample(hidden_over.astype(np.float64), oversample_v, oversample_u) >= 0.5
+            )
+            occluder = hidden_local if occluder is None else (occluder | hidden_local)
+        if occluder is None or not occluder.any():
+            return None
+        return occluder
 
     def to_features(self, context: NavContext) -> list[NavFeature]:
         """Emit the body's NavFeatures per the design's gate rules."""
@@ -822,6 +919,15 @@ class NavModelBody(NavModelBodyBase):
         v_min, u_min, v_max, u_max = self._bbox_extfov_vu
         template_img = self._model_img[v_min:v_max, u_min:u_max].copy()
         template_mask = self._body_mask[v_min:v_max, u_min:u_max].copy()
+        # A nearer sibling body hides part of this disc; the image shows the
+        # occluder there, not this body, so drop the occluded pixels from the
+        # template.  Correlating against disc brightness that is not present
+        # would be a coherent mismatch the correlator's robust machinery
+        # absorbs rather than discounts.
+        if self._occluder_mask is not None:
+            occluded_bbox = self._occluder_mask[v_min:v_max, u_min:u_max]
+            template_img[occluded_bbox] = 0.0
+            template_mask[occluded_bbox] = False
         return NavFeature(
             feature_id=f'body_disc:{self._body_name}',
             feature_type=NavFeatureType.BODY_DISC,
@@ -986,6 +1092,7 @@ def _build_polyline_sampler(
     region_mask: NDArrayBoolType,
     incidence_local: NDArrayFloatType,
     km_per_pixel_local: NDArrayFloatType,
+    occluder_local: NDArrayBoolType | None = None,
     ext_v0: int,
     ext_u0: int,
 ) -> _PolylineSampler:
@@ -1012,6 +1119,10 @@ def _build_polyline_sampler(
             defines the outward normal.  Same shape as ``local_mask``.
         incidence_local: Per-pixel incidence angle (radians).
         km_per_pixel_local: Per-pixel km/px scale.
+        occluder_local: Optional body-body occlusion mask on the same local
+            grid; ridge vertices a nearer body hides are dropped from the
+            polyline while ``total_vertices`` keeps the full ridge, so the
+            visible-arc fraction reports the occlusion loss.
         ext_v0: Extfov v-offset of the local grid origin.
         ext_u0: Extfov u-offset of the local grid origin.
     """
@@ -1027,6 +1138,11 @@ def _build_polyline_sampler(
         # sampler's parallel arrays consistent and the downstream sigmas
         # finite and positive (which ``lm_subpixel_refine`` requires).
         resolved = km_per_pixel_local[vs, us] > 0.0
+        if occluder_local is not None:
+            # A ridge vertex a nearer body hides has no counterpart edge in
+            # the image; keep it in ``total_vertices`` but drop it from the
+            # fitted polyline so the visible-arc fraction reports the loss.
+            resolved = resolved & ~occluder_local[vs, us]
         vs, us = vs[resolved], us[resolved]
     if vs.size == 0:
         empty: NDArrayFloatType = np.empty((0, 2), dtype=np.float64)
@@ -1113,10 +1229,10 @@ def _visible_arc_fraction(sampler: _PolylineSampler) -> float:
     """Fraction of the predicted ridge vertices that survived to the fit.
 
     ``sampler.total_vertices`` is the ridge length found before per-vertex
-    drops (currently zero-resolution / off-body vertices; the table-driven
-    shadow extractor will add to this when wired), and ``vertices_vu`` holds
-    only the survivors, so the visible-arc fraction is ``survivors / total``.
-    Returns ``0.0`` when no ridge vertices were found at all.
+    drops (zero-resolution / off-body vertices and vertices a nearer sibling
+    body occludes), and ``vertices_vu`` holds only the survivors, so the
+    visible-arc fraction is ``survivors / total``.  Returns ``0.0`` when no
+    ridge vertices were found at all.
     """
     total = sampler.total_vertices
     if total <= 0:

--- a/src/spindoctor/nav_model/nav_model_body_simulated.py
+++ b/src/spindoctor/nav_model/nav_model_body_simulated.py
@@ -510,6 +510,20 @@ class NavModelBodySimulated(NavModelBodyBase):
         v_min, u_min, v_max, u_max = self._bbox_extfov_vu
         template_img = self._model_img[v_min:v_max, u_min:u_max].copy()
         template_mask = self._body_mask[v_min:v_max, u_min:u_max].copy()
+        # A nearer sibling body hides part of this disc; the image shows the
+        # occluder there, not this body.  Drop the occluded pixels from the
+        # correlation template so it scores only against disc brightness the
+        # image actually carries, and report a visible fraction that falls
+        # with occlusion depth (the sim mirror of the SPICE-backed model, so
+        # the two do not desync on disc occlusion).
+        disc_visible_fraction = 1.0
+        if self._occluder_mask is not None:
+            occluded_bbox = self._occluder_mask[v_min:v_max, u_min:u_max]
+            total_disc = int(np.count_nonzero(template_mask))
+            template_img[occluded_bbox] = 0.0
+            template_mask[occluded_bbox] = False
+            visible_disc = int(np.count_nonzero(template_mask))
+            disc_visible_fraction = visible_disc / max(total_disc, 1)
         features: list[NavFeature] = [
             NavFeature(
                 feature_id=f'body_disc:{self._body_name}',
@@ -524,9 +538,9 @@ class NavModelBodySimulated(NavModelBodyBase):
                 position_cov_px=None,
                 intensity_sigma_rel=0.0,
                 preferred_filter=NavFilterSpec(kind=NavFilterKind.NONE),
-                reliability=1.0,
+                reliability=disc_visible_fraction,
                 reliability_reasons=NavReliabilityBreakdown(
-                    visible_lit_fraction=1.0, overflow_fraction=0.0
+                    visible_lit_fraction=disc_visible_fraction, overflow_fraction=0.0
                 ),
                 usable_types=frozenset({NavFeatureType.BODY_DISC}),
                 flags=BodyDiscFlags(body_name=self._body_name, overflow_fov_fraction=0.0),

--- a/tests/integration/sim_baselines/mutual_deep.json
+++ b/tests/integration/sim_baselines/mutual_deep.json
@@ -1,7 +1,7 @@
 {
   "confidence": 0.99,
-  "offset_du_px": -1.58,
-  "offset_dv_px": 2.49,
+  "offset_du_px": -1.49,
+  "offset_dv_px": 2.51,
   "scene_name": "mutual_deep",
   "status": "success"
 }

--- a/tests/spindoctor/nav_model/test_nav_model_body_occlusion.py
+++ b/tests/spindoctor/nav_model/test_nav_model_body_occlusion.py
@@ -1,0 +1,378 @@
+"""Body-body occlusion tests for the SPICE-backed ``NavModelBody``.
+
+A nearer sibling body hides part of the target's predicted disc.  The model
+must drop the hidden limb / terminator vertices from the emitted polylines
+(so the distance-transform fit never chases an arc the image does not show),
+report an honest ``visible_arc_fraction`` that falls with occlusion depth, and
+trim the hidden region out of the ``BODY_DISC`` correlation template (so the
+correlator does not score against disc brightness that is not present).
+
+The scene is analytic and hermetic: two orthographic spheres over a fake
+meshgrid, with a ``where_in_front`` stand-in that returns the nearer body's
+silhouette.  No SPICE, no holdings.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, cast
+
+import numpy as np
+import polymath
+import pytest
+from tests.shims import BodyBackplaneData, FakeBackplane, FakeMeshgrid, FakeObs, bare_nav_context
+
+import spindoctor.nav_model.nav_model_body as nav_model_body_module
+from spindoctor.feature.feature import NavFeature
+from spindoctor.feature.flags import LimbArcFlags, TerminatorArcFlags
+from spindoctor.feature.geometry import LimbPolyline
+from spindoctor.nav_model.nav_model_body import NavModelBody
+from spindoctor.support.types import NDArrayBoolType, NDArrayFloatType
+
+_TARGET = 'TARGET'
+_OCCLUDER = 'OCCLUDER'
+
+
+@dataclass(frozen=True)
+class _Sphere:
+    """Analytic orthographic-sphere geometry driving the fake backplane.
+
+    Parameters:
+        center_vu: Sphere centre in FOV pixel coordinates ``(v, u)``.
+        radius_px: Sphere radius in pixels.
+        sun_vuz: Sun direction in the ``(v, u, z)`` image frame; ``+z`` points
+            toward the observer.  Normalised on use.
+        km_per_px: Constant km/px scale on the resolved body.
+    """
+
+    center_vu: tuple[float, float]
+    radius_px: float
+    sun_vuz: tuple[float, float, float] = (0.0, 0.0, 1.0)
+    km_per_px: float = 5.0
+
+
+def _grid(mg: FakeMeshgrid) -> tuple[NDArrayFloatType, NDArrayFloatType]:
+    """Return ``(vv, uu)`` sample-centre coordinate arrays for a meshgrid."""
+    assert mg.origin is not None
+    assert mg.limit is not None
+    assert mg.oversample is not None
+    origin_u, origin_v = mg.origin
+    limit_u, limit_v = mg.limit
+    over_u, over_v = mg.oversample
+    n_u = round((limit_u - origin_u) * over_u) + 1
+    n_v = round((limit_v - origin_v) * over_v) + 1
+    u = origin_u + np.arange(n_u, dtype=np.float64) / over_u
+    v = origin_v + np.arange(n_v, dtype=np.float64) / over_v
+    vv, uu = np.meshgrid(v, u, indexing='ij')
+    return vv, uu
+
+
+def _sphere_geometry(
+    spec: _Sphere, vv: NDArrayFloatType, uu: NDArrayFloatType
+) -> tuple[NDArrayBoolType, NDArrayFloatType, NDArrayFloatType]:
+    """Return ``(on_body, incidence_rad, cos_incidence)`` over a grid."""
+    sun = np.asarray(spec.sun_vuz, dtype=np.float64)
+    sun = sun / np.linalg.norm(sun)
+    center_v, center_u = spec.center_vu
+    dv = vv - center_v
+    du = uu - center_u
+    dist = np.hypot(dv, du)
+    on_body = dist <= spec.radius_px
+    r = spec.radius_px
+    z = np.sqrt(np.clip(r * r - dist * dist, 0.0, None))
+    cos_inc = (dv * sun[0] + du * sun[1] + z * sun[2]) / r
+    incidence = np.arccos(np.clip(cos_inc, -1.0, 1.0))
+    return on_body, incidence, cos_inc
+
+
+def _two_body_backplane_class(target: _Sphere, occluder: _Sphere) -> type:
+    """Build a Backplane stand-in rendering ``target`` with an occluder in front.
+
+    ``incidence_angle`` / ``lambert_law`` / ``resolution`` render ``target``
+    (as the single-body sphere backplane does).  ``where_in_front(event,
+    surface)`` returns the ``occluder`` silhouette whenever ``event`` names the
+    occluder body -- the pixels where the nearer body sits in front of the
+    target.
+
+    Parameters:
+        target: Sphere the backplane renders as the navigated body.
+        occluder: Nearer sphere whose silhouette hides part of ``target``.
+    """
+
+    class _TwoBodyBackplane:
+        """Backplane stand-in over a fake meshgrid for a two-body scene.
+
+        Parameters:
+            obs: Observation (unused; accepted for signature parity).
+            meshgrid: ``FakeMeshgrid`` carrying origin / limit / oversample.
+        """
+
+        def __init__(self, obs: Any, meshgrid: FakeMeshgrid | None = None) -> None:
+            assert meshgrid is not None
+            self._mg = meshgrid
+
+        def incidence_angle(self, body_name: str) -> polymath.Scalar:
+            """Return per-sample incidence angle masked off the target."""
+            del body_name
+            vv, uu = _grid(self._mg)
+            on_body, incidence, _ = _sphere_geometry(target, vv, uu)
+            return polymath.Scalar(np.ma.array(incidence, mask=~on_body))
+
+        def lambert_law(self, body_name: str) -> polymath.Scalar:
+            """Return per-sample Lambert reflectance masked off the target."""
+            del body_name
+            vv, uu = _grid(self._mg)
+            on_body, _, cos_inc = _sphere_geometry(target, vv, uu)
+            lam = np.clip(cos_inc, 0.0, None)
+            return polymath.Scalar(np.ma.array(lam, mask=~on_body))
+
+        def resolution(self, body_name: str) -> polymath.Scalar:
+            """Return the constant km/px scale masked off the target."""
+            del body_name
+            vv, uu = _grid(self._mg)
+            on_body, _, _ = _sphere_geometry(target, vv, uu)
+            res = np.full(on_body.shape, target.km_per_px, dtype=np.float64)
+            return polymath.Scalar(np.ma.array(res, mask=~on_body))
+
+        def where_in_front(self, event_key: str, surface_key: str) -> polymath.Scalar:
+            """Return the occluder silhouette where it sits in front of the target."""
+            del surface_key
+            vv, uu = _grid(self._mg)
+            if event_key.upper() == _OCCLUDER:
+                on_occ, _, _ = _sphere_geometry(occluder, vv, uu)
+                return polymath.Scalar(on_occ.astype(np.float64))
+            return polymath.Scalar(np.zeros(vv.shape, dtype=np.float64))
+
+    return _TwoBodyBackplane
+
+
+def _make_obs(
+    target: _Sphere,
+    *,
+    data_shape: tuple[int, int] = (100, 100),
+    margin: int = 10,
+    phase_deg: float = 30.0,
+    target_range_km: float = 1.0e6,
+) -> tuple[FakeObs, dict[str, Any]]:
+    """Build a ``FakeObs`` plus the target sphere's inventory record.
+
+    Parameters:
+        target: Target sphere geometry (drives the inventory bounding box).
+        data_shape: Sensor-area ``(rows, cols)`` shape.
+        margin: Extfov margin applied to both axes.
+        phase_deg: Centre phase angle reported by the geometry backplane.
+        target_range_km: Subject range recorded in the inventory.
+    """
+    center_v, center_u = target.center_vu
+    r = target.radius_px
+    inventory = {
+        'u_min_unclipped': int(np.floor(center_u - r)),
+        'u_max_unclipped': int(np.ceil(center_u + r)),
+        'v_min_unclipped': int(np.floor(center_v - r)),
+        'v_max_unclipped': int(np.ceil(center_v + r)),
+        'u_pixel_size': 2.0 * r,
+        'v_pixel_size': 2.0 * r,
+        'range': target_range_km,
+    }
+    geometry_body = BodyBackplaneData(
+        body_mask=np.ones((1, 1), dtype=bool),
+        incidence_rad=np.zeros((1, 1), dtype=np.float64),
+        center_phase_rad=math.radians(phase_deg),
+    )
+    obs = FakeObs(
+        data=np.zeros(data_shape, dtype=np.float64),
+        extfov_margin_vu=(margin, margin),
+        closest_planet='SATURN',
+        ext_bp=FakeBackplane(per_body={_TARGET: geometry_body}),
+        inventory_records={_TARGET: inventory},
+    )
+    return obs, inventory
+
+
+def _make_model(
+    monkeypatch: pytest.MonkeyPatch,
+    target: _Sphere,
+    occluder: _Sphere | None,
+    *,
+    occluder_range_km: float = 5.0e5,
+    target_range_km: float = 1.0e6,
+    phase_deg: float = 30.0,
+) -> tuple[NavModelBody, FakeObs]:
+    """Build a ``NavModelBody`` wired to the analytic two-body backplane.
+
+    Parameters:
+        monkeypatch: Pytest monkeypatch fixture patching the module's oops
+            ``Meshgrid`` / ``Backplane`` names.
+        target: Sphere the model navigates.
+        occluder: Nearer sphere wired in as a sibling, or ``None`` for the
+            single-body baseline.
+        occluder_range_km: Sibling range recorded on the wiring; strictly
+            nearer than ``target_range_km`` unless overridden.
+        target_range_km: Subject range of the navigated body.
+        phase_deg: Centre phase angle reported by the geometry backplane.
+    """
+    obs, inventory = _make_obs(target, phase_deg=phase_deg, target_range_km=target_range_km)
+    render_occluder = occluder if occluder is not None else target
+    monkeypatch.setattr(nav_model_body_module, 'Meshgrid', FakeMeshgrid)
+    monkeypatch.setattr(
+        nav_model_body_module, 'Backplane', _two_body_backplane_class(target, render_occluder)
+    )
+    siblings = [] if occluder is None else [(_OCCLUDER, occluder_range_km)]
+    model = NavModelBody(
+        f'body:{_TARGET}',
+        cast(Any, obs),
+        _TARGET,
+        inventory=inventory,
+        siblings=siblings,
+    )
+    return model, obs
+
+
+def _limb_feature(model: NavModelBody, obs: FakeObs) -> NavFeature:
+    """Create the model and return its emitted LIMB_ARC feature."""
+    model.create_model()
+    features = model.to_features(bare_nav_context(cast(Any, obs)))
+    return next(f for f in features if f.feature_type.name == 'LIMB_ARC')
+
+
+def _disc_feature(model: NavModelBody, obs: FakeObs) -> NavFeature:
+    """Create the model and return its emitted BODY_DISC feature."""
+    model.create_model()
+    features = model.to_features(bare_nav_context(cast(Any, obs)))
+    return next(f for f in features if f.feature_type.name == 'BODY_DISC')
+
+
+def _arc_fraction(feature: NavFeature) -> float:
+    """Return the ``visible_arc_fraction`` of a limb / terminator feature."""
+    flags = feature.flags
+    assert isinstance(flags, LimbArcFlags | TerminatorArcFlags)
+    return float(flags.visible_arc_fraction)
+
+
+def _limb_vertices(feature: NavFeature) -> NDArrayFloatType:
+    """Return the limb polyline vertices of a LIMB_ARC feature."""
+    geometry = feature.geometry
+    assert isinstance(geometry, LimbPolyline)
+    return np.asarray(geometry.vertices_vu, dtype=np.float64)
+
+
+# A target sphere fully lit and framed, plus a nearer sibling overlapping its
+# +u half.  The overlap hides the right-side limb.
+_TARGET_SPHERE = _Sphere((50.0, 50.0), 20.0)
+_OCCLUDER_SPHERE = _Sphere((50.0, 62.0), 20.0)
+# A lighter sibling clipping only the +u edge: the disc stays above the
+# visible-lit gate so BODY_DISC is still emitted, but its template is trimmed.
+_DISC_OCCLUDER = _Sphere((50.0, 75.0), 18.0)
+
+
+def test_occluded_limb_fraction_drops(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A nearer sibling hides part of the limb; the fraction reports the loss."""
+    alone_model, alone_obs = _make_model(monkeypatch, _TARGET_SPHERE, None)
+    alone = _limb_feature(alone_model, alone_obs)
+    occ_model, occ_obs = _make_model(monkeypatch, _TARGET_SPHERE, _OCCLUDER_SPHERE)
+    occluded = _limb_feature(occ_model, occ_obs)
+    assert _arc_fraction(occluded) < _arc_fraction(alone) - 0.1
+
+
+def test_occluded_limb_reliability_drops(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The reduced arc fraction lowers the limb reliability."""
+    alone_model, alone_obs = _make_model(monkeypatch, _TARGET_SPHERE, None)
+    alone = _limb_feature(alone_model, alone_obs)
+    occ_model, occ_obs = _make_model(monkeypatch, _TARGET_SPHERE, _OCCLUDER_SPHERE)
+    occluded = _limb_feature(occ_model, occ_obs)
+    assert occluded.reliability < alone.reliability
+
+
+def test_occluded_limb_vertices_leave_the_polyline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No surviving limb vertex sits inside the nearer sibling's silhouette."""
+    model, obs = _make_model(monkeypatch, _TARGET_SPHERE, _OCCLUDER_SPHERE)
+    occluded = _limb_feature(model, obs)
+    vertices = _limb_vertices(occluded)
+    center_v = _OCCLUDER_SPHERE.center_vu[0] + obs.extfov_margin_v
+    center_u = _OCCLUDER_SPHERE.center_vu[1] + obs.extfov_margin_u
+    dist = np.hypot(vertices[:, 0] - center_v, vertices[:, 1] - center_u)
+    assert int(np.count_nonzero(dist < _OCCLUDER_SPHERE.radius_px - 1.0)) == 0
+
+
+def test_farther_sibling_does_not_occlude(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A sibling with a larger range hides nothing of this body's limb."""
+    alone_model, alone_obs = _make_model(monkeypatch, _TARGET_SPHERE, None)
+    alone = _limb_feature(alone_model, alone_obs)
+    behind_model, behind_obs = _make_model(
+        monkeypatch, _TARGET_SPHERE, _OCCLUDER_SPHERE, occluder_range_km=2.0e6
+    )
+    behind = _limb_feature(behind_model, behind_obs)
+    assert _arc_fraction(behind) == pytest.approx(_arc_fraction(alone))
+
+
+def test_disc_template_trimmed_of_occluded_pixels(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The BODY_DISC template mask excludes pixels the nearer body hides."""
+    model, obs = _make_model(monkeypatch, _TARGET_SPHERE, _DISC_OCCLUDER)
+    disc = _disc_feature(model, obs)
+    v_min, u_min, _v_max, _u_max = disc.geometry.bbox_extfov_vu
+    template_mask = np.asarray(disc.template_mask, dtype=bool)
+    vs, us = np.where(template_mask)
+    center_v = _DISC_OCCLUDER.center_vu[0] + obs.extfov_margin_v - v_min
+    center_u = _DISC_OCCLUDER.center_vu[1] + obs.extfov_margin_u - u_min
+    dist = np.hypot(vs - center_v, us - center_u)
+    assert int(np.count_nonzero(dist < _DISC_OCCLUDER.radius_px - 1.0)) == 0
+
+
+def test_disc_template_img_zero_under_occluder(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The BODY_DISC template brightness is zero where the occluder hides it."""
+    model, obs = _make_model(monkeypatch, _TARGET_SPHERE, _DISC_OCCLUDER)
+    disc = _disc_feature(model, obs)
+    v_min, u_min, _v_max, _u_max = disc.geometry.bbox_extfov_vu
+    template_img = np.asarray(disc.template_img, dtype=np.float64)
+    rows, cols = template_img.shape
+    vv, uu = np.meshgrid(np.arange(rows), np.arange(cols), indexing='ij')
+    center_v = _DISC_OCCLUDER.center_vu[0] + obs.extfov_margin_v - v_min
+    center_u = _DISC_OCCLUDER.center_vu[1] + obs.extfov_margin_u - u_min
+    deep = np.hypot(vv - center_v, uu - center_u) < _DISC_OCCLUDER.radius_px - 3.0
+    assert float(np.max(template_img[deep])) == 0.0
+
+
+def test_occluded_disc_visible_lit_fraction_drops(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Occlusion lowers ``visible_lit_fraction`` toward the surviving crescent."""
+    alone_model, _alone_obs = _make_model(monkeypatch, _TARGET_SPHERE, None)
+    alone_model.create_model()
+    occ_model, _occ_obs = _make_model(monkeypatch, _TARGET_SPHERE, _OCCLUDER_SPHERE)
+    occ_model.create_model()
+    assert occ_model._visible_lit_fraction < alone_model._visible_lit_fraction - 0.1
+
+
+def test_occluded_terminator_fraction_drops(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sibling occlusion also reduces the terminator's visible-arc fraction."""
+    tilt = math.radians(60.0)
+    target = _Sphere((50.0, 50.0), 20.0, sun_vuz=(0.0, math.sin(tilt), math.cos(tilt)))
+    # A sibling clipping the upper -u part of the terminator arc: it removes
+    # some, not all, terminator vertices so the arc is still emitted.
+    occluder = _Sphere((38.0, 44.0), 14.0)
+    alone_model, alone_obs = _make_model(monkeypatch, target, None, phase_deg=60.0)
+    alone_model.create_model()
+    alone_features = alone_model.to_features(bare_nav_context(cast(Any, alone_obs)))
+    alone_term = next(f for f in alone_features if f.feature_type.name == 'TERMINATOR_ARC')
+    occ_model, occ_obs = _make_model(monkeypatch, target, occluder, phase_deg=60.0)
+    occ_model.create_model()
+    occ_features = occ_model.to_features(bare_nav_context(cast(Any, occ_obs)))
+    occ_term = next(f for f in occ_features if f.feature_type.name == 'TERMINATOR_ARC')
+    assert _arc_fraction(occ_term) < _arc_fraction(alone_term) - 0.05
+
+
+def test_instances_for_obs_wires_nearer_siblings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each per-body model instance receives the other in-FOV bodies as siblings."""
+    obs, target_inv = _make_obs(_TARGET_SPHERE)
+    occ_inv = dict(target_inv)
+    occ_inv['range'] = 5.0e5
+    obs.inventory_records[_OCCLUDER] = occ_inv
+    # Drive selection past the satellite-catalog lookup by naming both bodies
+    # as the in-FOV set directly; the wiring under test is the sibling list.
+    entries = [
+        (_TARGET, obs.inventory_records[_TARGET]),
+        (_OCCLUDER, occ_inv),
+    ]
+    monkeypatch.setattr(nav_model_body_module, 'bodies_in_extfov', lambda *_a, **_k: entries)
+    models = cast(list[NavModelBody], NavModelBody.instances_for_obs(cast(Any, obs)))
+    target_model = next(m for m in models if m._body_name == _TARGET)
+    assert target_model._siblings == [(_OCCLUDER, 5.0e5)]

--- a/tests/spindoctor/nav_model/test_nav_model_body_simulated.py
+++ b/tests/spindoctor/nav_model/test_nav_model_body_simulated.py
@@ -665,6 +665,56 @@ def test_occluded_terminator_fraction_drops() -> None:
     assert occluded.flags.visible_arc_fraction < alone.flags.visible_arc_fraction - 0.1
 
 
+def _disc_feature(
+    obs: ObsSim,
+    body_params: dict[str, Any],
+    *,
+    sibling_bodies: list[dict[str, Any]] | None = None,
+) -> Any:
+    """Build the model and return its emitted BODY_DISC feature."""
+    model = NavModelBodySimulated(
+        'body', obs, body_params['name'], body_params, sibling_bodies=sibling_bodies
+    )
+    model.create_model()
+    return next(
+        f for f in model.to_features(bare_nav_context(obs)) if f.feature_type.name == 'BODY_DISC'
+    )
+
+
+def test_occluded_disc_template_drops_hidden_pixels() -> None:
+    """The BODY_DISC template mask excludes pixels a nearer sibling hides."""
+    body = _large_body(range_km=700000.0)
+    disc = _disc_feature(_limb_obs(), body, sibling_bodies=[_near_sibling()])
+    v_min, u_min, _v_max, _u_max = disc.geometry.bbox_extfov_vu
+    obs = _limb_obs()
+    template_mask = np.asarray(disc.template_mask, dtype=bool)
+    vs, us = np.where(template_mask)
+    sib_v = _LIMB_SIZE / 2.0 + int(obs.extfov_margin_v) - v_min
+    sib_u = _LIMB_SIZE / 2.0 + 55.0 + int(obs.extfov_margin_u) - u_min
+    dist = np.hypot(vs - sib_v, us - sib_u)
+    # The sibling is a radius-50 sphere; no template pixel survives deep inside it.
+    assert int(np.count_nonzero(dist < 40.0)) == 0
+
+
+def test_occluded_disc_reliability_drops() -> None:
+    """A nearer sibling lowers the BODY_DISC visible fraction and reliability."""
+    body = _large_body(range_km=700000.0)
+    alone = _disc_feature(_limb_obs(), body)
+    occluded = _disc_feature(_limb_obs(), body, sibling_bodies=[_near_sibling()])
+    assert alone.reliability == pytest.approx(1.0)
+    assert occluded.reliability < 0.9
+
+
+def test_farther_sibling_leaves_disc_template_intact() -> None:
+    """A sibling with a larger range does not trim the disc template."""
+    body = _large_body(range_km=500000.0)
+    alone = _disc_feature(_limb_obs(), body)
+    behind = _disc_feature(_limb_obs(), body, sibling_bodies=[_near_sibling(range_km=700000.0)])
+    alone_pixels = int(np.count_nonzero(np.asarray(alone.template_mask, dtype=bool)))
+    behind_pixels = int(np.count_nonzero(np.asarray(behind.template_mask, dtype=bool)))
+    assert behind_pixels == alone_pixels
+
+
 def test_instances_for_obs_wires_siblings() -> None:
     """Each per-body model instance receives the other bodies as siblings."""
     far = _large_body(range_km=700000.0)


### PR DESCRIPTION
## Purpose

Closes #326. Closes #327.

At deep mutual-event overlap one body partly hides another, but both body models rendered each body in isolation, so a limb, terminator, or disc region actually hidden behind a nearer body was still fully credited. This over-credits occluded features: `NavModelBody` reported a full `visible_arc_fraction` for an occluded limb (#327), and the BODY_DISC correlation template included disc area that is not visible (#326) — a coherent mismatch the correlator silently absorbs.

## Changes

`src/spindoctor/nav_model/nav_model_body.py`:
- `instances_for_obs` now wires each per-body model with the other in-FOV bodies as `(name, range)` siblings.
- `_compute_occluder_local` queries the oops backplane `where_in_front(sibling, target)` depth predicate over the body's bbox for each strictly-nearer sibling and unions the result into an occluder mask (reusing the same machinery `NavModelRings` uses for planet occlusion).
- Occluded limb/terminator ridge vertices are dropped from the fitted polylines while `total_vertices` is kept, so `visible_arc_fraction` reports the loss instead of claiming a full arc the DT fit would chase.
- The occluder mask trims the BODY_DISC `template_img`/`template_mask` and leaves occluded lit pixels out of `visible_lit_fraction`, so the disc reliability tracks the surviving crescent.

`nav_model_body_simulated.py`: the simulated model's BODY_DISC template is trimmed against the same nearer-sibling occluder mask and its disc reliability reports the visible fraction, closing the last sim/nav mirror asymmetry.

Developer guides: a new "Body-body occlusion" section in the body-model dev guide; the simulator dev guide and report updated (the corresponding known simulator-fidelity gap is closed and the remaining gaps renumbered).

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (fix or feature that alters existing behavior or public API)
- [ ] Refactor (no functional or API changes)
- [x] Documentation
- [x] Tests only (no production code change)
- [ ] CI / Build / Dependencies

"Breaking" only in the sense that navigation output changes on deep mutual-event frames (see Potential Impacts); no API change.

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] End-to-end tests pass (if applicable)
- [x] New or updated tests for changed code
- [x] Tested manually (describe below if applicable)

New `tests/spindoctor/nav_model/test_nav_model_body_occlusion.py` (9 tests, hermetic two-sphere `where_in_front` backplane): limb/terminator fraction drops under occlusion, occluded vertices leave the polyline, a farther sibling does not occlude, the disc template mask/image are trimmed, visible-lit fraction drops, and the sibling wiring. Plus 3 simulated-disc tests. Full `nav_model` unit suite (628) passes; `ruff`, `ruff format --check`, `mypy` clean.

## Potential Impacts

- **Public API:** none.
- **Behavior:** on deep mutual-event overlap, an occluded body's disc/limb is now honestly de-credited. The only sim baseline that changes is `mutual_deep.json`: (2.49, -1.58) -> (2.51, -1.49), confidence unchanged (0.99). The far body's disc is over 90% hidden, so its honest `visible_lit_fraction` (0.088) gates that disc out, and the accurate near-body disc plus both limbs fuse *closer* to the planted truth (2.5, -1.5). No other multi-body scene regresses; no curated image-library sidecar touched.

## Checklist

- [x] Code follows project style (`ruff check`, `ruff format`)
- [x] Type annotations present and `mypy` passes
- [x] Docstrings and Sphinx docs updated (body-model + simulator dev guides)
- [ ] CHANGES.md updated (no CHANGES.md in this repo)
- [x] No temporary or debug code left in
- [x] Breaking changes flagged in Type of Change above

## Notes

Adversarially reviewed by a separate agent (clean; the reviewer read the oops `where_in_front` source to confirm argument order and mask polarity, and verified the strictly-nearer predicate, bbox mapping, and no-divide-by-zero paths). Real live-SPICE mutual events cannot run in CI (no kernels); verification uses hermetic two-body backplanes and in-process sim scenes, the same strategy the existing NavModelBody render tests use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HoCUAeNeMz5bFmGk2iVBf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added body-to-body occlusion awareness for simulated and SPICE-backed navigation features.
  * Hidden portions of limb and terminator arcs are excluded, reducing visible-arc fractions and reliability.
  * Disc templates now omit occluded pixels, with reliability reflecting the remaining visible area.
  * Occlusion handling accounts for which body is nearer and degrades gracefully when visibility data is unavailable.

* **Documentation**
  * Updated developer guides and simulator reports to describe mutual-event occlusion behavior and revised known-gap references.

* **Tests**
  * Added comprehensive regression coverage for occluded arcs, discs, reliability, and nearer/farther body ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->