### PR TITLE
fix: harden star-navigation robustness (#337, #376, #367)

### DIFF
--- a/docs/dev_guide/dev_guide_navigation_models_star.rst
+++ b/docs/dev_guide/dev_guide_navigation_models_star.rst
@@ -98,10 +98,21 @@ radius in proportion to how much fainter the record reads --
 :data:`~spindoctor.nav_model.stars.saturation.SATURATION_MATCH_WIDEN_PER_MAG` base radii per
 magnitude of gap, capped at
 :data:`~spindoctor.nav_model.stars.saturation.SATURATION_MATCH_MAX_WIDEN_RADII` base radii so
-the widened match never reaches an unrelated field star. A larger saturation error implies a
-larger displacement, so the widening scales with the gap. Each reference star is consumed by
-at most one corrected record, so one true-magnitude star cannot correct or absorb two
-distinct saturated records.
+the widened match stays inside the arc-minute spacing of bright stars. A larger saturation
+error implies a larger displacement, so the widening scales with the gap. Each reference star
+is consumed by at most one corrected record, so one true-magnitude star cannot correct or
+absorb two distinct saturated records.
+
+Among the references that fall inside their own widened reach the match takes the brightest,
+not the merely nearest, breaking a brightness tie on separation. A bright unrelated reference
+earns a wide reach of its own from its large magnitude gap to the saturated candidate, so a
+pure nearest-neighbour rule could let it capture the candidate when it happens to sit closer
+than the true twin. Preferring the brightest qualifying reference blocks that: UCAC4
+saturation drives a bright star's reading systematically faint, so a faint reading is best
+explained by the brightest reference that can account for it. The failure mode this guards
+needs two bright stars within the widened reach, which the sparse fields the pipeline
+navigates do not present, so in practice the two rules agree; the brightness preference only
+diverges on a crowded bright field.
 
 **Detectability consumes the flag.** The detectability model exempts a ``photometry_saturated``
 star from the faint-magnitude gate -- its recorded magnitude is a too-faint saturated

--- a/docs/dev_guide/dev_guide_techniques_star_field.rst
+++ b/docs/dev_guide/dev_guide_techniques_star_field.rst
@@ -30,10 +30,25 @@ Triplet hashing
 ---------------
 
 For every triplet of three predictable catalog stars the matcher computes a translation- and
-rotation-invariant hash ``(d_AB / d_AC, d_BC / d_AC, angle BAC)``, where vertex ``A`` is
-canonicalised as the brightest star of the triplet and the other two follow in sorted-index
-order. The same hash is computed for every triplet of three detected sources in the image.
-Triplets with matching hashes (within a small tolerance) are candidate correspondences.
+rotation-invariant hash ``(d_AB / d_AC, d_BC / d_AC, angle BAC)``. The three vertices are put
+in a canonical order by triangle geometry: ``A`` sits opposite the longest side, ``B`` opposite
+the next-longest, and ``C`` opposite the shortest. Side lengths scale uniformly under a
+similarity transform, so this order is the same physical vertex labelling for a triangle and any
+translated, rotated, or uniformly scaled copy of it, and the detection triplet and its catalog
+counterpart canonicalise identically. The same hash is computed for every triplet of three
+detected sources in the image. Triplets with matching hashes (within a small tolerance) are
+candidate correspondences.
+
+The order is geometric rather than brightness-keyed on purpose. Ordering the vertices by
+brightness ties on an equal-magnitude field, and the pipeline's predicted magnitudes carry error
+that can manufacture ties that are not physically present, so a brightness-keyed apex would be
+decided by an arbitrary tie-break that flips the labelling between the detection and catalog
+sides from run to run and under image rotation. On a field near the inlier floor that flipped
+labelling flips the navigation outcome, giving non-deterministic output on unchanged input. The
+geometric order is total and rotation-stable: for the ordinary scalene triangle the side lengths
+fix the vertex assignment outright, and only a near-isosceles triangle (two opposite sides of
+equal length) falls through to the secondary tie-break of brightness rank and then original
+index.
 
 Source detection
 ----------------
@@ -121,6 +136,38 @@ clean lock lands in the medium tier. The
 :attr:`~spindoctor.nav_technique.diagnostics.StarFieldDiagnostics.wide_offset_lock` and
 :attr:`~spindoctor.nav_technique.diagnostics.StarFieldDiagnostics.wide_offset_false_lock_expectation`
 diagnostics record that the fallback fired and the significance it cleared.
+
+Single-bright-star wide-offset acquisition
+------------------------------------------
+
+A sparse field can carry exactly one confidently-detectable catalog star at a large unknown
+offset: on a glare-elevated frame the fainter members drop below the detection limit or fall
+off-frame, leaving one bright anchor and no corroborating star. Neither the triplet RANSAC nor
+the ``>= wide_offset_min_inliers`` asterism fallback can lock there, because a one-star lock has
+no corroborating inlier and so cannot clear the chance-alignment budget (a single anchor pair
+defines an exact offset, so a one-inlier lock is a chance alignment with probability one).
+
+When both fallbacks miss, and only when ``wide_offset_one_star_enabled`` is set, the technique
+attempts a one-star lock. With no corroboration to lean on, the anchor pairing itself must be
+unambiguous, which is gated on two brightness-uniqueness margins:
+
+- The brightest predictable catalog star must outshine the next by at least
+  ``wide_offset_one_star_catalog_margin_mag``, so exactly one plausible bright anchor exists on
+  the catalog side, and it must be photometry-trusted (a ``photometry_saturated`` anchor, whose
+  brightness ordering is an untrusted lower bound, is refused).
+- The brightest detection must outshine the next by a peak-DN factor of at least
+  ``wide_offset_one_star_detection_margin_ratio``, so the dominant peak is uniquely the anchor.
+  A glare field routinely raises peaks brighter than a real faint star, so a frame whose
+  brightest detection is not uniquely dominant (two comparably bright peaks) fails this gate and
+  correctly stays unlocked: pairing the anchor with one of two rival peaks would be a guess.
+
+The lock also requires the anchor offset to fall inside the search window. An accepted one-star
+lock is confidence-capped at ``wide_offset_one_star_confidence_cap``, below even the
+``>= 3``-inlier wide-offset cap, and must still clear the ensemble gate to navigate. The
+capability is validated on planted-truth scenes but ``wide_offset_one_star_enabled`` defaults to
+off, pending an image-library false-lock sweep against the SPICE holdings the unit suite does not
+reach; enabling it is a per-instrument configuration choice once that sweep confirms the
+whole-library false-lock rate stays flat.
 
 PSF-fit inlier refinement
 -------------------------
@@ -278,6 +325,20 @@ in ``src/spindoctor/config_files/config_510_techniques.yaml``.
   Post-formula confidence cap for a wide-offset lock. Fewer corroborating stars than a
   strong-tier match means the result cannot claim the high tier on its own; it must still
   clear the ensemble gate to navigate. 0.6 lands a clean lock in the medium / low tier.
+- ``wide_offset_one_star_enabled`` — int flag, default ``0``. ``1`` enables the
+  single-bright-star wide-offset acquisition (a one-inlier lock from a uniquely-bright anchor
+  pair); ``0`` disables it. Off by default pending an image-library false-lock sweep.
+- ``wide_offset_one_star_catalog_margin_mag`` — float, default ``1.0`` mag. Minimum
+  predicted-brightness margin of the catalog anchor over the next predictable star for a
+  one-star lock; a smaller margin leaves more than one plausible anchor, so the pairing is
+  ambiguous and the lock is refused.
+- ``wide_offset_one_star_detection_margin_ratio`` — float, default ``3.0`` (dimensionless).
+  Minimum peak-DN ratio of the brightest detection to the next for a one-star lock; below this
+  the dominant peak is not uniquely bright and the lock is refused.
+- ``wide_offset_one_star_confidence_cap`` — float, default ``0.4`` (dimensionless, in
+  ``[0, 1]``). Post-formula confidence cap for a one-star lock. A single uncorroborated anchor
+  pairing sits below even the ``>= 3``-inlier wide-offset cap; 0.4 lands a clean one-star lock
+  in the low tier.
 - ``at_edge_tolerance_px`` — float, default ``1.0`` px. A converged offset whose absolute
   distance from any search-window axis bound falls within this tolerance is flagged
   :attr:`~spindoctor.nav_technique.technique_result.NavTechniqueResult.at_edge`.

--- a/src/spindoctor/config_files/config_510_techniques.yaml
+++ b/src/spindoctor/config_files/config_510_techniques.yaml
@@ -906,6 +906,38 @@ techniques:
       # claim the high tier on its own; it must still clear the ensemble gate
       # to navigate.  0.6 lands a clean lock in the medium / low tier.
       wide_offset_confidence_cap: 0.6
+      # Single-bright-star wide-offset acquisition.  When neither the triplet
+      # RANSAC nor the >=3-inlier asterism fallback locks, a field can still
+      # carry exactly one confidently-detectable catalog star at a large
+      # unknown offset (the glare-elevated Pleiades regime, where the fainter
+      # members drop below the detection limit).  A one-star lock has no
+      # corroborating inlier and so cannot clear the chance-alignment budget;
+      # in its place the anchor pairing itself must be unambiguous, which
+      # holds only when BOTH the catalog anchor and the detection anchor are
+      # uniquely bright by a large margin.  A glare field routinely produces
+      # peaks brighter than a real faint star, so a frame whose brightest
+      # detection is not uniquely dominant (e.g. 1694 vs 1240 DN) correctly
+      # fails this gate and stays unlocked.  1 enables the one-star lock; 0
+      # disables it.  Default 0: the capability is validated on the sim
+      # scenes but held off by default pending an image-library false-lock
+      # sweep (which needs SPICE holdings the unit suite does not reach).
+      wide_offset_one_star_enabled: 0
+      # Minimum predicted-brightness margin (mag) of the catalog anchor over
+      # the next-brightest predictable catalog star for a one-star lock.  A
+      # smaller margin means more than one plausible bright anchor, so the
+      # single pairing is ambiguous and the lock is refused.
+      wide_offset_one_star_catalog_margin_mag: 1.0
+      # Minimum peak-DN ratio of the brightest detection to the
+      # next-brightest for a one-star lock.  Below this the dominant peak is
+      # not uniquely bright (a glare artifact or a comparably bright rival
+      # could be the true anchor), so the single pairing is ambiguous and the
+      # lock is refused.
+      wide_offset_one_star_detection_margin_ratio: 3.0
+      # Post-formula confidence cap for a one-star wide-offset lock.  A lock
+      # resting on a single uncorroborated anchor pairing sits below even the
+      # >=3-inlier wide-offset cap; it must still clear the ensemble gate to
+      # navigate.  0.4 lands a clean one-star lock in the low tier.
+      wide_offset_one_star_confidence_cap: 0.4
       # Pixels of slack around the search-window axis bounds for the
       # at-edge check (see StarUniqueMatchNav.at_edge_tolerance_px).
       at_edge_tolerance_px: 1.0

--- a/src/spindoctor/nav_model/stars/saturation.py
+++ b/src/spindoctor/nav_model/stars/saturation.py
@@ -132,10 +132,13 @@ several-arcsecond slack its displacement needs.
 SATURATION_MATCH_MAX_WIDEN_RADII: float = 3.0
 """Cap on the widened position-match radius, in base radii.
 
-The widening is bounded so the match never reaches an unrelated field
-star: at the default 5 arcsec base radius the widest match is 15 arcsec,
-comfortably inside the arc-minute spacing of bright stars even in a dense
-field such as the Pleiades.
+The widening is bounded to stay inside the arc-minute spacing of bright
+stars: at the default 5 arcsec base radius the widest match is 15 arcsec,
+comfortably below the separation of bright stars even in a dense field
+such as the Pleiades.  Within the widened reach the match prefers the
+brightest qualifying reference (see :func:`_best_mag_aware_match`), so a
+nearer unrelated bright star does not capture a saturated candidate away
+from its true-magnitude twin.
 """
 
 
@@ -242,7 +245,7 @@ def _widened_radius(mag_gap: float, base_radius: float) -> float:
     return base_radius * min(factor, SATURATION_MATCH_MAX_WIDEN_RADII)
 
 
-def _nearest_mag_aware(
+def _best_mag_aware_match(
     ra: float,
     dec: float,
     vmag: float,
@@ -253,14 +256,26 @@ def _nearest_mag_aware(
     *,
     available: NDArrayBoolType | None = None,
 ) -> int | None:
-    """Return the nearest reference within a magnitude-widened match radius.
+    """Return the reference within reach that best explains the saturation.
 
     For each reference star the allowed radius is the base radius widened
     by the amount the candidate reads fainter than that reference (see
     :func:`_widened_radius`), so a strongly saturated candidate collapses
     against a displaced true-magnitude reference while a well-behaved one
-    stays near the base radius.  The nearest reference whose separation
-    falls inside its own allowed radius wins.
+    stays near the base radius.  Among the references whose separation
+    falls inside their own allowed radius, the brightest (largest
+    magnitude gap to the candidate) wins, with the nearest breaking a
+    brightness tie.
+
+    Preferring the brightest qualifying reference over the merely nearest
+    keeps a nearer unrelated bright field star from capturing a saturated
+    candidate away from its true twin: UCAC4 saturation drives a bright
+    star's reading systematically faint, so a faint reading is best
+    explained by the brightest reference that can account for it, not by
+    whichever bright star happens to sit closest.  Because a bright
+    unrelated reference earns a wide reach of its own from its large
+    magnitude gap, a pure nearest-neighbour rule would let it win over the
+    true twin when it sits closer; the brightness preference does not.
 
     Parameters:
         ra: Candidate right ascension in radians.
@@ -289,8 +304,13 @@ def _nearest_mag_aware(
         ok = ok & available
     if not bool(ok.any()):
         return None
-    masked = np.where(ok, d2, np.inf)
-    return int(np.argmin(masked))
+    # Brightest (lowest ref_vmag) qualifying reference wins; separation and
+    # then index break ties for a deterministic result.
+    big = float(np.max(d2)) + 1.0
+    ref_vmag_key = np.where(ok, ref_vmag, np.inf)
+    d2_key = np.where(ok, d2, big)
+    order = np.lexsort((np.arange(ref_ra.size), d2_key, ref_vmag_key))
+    return int(order[0])
 
 
 def reference_photometry(
@@ -422,7 +442,7 @@ def correct_star_photometry(
             continue
         if star.vmag is None or float(star.vmag) >= saturation_limit:
             continue
-        idx = _nearest_mag_aware(
+        idx = _best_mag_aware_match(
             float(star.ra_pm),
             float(star.dec_pm),
             float(star.vmag),
@@ -632,7 +652,7 @@ def correct_saturated_vmags(
         if vmag >= saturation_limit:
             out.append(float(vmag))
             continue
-        idx = _nearest_mag_aware(
+        idx = _best_mag_aware_match(
             ra, dec, vmag, ref_ra, ref_dec, ref_vmag, match_radius_rad, available=~consumed
         )
         if idx is None:

--- a/src/spindoctor/nav_technique/nav_technique_star_field.py
+++ b/src/spindoctor/nav_technique/nav_technique_star_field.py
@@ -13,12 +13,19 @@ Algorithm — four sub-pieces:
    weighted centroid pins each peak's sub-pixel position.  The
    brightest ``max_sources`` survivors (default 30) feed the matcher.
 2. **Triplet hashing.**  For every unordered triplet of detected
-   sources ``{A, B, C}`` with ``A`` brightest, the hash
-   ``(d_AB / d_AC, d_BC / d_AC, ∠BAC)`` is computed.  The same hash is
-   computed for catalog triplets (``A`` = brightest by predicted SNR).
-   The hash is similarity-invariant — translation, rotation, and
-   uniform scale all leave it unchanged — so the matcher recovers
-   correspondences without already knowing the offset.
+   sources ``{A, B, C}`` the hash ``(d_AB / d_AC, d_BC / d_AC, ∠BAC)``
+   is computed.  The vertex order is canonicalised by triangle geometry
+   -- ``A`` sits opposite the longest side, ``B`` opposite the next,
+   ``C`` opposite the shortest -- which is the same physical labelling
+   for a triangle and any translated, rotated, or uniformly scaled copy.
+   The same hash is computed for catalog triplets.  The hash is
+   similarity-invariant -- translation, rotation, and uniform scale all
+   leave it unchanged -- so the matcher recovers correspondences without
+   already knowing the offset.  A purely geometric canonical order is
+   used rather than a brightness order because brightness ties on
+   equal-magnitude fields, where a brightness-keyed order would flip the
+   labelling between the detection and catalog sides run to run and under
+   image rotation.
 3. **RANSAC.**  Each (detection-triplet, catalog-triplet) candidate is
    scored by counting detection-to-catalog inliers under the
    translation it implies.  Candidates are iterated in deterministic
@@ -52,6 +59,7 @@ from spindoctor.feature.flags import StarFlags
 from spindoctor.nav_model.stars.detection import matched_filter_image
 from spindoctor.nav_technique._star_helpers import (
     SimilarityFit,
+    brightness_margin_mag,
     predicted_snr,
     predicted_vu,
     similarity_transform_fit,
@@ -142,6 +150,9 @@ class _WideOffsetMatch:
             the false-lock significance the acceptance budget bounds.
         n_seeds: Number of distinct bright-anchor seed offsets evaluated (the
             multiple-testing trial count folded into ``expectation``).
+        is_one_star: True for a single-bright-star wide-offset lock, False for
+            an asterism (multi-inlier) lock; the ensemble caps a one-star lock's
+            confidence.
     """
 
     n_inliers: int
@@ -149,6 +160,7 @@ class _WideOffsetMatch:
     offset: tuple[float, float]
     expectation: float
     n_seeds: int
+    is_one_star: bool
 
 
 def _star_photometry_saturated(feature: NavFeature) -> bool:
@@ -339,18 +351,18 @@ def _triplet_hash(
 ) -> tuple[float, float, float] | None:
     """Return the similarity-invariant ``(d_AB / d_AC, d_BC / d_AC, ∠BAC)`` triple.
 
-    Per Part 3 §"Algorithm specifics" the hash is computed with ``A``
-    canonicalised as the brightest of the triplet (the caller is
-    responsible for that canonicalisation); both ratios survive
-    arbitrary rotation, translation, and uniform scale, which is what
-    lets the matcher recover correspondences without knowing the
-    transform.
+    The hash is computed with ``A`` as the caller's canonical vertex
+    (the vertex opposite the longest side; the caller is responsible for
+    that canonicalisation); both ratios survive arbitrary rotation,
+    translation, and uniform scale, which is what lets the matcher
+    recover correspondences without knowing the transform.
 
     Parameters:
-        pa: Brightest vertex of the triplet.
-        pb, pc: The other two vertices, in caller-canonical
-            (sorted-index) order so each unordered triplet hashes
-            once.
+        pa: Canonical apex vertex of the triplet (opposite the longest
+            side).
+        pb, pc: The other two vertices, in caller-canonical order
+            (opposite the next-longest and shortest side respectively)
+            so each unordered triplet hashes once.
 
     Returns:
         ``(r1, r2, theta)`` tuple, or ``None`` for degenerate
@@ -390,8 +402,9 @@ class _Triplet:
     """One enumerated triplet, hashed in canonical form.
 
     ``idx_a / idx_b / idx_c`` reference back into the source point
-    list; ``a`` is the brightest of the three and ``(b, c)`` are
-    sorted by index ascending so each unordered triplet appears once.
+    list; ``a`` is the vertex opposite the longest side, ``b`` opposite
+    the next-longest, and ``c`` opposite the shortest, so each unordered
+    triplet appears once in a rotation-stable order.
     """
 
     idx_a: int
@@ -400,15 +413,59 @@ class _Triplet:
     hash_v: tuple[float, float, float]
 
 
+def _canonical_triplet_order(
+    points: list[tuple[float, float]],
+    triple: tuple[int, int, int],
+    brightness_rank: list[int],
+) -> tuple[int, int, int]:
+    """Return the vertex indices of ``triple`` in geometric canonical order.
+
+    Vertices are ordered by the length of the side opposite each one,
+    longest first: ``A`` sits opposite the longest side, ``B`` opposite
+    the next, ``C`` opposite the shortest.  Side lengths scale uniformly
+    under a similarity transform, so this order is identical for a
+    triangle and any translated, rotated, or uniformly scaled copy of it;
+    the detection triplet and its catalog counterpart therefore
+    canonicalise to the same physical vertex assignment without appealing
+    to brightness -- which ties on the equal-magnitude fields that made a
+    brightness-keyed order a run-to-run and by-rotation seed lottery.  A
+    near-isosceles triangle (two opposite sides of equal length) breaks
+    the tie on brightness rank ascending, then original index ascending,
+    so the order stays total and deterministic.
+
+    Parameters:
+        points: The full point list the triple indexes into.
+        triple: The three point indices, in ascending order.
+        brightness_rank: Per-point brightness rank (``0`` = brightest),
+            the secondary tie-break for a near-isosceles triangle.
+
+    Returns:
+        ``(idx_a, idx_b, idx_c)`` in canonical apex-first order.
+    """
+    i, j, k = triple
+    pi, pj, pk = points[i], points[j], points[k]
+    opp_i = math.hypot(pj[0] - pk[0], pj[1] - pk[1])
+    opp_j = math.hypot(pi[0] - pk[0], pi[1] - pk[1])
+    opp_k = math.hypot(pi[0] - pj[0], pi[1] - pj[1])
+    keyed = sorted(
+        (
+            (-opp_i, brightness_rank[i], i),
+            (-opp_j, brightness_rank[j], j),
+            (-opp_k, brightness_rank[k], k),
+        )
+    )
+    return keyed[0][2], keyed[1][2], keyed[2][2]
+
+
 def _enumerate_triplets(
     points: list[tuple[float, float]],
     brightness_rank: list[int],
 ) -> list[_Triplet]:
     """Return every canonical ``_Triplet`` over ``points``.
 
-    ``brightness_rank[i]`` is the brightness rank of point ``i``
-    (``0`` = brightest); it picks the ``a`` vertex within each
-    unordered ``(i, j, k)`` triple.  Degenerate triplets (collinear or
+    Each unordered ``(i, j, k)`` triple is canonicalised by triangle
+    geometry via :func:`_canonical_triplet_order` (``brightness_rank``
+    only breaks a near-isosceles tie).  Degenerate triplets (collinear or
     coincident) are dropped silently.
     """
     n = len(points)
@@ -416,12 +473,7 @@ def _enumerate_triplets(
     for i in range(n):
         for j in range(i + 1, n):
             for k in range(j + 1, n):
-                triple = (i, j, k)
-                ranks = (brightness_rank[i], brightness_rank[j], brightness_rank[k])
-                a_pos = int(np.argmin(np.asarray(ranks)))
-                idx_a = triple[a_pos]
-                rest = sorted(idx for idx in triple if idx != idx_a)
-                idx_b, idx_c = rest
+                idx_a, idx_b, idx_c = _canonical_triplet_order(points, (i, j, k), brightness_rank)
                 hashed = _triplet_hash(points[idx_a], points[idx_b], points[idx_c])
                 if hashed is None:
                     continue
@@ -636,6 +688,18 @@ class StarFieldFromCatalogNav(NavTechnique):
             self.tuning['wide_offset_max_residual_rms_px']
         )
         self._wide_offset_confidence_cap = float(self.tuning['wide_offset_confidence_cap'])
+        # Single-bright-star wide-offset acquisition (see
+        # config_510_techniques.yaml and ``_wide_offset_one_star_match``).
+        self._wide_offset_one_star_enabled = bool(int(self.tuning['wide_offset_one_star_enabled']))
+        self._wide_offset_one_star_catalog_margin_mag = float(
+            self.tuning['wide_offset_one_star_catalog_margin_mag']
+        )
+        self._wide_offset_one_star_detection_margin_ratio = float(
+            self.tuning['wide_offset_one_star_detection_margin_ratio']
+        )
+        self._wide_offset_one_star_confidence_cap = float(
+            self.tuning['wide_offset_one_star_confidence_cap']
+        )
         # PSF-fit re-centroiding of matched inliers (see config_510_techniques.yaml).
         self._psf_refine_enabled = bool(int(self.tuning['psf_refine_enabled']))
         self._psf_refine_box_px = int(self.tuning['psf_refine_box_px'])
@@ -673,6 +737,21 @@ class StarFieldFromCatalogNav(NavTechnique):
             raise ValueError(
                 f'wide_offset_confidence_cap must lie in [0, 1]; '
                 f'got {self._wide_offset_confidence_cap}'
+            )
+        if self._wide_offset_one_star_catalog_margin_mag <= 0.0:
+            raise ValueError(
+                f'wide_offset_one_star_catalog_margin_mag must be > 0; '
+                f'got {self._wide_offset_one_star_catalog_margin_mag}'
+            )
+        if self._wide_offset_one_star_detection_margin_ratio < 1.0:
+            raise ValueError(
+                f'wide_offset_one_star_detection_margin_ratio must be >= 1; '
+                f'got {self._wide_offset_one_star_detection_margin_ratio}'
+            )
+        if not 0.0 <= self._wide_offset_one_star_confidence_cap <= 1.0:
+            raise ValueError(
+                f'wide_offset_one_star_confidence_cap must lie in [0, 1]; '
+                f'got {self._wide_offset_one_star_confidence_cap}'
             )
 
     def is_feasible(self, features: list[NavFeature]) -> NavFeasibilityReport:
@@ -896,6 +975,7 @@ class StarFieldFromCatalogNav(NavTechnique):
             cat_points_arr=cat_points_arr,
         )
         wide_offset_lock = False
+        one_star_lock = False
         wide_offset_expectation = 0.0
         if best is None or best[0] < self._min_inliers:
             # The triplet RANSAC could not reach its strong-evidence floor.
@@ -918,6 +998,20 @@ class StarFieldFromCatalogNav(NavTechnique):
                 image_area=image_area,
             )
             if wide is None:
+                # A field can still carry exactly one confidently-detectable
+                # star at a large offset (the fainter members below the
+                # glare-elevated detection limit).  A one-star lock has no
+                # corroborating inlier, so the anchor pairing itself must be
+                # unambiguous: both the catalog anchor and the detection
+                # anchor uniquely bright by a large margin.
+                wide = self._wide_offset_one_star_match(
+                    det_points_arr=det_points_arr,
+                    det_dn=det_dn,
+                    cat_points_arr=cat_points_arr,
+                    ranked_catalog=ranked_catalog,
+                    context=context,
+                )
+            if wide is None:
                 n_inliers = 0 if best is None else best[0]
                 return self._fail(
                     features=features,
@@ -936,6 +1030,7 @@ class StarFieldFromCatalogNav(NavTechnique):
                 )
             best = (wide.n_inliers, wide.correspondences, wide.offset)
             wide_offset_lock = True
+            one_star_lock = wide.is_one_star
             wide_offset_expectation = wide.expectation
         n_inliers, correspondences, _coarse_offset = best
         det_inliers: NDArrayFloatType = det_points_arr[[d for d, _ in correspondences]]
@@ -1009,7 +1104,14 @@ class StarFieldFromCatalogNav(NavTechnique):
             # the strong-tier ceiling regardless of how the formula scores
             # the inlier count; it must still clear the ensemble gate to
             # navigate, but it cannot claim a high-tier result on its own.
-            capped = min(confidence, self._wide_offset_confidence_cap)
+            # A one-star lock has no corroborating inlier at all and is
+            # capped lower still.
+            cap = (
+                self._wide_offset_one_star_confidence_cap
+                if one_star_lock
+                else self._wide_offset_confidence_cap
+            )
+            capped = min(confidence, cap)
             if capped < confidence:
                 self.logger.info(
                     'Wide-offset lock: confidence %.4f capped to %.4f',
@@ -1065,10 +1167,10 @@ class StarFieldFromCatalogNav(NavTechnique):
         detection-source indices ascending, catalog-triplet index)`` —
         per plans/archive/AUTONAV_PLAN_2026-06-19.md §33 the sorted-ascending detection tuple
         ``(min, mid, max)`` is the canonical tie-breaker, not the
-        canonical (a=brightest, b<c) order, because the
-        sorted-ascending key is invariant under brightness re-ranking
-        and yields bit-identical iteration across two back-to-back
-        invocations on the same obs (Cardinal Principle 3).
+        geometric apex-first ``(a, b, c)`` order, because the
+        sorted-ascending key is invariant under the vertex
+        canonicalisation and yields bit-identical iteration across two
+        back-to-back invocations on the same obs (Cardinal Principle 3).
         """
         tol_sq = self._hash_match_tolerance * self._hash_match_tolerance
         out: list[tuple[float, int, int, int, int, int, int, int]] = []
@@ -1281,6 +1383,108 @@ class StarFieldFromCatalogNav(NavTechnique):
             offset=off,
             expectation=expectation,
             n_seeds=n_unique_seeds,
+            is_one_star=False,
+        )
+
+    def _wide_offset_one_star_match(
+        self,
+        *,
+        det_points_arr: NDArrayFloatType,
+        det_dn: NDArrayFloatType,
+        cat_points_arr: NDArrayFloatType,
+        ranked_catalog: list[NavFeature],
+        context: NavContext,
+    ) -> _WideOffsetMatch | None:
+        """Attempt a wide-offset lock from a single uniquely-bright anchor pair.
+
+        The last resort when neither the triplet RANSAC nor the
+        ``>= wide_offset_min_inliers`` asterism fallback locks and a field
+        carries exactly one confidently-detectable star at a large offset.
+        A one-star lock has no corroborating inlier, so the chance-alignment
+        budget cannot vouch for it; the anchor pairing itself must instead be
+        unambiguous.  That holds only when the single trusted bright catalog
+        anchor outshines the next predictable star by
+        ``wide_offset_one_star_catalog_margin_mag`` AND the brightest
+        detection outshines the next by a peak-DN factor of
+        ``wide_offset_one_star_detection_margin_ratio``.  A glare field
+        routinely raises peaks brighter than a real faint star, so a frame
+        whose brightest detection is not uniquely dominant fails the
+        detection-margin gate and stays unlocked -- the correct verdict on a
+        field with two comparably bright peaks, where pairing the anchor with
+        the brightest peak would be a guess.
+
+        Parameters:
+            det_points_arr: ``(N_det, 2)`` detection ``(v, u)`` positions.
+            det_dn: ``(N_det,)`` detection matched-filter peak amplitudes.
+            cat_points_arr: ``(N_cat, 2)`` predicted catalog ``(v, u)``
+                positions, brightest first.
+            ranked_catalog: The catalog features parallel to
+                ``cat_points_arr`` (supplies the photometry flags).
+            context: Per-image NavContext (search-window bounds).
+
+        Returns:
+            A single-inlier :class:`_WideOffsetMatch` when the anchor pairing
+            is unambiguous and inside the search window, else ``None``.
+        """
+        if not self._wide_offset_one_star_enabled:
+            return None
+        n_det = int(det_points_arr.shape[0])
+        n_cat = int(cat_points_arr.shape[0])
+        if n_det < 1 or n_cat < 1:
+            return None
+        # The catalog anchor is the brightest predictable star.  It must be
+        # photometry-trusted (its brightness ordering is real, not a saturated
+        # lower bound) and uniquely bright over the next predictable star.
+        if _star_photometry_saturated(ranked_catalog[0]):
+            self.logger.debug('One-star: brightest catalog anchor is photometry-saturated')
+            return None
+        next_cat_snr = predicted_snr(ranked_catalog[1]) if n_cat > 1 else 0.0
+        cat_margin_mag = brightness_margin_mag(predicted_snr(ranked_catalog[0]), next_cat_snr)
+        if cat_margin_mag < self._wide_offset_one_star_catalog_margin_mag:
+            self.logger.debug(
+                'One-star: catalog anchor margin %.3f mag below floor %.3f; skipping',
+                cat_margin_mag,
+                self._wide_offset_one_star_catalog_margin_mag,
+            )
+            return None
+        # The detection anchor is the brightest peak; it must be uniquely
+        # bright over the next peak so the single pairing is not a guess.
+        order = np.argsort(-det_dn, kind='stable')
+        det_i = int(order[0])
+        dn_top = float(det_dn[det_i])
+        dn_next = float(det_dn[int(order[1])]) if n_det > 1 else 0.0
+        det_ratio = math.inf if dn_next <= 0.0 else dn_top / dn_next
+        if det_ratio < self._wide_offset_one_star_detection_margin_ratio:
+            self.logger.info(
+                'One-star: brightest detection peak ratio %.3f below floor %.3f; '
+                'rejecting (not uniquely dominant)',
+                det_ratio,
+                self._wide_offset_one_star_detection_margin_ratio,
+            )
+            return None
+        off = (
+            float(det_points_arr[det_i, 0] - cat_points_arr[0, 0]),
+            float(det_points_arr[det_i, 1] - cat_points_arr[0, 1]),
+        )
+        margin_v, margin_u = search_window_for_obs(context)
+        if abs(off[0]) > margin_v or abs(off[1]) > margin_u:
+            self.logger.debug('One-star: anchor offset outside search window; skipping')
+            return None
+        self.logger.info(
+            'One-star wide-offset lock: offset (%.4f, %.4f) px; catalog margin '
+            '%.3f mag; detection peak ratio %.3f',
+            off[0],
+            off[1],
+            cat_margin_mag,
+            det_ratio,
+        )
+        return _WideOffsetMatch(
+            n_inliers=1,
+            correspondences=[(det_i, 0)],
+            offset=off,
+            expectation=0.0,
+            n_seeds=1,
+            is_one_star=True,
         )
 
     def _tukey_refit(

--- a/tests/integration/sim_baselines/star_equal_brightness.json
+++ b/tests/integration/sim_baselines/star_equal_brightness.json
@@ -1,0 +1,7 @@
+{
+  "confidence": 0.8,
+  "offset_du_px": 0.0,
+  "offset_dv_px": -0.0,
+  "scene_name": "star_equal_brightness",
+  "status": "success"
+}

--- a/tests/integration/sim_scenes/regression/star_equal_brightness.yaml
+++ b/tests/integration/sim_scenes/regression/star_equal_brightness.yaml
@@ -1,0 +1,34 @@
+schema_version: 2
+scene_name: star_equal_brightness
+instrument: coiss_nac
+size_v: 200
+size_u: 200
+random_seed: 7
+exposure_sec: 1.0
+# Regression scene for the triplet-canonicalisation seed lottery: every star
+# shares one magnitude, so a brightness-keyed apex choice would break ties
+# differently on the catalog and detection sides and the pattern match became a
+# lottery over the noise realization.  The geometric (opposite-side-length)
+# canonicalisation is invariant to that tie, so the star field recovers the
+# zero planted offset on an equal-brightness field.
+# Stars deposit as point masses; an explicit navigator-matched PSF gives them a
+# finite (floor-form) profile instead of a 1-pixel spike.
+optics:
+  psf:
+    match_navigator: true
+bodies: []
+stars:
+  - {name: S1, v: 40.0, u: 50.0, vmag: 3.3}
+  - {name: S2, v: 160.0, u: 150.0, vmag: 3.3}
+  - {name: S3, v: 70.0, u: 165.0, vmag: 3.3}
+  - {name: S4, v: 150.0, u: 55.0, vmag: 3.3}
+  - {name: S5, v: 50.0, u: 120.0, vmag: 3.3}
+  - {name: S6, v: 150.0, u: 100.0, vmag: 3.3}
+  - {name: S7, v: 112.0, u: 172.0, vmag: 3.3}
+  - {name: S8, v: 88.0, u: 38.0, vmag: 3.3}
+noise:
+  poisson: true
+  read_noise_dn: 4.0
+offset_v: 0.0
+offset_u: 0.0
+offset_rotation_deg: 0.0

--- a/tests/integration/sim_scenes/regression/star_zero_offset.yaml
+++ b/tests/integration/sim_scenes/regression/star_zero_offset.yaml
@@ -11,10 +11,10 @@ exposure_sec: 1.0
 # cosmic-ray detector, so at a near-zero offset (prediction on the star) every
 # star was gated and the star techniques had nothing to navigate.  With a zero
 # planted offset the prediction coincides exactly with each star; the star field
-# must still recover it.  Magnitudes are distinct so the pattern matcher's
-# brightest-vertex canonicalisation is deterministic on both the catalog and the
-# detection side; equal magnitudes made the match a tie-breaking lottery over
-# the noise realization.
+# must still recover it.  Magnitudes are distinct here so the detection is
+# unambiguous; the equal-magnitude sibling scene star_equal_brightness exercises
+# the geometric triplet canonicalisation that keeps the match deterministic when
+# the magnitudes tie.
 # Stars deposit as point masses; an explicit navigator-matched PSF gives them a
 # finite (floor-form) profile instead of a 1-pixel spike.
 optics:

--- a/tests/integration/test_sim_regression.py
+++ b/tests/integration/test_sim_regression.py
@@ -65,3 +65,17 @@ def test_star_field_recovers_zero_offset() -> None:
     assert _technique_offset_error('star_zero_offset', 'StarFieldFromCatalogNav') < (
         _STAR_ZERO_OFFSET_TOLERANCE_PX
     )
+
+
+def test_star_field_recovers_zero_offset_on_equal_brightness_field() -> None:
+    """The star field recovers the offset when every star shares one magnitude.
+
+    Guards the triplet-canonicalisation seed lottery: with equal magnitudes the
+    brightness tie-break was decided differently on the catalog and detection
+    sides, so the pattern match flipped with the noise realization. The geometric
+    (opposite-side-length) canonicalisation is invariant to the tie, so recovery
+    no longer depends on which equal-brightness star wins an arbitrary tie-break.
+    """
+    assert _technique_offset_error('star_equal_brightness', 'StarFieldFromCatalogNav') < (
+        _STAR_ZERO_OFFSET_TOLERANCE_PX
+    )

--- a/tests/spindoctor/nav_model/stars/test_saturation.py
+++ b/tests/spindoctor/nav_model/stars/test_saturation.py
@@ -19,7 +19,7 @@ from spindoctor.nav_model.stars.saturation import (
     SATURATION_MATCH_MAX_WIDEN_RADII,
     SATURATION_MATCH_WIDEN_PER_MAG,
     UCAC4_SATURATION_VMAG_LIMIT,
-    _nearest_mag_aware,
+    _best_mag_aware_match,
     _nearest_within,
     _widened_radius,
     correct_saturated_vmags,
@@ -683,31 +683,57 @@ def test_widened_radius_uses_per_mag_slope() -> None:
     assert got == pytest.approx(expected)
 
 
-def test_nearest_mag_aware_returns_none_for_empty_reference() -> None:
+def test_best_mag_aware_match_returns_none_for_empty_reference() -> None:
     """An empty reference set yields no match."""
     empty = np.asarray([], dtype=np.float64)
-    assert _nearest_mag_aware(0.0, 0.0, 6.0, empty, empty, empty, _MATCH_RAD) is None
+    assert _best_mag_aware_match(0.0, 0.0, 6.0, empty, empty, empty, _MATCH_RAD) is None
 
 
-def test_nearest_mag_aware_respects_available_mask() -> None:
+def test_best_mag_aware_match_respects_available_mask() -> None:
     """A reference masked unavailable is not matched even when in range."""
     ref_ra = np.asarray([_ETA_TAU[0]], dtype=np.float64)
     ref_dec = np.asarray([_ETA_TAU[1]], dtype=np.float64)
     ref_vmag = np.asarray([2.87], dtype=np.float64)
     available = np.asarray([False], dtype=np.bool_)
-    idx = _nearest_mag_aware(
+    idx = _best_mag_aware_match(
         _ETA_TAU[0], _ETA_TAU[1], 6.68, ref_ra, ref_dec, ref_vmag, _MATCH_RAD, available=available
     )
     assert idx is None
 
 
-def test_nearest_mag_aware_matches_nearest_in_range() -> None:
-    """The nearest reference inside its widened radius is returned."""
+def test_best_mag_aware_match_matches_coincident_reference() -> None:
+    """A coincident reference is returned over a fainter distant one."""
     ref_ra = np.asarray([_ETA_TAU[0], _MEROPE[0]], dtype=np.float64)
     ref_dec = np.asarray([_ETA_TAU[1], _MEROPE[1]], dtype=np.float64)
     ref_vmag = np.asarray([2.87, 4.18], dtype=np.float64)
-    idx = _nearest_mag_aware(_ETA_TAU[0], _ETA_TAU[1], 6.68, ref_ra, ref_dec, ref_vmag, _MATCH_RAD)
+    idx = _best_mag_aware_match(
+        _ETA_TAU[0], _ETA_TAU[1], 6.68, ref_ra, ref_dec, ref_vmag, _MATCH_RAD
+    )
     assert idx == 0
+
+
+def test_best_mag_aware_match_prefers_brighter_true_twin_over_nearer_unrelated() -> None:
+    """A nearer unrelated bright star does not capture the saturated candidate.
+
+    The candidate reads V6.7 (a saturated bright star).  A V4.0 reference
+    sits 4 arcsec away and the candidate's true V2.8 twin sits 8 arcsec
+    away; both fall inside their own magnitude-widened reach.  A pure
+    nearest-neighbour rule would correct the candidate to the nearer,
+    unrelated V4.0 star; the brightness preference returns the V2.8 twin
+    instead.
+    """
+    # Candidate at Eta Tau's true position; references offset east by 4 and 8
+    # arcsec.  cos(dec) ~ 1 over this small field, so a pure RA offset gives
+    # the intended separations to within the small-angle tolerance.
+    arcsec = math.radians(1.0 / 3600.0)
+    cand_ra, cand_dec = _ETA_TAU
+    unrelated_ra = cand_ra + 4.0 * arcsec / math.cos(cand_dec)
+    twin_ra = cand_ra + 8.0 * arcsec / math.cos(cand_dec)
+    ref_ra = np.asarray([unrelated_ra, twin_ra], dtype=np.float64)
+    ref_dec = np.asarray([cand_dec, cand_dec], dtype=np.float64)
+    ref_vmag = np.asarray([4.0, 2.8], dtype=np.float64)
+    idx = _best_mag_aware_match(cand_ra, cand_dec, 6.7, ref_ra, ref_dec, ref_vmag, _MATCH_RAD)
+    assert idx == 1
 
 
 # --------------------------------------------------------------------------

--- a/tests/spindoctor/nav_technique/test_nav_technique_star_field.py
+++ b/tests/spindoctor/nav_technique/test_nav_technique_star_field.py
@@ -22,6 +22,7 @@ from spindoctor.nav_technique.nav_technique import ROTATION_UNOBSERVABLE_VARIANC
 from spindoctor.nav_technique.nav_technique_star_field import (
     StarFieldFromCatalogNav,
     _binomial_upper_tail,
+    _canonical_triplet_order,
     _detect_image_sources,
     _enumerate_triplets,
     _hash_distance_sq,
@@ -188,30 +189,95 @@ def test_triplet_hash_drops_collinear() -> None:
 
 
 def test_enumerate_triplets_yields_one_per_unordered_set() -> None:
-    """Each unordered triplet appears exactly once with A=brightest."""
+    """Each unordered triplet appears once, apex opposite the longest side."""
     points = [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (5.0, 5.0)]
-    # Brightness rank 0 = brightest; rank by index here.
     brightness_rank = [0, 1, 2, 3]
     triplets = _enumerate_triplets(points, brightness_rank)
     # C(4,3) = 4 triplets.
     assert len(triplets) == 4
-    # The brightest of each unordered set is correctly identified as A.
     seen_keys: set[tuple[int, int, int]] = set()
     for t in triplets:
-        # b and c indices are sorted ascending.
-        assert t.idx_b < t.idx_c
-        # A index has the lowest brightness rank.
-        ranks = (
-            brightness_rank[t.idx_a],
-            brightness_rank[t.idx_b],
-            brightness_rank[t.idx_c],
-        )
-        assert ranks[0] == min(ranks)
+        # A sits opposite the longest side (the side b--c is longest).
+        pa = points[t.idx_a]
+        pb = points[t.idx_b]
+        pc = points[t.idx_c]
+        opp_a = math.hypot(pb[0] - pc[0], pb[1] - pc[1])
+        opp_b = math.hypot(pa[0] - pc[0], pa[1] - pc[1])
+        opp_c = math.hypot(pa[0] - pb[0], pa[1] - pb[1])
+        assert opp_a == max(opp_a, opp_b, opp_c)
+        # B's opposite side is at least C's opposite side.
+        assert opp_b >= opp_c
         # Unordered triplet seen once.
-        sorted_indices = sorted([t.idx_a, t.idx_b, t.idx_c])
-        key = (sorted_indices[0], sorted_indices[1], sorted_indices[2])
+        ordered = sorted([t.idx_a, t.idx_b, t.idx_c])
+        key = (ordered[0], ordered[1], ordered[2])
         assert key not in seen_keys
         seen_keys.add(key)
+
+
+def test_enumerate_triplets_order_is_rotation_stable_on_equal_brightness() -> None:
+    """Equal-brightness triplet canonicalisation is stable under rotation.
+
+    A brightness-keyed apex would break the tie arbitrarily and flip the
+    labelling when the field rotates; the geometric order canonicalises to
+    the same physical vertex assignment for a triangle and any rotated copy.
+    """
+    points = [(0.0, 0.0), (30.0, 4.0), (10.0, 25.0)]
+    equal_brightness = [0, 0, 0]
+    base = _enumerate_triplets(points, equal_brightness)
+    assert len(base) == 1
+    theta = math.radians(37.0)
+    cos_t = math.cos(theta)
+    sin_t = math.sin(theta)
+    rotated = [(cos_t * v - sin_t * u, sin_t * v + cos_t * u) for v, u in points]
+    rotated_triplets = _enumerate_triplets(rotated, equal_brightness)
+    assert len(rotated_triplets) == 1
+    # The apex-first index order is identical before and after rotation.
+    assert (base[0].idx_a, base[0].idx_b, base[0].idx_c) == (
+        rotated_triplets[0].idx_a,
+        rotated_triplets[0].idx_b,
+        rotated_triplets[0].idx_c,
+    )
+
+
+def test_enumerate_triplets_order_independent_of_brightness_ranking() -> None:
+    """Two brightness rankings produce the same scalene-triangle apex order.
+
+    With a scalene triangle the geometry fixes the vertex order regardless
+    of how brightness ranks the vertices, so a re-ranking (the equal-vmag
+    seed lottery) cannot change which correspondences the matcher forms.
+    """
+    points = [(0.0, 0.0), (30.0, 4.0), (10.0, 25.0)]
+    order_one = _enumerate_triplets(points, [0, 1, 2])
+    order_two = _enumerate_triplets(points, [2, 0, 1])
+    assert (order_one[0].idx_a, order_one[0].idx_b, order_one[0].idx_c) == (
+        order_two[0].idx_a,
+        order_two[0].idx_b,
+        order_two[0].idx_c,
+    )
+
+
+def test_canonical_triplet_order_isosceles_breaks_tie_on_brightness() -> None:
+    """An isosceles triangle breaks the equal-opposite-side tie on brightness.
+
+    Vertices 0 and 1 have equal-length opposite sides, so geometry alone cannot
+    order them; the documented fallback orders the tied pair by brightness rank
+    ascending. With vertex 0 the brighter (lower rank), it precedes vertex 1.
+    """
+    points = [(0.0, 0.0), (10.0, 0.0), (5.0, 8.0)]
+    order = _canonical_triplet_order(points, (0, 1, 2), [0, 1, 2])
+    assert order == (2, 0, 1)
+
+
+def test_canonical_triplet_order_isosceles_tie_follows_brightness_rank() -> None:
+    """Reversing the tied pair's brightness rank swaps their canonical order.
+
+    The apex (vertex 2, opposite the longest side) is fixed by geometry, but
+    the two equal-opposite-side vertices are ordered by brightness rank, so
+    ranking vertex 1 brighter than vertex 0 places it first.
+    """
+    points = [(0.0, 0.0), (10.0, 0.0), (5.0, 8.0)]
+    order = _canonical_triplet_order(points, (0, 1, 2), [1, 0, 2])
+    assert order == (2, 1, 0)
 
 
 def test_hash_distance_sq_zero_for_identical_hashes() -> None:
@@ -471,6 +537,48 @@ def test_star_field_min_inliers_less_than_three_raises() -> None:
     try:
         technique_class.tuning = bad_tuning
         with pytest.raises(ValueError, match='pattern_match_min_inliers'):
+            technique_class()
+    finally:
+        technique_class.tuning = original_tuning
+
+
+def test_wide_offset_one_star_catalog_margin_not_positive_raises() -> None:
+    """Construction rejects a non-positive ``wide_offset_one_star_catalog_margin_mag``."""
+    technique_class = StarFieldFromCatalogNav
+    bad_tuning = dict(technique_class.tuning)
+    bad_tuning['wide_offset_one_star_catalog_margin_mag'] = 0.0
+    original_tuning = technique_class.tuning
+    try:
+        technique_class.tuning = bad_tuning
+        with pytest.raises(ValueError, match='wide_offset_one_star_catalog_margin_mag'):
+            technique_class()
+    finally:
+        technique_class.tuning = original_tuning
+
+
+def test_wide_offset_one_star_detection_ratio_below_one_raises() -> None:
+    """Construction rejects a ``wide_offset_one_star_detection_margin_ratio`` below 1."""
+    technique_class = StarFieldFromCatalogNav
+    bad_tuning = dict(technique_class.tuning)
+    bad_tuning['wide_offset_one_star_detection_margin_ratio'] = 0.9
+    original_tuning = technique_class.tuning
+    try:
+        technique_class.tuning = bad_tuning
+        with pytest.raises(ValueError, match='wide_offset_one_star_detection_margin_ratio'):
+            technique_class()
+    finally:
+        technique_class.tuning = original_tuning
+
+
+def test_wide_offset_one_star_confidence_cap_out_of_range_raises() -> None:
+    """Construction rejects a ``wide_offset_one_star_confidence_cap`` outside [0, 1]."""
+    technique_class = StarFieldFromCatalogNav
+    bad_tuning = dict(technique_class.tuning)
+    bad_tuning['wide_offset_one_star_confidence_cap'] = 1.5
+    original_tuning = technique_class.tuning
+    try:
+        technique_class.tuning = bad_tuning
+        with pytest.raises(ValueError, match='wide_offset_one_star_confidence_cap'):
             technique_class()
     finally:
         technique_class.tuning = original_tuning
@@ -1232,6 +1340,129 @@ def test_wide_offset_rejects_incoherent_field(
         make_star_feature('star:UCAC4:2', predicted_vu=(40.0, 360.0), predicted_snr=40.0),
     ]
     technique = StarFieldFromCatalogNav()
+    context = make_nav_context(image, extfov_margin_vu=(150, 150))
+    result = technique.navigate(features, context)
+    assert result.spurious is True
+
+
+def _one_star_wide_field(
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+    *,
+    offset: tuple[float, float],
+    second_detection_dn: float = 120.0,
+) -> tuple[np.ndarray, list[NavFeature]]:
+    """Plant one dominant star at a wide offset plus two off-pattern detections.
+
+    Three predictable catalog stars and three detections satisfy the
+    technique's minimum cohort, but only the bright anchor pairs (the two
+    faint detections align with neither faint catalog star under the
+    anchor's offset), so nothing above a single inlier can lock.
+    ``second_detection_dn`` controls whether the brightest detection is
+    uniquely dominant.
+    """
+    shape = (400, 400)
+    image = np.zeros(shape, dtype=np.float64)
+    anchor_pred = (40.0, 50.0)
+    anchor_det = (anchor_pred[0] + offset[0], anchor_pred[1] + offset[1])
+    draw_gaussian_star(image, anchor_det, peak_dn=400.0, sigma=1.2)
+    draw_gaussian_star(image, (150.0, 150.0), peak_dn=second_detection_dn, sigma=1.2)
+    draw_gaussian_star(image, (350.0, 350.0), peak_dn=120.0, sigma=1.2)
+    features = [
+        make_star_feature('star:UCAC4:anchor', predicted_vu=anchor_pred, predicted_snr=400.0),
+        make_star_feature('star:UCAC4:faint1', predicted_vu=(210.0, 300.0), predicted_snr=30.0),
+        make_star_feature('star:UCAC4:faint2', predicted_vu=(300.0, 210.0), predicted_snr=15.0),
+    ]
+    return image, features
+
+
+def test_one_star_wide_offset_lock_recovers_offset(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """A single uniquely-bright star locks a wide offset when enabled."""
+    planted = (60.0, 80.0)
+    image, features = _one_star_wide_field(make_star_feature, draw_gaussian_star, offset=planted)
+    technique = StarFieldFromCatalogNav()
+    technique._wide_offset_one_star_enabled = True
+    context = make_nav_context(image, extfov_margin_vu=(150, 150))
+    result = technique.navigate(features, context)
+    assert result.spurious is False
+    assert isinstance(result.diagnostics, StarFieldDiagnostics)
+    assert result.diagnostics.wide_offset_lock is True
+    assert result.diagnostics.n_inliers == 1
+    assert result.offset_px[0] == pytest.approx(planted[0], abs=0.5)
+    assert result.offset_px[1] == pytest.approx(planted[1], abs=0.5)
+
+
+def test_one_star_wide_offset_lock_confidence_capped_low(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """A one-star lock is capped below the >=3-inlier wide-offset cap."""
+    image, features = _one_star_wide_field(
+        make_star_feature, draw_gaussian_star, offset=(60.0, 80.0)
+    )
+    technique = StarFieldFromCatalogNav()
+    technique._wide_offset_one_star_enabled = True
+    context = make_nav_context(image, extfov_margin_vu=(150, 150))
+    result = technique.navigate(features, context)
+    assert result.confidence <= technique._wide_offset_one_star_confidence_cap + 1e-9
+
+
+def test_one_star_wide_offset_disabled_by_default(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """With the one-star lock off (the default), the same field stays failed."""
+    image, features = _one_star_wide_field(
+        make_star_feature, draw_gaussian_star, offset=(60.0, 80.0)
+    )
+    technique = StarFieldFromCatalogNav()
+    assert technique._wide_offset_one_star_enabled is False
+    context = make_nav_context(image, extfov_margin_vu=(150, 150))
+    result = technique.navigate(features, context)
+    assert result.spurious is True
+
+
+def test_one_star_wide_offset_rejects_non_unique_detection(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """A field with two comparably bright peaks fails the detection-margin gate.
+
+    This is the C0059893300R regime (1694 vs 1240 DN): the brightest
+    detection is not uniquely dominant, so pairing the anchor with it would
+    be a guess and the lock is correctly refused.
+    """
+    image, features = _one_star_wide_field(
+        make_star_feature, draw_gaussian_star, offset=(60.0, 80.0), second_detection_dn=400.0
+    )
+    technique = StarFieldFromCatalogNav()
+    technique._wide_offset_one_star_enabled = True
+    context = make_nav_context(image, extfov_margin_vu=(150, 150))
+    result = technique.navigate(features, context)
+    assert result.spurious is True
+
+
+def test_one_star_wide_offset_rejects_untrusted_anchor(
+    make_nav_context: NavContextFactory,
+    make_star_feature: NavFeatureFactory,
+    draw_gaussian_star: DrawGaussianStarFactory,
+) -> None:
+    """A photometry-saturated brightest catalog anchor is not one-star locked."""
+    image, features = _one_star_wide_field(
+        make_star_feature, draw_gaussian_star, offset=(60.0, 80.0)
+    )
+    features[0] = replace(
+        features[0], flags=replace(cast(StarFlags, features[0].flags), photometry_saturated=True)
+    )
+    technique = StarFieldFromCatalogNav()
+    technique._wide_offset_one_star_enabled = True
     context = make_nav_context(image, extfov_margin_vu=(150, 150))
     result = technique.navigate(features, context)
     assert result.spurious is True


### PR DESCRIPTION
## Purpose

Closes #337. Closes #376. Closes #367.

Three star-navigation robustness defects:
- **#337** — the star-field pattern matcher canonicalised each triplet's vertices by *brightness rank*. On equal- or near-equal-magnitude fields that tie was broken differently on the detection side (peak DN, which rotates) than on the catalog side (predicted SNR), so the two sides canonicalised to *different* physical vertices, the triplet hashes stopped matching, and the navigation outcome flipped run-to-run and under image rotation near the inlier floor.
- **#376** — the magnitude-widened saturation reference match returned the *nearest* reference within reach; a nearer unrelated bright star (which earns a wide reach from its own large magnitude gap) could capture a saturated candidate away from its true, more-distant twin.
- **#367** — autonomous star navigation could not lock a wide offset from a single detectable star (a capability gap in the one-star path).

## Changes

- **#337** (`nav_technique_star_field.py`): `_canonical_triplet_order` orders the vertices geometrically — the apex sits opposite the longest side, the other two follow by opposite-side length. Side lengths are similarity-invariant, so detection and catalog triplets canonicalise to the same physical vertex assignment from geometry alone; brightness rank then index only break a near-isosceles tie (and for an exactly isosceles/equilateral triangle the tied vertices are mirror-symmetric, so the tie cannot change the hash). Total and rotation-stable.
- **#376** (`nav_model/stars/saturation.py`): `_best_mag_aware_match` prefers the *brightest* qualifying reference (largest magnitude gap best explains the saturation), separation then index breaking ties. Sparse-field (one reference in reach) behavior is unchanged.
- **#367** (`nav_technique_star_field.py`): a new `_wide_offset_one_star_match` one-star wide-offset lock that fires only after RANSAC and the >=3-inlier asterism fallback both fail. Because a one-inlier lock cannot clear the chance-alignment budget, safety comes from two uniqueness gates — catalog anchor uniquely bright by a margin AND brightest detection uniquely bright by a ratio — with a low confidence cap. It is gated behind `wide_offset_one_star_enabled`, **default off**, pending an image-library false-lock sweep that needs SPICE holdings the unit suite cannot reach.
- Developer guides (`dev_guide_techniques_star_field.rst`, `dev_guide_navigation_models_star.rst`) document the geometric canonicalisation, the brightest-reference rule, and the one-star acquisition path + config keys.

## Type of Change

- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that alters existing behavior or public API)
- [ ] Refactor (no functional or API changes)
- [x] Documentation
- [x] Tests only (no production code change)
- [ ] CI / Build / Dependencies

(#367 adds a capability that is inert by default.)

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] End-to-end tests pass (if applicable)
- [x] New or updated tests for changed code
- [x] Tested manually (describe below if applicable)

Unit tests: rotation-stability and brightness-independence of the triplet order (#337); the adversarial wrong-reference case now resolving to the true twin (#376); one-star lock succeeds / confidence capped / disabled-by-default stays failed / non-unique-detection rejected / untrusted-anchor rejected (#367); and construction-time validation of the three new config keys. New end-to-end regression: an equal-magnitude planted-truth scene (`star_equal_brightness`) that the star field now recovers to a near-zero offset, plus its baseline; the pre-existing `star_zero_offset` scene comment is corrected to describe the geometric canonicalisation. Star sim scenes pass. `ruff`, `ruff format --check`, `mypy` clean.

## Potential Impacts

- **Public API:** none. New config keys under the star-field technique tuning; #367's path defaults off.
- **Behavior:** #337 makes equal-brightness star navigation deterministic (was a seed lottery); #376 changes reference selection only in the crowded regime with two bright references within the widened reach (sparse NAC/LORRI fields unchanged); #367 is inert until enabled. No sim baseline regresses.

## Checklist

- [x] Code follows project style (`ruff check`, `ruff format`)
- [x] Type annotations present and `mypy` passes
- [x] Docstrings and Sphinx docs updated (star technique + model dev guides)
- [ ] CHANGES.md updated (no CHANGES.md in this repo)
- [x] No temporary or debug code left in
- [x] Breaking changes flagged in Type of Change above

## Notes

Adversarially reviewed by a separate agent, which worked the triangle side-length invariance argument by hand (confirming the isosceles/equilateral tie is hash-invariant) and traced the single-inlier similarity-fit degeneracy. Its MEDIUM finding — the issue's requested end-to-end equal-magnitude regression scene and a stale scene comment — is addressed in this PR (the `star_equal_brightness` scene + test, and the corrected comment); its LOW finding on untested validation branches is addressed by the three new construction-time tests. #367 stays default-off until the whole-library false-lock sweep (SPICE/holdings) can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HoCUAeNeMz5bFmGk2iVBf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced bright-star saturation correction to prefer the brightest qualifying reference within the widened match radius, reducing crowded-field misidentification.
  - Made star-pattern triplet hashing fully geometric and deterministic, improving consistency across rotations and brightness ties.
  - Added an optional single-bright-star wide-offset acquisition fallback with stricter ambiguity and photometry safeguards.
- **Documentation**
  - Updated developer guidance and tuning documentation for the widened matching rules and new one-star fallback parameters.
- **Tests**
  - Expanded regression and unit/integration tests for equal-brightness fields, saturation matching, and single-star recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->