### PR TITLE
fix: require explicit ranges for disc occlusion

### DIFF
--- a/docs/dev_guide/dev_guide_navigation_models_body.rst
+++ b/docs/dev_guide/dev_guide_navigation_models_body.rst
@@ -155,6 +155,8 @@ disc albedo variation in a way the lit limb is not.
 Per-vertex tangent sigma is set to a small constant matching the polyline-sampling resolution;
 the DT-based fit treats motion along the polyline as essentially unobservable by construction.
 
+.. _body-visible-lit-fraction:
+
 Visible-lit and overflow fractions
 ----------------------------------
 
@@ -285,8 +287,8 @@ The occluder mask feeds three products:
   fitted polyline. It stays in the ridge total, so the ``visible_arc_fraction`` reports the loss:
   a mutual-event limb scores like the partial arc it is rather than claiming a full limb the
   distance-transform fit would then try to align against an arc the image does not show.
-- **The visible-lit fraction**, as described above, which drops the disc reliability with
-  occlusion depth.
+- **The visible-lit fraction** (:ref:`body-visible-lit-fraction`), which drops the disc
+  reliability with occlusion depth.
 - **The disc template.** The occluded pixels are trimmed out of the correlation template (both
   the brightness image and its mask), so the correlator scores only against disc brightness the
   image carries. Correlating against the missing disc area would be a coherent mismatch the

--- a/docs/dev_guide/dev_guide_simulator.rst
+++ b/docs/dev_guide/dev_guide_simulator.rst
@@ -1277,11 +1277,14 @@ and the disc correlator scores only against disc brightness the image carries.
 Nothing reads a truth key: the occlusion is derived from the same idealized
 sibling geometry both models already hold.
 
-The measured technique-level behavior is accurate and honest across grazing,
-half, and deep overlap. On the deep scene the far body's disc is over 90 percent
+Across grazing, half, and deep overlap the navigator recovers each scene's
+planted offset within the tolerance the mutual-event regression pins. That is a
+statement about these simulated scenes, not a certification of real-frame
+accuracy: the sim renders an idealized occlusion the true optics only
+approximate. On the deep scene the far body's disc is over 90 percent
 hidden, so its ``visible_lit_fraction`` collapses and the disc gate drops that
-feature; the near body's disc plus both visible limb arcs fuse to an accurate
-result. The joint limb fit runs on arcs the image actually shows -- the robust
+feature; the near body's disc plus both visible limb arcs fuse to the recovered
+offset. The joint limb fit runs on arcs the image actually shows -- the robust
 Tukey biweight loss is a second line of defense against a stray vertex, not the
 mechanism that carries the result -- and no confident-wrong result or
 double-counting conflict arises. The mutual-event scenes pin the arc fractions

