### PR TITLE
feat: veto shape-lock and haze-crescent body nav (#328, #291)

### DIFF
--- a/docs/api_reference/api_nav_orchestrator.rst
+++ b/docs/api_reference/api_nav_orchestrator.rst
@@ -58,6 +58,11 @@ spindoctor.nav_orchestrator
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: spindoctor.nav_orchestrator.body_witness_veto
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: spindoctor.nav_orchestrator.curator
    :members:
    :undoc-members:

--- a/docs/dev_guide/dev_guide_navigation_models_body.rst
+++ b/docs/dev_guide/dev_guide_navigation_models_body.rst
@@ -233,12 +233,21 @@ the silhouette extraction:
   measures how far the limb fit can be expected to wander given the body's intrinsic
   ellipsoid-fit residual. When this scalar exceeds the documented cap the limb fit is
   information-limited; the gate rejects the
-  :attr:`~spindoctor.feature.feature_type.NavFeatureType.LIMB_ARC` and falls back to the
-  brightness-weighted-centroid path.
+  :attr:`~spindoctor.feature.feature_type.NavFeatureType.LIMB_ARC` and the
+  brightness-weighted-centroid path carries the body instead.
 - The **visible-lit fraction** and **overflow fraction** above. The disc gate fires only
   when :attr:`~spindoctor.feature.feature_type.NavFeatureType.LIMB_ARC` was emitted, the
   visible-lit fraction is at or above its minimum, and the
   overflow fraction is at or below its maximum.
+
+The :data:`~spindoctor.feature.feature_type.NavFeatureType.BODY_BLOB` gate fires whenever the
+predicted diameter clears its minimum and the body has any lit signal, independent of the limb
+gate: on a small or high-uncertainty body the blob is the *only* body feature, while on a
+well-resolved body it is co-emitted **alongside** the limb (and disc) as a witness. The
+witness blob is superseded in the fuse by any non-spurious geometric result, so it does not
+dilute the geometric offset; the ensemble's body-witness veto reads it as an independent
+pose-free cross-check against a geometric technique locked onto a mismatched shape (see
+:doc:`dev_guide_orchestrator_ensemble`).
 
 The terminator polyline gates fire when the surviving vertex count is at or above the
 configured minimum and the phase factor :math:`\sin\phi` is at or above its minimum.

--- a/docs/dev_guide/dev_guide_navigation_models_body.rst
+++ b/docs/dev_guide/dev_guide_navigation_models_body.rst
@@ -676,14 +676,18 @@ Call path traced through
      :data:`~spindoctor.feature.feature_type.NavFeatureType.LIMB_ARC` feature is emitted. The
      downstream disc gate then has a chance to fire alongside the limb arc when
      ``visible_lit_fraction`` and ``overflow_fraction`` allow.
-   - When the limb arc was rejected, the predicted disc diameter is at least
+   - The blob gate is met when the predicted disc diameter is at least
      ``max(`` :data:`~spindoctor.nav_model.nav_model_body.BODY_BLOB_MIN_DIAMETER_PX` ``,``
-     :attr:`~spindoctor.nav_model.body_shape.BodyShape.min_blob_diameter_px` ``)``, and the
-     rendered silhouette contains at least one lit pixel, a
-     :data:`~spindoctor.feature.feature_type.NavFeatureType.BODY_BLOB` feature is emitted instead.
-     The blob feature carries the lit-weighted predicted centroid and the
-     phase-and-irregularity factor :math:`\kappa` on its
-     :class:`~spindoctor.feature.flags.BodyBlobFlags`.
+     :attr:`~spindoctor.nav_model.body_shape.BodyShape.min_blob_diameter_px` ``)`` and the
+     rendered silhouette contains at least one lit pixel. When the limb arc was rejected but
+     the blob gate is met, a
+     :data:`~spindoctor.feature.feature_type.NavFeatureType.BODY_BLOB` feature is emitted as
+     the sole body feature. When the limb arc was emitted and the blob gate is also met, a
+     BODY_BLOB is co-emitted alongside the limb (and disc) as a witness. Either way the blob
+     feature carries the lit-weighted predicted centroid and the phase-and-irregularity factor
+     :math:`\kappa` on its :class:`~spindoctor.feature.flags.BodyBlobFlags`; the witness blob
+     is superseded in the fuse by any non-spurious geometric result and is read only by the
+     ensemble body-witness veto.
    - Otherwise no body feature is emitted (the body is too small to fit and too unresolved
      to centroid, or its silhouette is entirely in shadow and there is no photometric
      signal to centroid).

--- a/docs/dev_guide/dev_guide_orchestrator_ensemble.rst
+++ b/docs/dev_guide/dev_guide_orchestrator_ensemble.rst
@@ -402,10 +402,14 @@ constructor accepts an :class:`~spindoctor.nav_orchestrator.ensemble.EnsembleCon
   contributing technique clamps its rotation fit to this bound, so a result arriving
   outside it is an upstream programming error and raises
   :class:`~spindoctor.support.exceptions.NavContractError`.
-- :attr:`~spindoctor.nav_orchestrator.ensemble.EnsembleConfig.body_witness_max_phase_deg` —
-  float, default ``90.0``. Largest blob phase at which the pose-free centroid is
-  treated as a trustworthy position witness for the shape-lock veto; past half phase
-  the centroid is itself crescent- and haze-biased.
+- :attr:`~spindoctor.nav_orchestrator.ensemble.EnsembleConfig.body_witness_shape_lock_max_phase_deg` —
+  float, default ``60.0``. Phase ceiling below which the pose-free centroid is treated as a
+  trustworthy position witness for the shape-lock veto; past it the centroid's lit-hemisphere
+  bias grows and would disagree with a correct geometric fit.
+- :attr:`~spindoctor.nav_orchestrator.ensemble.EnsembleConfig.body_witness_collapse_min_phase_deg` —
+  float, default ``90.0``. Phase floor above which a lone blob is the haze-bias suspect for the
+  collapsed-regime veto. It sits above the shape-lock ceiling, so the two checks bracket the
+  centroid's reliable-witness regime.
 - :attr:`~spindoctor.nav_orchestrator.ensemble.EnsembleConfig.body_witness_disagreement_floor_px` —
   float, default ``4.0``. Absolute floor of the shape-lock veto's blob-vs-fused
   disagreement tolerance.
@@ -417,6 +421,10 @@ constructor accepts an :class:`~spindoctor.nav_orchestrator.ensemble.EnsembleCon
   float, default ``2.0``. Mahalanobis-distance threshold the blob-vs-consensus disagreement
   must exceed under the combined translation covariance before the veto fires; the pixel
   floor is a lower bound, this is the statistical gate.
+- :attr:`~spindoctor.nav_orchestrator.ensemble.EnsembleConfig.scattered_light_gradient_score` —
+  float, default ``5.0``. Background-gradient score at or above which the frame is treated as
+  scattered-light, so the disc and limb techniques on one body are fused as a single
+  correlated witness rather than two independent ones.
 - :attr:`~spindoctor.nav_orchestrator.ensemble.EnsembleConfig.tier_thresholds` — mapping
   ``rank -> {min_confidence, max_sigma_px}``; default thresholds give ``'high'`` for
   confidence at or above 0.85 with sigma at most 0.5 px, ``'medium'`` for confidence at
@@ -437,7 +445,7 @@ constructor accepts an :class:`~spindoctor.nav_orchestrator.ensemble.EnsembleCon
 Implementation
 ==============
 
-The ensemble is split across four modules under ``src/spindoctor/nav_orchestrator/``:
+The ensemble is split across the following modules under ``src/spindoctor/nav_orchestrator/``:
 
 - ``ensemble.py`` — the reconciler itself:
   :func:`~spindoctor.nav_orchestrator.ensemble.ensemble`,
@@ -470,7 +478,7 @@ Public surface (autodocumented at :doc:`/api_reference/api_nav_orchestrator`):
 - :func:`~spindoctor.nav_orchestrator.ensemble.derive_confidence_rank` — assign the
   five-bucket rank from a confidence / sigma pair.
 - :class:`~spindoctor.nav_orchestrator.ensemble.EnsembleConfig` — frozen dataclass carrying
-  the nine tunables documented above.
+  the tunables documented above.
 
 Grouping is sponsored-neighborhood consensus selection
 (:func:`~spindoctor.nav_orchestrator.ensemble_consensus.consensus_selection`): every

--- a/docs/dev_guide/dev_guide_orchestrator_ensemble.rst
+++ b/docs/dev_guide/dev_guide_orchestrator_ensemble.rst
@@ -194,24 +194,74 @@ fit-quality gates
 (:doc:`dev_guide_techniques_dt_fitting`) close the adjacent
 unverified-fit family before results reach the ensemble at all.
 
-What remains unpriced is systematic error nobody declares. The standing
-evidence:
+The second defense is a cross-technique one, the *body-witness veto*
+(:mod:`spindoctor.nav_orchestrator.body_witness_veto`, applied inside
+:func:`~spindoctor.nav_orchestrator.ensemble.ensemble` just before a body
+consensus would be reported as a success). A systematic bias one body
+technique cannot see is often visible as a *disagreement* against another
+technique with a different failure mode, and the pose-free brightness centroid
+(:class:`~spindoctor.nav_technique.nav_technique_body_blob.BodyBlobNav`) is the
+witness the veto reads. So the witness exists on real frames as well as
+simulated ones, :class:`~spindoctor.nav_model.nav_model_body.NavModelBody` emits
+a ``BODY_BLOB`` alongside the geometric limb / disc rather than only when the
+limb is unusable (see :doc:`dev_guide_navigation_models_body`). The blob runs
+even when a primary already covers the body -- it opts in via
+:attr:`~spindoctor.nav_technique.nav_technique.NavTechnique.runs_as_witness`,
+and is still superseded in the fuse, so only the veto sees it and the fused
+offset on a passing frame is unchanged. The veto fires in two shapes:
+
+- **Shape lock.** When the winning consensus is a geometric body technique
+  (disc correlation, limb fit) and the blob witness on the same body, at or
+  below half phase where its centroid is a trustworthy position reference,
+  disagrees with the fused offset, the geometric techniques have locked onto a
+  mismatched shape. The result is reported ``conflicted`` (``status_reason``
+  ``body_shape_lock_suspect``) rather than a confident success.
+- **Collapsed regime.** When the only surviving body offset is a past-half-phase
+  blob centroid and a sibling geometric technique on the same body self-flagged
+  spurious, the geometric fit structurally failed and only the
+  photometric-bias-prone centroid remains. If the blob disagrees with the
+  spurious technique's own coarse position -- the disc located the body while a
+  forward-scattering haze dragged the centroid away -- the frame is declined
+  (``failed``, ``status_reason`` ``lone_blob_in_collapsed_regime``). A small or
+  faint body whose spurious disc agrees with the blob (both found the same
+  body) is a legitimate blob-only success and is left alone.
+
+Each disagreement is a two-sided gate: the Euclidean separation must clear a
+body-scaled pixel floor (``max(disagreement_floor_px, disagreement_frac *
+diameter)``) *and* the Mahalanobis distance under the combined translation
+covariance must exceed ``body_witness_agreement_sigma``, so a low-SNR or
+small-body centroid whose large sigma makes the separation statistically
+consistent with agreement is not vetoed on scatter alone. Both checks apply
+only to single-body frames, where no companion body corrupts the centroid and
+the whole-frame verdict maps to one body.
+
+The two modes below are the standing evidence that motivated the veto; each is
+caught and asserts its declined outcome as a regression:
 
 - ``tests/integration/sim_sweeps/irregularity_shape_mismatch.yaml`` -- at
-  extreme mesh-vs-ellipsoid shape mismatch the disc correlation locks onto
-  the mismatched model and the fused confidence re-saturates to ~0.99 at a
-  10-17 px error (measured 2026-07-19: 0.98 at 10.9 px, 0.99 at 14.0 and
-  17.0 px). A cross-technique veto (the pose-free blob disagrees by pixels),
-  not a per-technique channel, is the shape of a fix.
+  mesh-vs-ellipsoid shape mismatch the disc correlation and the limb fit both
+  lock onto the mismatched model and agree at a multi-pixel wrong offset, and
+  the fused confidence re-saturates to ~0.99 at a 10-17 px error. The pose-free
+  blob, which does not chase the shape, disagrees by pixels; the shape-lock
+  veto reports the steps whose disagreement clears the statistical gate
+  ``conflicted``. The clean (zero-relief) step recovers the planted offset
+  sub-pixel and stays a success, so the veto separates the shape lock from the
+  legitimate fit rather than blanketing the sweep.
 - ``tests/integration/sim_scenes/atmosphere/titan_crescent_horns.yaml`` (and
   its noiseless twin) -- a 155-degree haze crescent drags the blob centroid to
-  a ~30 px wrong offset that passes the acceptance gate at the blob's 0.40
-  cap, tier ``low``.
+  a ~30 px wrong offset while the disc correlation self-flags spurious. The
+  collapsed-regime veto declines the frame instead of reporting the lone-blob
+  success.
 
-These are asserted as honest pins or documented sweep behavior (see
-:ref:`sim-expected`), so a worsening regression and a silent fix both fail
-CI. A high tier on a frame with plausible *undeclared* systematic error is
-not evidence against that error.
+The witness is a defense against a geometric lock, not a cure for the blob's
+own bias: past half phase the centroid is itself crescent- and haze-biased, so
+the shape-lock check does not trust it there, and on a multi-body frame it is
+excluded. What remains unpriced is systematic error that displaces *every*
+technique on a frame coherently, with no surviving witness that fails
+differently -- a high tier on a frame with plausible *undeclared* systematic
+error of that kind is not evidence against the error. The declined outcomes
+above are asserted (see :ref:`sim-expected`), so a worsening regression and a
+silent revert both fail CI.
 
 A related honesty caveat survives inside the confidence scalar itself: the
 two-member agreement boost assumes the members' errors are independent, so
@@ -302,6 +352,21 @@ constructor accepts an :class:`~spindoctor.nav_orchestrator.ensemble.EnsembleCon
   contributing technique clamps its rotation fit to this bound, so a result arriving
   outside it is an upstream programming error and raises
   :class:`~spindoctor.support.exceptions.NavContractError`.
