### PR TITLE
style: put None last in mosaic-limit unions (RUF036)

### DIFF
--- a/src/spindoctor/reproj/bodies.py
+++ b/src/spindoctor/reproj/bodies.py
@@ -1402,9 +1402,9 @@ class BodyMosaic:
         *,
         resolution_threshold: float = 1.0,
         copy_slop: int = 0,
-        max_incidence: float | None | _UseMosaicLimitsSentinel = USE_MOSAIC_LIMITS,
-        max_emission: float | None | _UseMosaicLimitsSentinel = USE_MOSAIC_LIMITS,
-        max_resolution: float | None | _UseMosaicLimitsSentinel = USE_MOSAIC_LIMITS,
+        max_incidence: float | _UseMosaicLimitsSentinel | None = USE_MOSAIC_LIMITS,
+        max_emission: float | _UseMosaicLimitsSentinel | None = USE_MOSAIC_LIMITS,
+        max_resolution: float | _UseMosaicLimitsSentinel | None = USE_MOSAIC_LIMITS,
     ) -> None:
         """Add a reprojected image to the mosaic.
 


### PR DESCRIPTION
## Summary

CI's lint job installs `ruff` unpinned, so a fresh runner now resolves ruff 0.16.0, which promotes RUF036 (`None` must be the last member of a `|` type union) to an enforced error. Three `BodyMosaic.add()` keyword annotations in `src/spindoctor/reproj/bodies.py` wrote `float | None | _UseMosaicLimitsSentinel`, with `None` in the middle, so `ruff check src tests` fails with three RUF036 errors on every branch built against current `main` — including this batch of open PRs.

This reorders the three annotations to `float | _UseMosaicLimitsSentinel | None`. The union is semantically identical; only member order changes. No runtime or typing behavior is affected.

## Why this is separate

The break is not caused by any feature branch — the offending lines already sit on `main` (merged in #384) and only started failing when ruff 0.16.0 became the resolved version in CI. Landing the fix on `main` unblocks the lint job for every open and future PR at once; those branches pick it up on rebase.

## Follow-up

The root cause is an unpinned linter drifting under CI. Tracked in #391 for a decision on pinning `ruff` (and other lint tools) so a new release cannot turn `main` red without a code change.

## Testing

- `ruff check src tests` under ruff 0.16.0 (isolated venv): All checks passed
- `ruff format --check src tests` under ruff 0.16.0: 519 files already formatted

## Type of change

- [x] Code style update (formatting, local variables)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)