--- a/src/spindoctor/nav_model/nav_model_body_simulated.py
+++ b/src/spindoctor/nav_model/nav_model_body_simulated.py
@@ -609,9 +609,14 @@ class NavModelBodySimulated(NavModelBodyBase):
             The extfov-shape boolean mask, or ``None`` when no sibling
             occludes (the common single-body case costs nothing).
         """
-        own_range = float(self._sim_params.get('range_km', float('inf')))
+        # Occlusion requires a known depth order: without the subject's own
+        # explicit range there is nothing to compare against, so no sibling is
+        # treated as nearer and the template is left whole rather than erased.
+        if 'range_km' not in self._sim_params:
+            return None
+        own_range = float(self._sim_params['range_km'])
         occluders = [
-            s for s in self._sibling_bodies if float(s.get('range_km', float('inf'))) < own_range
+            s for s in self._sibling_bodies if 'range_km' in s and float(s['range_km']) < own_range
         ]
         if not occluders:
             return None

--- a/tests/spindoctor/nav_model/test_nav_model_body_occlusion.py
+++ b/tests/spindoctor/nav_model/test_nav_model_body_occlusion.py
@@ -333,13 +333,13 @@ def test_disc_template_img_zero_under_occluder(monkeypatch: pytest.MonkeyPatch) 
     assert float(np.max(template_img[deep])) == 0.0
 
 
-def test_occluded_disc_visible_lit_fraction_drops(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Occlusion lowers ``visible_lit_fraction`` toward the surviving crescent."""
-    alone_model, _alone_obs = _make_model(monkeypatch, _TARGET_SPHERE, None)
-    alone_model.create_model()
-    occ_model, _occ_obs = _make_model(monkeypatch, _TARGET_SPHERE, _OCCLUDER_SPHERE)
-    occ_model.create_model()
-    assert occ_model._visible_lit_fraction < alone_model._visible_lit_fraction - 0.1
+def test_occluded_disc_reliability_drops(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Occlusion lowers the emitted BODY_DISC feature's reliability."""
+    alone_model, alone_obs = _make_model(monkeypatch, _TARGET_SPHERE, None)
+    alone = _disc_feature(alone_model, alone_obs)
+    occ_model, occ_obs = _make_model(monkeypatch, _TARGET_SPHERE, _DISC_OCCLUDER)
+    occluded = _disc_feature(occ_model, occ_obs)
+    assert occluded.reliability < alone.reliability
 
 
 def test_occluded_terminator_fraction_drops(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/spindoctor/nav_model/test_nav_model_body_simulated.py
+++ b/tests/spindoctor/nav_model/test_nav_model_body_simulated.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 from tests.shims import bare_nav_context
 
+from spindoctor.feature.feature import NavFeature
 from spindoctor.nav_model.nav_model_body_simulated import NavModelBodySimulated
 from spindoctor.nav_orchestrator.nav_context import NavContext
 from spindoctor.obs.obs_inst_sim import ObsSim
@@ -670,8 +671,19 @@ def _disc_feature(
     body_params: dict[str, Any],
     *,
     sibling_bodies: list[dict[str, Any]] | None = None,
-) -> Any:
-    """Build the model and return its emitted BODY_DISC feature."""
+) -> NavFeature:
+    """Build the simulated body model and return its emitted BODY_DISC feature.
+
+    Parameters:
+        obs: Simulated observation the model renders against.
+        body_params: Idealized parameter dict for the navigated body.
+        sibling_bodies: Idealized parameter dicts of the other bodies sharing
+            the scene, wired in as occlusion candidates; None for the
+            single-body case.
+
+    Returns:
+        The single BODY_DISC feature the model emits for this body.
+    """
     model = NavModelBodySimulated(
         'body', obs, body_params['name'], body_params, sibling_bodies=sibling_bodies
     )
@@ -694,6 +706,23 @@ def test_occluded_disc_template_drops_hidden_pixels() -> None:
     dist = np.hypot(vs - sib_v, us - sib_u)
     # The sibling is a radius-50 sphere; no template pixel survives deep inside it.
     assert int(np.count_nonzero(dist < 40.0)) == 0
+
+
+def test_occluded_disc_template_img_zero_under_sibling() -> None:
+    """The BODY_DISC template brightness is zero deep inside a nearer sibling."""
+    body = _large_body(range_km=700000.0)
+    disc = _disc_feature(_limb_obs(), body, sibling_bodies=[_near_sibling()])
+    v_min, u_min, _v_max, _u_max = disc.geometry.bbox_extfov_vu
+    obs = _limb_obs()
+    template_img = np.asarray(disc.template_img, dtype=np.float64)
+    rows, cols = template_img.shape
+    vv, uu = np.meshgrid(np.arange(rows), np.arange(cols), indexing='ij')
+    sib_v = _LIMB_SIZE / 2.0 + int(obs.extfov_margin_v) - v_min
+    sib_u = _LIMB_SIZE / 2.0 + 55.0 + int(obs.extfov_margin_u) - u_min
+    # Deep inside the radius-50 sibling the target disc is fully hidden, so the
+    # image-zeroing (not just the mask) must drive the brightness to zero there.
+    deep = np.hypot(vv - sib_v, uu - sib_u) < 40.0
+    assert float(np.max(template_img[deep])) == 0.0
 
 
 def test_occluded_disc_reliability_drops() -> None:


### PR DESCRIPTION
## Purpose

Follow-up refinements to the body-body disc occlusion work merged in #384, addressing post-merge CodeRabbit review comments. #384 already closed #326 and #327; this PR does not re-close them.

Body-body occlusion is what happens during a mutual event, when one body passes in front of another along the line of sight: the nearer body hides part of the farther body's disc, and the image shows the occluder there, not the target. Both body models are occlusion-aware so the features they emit (limb and terminator polylines, the disc correlation template, and the reported visible fraction) describe only the arcs and disc area the image actually carries. The simulated model derives the depth order from each body's explicit `range_km`; the SPICE-backed model uses the inventory center range.

The one behavioral bug: in the simulated model a body with no explicit `range_km` defaulted to infinitely far. Any sibling that did carry a finite range was then wrongly judged nearer, so its silhouette erased template pixels and lowered the subject's reliability even though the true depth order was unknown. Erasing pixels on an unknown ordering is worse than leaving them: it can throw away real disc brightness the correlator needs. This affects only the simulated path, where an operator may omit `range_km`; real SPICE-backed siblings always carry an explicit range.

## Changes

- **Major fix (correctness).** `NavModelBodySimulated._compute_occluder_mask` now requires an explicit subject `range_km` before applying any disc occlusion (it returns no mask otherwise), and only treats a sibling as an occluder when that sibling carries an explicit `range_km` strictly nearer than the subject's. Unknown ranges leave the template whole. This matches the method's documented contract that both ranges must be explicit before their stacking means anything.
- **Test hardening.**
  - Typed the simulated disc-feature test helper as its concrete `NavFeature` return and gave it a full docstring.
  - Added a deep-occluder assertion that the simulated `BODY_DISC` template *brightness* is zeroed under the occluder, so removing the image-zeroing (not just the mask update) would fail a test.
  - Rewrote the SPICE-backed occlusion test to assert the emitted `BODY_DISC` feature's `reliability` drops under occlusion, rather than only asserting the private visible-lit input.
- **Doc corrections.**
  - Qualified the simulator "accurate result" claim as recovery of the planted offset within the pinned simulated tolerance, conditional on the simulated scene, and explicitly not a certification of real-frame accuracy. The visible-arc, robust-loss, and mutual-event regression explanations are preserved.
  - Added an explicit `.. _body-visible-lit-fraction:` label and converted an implicit "as described above" cross-reference in the occlusion section to a `:ref:`.

## Deferred

One CodeRabbit item, a bbox-intersection pre-filter to skip `where_in_front` queries for non-overlapping occluder candidates in the SPICE-backed model, is deferred to #388. The inventory bounding box is in the data/FOV frame while the target's bbox is in the margin-shifted extended-FOV frame, so a correct pre-filter needs the full margin/slop/clip transform rather than a raw bbox comparison. That is a pure performance optimization with no behavior change and is out of scope for this correctness/hardening PR.

## Type of Change

- [x] Bug fix (non-breaking)
- [x] Tests only (no production code change)
- [x] Documentation

## Testing

- [x] Unit tests pass
- [x] New or updated tests for changed code

Ran `tests/spindoctor/nav_model/test_nav_model_body_simulated.py` and `tests/spindoctor/nav_model/test_nav_model_body_occlusion.py` (53 passed), the full non-integration suite (3874 passed, 7 xfailed), `ruff check` / `ruff format --check`, `mypy` strict (no issues in 518 files), and `sphinx-build -W` (clean).

## Potential Impacts

Public API: none. The simulated occlusion behavior changes only when a scene omits `range_km` on a body that overlaps a sibling; occlusion is now suppressed there instead of applied on a guessed depth order. The SPICE-backed navigation path is unchanged (real siblings always carry explicit ranges).

## Checklist

- [x] Code follows project style (`ruff check`, `ruff format`)
- [x] Type annotations present and `mypy` passes
- [x] Docstrings and Sphinx docs updated (if applicable)
- [x] No temporary or debug code left in
- [x] Breaking changes flagged in Type of Change above

🤖 Generated with [Claude Code](https://claude.com/claude-code)