+- :attr:`~spindoctor.nav_orchestrator.ensemble.EnsembleConfig.body_witness_max_phase_deg` —
+  float, default ``90.0``. Largest blob phase at which the pose-free centroid is
+  treated as a trustworthy position witness for the shape-lock veto; past half phase
+  the centroid is itself crescent- and haze-biased.
+- :attr:`~spindoctor.nav_orchestrator.ensemble.EnsembleConfig.body_witness_disagreement_floor_px` —
+  float, default ``4.0``. Absolute floor of the shape-lock veto's blob-vs-fused
+  disagreement tolerance.
+- :attr:`~spindoctor.nav_orchestrator.ensemble.EnsembleConfig.body_witness_disagreement_frac` —
+  float, default ``0.03``. Fraction of the body diameter added to the floor as the
+  body-witness veto's disagreement lower bound. Well-navigated single-body frames hold the
+  blob within ~1.5 px of the fused offset; a shape lock disagrees by 5 px and up.
+- :attr:`~spindoctor.nav_orchestrator.ensemble.EnsembleConfig.body_witness_agreement_sigma` —
+  float, default ``2.0``. Mahalanobis-distance threshold the blob-vs-consensus disagreement
+  must exceed under the combined translation covariance before the veto fires; the pixel
+  floor is a lower bound, this is the statistical gate.
 - :attr:`~spindoctor.nav_orchestrator.ensemble.EnsembleConfig.tier_thresholds` — mapping
   ``rank -> {min_confidence, max_sigma_px}``; default thresholds give ``'high'`` for
   confidence at or above 0.85 with sigma at most 0.5 px, ``'medium'`` for confidence at
@@ -338,6 +403,10 @@ The ensemble is split across three modules under ``src/spindoctor/nav_orchestrat
   :func:`~spindoctor.nav_orchestrator.ensemble_observability.observable_basis`,
   :func:`~spindoctor.nav_orchestrator.ensemble_observability.observable_intersection_basis`,
   and :func:`~spindoctor.nav_orchestrator.ensemble_observability.mahalanobis_distance`.
+- ``body_witness_veto.py`` — the cross-technique body-witness veto:
+  :func:`~spindoctor.nav_orchestrator.body_witness_veto.evaluate_body_witness_veto`
+  and the :class:`~spindoctor.nav_orchestrator.body_witness_veto.BodyWitnessVeto`
+  verdict, read by the ensemble before a body consensus is reported.
 
 Public surface (autodocumented at :doc:`/api_reference/api_nav_orchestrator`):
 

--- a/docs/dev_guide/dev_guide_simulator.rst
+++ b/docs/dev_guide/dev_guide_simulator.rst
@@ -347,10 +347,12 @@ What it cannot do
   shear, stars occulted by a dark limb (simulated star success is optimistic
   where an unlit body should block the star), and body-on-body cast shadows
   (mutual events render occlusion, not shadowing).
-- **Fix the gaps it exposes.** The confident-wrong pins are evidence, not
-  mitigation; closing them requires ensemble work (consuming declared
-  model-error bars, cross-technique vetoes), and until then the pinned
-  hazards stand (see the ensemble chapter,
+- **Fix the gaps it exposes.** A confident-wrong pin is evidence, not
+  mitigation; closing it requires ensemble work (consuming declared
+  model-error bars, cross-technique vetoes). The body-witness veto closes the
+  shape-mismatch and haze-crescent modes; the remaining pinned hazard (the
+  ring planted-orbit-error lock) stands until its own fix lands (see the
+  ensemble chapter,
   :doc:`dev_guide_orchestrator_ensemble`).
 - **Transfer its calibration to real frames by itself.** That path runs
   through the sidecar re-ratchet and a pre-stated transfer criterion (the
@@ -986,22 +988,24 @@ position, or drowns a lone star in an overwhelming confounder field, the
 confident wrong offset. Each such scene carries an ``expected`` block, and the
 machinery turns "must not be confidently wrong here" into a passing assertion.
 
-**The honest pin.** A small second family inverts the reading: scenes whose
-measured behavior *is* a wrong offset the ensemble cannot remove (the
-``orbit_error_ringlet`` planted radial catalog error, whose bias survives
-even though the declared-sigma covariance channel demotes its tier, and the
-``titan_crescent_horns`` pair's haze-dragged blob centroid). Pinning bare
+**The honest pin.** A small second family inverts the reading: a scene whose
+measured behavior *is* a wrong offset the ensemble cannot remove -- the
+``orbit_error_ringlet`` planted radial catalog error, whose bias survives even
+though the declared-sigma covariance channel demotes its tier. Pinning bare
 ``status: success`` on such a scene would quietly freeze the wrong answer as
-correct behavior, so these scenes also declare ``known_offset_error_px`` --
-the measured fused error magnitude, from the scene's recorded baseline -- with
-a ``known_offset_error_tol_px`` band. The assertion then fails in *both*
+correct behavior, so it also declares ``known_offset_error_px`` -- the measured
+fused error magnitude, from the scene's recorded baseline -- with a
+``known_offset_error_tol_px`` band. The assertion then fails in *both*
 directions: a regression that worsens the error fails, and a genuine fix that
 shrinks it also fails loudly, prompting a deliberate re-pin (or retirement of
 the pin) instead of a silent behavior change. The pinned success is a
 documented hazard held in view, never an endorsement; the scene comments and
 the campaign record carry the analysis, and the ensemble chapter
 (:doc:`dev_guide_orchestrator_ensemble`) names the failure family for the
-readers who consume tiers.
+readers who consume tiers. The ``titan_crescent_horns`` pair left this family
+once the cross-technique body-witness veto closed it: its haze-dragged
+lone-blob offset is declined outright, so the scenes assert that ``failed``
+outcome instead of an honest-pin success.
 
 .. _sim-floor:
 
@@ -1338,18 +1342,20 @@ defeats the disc correlation (spurious -- there is no full lit disc), the
 predicted terminator arc is emitted but dropped by the feature reliability
 gate before any technique runs (its honestly computed reliability, capped by
 ``sin(155 deg)`` = 0.42, scores 0.26 against the 0.30 ``TERMINATOR_ARC``
-threshold), and the haze-dragged blob centroid alone carries the fused answer:
-a *low-tier success roughly 30 px off* in ``du``. Nothing vetoes that wrong
-answer -- the low tier, at the blob's 0.40 confidence cap, is the only flag --
-so the scene pins the tier and status rather than presenting the outcome as
-safe.  Re-measured under the 2026-07-18 recalibration, the outcome persists
-with a thinner margin: the fused 0.40 sits 0.05 above the 0.35 ensemble
-acceptance gate, and the scene stands as ensemble-gap evidence (no blob
-diagnostic can see a systematic photometric bias). The noiseless
+threshold), and the haze-dragged blob centroid alone would carry the fused
+answer roughly 30 px off in ``du``. That is exactly the lone-blob collapsed
+regime the body-witness veto (see :doc:`dev_guide_orchestrator_ensemble`)
+guards: the only surviving body offset is the bias-prone centroid while a
+sibling geometric technique on the same body self-flagged spurious, so the
+frame is declined (``failed``, ``status_reason``
+``lone_blob_in_collapsed_regime``) rather than reported as a 30-px-wrong
+success -- a wrong offset that passes the acceptance gate is worse than a
+declared failure. The scene asserts that decline. The noiseless
 sibling ``titan_crescent_horns_noiseless`` -- Poisson and read noise off, the
-same haze and phase geometry -- pins the systematic bias itself
-deterministically (planted ``du`` -0.8, recovered 29.17), so the ring of
-light alone, not the noise, carries the answer that far. The haze evaluation
+same haze and phase geometry -- pins the underlying centroid bias
+deterministically (planted ``du`` -0.8, blob centroid at 29.17), so the ring
+of light alone, not the noise, drives the collapse, and the decline is stable
+rather than noise-dependent. The haze evaluation
 is restricted to the bounding box of the
 body plus its halo (out to a detached shell's reach), so its cost scales with
 that box rather than the frame, and a body without an ``atmosphere`` block

--- a/src/spindoctor/config_files/config_540_orchestrator.yaml
+++ b/src/spindoctor/config_files/config_540_orchestrator.yaml
@@ -67,6 +67,30 @@ orchestrator:
     pinvh_rcond: 1.0e-9
     # Maximum |rotation| (deg) a 3-DoF result may take before rejection.
     max_allowed_rotation_deg: 5.0
+    # Body-witness veto: cross-technique guards on confident-wrong body
+    # locks the per-technique diagnostics cannot see (a disc / limb
+    # consensus that agreed at a shape-mismatched offset the pose-free
+    # blob contradicts, or a lone blob carrying the answer while the
+    # geometric technique on the same body self-flagged spurious).  The
+    # blob centroid's lit-hemisphere bias grows toward half phase and is
+    # re-modeled only once the coarse acquisition switches to the crescent
+    # template past it, so the two checks bracket its reliable-witness
+    # regime: the shape-lock check trusts the blob only below the low
+    # phase ceiling, the collapsed-regime check treats it as the haze-bias
+    # suspect only above the high phase floor.  The disagreement tolerance
+    # is the larger of the floor and a fraction of the body diameter;
+    # well-navigated frames hold the blob within ~1.5 px of the fused
+    # offset, while a shape lock or haze drag disagrees by 5 px and up.
+    body_witness_shape_lock_max_phase_deg: 60.0
+    body_witness_collapse_min_phase_deg: 90.0
+    body_witness_disagreement_floor_px: 4.0
+    body_witness_disagreement_frac: 0.03
+    # Mahalanobis-distance threshold the blob-vs-consensus disagreement must
+    # exceed under the combined covariance before the veto fires: the pixel
+    # floor above is a lower bound, this is the statistical gate so a low-SNR
+    # or small-body centroid whose large sigma makes the separation consistent
+    # with agreement is not vetoed on scatter alone.
+    body_witness_agreement_sigma: 2.0
     # Confidence/sigma requirements per confidence tier; max_sigma_px
     # null means no sigma requirement for that tier.
     tier_thresholds:

--- a/src/spindoctor/nav_model/nav_model_body.py
+++ b/src/spindoctor/nav_model/nav_model_body.py
@@ -735,6 +735,7 @@ class NavModelBody(NavModelBodyBase):
                 )
             limb_arc_emitted = False
             blob_min_px = max(BODY_BLOB_MIN_DIAMETER_PX, shape.min_blob_diameter_px)
+            blob_gate_ok = self._predicted_diameter_px >= blob_min_px and self._lit_pixel_count > 0
             if (
                 not suppress_shape_features
                 and limb_vertices >= LIMB_ARC_MIN_VERTICES
@@ -753,7 +754,7 @@ class NavModelBody(NavModelBodyBase):
                     )
                 )
                 limb_arc_emitted = True
-            elif self._predicted_diameter_px >= blob_min_px and self._lit_pixel_count > 0:
+            elif blob_gate_ok:
                 features.append(self._build_blob_feature(shape, context=context))
             else:
                 self._logger.debug(
@@ -768,6 +769,15 @@ class NavModelBody(NavModelBodyBase):
                     blob_min_px,
                     self._lit_pixel_count,
                 )
+
+            # Witness BODY_BLOB alongside a geometric limb (the disc, when
+            # emitted, only accompanies the limb).  The pose-free brightness
+            # centroid is a cross-check the ensemble body-witness veto reads to
+            # catch a geometric technique locked onto a mismatched shape.  It is
+            # superseded in the fuse (BodyBlobNav.runs_as_witness), so it does
+            # not dilute the geometric offset; only the veto consumes it.
+            if limb_arc_emitted and blob_gate_ok:
+                features.append(self._build_blob_feature(shape, context=context))
 
             if not suppress_shape_features and self._should_emit_disc(limb_arc_emitted):
                 features.append(self._build_disc_feature(shape))

--- a/src/spindoctor/nav_orchestrator/body_witness_veto.py
+++ b/src/spindoctor/nav_orchestrator/body_witness_veto.py
@@ -1,0 +1,340 @@
+"""Body-witness veto -- cross-technique guards on confident-wrong body locks.
+
+Two body failure modes converge cleanly and yet pass the ordinary ensemble
+gates, because the offending offset carries a coherent *systematic* bias no
+per-technique diagnostic can see:
+
+- **Shape lock.**  On a body whose real silhouette departs from the predicted
+  ellipsoid (mesh-level shape mismatch), the full-disc NCC
+  (:class:`~spindoctor.nav_technique.nav_technique_body_disc.BodyDiscCorrelateNav`)
+  and the limb fit
+  (:class:`~spindoctor.nav_technique.nav_technique_body_limb.BodyLimbNav`) both
+  lock onto the mismatched model and agree with each other at a multi-pixel
+  wrong offset, fusing to a high confidence.  The pose-free brightness centroid
+  (:class:`~spindoctor.nav_technique.nav_technique_body_blob.BodyBlobNav`) does
+  not chase the shape, so it disagrees by pixels -- the one signal that the
+  geometric lock is wrong.
+
+- **Collapsed regime.**  At extreme phase a forward-scattering haze crescent
+  defeats the disc correlation (it self-flags spurious) while dragging the
+  brightness centroid tens of pixels off the body center.  The lone surviving
+  blob then carries the fused answer at its structural cap, above the
+  acceptance gate.  The defeated disc still self-flags spurious *at a
+  position*: its coarse silhouette peak sits near the true center, so the
+  spurious result's offset is the witness -- when the high-phase blob disagrees
+  with it by pixels, the centroid was haze-dragged and the frame is declined.
+  A small or faint body whose disc merely fails to lock does not trip this: the
+  spurious disc there agrees with the blob (both found the same body), and
+  below half phase the centroid is a reliable geometric-center proxy anyway.
+
+Neither mode is visible inside a single technique's diagnostics, so the guard
+is cross-technique: it reads the pose-free blob against the geometric
+techniques. The blob is kept available by
+:attr:`~spindoctor.nav_technique.nav_technique.NavTechnique.runs_as_witness`
+even when a primary already covers the body, and is still superseded in the
+fuse. The brightness centroid tracks the geometric center at low phase, but its
+lit-hemisphere bias grows toward half phase and is re-modeled only once the
+coarse acquisition switches to the crescent template past it. The two checks
+therefore bracket the centroid's reliable-witness regime by phase: the
+shape-lock check trusts the blob as a witness only below a low phase ceiling,
+while the collapsed-regime check treats it as the haze-bias suspect only above
+a high phase floor. Both apply only to single-body frames, where no companion
+body corrupts the centroid and the whole-frame verdict maps to one body. Each
+disagreement is a Mahalanobis gate under the combined covariance with a
+body-scaled pixel floor as its lower bound, so a low-SNR centroid whose scatter
+is statistically consistent with the geometric position is not vetoed.
+"""
+
+from __future__ import annotations
+
+import math
+from enum import Enum, auto
+
+import numpy as np
+
+from spindoctor.nav_orchestrator.ensemble_observability import mahalanobis_distance
+from spindoctor.nav_technique.technique_result import NavTechniqueResult
+from spindoctor.support.types import NDArrayFloatType
+
+__all__ = ['BodyWitnessVeto', 'evaluate_body_witness_veto']
+
+_BLOB_TECHNIQUE = 'BodyBlobNav'
+_GEOMETRIC_BODY_TECHNIQUES = frozenset({'BodyDiscCorrelateNav', 'BodyLimbNav'})
+
+
+def _translation_block(covariance_px2: NDArrayFloatType) -> NDArrayFloatType:
+    """Return the ``(2, 2)`` translation block of a 2- or 3-DoF covariance."""
+    cov = np.asarray(covariance_px2, np.float64)
+    return np.ascontiguousarray(cov[:2, :2])
+
+
+def _significant_disagreement(
+    mu_a: tuple[float, float],
+    cov_a: NDArrayFloatType,
+    mu_b: tuple[float, float],
+    cov_b: NDArrayFloatType,
+    *,
+    floor_px: float,
+    frac: float,
+    extent_px: float,
+    agreement_sigma: float,
+    rcond: float,
+) -> bool:
+    """Return whether two body offsets disagree beyond noise.
+
+    The gate is two-sided so a noisy estimate cannot force a veto on scatter
+    alone: the Euclidean separation must clear the body-scaled pixel floor
+    ``max(floor_px, frac * extent_px)`` -- a lower bound that never vetoes a
+    sub-pixel disagreement however tight the covariances -- *and* the
+    Mahalanobis distance under the combined translation covariance must exceed
+    ``agreement_sigma``, so a low-SNR or small-body centroid whose large sigma
+    makes the separation statistically consistent with agreement is not vetoed.
+    """
+    euclidean_px = math.hypot(mu_a[0] - mu_b[0], mu_a[1] - mu_b[1])
+    if euclidean_px <= max(floor_px, frac * extent_px):
+        return False
+    distance = mahalanobis_distance(
+        np.asarray(mu_a, np.float64),
+        _translation_block(cov_a),
+        np.asarray(mu_b, np.float64),
+        _translation_block(cov_b),
+        rcond=rcond,
+    )
+    return distance > agreement_sigma
+
+
+class BodyWitnessVeto(Enum):
+    """Verdict of :func:`evaluate_body_witness_veto`.
+
+    - ``NONE``: no body-witness veto fires; the consensus stands.
+    - ``SHAPE_LOCK_SUSPECT``: a geometric body consensus is contradicted by the
+      pose-free blob witness on the same well-lit body -- the offset is
+      reported ``conflicted`` rather than a confident success.
+    - ``LONE_BLOB_COLLAPSED_REGIME``: the consensus rests solely on a high-phase
+      blob centroid that disagrees with the position of a sibling geometric
+      technique on the same body that self-flagged spurious -- the centroid was
+      haze-dragged, so the frame is declined (``failed``) rather than reported
+      as a lone-blob success.
+    """
+
+    NONE = auto()
+    SHAPE_LOCK_SUSPECT = auto()
+    LONE_BLOB_COLLAPSED_REGIME = auto()
+
+
+def _consensus_bodies(best_group: list[NavTechniqueResult]) -> frozenset[str]:
+    """Return the union of source bodies over the winning consensus group."""
+    bodies: set[str] = set()
+    for result in best_group:
+        bodies.update(result.source_bodies)
+    return frozenset(bodies)
+
+
+def _distinct_body_count(results: list[NavTechniqueResult]) -> int:
+    """Return the number of distinct bodies any body technique reported on.
+
+    Ring and star techniques leave ``source_bodies`` empty, so they do not
+    count.  A frame with more than one body is a multi-body frame, where a
+    companion body can corrupt a brightness centroid and the blob is not a
+    trustworthy position witness.
+    """
+    bodies: set[str] = set()
+    for result in results:
+        bodies.update(result.source_bodies)
+    return len(bodies)
+
+
+def _lone_blob_collapsed(
+    best_group: list[NavTechniqueResult],
+    results: list[NavTechniqueResult],
+    fused_offset_px: tuple[float, float],
+    fused_covariance_px2: NDArrayFloatType,
+    consensus_bodies: frozenset[str],
+    *,
+    min_phase_deg: float,
+    disagreement_floor_px: float,
+    disagreement_frac: float,
+    agreement_sigma: float,
+    rcond: float,
+) -> bool:
+    """Return whether the collapsed-regime lone-blob signature holds.
+
+    The winning consensus rests solely on the blob centroid, at least one
+    consensus blob is at the extreme phase (above ``min_phase_deg``) where a
+    forward-scattering haze can drag the centroid, and a sibling geometric
+    technique on a consensus body self-flagged spurious *at a position* that
+    disagrees significantly (see :func:`_significant_disagreement`) with the
+    fused blob offset -- the disc found the body while the haze dragged the
+    centroid away.  The spurious sibling self-flagged for a fit-consistency
+    reason, but its coarse silhouette peak still locates the body; the check
+    fails safe, since a wrong witness position only declines a frame rather
+    than reporting a bad offset.  A small or faint body whose spurious disc
+    agrees with the blob (both located the same body) does not trip this, and
+    neither does a moderate crescent whose blob remains accurate.
+    """
+    if not best_group:
+        return False
+    if any(result.technique_name != _BLOB_TECHNIQUE for result in best_group):
+        return False
+    high_phase_extents = [
+        float(getattr(result.diagnostics, 'body_extent_px', 0.0))
+        for result in best_group
+        if float(getattr(result.diagnostics, 'max_phase_angle_deg', 0.0)) > min_phase_deg
+    ]
+    if not high_phase_extents:
+        return False
+    extent_px = max(high_phase_extents)
+    for result in results:
+        if result.technique_name not in _GEOMETRIC_BODY_TECHNIQUES or not result.spurious:
+            continue
+        if not (result.source_bodies & consensus_bodies):
+            continue
+        if _significant_disagreement(
+            fused_offset_px,
+            fused_covariance_px2,
+            result.offset_px,
+            result.covariance_px2,
+            floor_px=disagreement_floor_px,
+            frac=disagreement_frac,
+            extent_px=extent_px,
+            agreement_sigma=agreement_sigma,
+            rcond=rcond,
+        ):
+            return True
+    return False
+
+
+def _shape_lock_suspect(
+    best_group: list[NavTechniqueResult],
+    results: list[NavTechniqueResult],
+    fused_offset_px: tuple[float, float],
+    fused_covariance_px2: NDArrayFloatType,
+    consensus_bodies: frozenset[str],
+    *,
+    max_phase_deg: float,
+    disagreement_floor_px: float,
+    disagreement_frac: float,
+    agreement_sigma: float,
+    rcond: float,
+) -> bool:
+    """Return whether a geometric body lock is contradicted by the blob witness.
+
+    Requires a geometric technique in the winning consensus and a non-spurious
+    blob witness on a consensus body, well-lit (phase at most ``max_phase_deg``)
+    so its centroid is a trustworthy position reference, whose offset disagrees
+    significantly (see :func:`_significant_disagreement`) with the fused offset.
+    The ceiling sits below half phase because the brightness centroid's
+    lit-hemisphere bias grows with phase and would otherwise disagree with a
+    correct geometric fit.
+    """
+    if not any(result.technique_name in _GEOMETRIC_BODY_TECHNIQUES for result in best_group):
+        return False
+    for result in results:
+        if result.technique_name != _BLOB_TECHNIQUE or result.spurious:
+            continue
+        if not (result.source_bodies & consensus_bodies):
+            continue
+        max_phase_angle_deg = float(getattr(result.diagnostics, 'max_phase_angle_deg', 0.0))
+        if max_phase_angle_deg > max_phase_deg:
+            continue
+        body_extent_px = float(getattr(result.diagnostics, 'body_extent_px', 0.0))
+        if _significant_disagreement(
+            result.offset_px,
+            result.covariance_px2,
+            fused_offset_px,
+            fused_covariance_px2,
+            floor_px=disagreement_floor_px,
+            frac=disagreement_frac,
+            extent_px=body_extent_px,
+            agreement_sigma=agreement_sigma,
+            rcond=rcond,
+        ):
+            return True
+    return False
+
+
+def evaluate_body_witness_veto(
+    best_group: list[NavTechniqueResult],
+    results: list[NavTechniqueResult],
+    fused_offset_px: tuple[float, float],
+    fused_covariance_px2: NDArrayFloatType,
+    *,
+    shape_lock_max_phase_deg: float,
+    collapse_min_phase_deg: float,
+    disagreement_floor_px: float,
+    disagreement_frac: float,
+    agreement_sigma: float,
+    rcond: float,
+) -> BodyWitnessVeto:
+    """Decide whether a body consensus is a confident-wrong lock to veto.
+
+    The two checks bracket the brightness centroid's reliable-witness regime.
+    The centroid tracks the geometric center at low phase, but its
+    lit-hemisphere bias grows toward half phase and is only re-modeled once the
+    coarse acquisition switches to the crescent template past it, so the
+    shape-lock check trusts the blob only below ``shape_lock_max_phase_deg``
+    while the collapsed-regime check treats it as the bias-prone suspect only
+    above ``collapse_min_phase_deg``.  Both checks apply only to single-body
+    frames: a companion body corrupts the brightness centroid, so on a
+    multi-body frame the blob is neither a trustworthy witness nor a reliably
+    attributable suspect, and the whole-frame verdict would mis-attribute one
+    body's outcome to another.
+
+    Parameters:
+        best_group: The winning consensus group the ensemble is about to fuse
+            and report.
+        results: Every per-technique result on the frame, including spurious
+            and fuse-superseded ones -- the full picture the veto reads.
+        fused_offset_px: The consensus fused offset ``(dv, du)``.
+        fused_covariance_px2: The consensus fused covariance; its translation
+            block enters the Mahalanobis disagreement gate.
+        shape_lock_max_phase_deg: Phase ceiling (degrees) below which the blob
+            centroid is a trustworthy position witness for the shape-lock check.
+        collapse_min_phase_deg: Phase floor (degrees) above which a lone blob is
+            the haze-bias-prone suspect for the collapsed-regime check.
+        disagreement_floor_px: Absolute floor of the cross-technique
+            disagreement tolerance (a lower bound on the gate).
+        disagreement_frac: Fraction of the body diameter added to the floor as
+            the cross-technique disagreement lower bound.
+        agreement_sigma: Mahalanobis-distance threshold the disagreement must
+            exceed under the combined covariance, so a large-sigma centroid
+            whose separation is statistically consistent is not vetoed.
+        rcond: rcond for the Mahalanobis pseudo-inverse.
+
+    Returns:
+        The :class:`BodyWitnessVeto` verdict; ``NONE`` when no guard fires.
+    """
+    consensus_bodies = _consensus_bodies(best_group)
+    if not consensus_bodies:
+        return BodyWitnessVeto.NONE
+    # The brightness centroid is trustworthy only on a single-body frame, where
+    # no companion corrupts it and the whole-frame verdict maps to one body.
+    if _distinct_body_count(results) != 1:
+        return BodyWitnessVeto.NONE
+    if _lone_blob_collapsed(
+        best_group,
+        results,
+        fused_offset_px,
+        fused_covariance_px2,
+        consensus_bodies,
+        min_phase_deg=collapse_min_phase_deg,
+        disagreement_floor_px=disagreement_floor_px,
+        disagreement_frac=disagreement_frac,
+        agreement_sigma=agreement_sigma,
+        rcond=rcond,
+    ):
+        return BodyWitnessVeto.LONE_BLOB_COLLAPSED_REGIME
+    if _shape_lock_suspect(
+        best_group,
+        results,
+        fused_offset_px,
+        fused_covariance_px2,
+        consensus_bodies,
+        max_phase_deg=shape_lock_max_phase_deg,
+        disagreement_floor_px=disagreement_floor_px,
+        disagreement_frac=disagreement_frac,
+        agreement_sigma=agreement_sigma,
+        rcond=rcond,
+    ):
+        return BodyWitnessVeto.SHAPE_LOCK_SUSPECT
+    return BodyWitnessVeto.NONE

--- a/src/spindoctor/nav_orchestrator/body_witness_veto.py
+++ b/src/spindoctor/nav_orchestrator/body_witness_veto.py
@@ -53,13 +53,43 @@ from enum import Enum, auto
 import numpy as np
 
 from spindoctor.nav_orchestrator.ensemble_observability import mahalanobis_distance
+from spindoctor.nav_technique.diagnostics import BodyBlobDiagnostics
 from spindoctor.nav_technique.technique_result import NavTechniqueResult
+from spindoctor.support.exceptions import NavContractError
 from spindoctor.support.types import NDArrayFloatType
 
 __all__ = ['BodyWitnessVeto', 'evaluate_body_witness_veto']
 
 _BLOB_TECHNIQUE = 'BodyBlobNav'
 _GEOMETRIC_BODY_TECHNIQUES = frozenset({'BodyDiscCorrelateNav', 'BodyLimbNav'})
+
+
+def _blob_diagnostics(result: NavTechniqueResult) -> BodyBlobDiagnostics:
+    """Return the ``BodyBlobDiagnostics`` a ``BodyBlobNav`` result must carry.
+
+    The veto only ever reads diagnostics off results it has already filtered to
+    :data:`_BLOB_TECHNIQUE`, so a blob result whose diagnostics are absent or of
+    the wrong type is a broken upstream contract, not a case to paper over with
+    defaults: silently reading a zero phase and zero extent would make a
+    malformed result look like a low-phase, zero-size witness and could bypass
+    the collapsed-regime veto or spuriously trip shape-lock detection.
+
+    Parameters:
+        result: A result whose ``technique_name`` is already ``BodyBlobNav``.
+
+    Returns:
+        The result's ``BodyBlobDiagnostics``.
+
+    Raises:
+        NavContractError: if the result carries no ``BodyBlobDiagnostics``.
+    """
+    diagnostics = result.diagnostics
+    if not isinstance(diagnostics, BodyBlobDiagnostics):
+        raise NavContractError(
+            f'{_BLOB_TECHNIQUE} result must carry BodyBlobDiagnostics, '
+            f'got {type(diagnostics).__name__}'
+        )
+    return diagnostics
 
 
 def _translation_block(covariance_px2: NDArrayFloatType) -> NDArrayFloatType:
@@ -177,9 +207,9 @@ def _lone_blob_collapsed(
     if any(result.technique_name != _BLOB_TECHNIQUE for result in best_group):
         return False
     high_phase_extents = [
-        float(getattr(result.diagnostics, 'body_extent_px', 0.0))
+        _blob_diagnostics(result).body_extent_px
         for result in best_group
-        if float(getattr(result.diagnostics, 'max_phase_angle_deg', 0.0)) > min_phase_deg
+        if _blob_diagnostics(result).max_phase_angle_deg > min_phase_deg
     ]
     if not high_phase_extents:
         return False
@@ -234,10 +264,10 @@ def _shape_lock_suspect(
             continue
         if not (result.source_bodies & consensus_bodies):
             continue
-        max_phase_angle_deg = float(getattr(result.diagnostics, 'max_phase_angle_deg', 0.0))
-        if max_phase_angle_deg > max_phase_deg:
+        diagnostics = _blob_diagnostics(result)
+        if diagnostics.max_phase_angle_deg > max_phase_deg:
             continue
-        body_extent_px = float(getattr(result.diagnostics, 'body_extent_px', 0.0))
+        body_extent_px = diagnostics.body_extent_px
         if _significant_disagreement(
             result.offset_px,
             result.covariance_px2,

--- a/src/spindoctor/nav_orchestrator/ensemble.py
+++ b/src/spindoctor/nav_orchestrator/ensemble.py
@@ -52,6 +52,10 @@ from spindoctor.feature.constants import (
     AGREEMENT_FACTOR_CAP,
     COMBINED_CONFIDENCE_CAP,
 )
+from spindoctor.nav_orchestrator.body_witness_veto import (
+    BodyWitnessVeto,
+    evaluate_body_witness_veto,
+)
 from spindoctor.nav_orchestrator.ensemble_consensus import (
     consensus_selection,
     corroborating_confidence,
@@ -92,6 +96,23 @@ DEFAULT_CONFLICTED_CONFIDENCE_MULTIPLIER = 0.3
 DEFAULT_MIN_CONFIDENCE = 0.35
 DEFAULT_PINVH_RCOND = 1.0e-9
 DEFAULT_MAX_ALLOWED_ROTATION_DEG = 5.0
+# Body-witness veto thresholds (see body_witness_veto).  The blob centroid's
+# lit-hemisphere bias grows toward half phase (and is re-modeled only once the
+# coarse acquisition switches to the crescent template past it), so the two
+# checks bracket the reliable-witness regime: the shape-lock check trusts the
+# blob only below the low phase ceiling, the collapsed-regime check treats it
+# as the haze-bias suspect only above the high phase floor.  The disagreement
+# tolerance is the larger of an absolute floor and a fraction of the body
+# diameter; well-navigated single-body frames hold the blob within ~1.5 px of
+# the fused offset, while a disc / limb shape lock disagrees by 5 px and up.
+DEFAULT_BODY_WITNESS_SHAPE_LOCK_MAX_PHASE_DEG = 60.0
+DEFAULT_BODY_WITNESS_COLLAPSE_MIN_PHASE_DEG = 90.0
+DEFAULT_BODY_WITNESS_DISAGREEMENT_FLOOR_PX = 4.0
+DEFAULT_BODY_WITNESS_DISAGREEMENT_FRAC = 0.03
+# Mahalanobis-distance threshold the blob-vs-consensus disagreement must exceed
+# under the combined covariance before the veto fires, so a large-sigma centroid
+# whose separation is statistically consistent is not vetoed on scatter alone.
+DEFAULT_BODY_WITNESS_AGREEMENT_SIGMA = 2.0
 # Tier confidence boundaries are sim-anchored (fitted 2026-07-18 on the
 # recalibrated simulated-scene campaign, with the #210 covariance
 # floors live and the ring truth vocabulary in the scene cohort): the
@@ -156,6 +177,20 @@ class EnsembleConfig:
             programming error upstream and raises ``NavContractError``.
         tier_thresholds: Mapping ``rank -> {min_confidence, max_sigma_px}``;
             see ``derive_confidence_rank``.
+        body_witness_shape_lock_max_phase_deg: Phase ceiling (degrees) below
+            which the pose-free brightness centroid is a trustworthy position
+            witness for the body shape-lock veto; the lit-hemisphere bias grows
+            toward half phase, so the ceiling sits below it.
+        body_witness_collapse_min_phase_deg: Phase floor (degrees) above which a
+            lone blob is the haze-bias-prone suspect for the collapsed-regime
+            veto.
+        body_witness_disagreement_floor_px: Absolute floor of the body-witness
+            veto's cross-technique disagreement tolerance (a lower bound).
+        body_witness_disagreement_frac: Fraction of the body diameter added to
+            the floor as the body-witness veto's disagreement lower bound.
+        body_witness_agreement_sigma: Mahalanobis-distance threshold the
+            disagreement must exceed under the combined covariance before the
+            body-witness veto fires.
     """
 
     agreement_sigma: float = DEFAULT_AGREEMENT_SIGMA
@@ -166,6 +201,11 @@ class EnsembleConfig:
     min_confidence: float = DEFAULT_MIN_CONFIDENCE
     pinvh_rcond: float = DEFAULT_PINVH_RCOND
     max_allowed_rotation_deg: float = DEFAULT_MAX_ALLOWED_ROTATION_DEG
+    body_witness_shape_lock_max_phase_deg: float = DEFAULT_BODY_WITNESS_SHAPE_LOCK_MAX_PHASE_DEG
+    body_witness_collapse_min_phase_deg: float = DEFAULT_BODY_WITNESS_COLLAPSE_MIN_PHASE_DEG
+    body_witness_disagreement_floor_px: float = DEFAULT_BODY_WITNESS_DISAGREEMENT_FLOOR_PX
+    body_witness_disagreement_frac: float = DEFAULT_BODY_WITNESS_DISAGREEMENT_FRAC
+    body_witness_agreement_sigma: float = DEFAULT_BODY_WITNESS_AGREEMENT_SIGMA
     tier_thresholds: dict[str, dict[str, float | None]] = field(
         default_factory=lambda: copy.deepcopy(DEFAULT_TIER_THRESHOLDS)
     )
@@ -759,6 +799,61 @@ def ensemble(
             provenance=provenance,
             per_technique=results,
             feature_inventory=feature_inventory,
+            model_metadata=md,
+            annotations=ann,
+        )
+    # Cross-technique body-witness veto: catch confident-wrong body locks the
+    # per-technique diagnostics cannot see -- a geometric consensus that agreed
+    # at a shape-mismatched offset the pose-free blob contradicts, or a lone
+    # blob carrying the answer in a regime where the geometric technique on the
+    # same body self-flagged spurious.
+    veto = evaluate_body_witness_veto(
+        best_group,
+        results,
+        combined.offset_px,
+        combined.covariance_px2,
+        shape_lock_max_phase_deg=cfg.body_witness_shape_lock_max_phase_deg,
+        collapse_min_phase_deg=cfg.body_witness_collapse_min_phase_deg,
+        disagreement_floor_px=cfg.body_witness_disagreement_floor_px,
+        disagreement_frac=cfg.body_witness_disagreement_frac,
+        agreement_sigma=cfg.body_witness_agreement_sigma,
+        rcond=cfg.pinvh_rcond,
+    )
+    if veto is BodyWitnessVeto.LONE_BLOB_COLLAPSED_REGIME:
+        IMAGE_LOGGER.info(
+            'Body-witness veto: the lone surviving body offset is the brightness '
+            'centroid while a geometric technique on the same body self-flagged '
+            'spurious; declining the frame (systematic photometric bias)'
+        )
+        return NavResult.failed(
+            status_reason=NavStatusReason.LONE_BLOB_IN_COLLAPSED_REGIME,
+            image_classifier=image_classifier,
+            provenance=provenance,
+            per_technique=results,
+            feature_inventory=feature_inventory,
+            model_metadata=md,
+            annotations=ann,
+        )
+    if veto is BodyWitnessVeto.SHAPE_LOCK_SUSPECT:
+        conflicted_confidence = combined_confidence * cfg.conflicted_confidence_multiplier
+        IMAGE_LOGGER.info(
+            'Body-witness veto: the geometric body consensus (%s) disagrees with '
+            'the pose-free blob witness by more than the shape-lock tolerance; '
+            'reporting conflicted (confidence %.3f)',
+            ', '.join(consensus_names),
+            conflicted_confidence,
+        )
+        return NavResult.conflicted(
+            offset_px=combined.offset_px,
+            covariance_px2=combined.covariance_px2,
+            confidence=conflicted_confidence,
+            per_technique=results,
+            feature_inventory=feature_inventory,
+            image_classifier=image_classifier,
+            provenance=provenance,
+            excluded_from_consensus=excluded_names,
+            consensus_techniques=consensus_names,
+            status_reason=NavStatusReason.BODY_SHAPE_LOCK_SUSPECT,
             model_metadata=md,
             annotations=ann,
         )

--- a/src/spindoctor/nav_orchestrator/ensemble.py
+++ b/src/spindoctor/nav_orchestrator/ensemble.py
@@ -230,6 +230,47 @@ class EnsembleConfig:
         default_factory=lambda: copy.deepcopy(DEFAULT_TIER_THRESHOLDS)
     )
 
+    def __post_init__(self) -> None:
+        """Reject body-witness thresholds that would misfire the veto.
+
+        Both direct construction and ``from_mapping`` land here, so a
+        non-finite value, a negative tolerance, an out-of-range phase, or an
+        inverted phase window is rejected the same way regardless of how the
+        config was built.  A negative Mahalanobis threshold, for instance,
+        would make nearly every separation veto-worthy.
+
+        Raises:
+            ValueError: if any body-witness threshold is non-finite, a
+                tolerance is negative, a phase falls outside ``[0, 180]``, or
+                the shape-lock ceiling is not below the collapse floor.
+        """
+        non_negative = {
+            'body_witness_disagreement_floor_px': self.body_witness_disagreement_floor_px,
+            'body_witness_disagreement_frac': self.body_witness_disagreement_frac,
+            'body_witness_agreement_sigma': self.body_witness_agreement_sigma,
+        }
+        for name, value in non_negative.items():
+            if not math.isfinite(value):
+                raise ValueError(f'{name} must be finite, got {value}')
+            if value < 0.0:
+                raise ValueError(f'{name} must be non-negative, got {value}')
+        phases = {
+            'body_witness_shape_lock_max_phase_deg': self.body_witness_shape_lock_max_phase_deg,
+            'body_witness_collapse_min_phase_deg': self.body_witness_collapse_min_phase_deg,
+        }
+        for name, value in phases.items():
+            if not math.isfinite(value):
+                raise ValueError(f'{name} must be finite, got {value}')
+            if not 0.0 <= value <= 180.0:
+                raise ValueError(f'{name} must lie in [0, 180] deg, got {value}')
+        if self.body_witness_shape_lock_max_phase_deg >= self.body_witness_collapse_min_phase_deg:
+            raise ValueError(
+                'body_witness_shape_lock_max_phase_deg '
+                f'({self.body_witness_shape_lock_max_phase_deg}) must be below '
+                'body_witness_collapse_min_phase_deg '
+                f'({self.body_witness_collapse_min_phase_deg})'
+            )
+
     @classmethod
     def from_mapping(cls, mapping: Mapping[str, Any] | None) -> 'EnsembleConfig':
         """Build an ``EnsembleConfig`` from a YAML-derived mapping.

--- a/src/spindoctor/nav_orchestrator/nav_result.py
+++ b/src/spindoctor/nav_orchestrator/nav_result.py
@@ -224,6 +224,7 @@ class NavResult:
         provenance: Provenance,
         excluded_from_consensus: list[str] | None = None,
         consensus_techniques: list[str] | None = None,
+        status_reason: NavStatusReason = NavStatusReason.CONFLICTED_TECHNIQUES,
         model_metadata: dict[str, dict[str, Any]] | None = None,
         annotations: Annotations | None = None,
     ) -> 'NavResult':
@@ -231,6 +232,9 @@ class NavResult:
 
         ``confidence_rank`` is hard-set to ``'conflicted'``; downstream
         consumers refuse to use these results without explicit opt-in.
+        ``status_reason`` defaults to the summed-confidence-gap conflict; a
+        cross-technique veto that reports its best group conflicted (for
+        example a suspected body shape lock) passes its own reason.
         """
         cov = np.asarray(covariance_px2, np.float64)
         sigma_dv = float(np.sqrt(max(cov[0, 0], 0.0)))
@@ -242,7 +246,7 @@ class NavResult:
             sigma_along_unobservable_px=None,
             confidence_rank='conflicted',
             confidence=confidence,
-            status_reason=NavStatusReason.CONFLICTED_TECHNIQUES,
+            status_reason=status_reason,
             covariance_px2=cov,
             per_technique=per_technique,
             feature_inventory=feature_inventory,

--- a/src/spindoctor/nav_orchestrator/orchestrator.py
+++ b/src/spindoctor/nav_orchestrator/orchestrator.py
@@ -845,7 +845,7 @@ class NavOrchestrator(NavBase):
                 continue
             technique = cls(config=self.config)
             available_features = features
-            if excluded_bodies and cls.tier == 'fallback':
+            if excluded_bodies and cls.tier == 'fallback' and not cls.runs_as_witness:
                 pre_filter_count = sum(
                     1 for f in features if f.feature_type in cls.accepts_feature_types
                 )

--- a/src/spindoctor/nav_orchestrator/status_reason_info.py
+++ b/src/spindoctor/nav_orchestrator/status_reason_info.py
@@ -22,6 +22,14 @@ STATUS_REASON_INFO_TEMPLATE: dict[NavStatusReason, list[str]] = {
         'Final: status=conflicted',
         'Best-vs-runner-up confidence gap below threshold',
     ],
+    NavStatusReason.BODY_SHAPE_LOCK_SUSPECT: [
+        'Final: status=conflicted',
+        'Geometric body lock contradicted by the pose-free blob witness',
+    ],
+    NavStatusReason.LONE_BLOB_IN_COLLAPSED_REGIME: [
+        'Final: status=failed',
+        'Lone blob centroid survived a body whose geometric fit self-flagged spurious',
+    ],
     NavStatusReason.NO_SIGNAL_IN_IMAGE: [
         'Final: status=failed',
         'Image classifier: blank / dark frame',

--- a/src/spindoctor/nav_technique/nav_technique.py
+++ b/src/spindoctor/nav_technique/nav_technique.py
@@ -256,6 +256,14 @@ class NavTechnique(NavBase, ABC):
     #: mis-converge on textured surfaces with no per-technique signal
     #: to detect the failure.
     tier: ClassVar[Literal['primary', 'fallback']] = 'primary'
+    #: If ``True``, this fallback technique still runs even when a
+    #: non-spurious primary already covers its source body, so its
+    #: pose-free estimate reaches the ensemble as an independent
+    #: cross-check.  The ensemble still supersedes it in the fuse
+    #: (``_drop_superseded_fallbacks``); only the body-witness veto reads
+    #: it, to catch a geometric technique that locked onto a wrong shape.
+    #: Ignored for primary-tier techniques, which always run.
+    runs_as_witness: ClassVar[bool] = False
     #: Confidence-formula spec consumed by ``evaluate_sigmoid_combination``.
     #: Loaded from ``config_510_techniques.yaml`` and assigned at
     #: ``Config.read_config`` time.  ``None`` for techniques that opt out

--- a/src/spindoctor/nav_technique/nav_technique_body_blob.py
+++ b/src/spindoctor/nav_technique/nav_technique_body_blob.py
@@ -699,6 +699,7 @@ class BodyBlobNav(NavTechnique):
     accepts_feature_types = frozenset({NavFeatureType.BODY_BLOB})
     requires_prior = False
     tier = 'fallback'
+    runs_as_witness = True
     confidence_attributes = frozenset(
         {
             'at_edge',

--- a/src/spindoctor/support/status_reason.py
+++ b/src/spindoctor/support/status_reason.py
@@ -30,6 +30,16 @@ class NavStatusReason(StrEnum):
     - ``CONFLICTED_TECHNIQUES``: multiple agreement groups exist after
       grouping and the best-vs-runner-up summed-confidence gap is below
       ``agreement_gap``; offset reported with reduced confidence.
+    - ``BODY_SHAPE_LOCK_SUSPECT``: a geometric body consensus (disc / limb)
+      agreed at a multi-pixel offset that the pose-free brightness centroid on
+      the same well-lit body contradicts, the signature of a lock onto a
+      mismatched shape; the offset is reported conflicted rather than as a
+      confident success.
+    - ``LONE_BLOB_IN_COLLAPSED_REGIME``: the only surviving body offset is the
+      brightness centroid while a sibling geometric technique on the same body
+      self-flagged spurious (a haze crescent or otherwise defeated disc); the
+      centroid carries a systematic photometric bias no diagnostic can see, so
+      the frame is declined rather than reported as a lone-blob success.
     - ``NO_SIGNAL_IN_IMAGE``: image classifier flagged a blank or dark frame.
     - ``IMAGE_OVEREXPOSED``: image classifier saw most pixels at full-well DN.
     - ``MISSING_DATA_DOMINANT``: image classifier saw too many missing-data
@@ -63,6 +73,8 @@ class NavStatusReason(StrEnum):
     OK = 'ok'
     RANK_1_ONLY = 'rank_1_only'
     CONFLICTED_TECHNIQUES = 'conflicted_techniques'
+    BODY_SHAPE_LOCK_SUSPECT = 'body_shape_lock_suspect'
+    LONE_BLOB_IN_COLLAPSED_REGIME = 'lone_blob_in_collapsed_regime'
     NO_SIGNAL_IN_IMAGE = 'no_signal_in_image'
     IMAGE_OVEREXPOSED = 'image_overexposed'
     MISSING_DATA_DOMINANT = 'missing_data_dominant'

--- a/tests/integration/sim_baselines/titan_crescent_horns.json
+++ b/tests/integration/sim_baselines/titan_crescent_horns.json
@@ -1,7 +1,7 @@
 {
-  "confidence": 0.4,
-  "offset_du_px": 29.26,
-  "offset_dv_px": 3.18,
+  "confidence": 0.0,
+  "offset_du_px": null,
+  "offset_dv_px": null,
   "scene_name": "titan_crescent_horns",
-  "status": "success"
+  "status": "failed"
 }

--- a/tests/integration/sim_baselines/titan_crescent_horns_noiseless.json
+++ b/tests/integration/sim_baselines/titan_crescent_horns_noiseless.json
@@ -1,7 +1,7 @@
 {
-  "confidence": 0.4,
-  "offset_du_px": 29.17,
-  "offset_dv_px": -0.36,
+  "confidence": 0.0,
+  "offset_du_px": null,
+  "offset_dv_px": null,
   "scene_name": "titan_crescent_horns_noiseless",
-  "status": "success"
+  "status": "failed"
 }

--- a/tests/integration/sim_scenes/atmosphere/titan_crescent_horns.yaml
+++ b/tests/integration/sim_scenes/atmosphere/titan_crescent_horns.yaml
@@ -33,23 +33,13 @@ offset_rotation_deg: 0.0
 # honestly computed reliability (visible-arc fraction ~1.0, the albedo penalty,
 # and the sin(155 deg) = 0.42 phase cap) it scores 0.26 against the 0.30
 # TERMINATOR_ARC reliability gate, so BodyBlobNav is the only surviving
-# technique.  Re-measured 2026-07-18 under the recalibrated formulas (seed
-# 20260718 campaign): the outcome PERSISTS -- a low-tier success at the
-# blob's 0.40 structural cap, ~30 px wrong (measured offset (3.18, 29.26)
-# vs planted (1.2, -0.8), fused sigma 4.25 px).  The recalibration
-# tightened the margin rather than closing the hole: the fused 0.40 now
-# sits 0.05 above the raised 0.35 ensemble gate (previously 0.20), and no
-# second technique remains to veto the haze-biased blob.  This scene is
-# standing ensemble-gap evidence: nothing in the blob's diagnostics can
-# see a systematic photometric bias, so only a cross-technique veto (or a
-# haze-aware blob model) can close it.  The low tier plus the
-# provisional-confidence marker remain the only flags.
-# known_offset_error_px is the honest pin: success/low is a documented
-# hazard, not an endorsement, and the measured fused error (30.13 px on
-# 2026-07-18) must stay inside its band -- silent improvement and
-# worsening both fail, so any change to this behavior is deliberate.
+# technique.  Its centroid carries a systematic photometric bias no blob
+# diagnostic can see, and the disc correlation on the same body self-flagged
+# spurious, so the lone-blob-in-collapsed-regime body-witness veto declines the
+# frame rather than reporting a low-tier success ~30 px wrong: a wrong offset
+# that passed the acceptance gate was worse than a declared failure.  This
+# scene asserts that decline -- a haze crescent whose only surviving
+# technique is the bias-prone centroid is correctly refused.
 expected:
-  status: success
-  confidence_tier: low
-  known_offset_error_px: 30.0
-  known_offset_error_tol_px: 4.0
+  status: failed
+  status_reason: lone_blob_in_collapsed_regime

--- a/tests/integration/sim_scenes/atmosphere/titan_crescent_horns_noiseless.yaml
+++ b/tests/integration/sim_scenes/atmosphere/titan_crescent_horns_noiseless.yaml
@@ -29,19 +29,14 @@ offset_rotation_deg: 0.0
 # See titan_crescent_horns: the ring of light drags the blob centroid ~30 px,
 # the disc correlation is spurious, and the terminator feature is dropped by
 # the reliability gate (0.26 vs the 0.30 threshold, the sin(155 deg) phase cap
-# doing most of the capping), leaving a low-tier blob-only success that is
-# roughly 30 px wrong -- no remaining technique vetoes it.  The noiseless twin
-# removes read/Poisson noise as a confound and pins the systematic bias itself
-# deterministically (recovered du ~29.2 vs planted -0.8): the haze alone, not
-# the noise, carries the answer that far.  Re-measured 2026-07-18 under the
-# recalibrated formulas: the outcome persists (fused 0.40 at the blob's
-# structural cap, now 0.05 above the raised 0.35 ensemble gate), so the
-# scene stands as ensemble-gap evidence alongside its noisy twin.
-# known_offset_error_px is the honest pin: the measured fused error
-# (30.01 px on 2026-07-18, deterministic in this noiseless twin) must
-# stay inside its band -- silent improvement and worsening both fail.
+# doing most of the capping), leaving the brightness centroid as the only
+# surviving technique.  The noiseless twin removes read/Poisson noise as a
+# confound and pins the systematic bias itself deterministically (recovered du
+# ~29.2 vs planted -0.8): the haze alone, not the noise, carries the answer
+# that far.  Because the disc correlation on the same body self-flagged
+# spurious, the lone-blob-in-collapsed-regime body-witness veto declines the
+# frame: the centroid's photometric bias is not reportable as a success.  The
+# deterministic twin asserts the decline is stable, not noise-dependent.
 expected:
-  status: success
-  confidence_tier: low
-  known_offset_error_px: 30.0
-  known_offset_error_tol_px: 4.0
+  status: failed
+  status_reason: lone_blob_in_collapsed_regime

--- a/tests/integration/sim_sweeps/irregularity_shape_mismatch.yaml
+++ b/tests/integration/sim_sweeps/irregularity_shape_mismatch.yaml
@@ -6,15 +6,15 @@ sweep_name: irregularity_shape_mismatch
 # predicted (smooth) one.  The recovered offset error -- the centroid bias the
 # ellipsoidal model cannot remove -- grows monotonically with irregularity, the
 # regime the phase_irregularity_factor term is meant to capture.  The walk runs
-# to 0.7 because the fused confidence is non-monotonic over this mesh
-# realization: it dips through the mid-range and re-saturates to 0.99 from
-# lumpiness 0.5 despite a 10+ px bias.  The 2026-07-18 recalibration measured
-# rather than fixed this: the campaign renders bodies at their published
-# shape-residual relief (lumpiness up to ~0.15), so the fitted formula has no
-# support beyond the physical range and the correlation diagnostics genuinely
-# carry no mismatch signal there -- standing ensemble-gap evidence (the
-# pose-free blob disagrees by pixels at the top of the walk; a cross-technique
-# veto, not a refit, is what could close it).
+# to 0.7 because the disc correlation and the limb fit both lock onto the
+# mismatched shape and agree at a multi-pixel wrong offset: the fused
+# confidence once re-saturated to 0.99 from lumpiness 0.5 despite a 10+ px
+# bias, a confident-wrong lock the correlation diagnostics carry no signal for.
+# The pose-free blob does not chase the shape, so the body-witness veto (see
+# the ensemble chapter) reports these mismatched steps conflicted; the
+# clean (zero-relief) step still recovers the planted offset sub-pixel and
+# stays a success, so the veto separates the shape lock from the legitimate
+# fit rather than blanketing the walk.
 base_scene: algorithmic_invariants/planted_offset_shapemismatch.yaml
 parameters: [bodies.0.mesh_lumpiness]
 values: [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]

--- a/tests/integration/test_sim_sweeps.py
+++ b/tests/integration/test_sim_sweeps.py
@@ -163,8 +163,7 @@ def test_irregularity_sweep_confidence_drops() -> None:
     confident success; every mismatched step sits below it.
     """
     rows = _rows('irregularity_shape_mismatch')
-    mismatched_min = min(row.confidence for row in rows[1:])
-    assert mismatched_min < rows[0].confidence
+    assert all(row.confidence < rows[0].confidence for row in rows[1:])
 
 
 def test_irregularity_sweep_extreme_mismatch_vetoed() -> None:

--- a/tests/integration/test_sim_sweeps.py
+++ b/tests/integration/test_sim_sweeps.py
@@ -159,18 +159,32 @@ def test_irregularity_sweep_confidence_drops() -> None:
     """Shape mismatch drops the fused confidence below the clean baseline.
 
     Introducing a predicted-shape mismatch pulls the fused confidence below the
-    clean (rows[0]) value somewhere in the sweep.  At the extreme mismatch the
-    fix becomes confidently wrong -- the disc correlation still locks onto the
-    blob and the confidence recovers even as the offset error grows to many
-    pixels -- so the assertion is on the confidence dip rather than a monotone
-    end-to-end drop (the same self-flag limitation the pose-disagreement sweep
-    documents).  The absolute confidence levels are sim-anchored and revisited
-    by the calibration refit; the render-robust signal here is that mismatch
-    degrades confidence at all.
+    clean (rows[0]) value somewhere in the sweep.  The clean step itself is a
+    confident success; every mismatched step sits below it.
     """
     rows = _rows('irregularity_shape_mismatch')
     mismatched_min = min(row.confidence for row in rows[1:])
     assert mismatched_min < rows[0].confidence
+
+
+def test_irregularity_sweep_extreme_mismatch_vetoed() -> None:
+    """At extreme mismatch the shape-lock veto reports conflicted, not success.
+
+    The disc correlation and the limb fit both lock onto the mismatched shape
+    and agree at a multi-pixel wrong offset that would otherwise fuse to a
+    confident success.  The pose-free blob does not chase the shape, so the
+    body-witness veto reports the extreme-mismatch step conflicted -- the
+    offset error is large (see ``test_irregularity_sweep_bias_grows``) yet does
+    not carry a confident-success tier.
+    """
+    rows = _rows('irregularity_shape_mismatch')
+    assert rows[-1].status == 'conflicted'
+
+
+def test_irregularity_sweep_clean_step_still_succeeds() -> None:
+    """The zero-relief step navigates cleanly: the veto does not blanket the sweep."""
+    rows = _rows('irregularity_shape_mismatch')
+    assert rows[0].status == 'success'
 
 
 def test_pose_disagreement_starts_clean() -> None:

--- a/tests/spindoctor/nav_model/test_nav_model_body_integration.py
+++ b/tests/spindoctor/nav_model/test_nav_model_body_integration.py
@@ -202,6 +202,38 @@ def test_to_features_emits_disc_alongside_limb_when_visibility_high(
     assert disc.template_mask is not None
 
 
+def test_to_features_co_emits_witness_blob_with_limb_and_disc(fake_obs: FakeObs) -> None:
+    """A resolved body co-emits BODY_BLOB alongside LIMB_ARC and BODY_DISC.
+
+    This is the reachability proof for the ensemble body-witness veto: on the
+    real (SPICE-backed) NavModelBody a single resolved body must yield the
+    geometric limb / disc AND the pose-free witness blob together, so the veto
+    has an independent cross-check to read on real frames rather than only on
+    the co-emitting simulated model.
+    """
+    model = _build_body(
+        obs=fake_obs,
+        km_per_pixel_at_limb=10.0,
+        visible_lit_fraction=BODY_DISC_MIN_VISIBLE_LIT_FRACTION + 0.1,
+        overflow_fraction=BODY_DISC_MAX_OVERFLOW_FRACTION - 0.1,
+    )
+    types = {f.feature_type for f in model.to_features(bare_nav_context(fake_obs))}
+    assert NavFeatureType.LIMB_ARC in types
+    assert NavFeatureType.BODY_DISC in types
+    assert NavFeatureType.BODY_BLOB in types
+
+
+def test_to_features_witness_blob_is_singular_with_limb(fake_obs: FakeObs) -> None:
+    """Exactly one BODY_BLOB is emitted alongside the limb (no duplicate feature)."""
+    model = _build_body(obs=fake_obs, km_per_pixel_at_limb=10.0)
+    blobs = [
+        f
+        for f in model.to_features(bare_nav_context(fake_obs))
+        if f.feature_type is NavFeatureType.BODY_BLOB
+    ]
+    assert len(blobs) == 1
+
+
 def test_to_features_skips_disc_when_overflow_high(fake_obs: FakeObs) -> None:
     """A body with too much overflow does not emit BODY_DISC."""
     model = _build_body(

--- a/tests/spindoctor/nav_model/test_nav_model_body_shape_gating.py
+++ b/tests/spindoctor/nav_model/test_nav_model_body_shape_gating.py
@@ -134,7 +134,14 @@ def test_irregular_body_emits_limb_when_resolved() -> None:
     assert NavFeatureType.LIMB_ARC in _emitted_types(model)
 
 
-def test_irregular_resolved_emits_no_blob_when_limb_present() -> None:
-    """The irregular path is unchanged: a resolved Phoebe emits LIMB_ARC, not BODY_BLOB."""
+def test_irregular_resolved_emits_witness_blob_with_limb() -> None:
+    """A resolved Phoebe emits its LIMB_ARC and a witness BODY_BLOB alongside it."""
     model = _make_body_model(body_name='PHOEBE', diameter_px=40.0)
-    assert NavFeatureType.BODY_BLOB not in _emitted_types(model)
+    types = _emitted_types(model)
+    assert NavFeatureType.LIMB_ARC in types
+
+
+def test_irregular_resolved_co_emits_blob_witness() -> None:
+    """The witness blob is co-emitted so the body-witness veto is reachable."""
+    model = _make_body_model(body_name='PHOEBE', diameter_px=40.0)
+    assert NavFeatureType.BODY_BLOB in _emitted_types(model)

--- a/tests/spindoctor/nav_orchestrator/test_body_witness_veto.py
+++ b/tests/spindoctor/nav_orchestrator/test_body_witness_veto.py
@@ -7,6 +7,7 @@ veto.
 """
 
 import numpy as np
+import pytest
 
 from spindoctor.nav_orchestrator.body_witness_veto import (
     BodyWitnessVeto,
@@ -19,6 +20,7 @@ from spindoctor.nav_technique.diagnostics import (
     NavTechniqueDiagnostics,
 )
 from spindoctor.nav_technique.technique_result import NavTechniqueResult
+from spindoctor.support.exceptions import NavContractError
 
 _SHAPE_LOCK_MAX_PHASE_DEG = 60.0
 _COLLAPSE_MIN_PHASE_DEG = 90.0
@@ -38,7 +40,20 @@ def _result(
     cov: np.ndarray | None = None,
     diagnostics: NavTechniqueDiagnostics | None = None,
 ) -> NavTechniqueResult:
-    """Build a minimal NavTechniqueResult for veto tests."""
+    """Build a minimal NavTechniqueResult for veto tests.
+
+    Parameters:
+        technique_name: Name the result reports as its producing technique.
+        offset: Predicted ``(dv, du)`` offset in pixels.
+        source_bodies: Bodies the result claims to have navigated.
+        spurious: Whether the result self-flagged spurious.
+        cov: Translation covariance; a tight default is used when None.
+        diagnostics: Per-technique diagnostics; a bare ``BodyLimbDiagnostics``
+            is used when None.
+
+    Returns:
+        The assembled ``NavTechniqueResult``.
+    """
     return NavTechniqueResult(
         technique_name=technique_name,
         feature_ids=(f'{technique_name}:f1',),
@@ -61,7 +76,19 @@ def _blob(
     spurious: bool = False,
     cov: np.ndarray | None = None,
 ) -> NavTechniqueResult:
-    """Build a BodyBlobNav witness result."""
+    """Build a BodyBlobNav witness result.
+
+    Parameters:
+        offset: Predicted ``(dv, du)`` blob-centroid offset in pixels.
+        body: The single body the blob witnesses.
+        phase_deg: Maximum phase angle carried on the blob diagnostics.
+        extent_px: Predicted body extent carried on the blob diagnostics.
+        spurious: Whether the blob result self-flagged spurious.
+        cov: Translation covariance; a tight default is used when None.
+
+    Returns:
+        A ``NavTechniqueResult`` carrying ``BodyBlobDiagnostics``.
+    """
     return _result(
         technique_name='BodyBlobNav',
         offset=offset,
@@ -78,7 +105,18 @@ def _evaluate(
     fused_offset: tuple[float, float],
     fused_cov: np.ndarray | None = None,
 ) -> BodyWitnessVeto:
-    """Call the veto with the module's default thresholds."""
+    """Call the veto with the module's default thresholds.
+
+    Parameters:
+        best_group: The winning consensus group of technique results.
+        results: All per-technique results available to the veto.
+        fused_offset: The ensemble's fused ``(dv, du)`` offset in pixels.
+        fused_cov: The fused translation covariance; a tight default is used
+            when None.
+
+    Returns:
+        The ``BodyWitnessVeto`` verdict for the scene.
+    """
     return evaluate_body_witness_veto(
         best_group,
         results,
@@ -204,6 +242,23 @@ def test_lone_blob_collapsed_fires_when_high_phase_blob_disagrees() -> None:
     blob = _blob(offset=(3.2, 29.3), body='TITAN', phase_deg=155.0, extent_px=170.0)
     verdict = _evaluate([blob], [disc, blob], (3.2, 29.3))
     assert verdict is BodyWitnessVeto.LONE_BLOB_COLLAPSED_REGIME
+
+
+def test_blob_result_without_blob_diagnostics_raises_contract_error() -> None:
+    """A BodyBlobNav result must carry BodyBlobDiagnostics, not a default.
+
+    Reading a zero phase and zero extent off a malformed blob would make it look
+    like a low-phase, zero-size witness and could bypass the collapsed-regime
+    veto, so the contract fails loudly instead.
+    """
+    bad_blob = _result(
+        technique_name='BodyBlobNav',
+        offset=(3.2, 29.3),
+        source_bodies=frozenset({'TITAN'}),
+        diagnostics=BodyLimbDiagnostics(),
+    )
+    with pytest.raises(NavContractError, match='must carry BodyBlobDiagnostics'):
+        _evaluate([bad_blob], [bad_blob], (3.2, 29.3))
 
 
 def test_lone_blob_not_vetoed_when_spurious_disc_agrees() -> None:

--- a/tests/spindoctor/nav_orchestrator/test_body_witness_veto.py
+++ b/tests/spindoctor/nav_orchestrator/test_body_witness_veto.py
@@ -1,0 +1,277 @@
+"""Tests for ``spindoctor.nav_orchestrator.body_witness_veto``.
+
+The veto is pure logic over already-computed per-technique results, so it is
+tested here directly (no rendering) with synthetic results that reproduce the
+two confident-wrong body signatures and the legitimate cases that must NOT
+veto.
+"""
+
+import numpy as np
+
+from spindoctor.nav_orchestrator.body_witness_veto import (
+    BodyWitnessVeto,
+    evaluate_body_witness_veto,
+)
+from spindoctor.nav_technique.diagnostics import (
+    BodyBlobDiagnostics,
+    BodyDiscDiagnostics,
+    BodyLimbDiagnostics,
+    NavTechniqueDiagnostics,
+)
+from spindoctor.nav_technique.technique_result import NavTechniqueResult
+
+_SHAPE_LOCK_MAX_PHASE_DEG = 60.0
+_COLLAPSE_MIN_PHASE_DEG = 90.0
+_FLOOR_PX = 4.0
+_FRAC = 0.03
+_AGREEMENT_SIGMA = 2.0
+_RCOND = 1.0e-9
+_TIGHT_COV = np.eye(2, dtype=np.float64) * 0.25
+
+
+def _result(
+    *,
+    technique_name: str,
+    offset: tuple[float, float],
+    source_bodies: frozenset[str],
+    spurious: bool = False,
+    cov: np.ndarray | None = None,
+    diagnostics: NavTechniqueDiagnostics | None = None,
+) -> NavTechniqueResult:
+    """Build a minimal NavTechniqueResult for veto tests."""
+    return NavTechniqueResult(
+        technique_name=technique_name,
+        feature_ids=(f'{technique_name}:f1',),
+        offset_px=offset,
+        covariance_px2=_TIGHT_COV if cov is None else cov,
+        confidence=0.8,
+        spurious=spurious,
+        at_edge=False,
+        diagnostics=diagnostics if diagnostics is not None else BodyLimbDiagnostics(),
+        source_bodies=source_bodies,
+    )
+
+
+def _blob(
+    *,
+    offset: tuple[float, float],
+    body: str,
+    phase_deg: float = 30.0,
+    extent_px: float = 150.0,
+    spurious: bool = False,
+    cov: np.ndarray | None = None,
+) -> NavTechniqueResult:
+    """Build a BodyBlobNav witness result."""
+    return _result(
+        technique_name='BodyBlobNav',
+        offset=offset,
+        source_bodies=frozenset({body}),
+        spurious=spurious,
+        cov=cov,
+        diagnostics=BodyBlobDiagnostics(body_extent_px=extent_px, max_phase_angle_deg=phase_deg),
+    )
+
+
+def _evaluate(
+    best_group: list[NavTechniqueResult],
+    results: list[NavTechniqueResult],
+    fused_offset: tuple[float, float],
+    fused_cov: np.ndarray | None = None,
+) -> BodyWitnessVeto:
+    """Call the veto with the module's default thresholds."""
+    return evaluate_body_witness_veto(
+        best_group,
+        results,
+        fused_offset,
+        _TIGHT_COV if fused_cov is None else fused_cov,
+        shape_lock_max_phase_deg=_SHAPE_LOCK_MAX_PHASE_DEG,
+        collapse_min_phase_deg=_COLLAPSE_MIN_PHASE_DEG,
+        disagreement_floor_px=_FLOOR_PX,
+        disagreement_frac=_FRAC,
+        agreement_sigma=_AGREEMENT_SIGMA,
+        rcond=_RCOND,
+    )
+
+
+def test_shape_lock_fires_when_blob_contradicts_geometric_consensus() -> None:
+    """A geometric lock the low-phase blob disagrees with reports shape-lock."""
+    disc = _result(
+        technique_name='BodyDiscCorrelateNav',
+        offset=(-14.5, -6.5),
+        source_bodies=frozenset({'HYPERION'}),
+        diagnostics=BodyDiscDiagnostics(),
+    )
+    limb = _result(
+        technique_name='BodyLimbNav', offset=(-14.5, -7.5), source_bodies=frozenset({'HYPERION'})
+    )
+    blob = _blob(offset=(-3.8, -3.1), body='HYPERION')
+    verdict = _evaluate([disc, limb], [disc, limb, blob], (-14.5, -7.0))
+    assert verdict is BodyWitnessVeto.SHAPE_LOCK_SUSPECT
+
+
+def test_shape_lock_silent_when_blob_agrees() -> None:
+    """A well-matched body whose blob agrees is not vetoed."""
+    disc = _result(
+        technique_name='BodyDiscCorrelateNav',
+        offset=(1.4, -0.6),
+        source_bodies=frozenset({'HYPERION'}),
+        diagnostics=BodyDiscDiagnostics(),
+    )
+    blob = _blob(offset=(1.4, -0.5), body='HYPERION')
+    verdict = _evaluate([disc], [disc, blob], (1.4, -0.6))
+    assert verdict is BodyWitnessVeto.NONE
+
+
+def test_shape_lock_silent_when_blob_sigma_makes_separation_insignificant() -> None:
+    """A noisy blob whose large sigma makes the pixel separation statistically
+    consistent with agreement is not vetoed, even past the pixel floor."""
+    disc = _result(
+        technique_name='BodyDiscCorrelateNav',
+        offset=(-14.5, -6.5),
+        source_bodies=frozenset({'HYPERION'}),
+        diagnostics=BodyDiscDiagnostics(),
+    )
+    # A 100 px-variance (10 px sigma) centroid puts the ~11 px separation at
+    # ~1.1 sigma -- below the 2.0 Mahalanobis gate.
+    blob = _blob(offset=(-3.8, -3.1), body='HYPERION', cov=np.eye(2, dtype=np.float64) * 100.0)
+    verdict = _evaluate([disc], [disc, blob], (-14.5, -6.5))
+    assert verdict is BodyWitnessVeto.NONE
+
+
+def test_shape_lock_silent_when_blob_is_high_phase() -> None:
+    """Past half phase the blob is not a trustworthy witness, so no veto fires."""
+    disc = _result(
+        technique_name='BodyDiscCorrelateNav',
+        offset=(-14.5, -6.5),
+        source_bodies=frozenset({'HYPERION'}),
+        diagnostics=BodyDiscDiagnostics(),
+    )
+    blob = _blob(offset=(-3.8, -3.1), body='HYPERION', phase_deg=155.0)
+    verdict = _evaluate([disc], [disc, blob], (-14.5, -6.5))
+    assert verdict is BodyWitnessVeto.NONE
+
+
+def test_shape_lock_silent_on_multi_body_frame() -> None:
+    """A companion body corrupts the centroid, so multi-body frames are exempt."""
+    disc = _result(
+        technique_name='BodyDiscCorrelateNav',
+        offset=(-14.5, -6.5),
+        source_bodies=frozenset({'RHEA'}),
+        diagnostics=BodyDiscDiagnostics(),
+    )
+    blob_a = _blob(offset=(-3.8, -3.1), body='RHEA')
+    blob_b = _blob(offset=(0.0, 0.0), body='DIONE')
+    verdict = _evaluate([disc], [disc, blob_a, blob_b], (-14.5, -6.5))
+    assert verdict is BodyWitnessVeto.NONE
+
+
+def test_shape_lock_silent_when_witness_is_spurious() -> None:
+    """A spurious blob witness carries no disagreement signal."""
+    disc = _result(
+        technique_name='BodyDiscCorrelateNav',
+        offset=(-14.5, -6.5),
+        source_bodies=frozenset({'HYPERION'}),
+        diagnostics=BodyDiscDiagnostics(),
+    )
+    blob = _blob(offset=(-3.8, -3.1), body='HYPERION', spurious=True)
+    verdict = _evaluate([disc], [disc, blob], (-14.5, -6.5))
+    assert verdict is BodyWitnessVeto.NONE
+
+
+def test_shape_lock_tolerance_scales_with_body_diameter() -> None:
+    """A disagreement under the diameter-scaled tolerance does not veto."""
+    disc = _result(
+        technique_name='BodyDiscCorrelateNav',
+        offset=(0.0, 0.0),
+        source_bodies=frozenset({'BIGMOON'}),
+        diagnostics=BodyDiscDiagnostics(),
+    )
+    # 5 px disagreement clears the 4 px floor but is under 0.03 * 400 = 12 px.
+    blob = _blob(offset=(5.0, 0.0), body='BIGMOON', extent_px=400.0)
+    verdict = _evaluate([disc], [disc, blob], (0.0, 0.0))
+    assert verdict is BodyWitnessVeto.NONE
+
+
+def test_lone_blob_collapsed_fires_when_high_phase_blob_disagrees() -> None:
+    """A haze-dragged high-phase blob far from the spurious disc declines the frame."""
+    disc = _result(
+        technique_name='BodyDiscCorrelateNav',
+        offset=(0.5, 0.5),
+        source_bodies=frozenset({'TITAN'}),
+        spurious=True,
+        diagnostics=BodyDiscDiagnostics(),
+    )
+    blob = _blob(offset=(3.2, 29.3), body='TITAN', phase_deg=155.0, extent_px=170.0)
+    verdict = _evaluate([blob], [disc, blob], (3.2, 29.3))
+    assert verdict is BodyWitnessVeto.LONE_BLOB_COLLAPSED_REGIME
+
+
+def test_lone_blob_not_vetoed_when_spurious_disc_agrees() -> None:
+    """A small body whose spurious disc agrees with the blob is a legitimate success."""
+    disc = _result(
+        technique_name='BodyDiscCorrelateNav',
+        offset=(1.5, -0.5),
+        source_bodies=frozenset({'RHEA'}),
+        spurious=True,
+        diagnostics=BodyDiscDiagnostics(),
+    )
+    blob = _blob(offset=(1.5, -0.5), body='RHEA', phase_deg=120.0, extent_px=20.0)
+    verdict = _evaluate([blob], [disc, blob], (1.5, -0.5))
+    assert verdict is BodyWitnessVeto.NONE
+
+
+def test_lone_blob_not_vetoed_when_blob_is_low_phase() -> None:
+    """Below half phase the centroid is reliable even if it disagrees with a spurious disc."""
+    disc = _result(
+        technique_name='BodyDiscCorrelateNav',
+        offset=(0.0, 0.0),
+        source_bodies=frozenset({'ENCELADUS'}),
+        spurious=True,
+        diagnostics=BodyDiscDiagnostics(),
+    )
+    blob = _blob(offset=(20.0, 0.0), body='ENCELADUS', phase_deg=35.0, extent_px=8.0)
+    verdict = _evaluate([blob], [disc, blob], (20.0, 0.0))
+    assert verdict is BodyWitnessVeto.NONE
+
+
+def test_lone_blob_collapsed_silent_on_multi_body_frame() -> None:
+    """A multi-body frame is exempt: a correct joint blob fit is not declined."""
+    disc = _result(
+        technique_name='BodyDiscCorrelateNav',
+        offset=(0.5, 0.5),
+        source_bodies=frozenset({'TITAN'}),
+        spurious=True,
+        diagnostics=BodyDiscDiagnostics(),
+    )
+    blob_a = _blob(offset=(3.2, 29.3), body='TITAN', phase_deg=155.0, extent_px=170.0)
+    blob_b = _blob(offset=(3.2, 29.3), body='RHEA', phase_deg=150.0, extent_px=90.0)
+    verdict = _evaluate([blob_a, blob_b], [disc, blob_a, blob_b], (3.2, 29.3))
+    assert verdict is BodyWitnessVeto.NONE
+
+
+def test_lone_blob_not_vetoed_without_spurious_sibling() -> None:
+    """A legitimate blob-only success (no geometric technique ran) is not vetoed."""
+    blob = _blob(offset=(1.0, -0.5), body='PHOEBE', phase_deg=155.0)
+    verdict = _evaluate([blob], [blob], (1.0, -0.5))
+    assert verdict is BodyWitnessVeto.NONE
+
+
+def test_lone_blob_not_vetoed_when_spurious_sibling_is_other_body() -> None:
+    """A spurious geometric result on a different body does not veto the blob."""
+    disc = _result(
+        technique_name='BodyDiscCorrelateNav',
+        offset=(0.5, 0.5),
+        source_bodies=frozenset({'RHEA'}),
+        spurious=True,
+        diagnostics=BodyDiscDiagnostics(),
+    )
+    blob = _blob(offset=(1.0, -0.5), body='PHOEBE', phase_deg=155.0)
+    verdict = _evaluate([blob], [disc, blob], (1.0, -0.5))
+    assert verdict is BodyWitnessVeto.NONE
+
+
+def test_no_veto_for_bodyless_consensus() -> None:
+    """A consensus with no source bodies (ring / star) is never body-vetoed."""
+    ring = _result(technique_name='RingEdgeNav', offset=(2.0, 1.0), source_bodies=frozenset())
+    verdict = _evaluate([ring], [ring], (2.0, 1.0))
+    assert verdict is BodyWitnessVeto.NONE

--- a/tests/spindoctor/nav_orchestrator/test_ensemble.py
+++ b/tests/spindoctor/nav_orchestrator/test_ensemble.py
@@ -1663,3 +1663,30 @@ def test_ensemble_untagged_results_unchanged_by_lineage_logic() -> None:
     assert result.consensus_techniques == ['TechniqueA', 'TechniqueB']
     # Two independent members still earn the 2-member agreement factor.
     assert result.confidence == pytest.approx(0.99)
+
+
+def test_config_rejects_negative_body_witness_agreement_sigma() -> None:
+    """A negative Mahalanobis threshold would veto nearly every separation."""
+    with pytest.raises(ValueError, match='body_witness_agreement_sigma must be non-negative'):
+        EnsembleConfig(body_witness_agreement_sigma=-1.0)
+
+
+def test_config_rejects_non_finite_body_witness_disagreement_floor() -> None:
+    """A non-finite disagreement floor is rejected rather than silently accepted."""
+    with pytest.raises(ValueError, match='body_witness_disagreement_floor_px must be finite'):
+        EnsembleConfig(body_witness_disagreement_floor_px=float('inf'))
+
+
+def test_config_rejects_out_of_range_shape_lock_phase() -> None:
+    """A phase ceiling outside [0, 180] deg is rejected."""
+    with pytest.raises(ValueError, match=r'body_witness_shape_lock_max_phase_deg must lie'):
+        EnsembleConfig(body_witness_shape_lock_max_phase_deg=200.0)
+
+
+def test_config_rejects_inverted_phase_window() -> None:
+    """The shape-lock ceiling must sit below the collapse floor."""
+    with pytest.raises(ValueError, match='must be below'):
+        EnsembleConfig(
+            body_witness_shape_lock_max_phase_deg=95.0,
+            body_witness_collapse_min_phase_deg=90.0,
+        )

--- a/tests/spindoctor/nav_orchestrator/test_ensemble.py
+++ b/tests/spindoctor/nav_orchestrator/test_ensemble.py
@@ -14,6 +14,8 @@ from spindoctor.nav_orchestrator.ensemble import (
 from spindoctor.nav_orchestrator.image_classifier_result import NavImageClassifierResult
 from spindoctor.nav_orchestrator.provenance import Provenance
 from spindoctor.nav_technique.diagnostics import (
+    BodyBlobDiagnostics,
+    BodyDiscDiagnostics,
     BodyLimbDiagnostics,
     NavTechniqueDiagnostics,
     StarRefineDiagnostics,
@@ -788,11 +790,19 @@ def test_ensemble_drops_blob_when_disc_succeeds_for_same_body() -> None:
         offset=(2.0, 3.0),
         confidence=0.6,
     )
-    blob = _body_feature_result(
+    # The blob sits far from the disc so a fused answer would be pulled off (2, 3);
+    # its high phase keeps the shape-lock witness veto from firing, isolating the
+    # supersession drop as the only reason it leaves the fuse.
+    blob = NavTechniqueResult(
         technique_name='BodyBlobNav',
-        feature_id='body_blob:MIMAS',
-        offset=(20.0, 30.0),
+        feature_ids=('body_blob:MIMAS',),
+        offset_px=(20.0, 30.0),
+        covariance_px2=np.eye(2, dtype=np.float64) * 0.25,
         confidence=0.4,
+        spurious=False,
+        at_edge=False,
+        diagnostics=BodyBlobDiagnostics(body_extent_px=80.0, max_phase_angle_deg=155.0),
+        source_bodies=frozenset({'MIMAS'}),
     )
     result = ensemble(
         [disc, blob],
@@ -1386,6 +1396,74 @@ def test_ensemble_descendant_backed_runner_up_has_no_quorum() -> None:
     # outlier-rejected instead.
     assert result.status == 'success'
     assert result.excluded_from_consensus == ['TechniqueB', 'StarRefineNav']
+
+
+def test_ensemble_shape_lock_veto_reports_conflicted() -> None:
+    """A geometric consensus the low-phase blob contradicts is reported conflicted."""
+    disc = NavTechniqueResult(
+        technique_name='BodyDiscCorrelateNav',
+        feature_ids=('disc:HYPERION',),
+        offset_px=(-14.5, -6.5),
+        covariance_px2=np.eye(2, dtype=np.float64) * 0.25,
+        confidence=0.8,
+        spurious=False,
+        at_edge=False,
+        diagnostics=BodyDiscDiagnostics(),
+        source_bodies=frozenset({'HYPERION'}),
+    )
+    blob = NavTechniqueResult(
+        technique_name='BodyBlobNav',
+        feature_ids=('blob:HYPERION',),
+        offset_px=(-3.8, -3.1),
+        covariance_px2=np.eye(2, dtype=np.float64) * 4.0,
+        confidence=0.4,
+        spurious=False,
+        at_edge=False,
+        diagnostics=BodyBlobDiagnostics(body_extent_px=150.0, max_phase_angle_deg=30.0),
+        source_bodies=frozenset({'HYPERION'}),
+    )
+    result = ensemble(
+        [disc, blob],
+        feature_inventory=[],
+        image_classifier=_classifier(),
+        provenance=_provenance(),
+    )
+    assert result.status == 'conflicted'
+    assert result.status_reason.value == 'body_shape_lock_suspect'
+
+
+def test_ensemble_lone_blob_collapsed_regime_veto_reports_failed() -> None:
+    """A lone blob with a spurious geometric sibling on the same body fails."""
+    disc = NavTechniqueResult(
+        technique_name='BodyDiscCorrelateNav',
+        feature_ids=('disc:TITAN',),
+        offset_px=(0.5, 0.5),
+        covariance_px2=np.eye(2, dtype=np.float64) * 0.25,
+        confidence=0.0,
+        spurious=True,
+        at_edge=False,
+        diagnostics=BodyDiscDiagnostics(),
+        source_bodies=frozenset({'TITAN'}),
+    )
+    blob = NavTechniqueResult(
+        technique_name='BodyBlobNav',
+        feature_ids=('blob:TITAN',),
+        offset_px=(3.2, 29.3),
+        covariance_px2=np.eye(2, dtype=np.float64) * 4.0,
+        confidence=0.4,
+        spurious=False,
+        at_edge=False,
+        diagnostics=BodyBlobDiagnostics(body_extent_px=170.0, max_phase_angle_deg=155.0),
+        source_bodies=frozenset({'TITAN'}),
+    )
+    result = ensemble(
+        [disc, blob],
+        feature_inventory=[],
+        image_classifier=_classifier(),
+        provenance=_provenance(),
+    )
+    assert result.status == 'failed'
+    assert result.status_reason.value == 'lone_blob_in_collapsed_regime'
 
 
 def test_ensemble_untagged_results_unchanged_by_lineage_logic() -> None:

--- a/tests/spindoctor/support/test_status_reason.py
+++ b/tests/spindoctor/support/test_status_reason.py
@@ -34,8 +34,8 @@ def test_navstatusreason_has_value(name: str) -> None:
 
 
 def test_navstatusreason_count_matches_plan() -> None:
-    """Exactly 18 values are defined; adding a value must update tests."""
-    assert len(list(NavStatusReason)) == 18
+    """Exactly 20 values are defined; adding a value must update tests."""
+    assert len(list(NavStatusReason)) == 20
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Purpose

Closes #328. Closes #291.

Two body-navigation modes converge cleanly yet pass the ensemble gates as **confident-wrong** results, because the offending offset carries a coherent systematic bias no per-technique diagnostic can see:

- **#291** — at extreme mesh-vs-ellipsoid shape mismatch the disc correlation and the limb fit both lock onto the mismatched shape and agree at a multi-pixel wrong offset, fusing to ~0.99 confidence at 10-17 px error.
- **#328** — at ~155 deg phase a forward-scattering haze crescent defeats the disc correlation (spurious) while dragging the lone surviving blob centroid ~30 px off, reported as a gate-passing low-tier success.

No per-technique diagnostic carries a signal for either. The one available independent cross-check is the pose-free brightness centroid (`BodyBlobNav`), which does not chase shape.

## Changes

- **Cross-technique body-witness veto** (`src/spindoctor/nav_orchestrator/body_witness_veto.py`), evaluated in the ensemble:
  - **Shape-lock (#291):** a single-body low-phase geometric consensus that the blob witness contradicts is reported `conflicted` (`body_shape_lock_suspect`).
  - **Collapsed-regime (#328):** a single-body lone past-half-phase blob whose offset disagrees with a same-body *spurious* geometric position is declined (`failed`, `lone_blob_in_collapsed_regime`); a small/faint body whose spurious disc *agrees* with the blob stays a legitimate blob-only success.
  - Each disagreement is a **two-sided gate**: the Euclidean separation must clear a body-scaled pixel floor AND the Mahalanobis distance under the combined blob+consensus covariance must exceed a sigma threshold — so a low-SNR centroid whose scatter is statistically consistent is not vetoed. Both checks apply only to single-body frames (a companion body corrupts the centroid).
- **Reachability on real frames:** the real `NavModelBody` now emits a witness `BODY_BLOB` **alongside** the geometric limb/disc (subject to the existing blob size/lit gate), instead of only when the limb is unusable. The blob runs even when a primary covers the body (a new `NavTechnique.runs_as_witness` flag) and stays superseded in the fuse, so fused offsets on passing frames are unchanged and only the veto reads it. Without this, the veto's "blob witness + geometric result on one body" precondition could only ever hold on the co-emitting *simulated* model.
- Config `config_540_orchestrator.yaml` (veto thresholds + `body_witness_agreement_sigma`); developer guides (ensemble, body-model, simulator) and the API reference updated.

## Type of Change

- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [x] Breaking change (fix or feature that alters existing behavior or public API)
- [ ] Refactor (no functional or API changes)
- [x] Documentation
- [x] Tests only (no production code change)
- [ ] CI / Build / Dependencies

"Breaking" only in that confident-wrong body frames now decline/conflict instead of passing (the intended fix); no API removed.

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] End-to-end tests pass (if applicable)
- [x] New or updated tests for changed code
- [x] Tested manually (describe below if applicable)

New: `test_body_witness_veto.py` (both vetoes fire; small-body / crescent / high-phase-agreeing / multi-body / large-sigma-blob cases do NOT fire); ensemble-level veto tests; and **a hermetic test proving the real `NavModelBody` co-emits a single witness `BODY_BLOB` with `LIMB_ARC`/`BODY_DISC`** (fails on `main`, passes here — the reachability proof). Integration: the `titan_crescent_horns` pair asserts the decline; the irregularity sweep asserts `conflicted` at the confident-wrong extreme and `success` on the clean step. Full `nav_model` + `nav_orchestrator` suites pass (858); `ruff`, `ruff format --check`, `mypy`, `sphinx -W` clean.

## Potential Impacts

- **Public API:** none removed. New `NavTechnique.runs_as_witness` flag (default off); new status reasons `body_shape_lock_suspect` / `lone_blob_in_collapsed_regime`; new config keys.
- **Behavior:** confident-wrong shape-lock and haze-crescent body frames now decline/conflict instead of reporting a confident-wrong success. On real frames every resolved body emits one extra witness blob (one extra blob correlation per body), superseded in the fuse so fused offsets are unchanged. Only the two crescent sim baselines change (`success` at ~29 px -> `failed`). `mutual_deep`/`saturated_star` sim-baseline failures are pre-existing local drift, independent of this change.

## Checklist

- [x] Code follows project style (`ruff check`, `ruff format`)
- [x] Type annotations present and `mypy` passes
- [x] Docstrings and Sphinx docs updated (ensemble + body-model + simulator dev guides, API reference)
- [ ] CHANGES.md updated (no CHANGES.md in this repo)
- [x] No temporary or debug code left in
- [x] Breaking changes flagged in Type of Change above

## Notes

Adversarially reviewed twice. The first review caught that the veto, though correct in isolation, was **unreachable on real frames** (the real body model emitted blob and limb/disc mutually exclusively) — so it would have fixed only the sim baselines. The rework makes the real model co-emit the witness blob; a focused re-review empirically confirmed the fix (the co-emission tests fail on `main`) and that the extra blob stays superseded in the fuse. Also applied: a Mahalanobis (uncertainty-aware) disagreement gate, a single-body guard on both branches, and doc-phrasing cleanups. Veto thresholds (phase gates, pixel floor, sigma) are config-exposed tunables calibrated against measured blob-vs-fused separations across the sim scenes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HoCUAeNeMz5bFmGk2iVBf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-technique body-witness validation to identify potentially incorrect navigation locks.
  * Navigation results can now report specific conflicted or failed outcomes for detected body-shape contradictions and collapsed regimes.
  * Body features can accompany limb-based detections to provide an independent validation signal.

* **Documentation**
  * Expanded API and developer documentation covering validation behavior, configuration options, and simulator expectations.

* **Bug Fixes**
  * Improved handling of witness-based fallback processing and clarified expected outcomes for challenging atmospheric and irregular-body scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->