### PR TITLE
feat: logging level resolver and logger builders (phase 2)

### DIFF
--- a/docs/api_reference/api_config.rst
+++ b/docs/api_reference/api_config.rst
@@ -18,6 +18,11 @@ spindoctor.config
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: spindoctor.config.logging_config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: spindoctor.config.logging_keys
    :members:
    :undoc-members:

--- a/plans/LOGGING_REDESIGN_PLAN.md
+++ b/plans/LOGGING_REDESIGN_PLAN.md
@@ -483,9 +483,14 @@ New module `spindoctor/config/logging_config.py` (the existing
   of `get_nav_results_root`.
 - Level-name validation extended with `NONE`.
 
-With the resolver in place, retire the old path: delete `_resolve_level` and
-the nine `log_level_*` keys from `config_010_general.yaml`, and update the one
-test that asserts on them (`test_config_helper.py:431`).
+This phase builds the core and tests it directly; it does not wire it into any
+program. Wiring happens in Phases 5 through 7, which replace the eight call
+sites that still reach the old `setup_logging` / `image_log_handlers` path.
+The old `_resolve_level` and the nine `log_level_*` keys in
+`config_010_general.yaml` are therefore retired in Phase 6, when the last of
+those callers goes, along with the one test that asserts on them
+(`test_config_helper.py:431`). Removing them earlier would leave a phase that
+only deletes working configurability.
 
 ### Phase 3 — Image logger proxy, role binding, and scope enforcement
 
@@ -541,6 +546,11 @@ Route `backplane` and `reproj` per-image logging through
 `{log_root}/reproj/`. Retire `image_log_handlers()` and the bespoke path
 builders in `sd_mosaic.py` and `sd_mosaic_cloud_tasks.py`. Repoint
 `bundle_data.py`'s per-image section at the main logger.
+
+This removes the last caller of the old resolution path, so `setup_logging`,
+`_resolve_level`, and the nine `log_level_*` keys in
+`config_010_general.yaml` are deleted here, along with
+`test_config_helper.py:431`, which asserts on one of them.
 
 ### Phase 7 — Cloud-task isolation
 

--- a/plans/LOGGING_REDESIGN_PLAN.md
+++ b/plans/LOGGING_REDESIGN_PLAN.md
@@ -163,9 +163,16 @@ Layout underneath it:
 {log_root}/{backend}/{results_path_stub}_{datetime}.log  # image logger
 ```
 
-`{datetime}` is `%Y-%m-%dT%H-%M-%S`, matching the current per-image
-convention, applied to main logs as well. `{backend}` is one of `nav`,
-`backplane`, `reproj`. `{results_path_stub}` is the existing
+`{datetime}` is `%Y-%m-%dT%H-%M-%S` **in UTC**, applied to main logs as well
+as image logs. The format matches the existing per-image convention; the
+timezone does not, because the three sites producing it today
+(`navigate_image_files.py:164`, `sd_offset.py:305`, `sd_mosaic.py:89`) use
+naive local time. Cloud-task workers processing one batch may sit in different
+zones, and a local-time name is ambiguous across a daylight-saving fall-back,
+so names would neither sort nor correlate. Those three sites are replaced in
+Phases 6 and 7.
+
+`{backend}` is one of `nav`, `backplane`, `reproj`. `{results_path_stub}` is the existing
 `ImageFile.results_path_stub`, which is `{volume}/{filespec}` without the
 extension (`dataset_pds3_cassini_iss.py:187`), so a Cassini image navigated
 by either nav driver lands at

--- a/plans/LOGGING_REDESIGN_PLAN.md
+++ b/plans/LOGGING_REDESIGN_PLAN.md
@@ -124,10 +124,16 @@ Each logger has two possible sinks, console (stdout) and file. Defaults:
 
 **When a sink is enabled, its level is the level for that module. Console
 and file always share a level.** There is no per-sink level anywhere in the
-system. This is what makes `logger.open(title, level=...)` sufficient to
-express a module's verbosity: pdslogger's section level is a floor applied
-before handlers, so with both handlers at the same level the floor *is* the
-effective level, and the two sinks cannot disagree.
+system, which is what makes `logger.open(title, level=...)` sufficient to
+express a module's verbosity.
+
+The mechanism needs care. A pdslogger section level is a floor applied before
+the handlers, and each handler then applies its own level, so what reaches a
+sink is the *more severe* of the two. Handlers are therefore built at the most
+verbose level any module could ask for, and the per-section floor does all of
+the discrimination. Building them at the plain `image` level instead silently
+drops every module configured more verbose than it, while the section summary
+still counts the dropped records — output reported but never written.
 
 Enabling and disabling a sink changes only which handlers are attached when
 the logger is built. Nothing else in the system is conditional on it.
@@ -475,10 +481,13 @@ New module `spindoctor/config/logging_config.py` (the existing
 - `resolve_log_levels(program_name, arguments, config)` implementing the
   merge and precedence of section 2.6, returning a `LogLevels` dataclass.
 - `LogSinks` dataclass: the four booleans plus the resolved log root.
-- `build_main_logger(program_name, sinks, levels)` and
-  `build_image_logger(backend, results_path_stub, sinks, levels)` — attach
-  exactly the enabled handlers, or `NULL_HANDLER` if none, and return the
-  logger and the path written.
+- `build_main_logger(logger, program_name, sinks, levels)` and
+  `build_image_log_handlers(backend, results_path_stub, sinks, levels)` —
+  attach exactly the enabled handlers, or `NULL_HANDLER` if none, and report
+  the path written.  The image side returns handlers rather than attaching
+  them, because they are scoped to one `logger.open(...)` section; the caller
+  owns closing them.  Neither builds a logger, so nothing is added to
+  pdslogger's process-global registry.
 - `get_log_root(arguments, config)` in `config_helper.py`, matching the shape
   of `get_nav_results_root`.
 - Level-name validation extended with `NONE`.

--- a/src/spindoctor/config/__init__.py
+++ b/src/spindoctor/config/__init__.py
@@ -14,6 +14,9 @@ from .logger import (
 )
 from .logging_config import (
     BACKEND_NAMES,
+    DEFAULT_LEVEL,
+    LOG_TIMESTAMP_FORMAT,
+    SILENT_LEVEL,
     LogLevels,
     LogSinks,
     build_image_log_handlers,
@@ -21,6 +24,7 @@ from .logging_config import (
     image_log_path,
     main_log_path,
     resolve_log_levels,
+    run_timestamp,
     sinks_from_arguments,
 )
 from .logging_keys import log_key_for, validate_logging_config
@@ -28,8 +32,11 @@ from .logging_keys import log_key_for, validate_logging_config
 __all__ = [
     'BACKEND_NAMES',
     'DEFAULT_CONFIG',
+    'DEFAULT_LEVEL',
     'IMAGE_LOGGER',
+    'LOG_TIMESTAMP_FORMAT',
     'MAIN_LOGGER',
+    'SILENT_LEVEL',
     'Config',
     'LogLevels',
     'LogSinks',
@@ -45,6 +52,7 @@ __all__ = [
     'log_key_for',
     'main_log_path',
     'resolve_log_levels',
+    'run_timestamp',
     'setup_logging',
     'sinks_from_arguments',
     'validate_logging_config',

--- a/src/spindoctor/config/__init__.py
+++ b/src/spindoctor/config/__init__.py
@@ -1,6 +1,7 @@
 from .config import DEFAULT_CONFIG, Config
 from .config_helper import (
     get_backplane_results_root,
+    get_log_root,
     get_nav_results_root,
     get_pds4_bundle_results_root,
     load_default_and_user_config,
@@ -11,19 +12,40 @@ from .logger import (
     image_log_handlers,
     setup_logging,
 )
+from .logging_config import (
+    BACKEND_NAMES,
+    LogLevels,
+    LogSinks,
+    build_image_log_handlers,
+    build_main_logger,
+    image_log_path,
+    main_log_path,
+    resolve_log_levels,
+    sinks_from_arguments,
+)
 from .logging_keys import log_key_for, validate_logging_config
 
 __all__ = [
+    'BACKEND_NAMES',
     'DEFAULT_CONFIG',
     'IMAGE_LOGGER',
     'MAIN_LOGGER',
     'Config',
+    'LogLevels',
+    'LogSinks',
+    'build_image_log_handlers',
+    'build_main_logger',
     'get_backplane_results_root',
+    'get_log_root',
     'get_nav_results_root',
     'get_pds4_bundle_results_root',
     'image_log_handlers',
+    'image_log_path',
     'load_default_and_user_config',
     'log_key_for',
+    'main_log_path',
+    'resolve_log_levels',
     'setup_logging',
+    'sinks_from_arguments',
     'validate_logging_config',
 ]

--- a/src/spindoctor/config/config_helper.py
+++ b/src/spindoctor/config/config_helper.py
@@ -80,6 +80,43 @@ def get_nav_results_root(arguments: argparse.Namespace, config: Config) -> str:
     return nav_results_root_str
 
 
+def get_log_root(arguments: argparse.Namespace, config: Config) -> str:
+    """Get the log root from the arguments, configuration, or environment.
+
+    First look in ``arguments.log_root``, then in ``config.environment.log_root``,
+    then in the environment variable ``NAV_LOG_ROOT``.  Unlike the other roots
+    this one has a fallback rather than an error: logs belong under the
+    navigation results root by default, so a run that has not been told where to
+    put them still puts them somewhere predictable.
+
+    Parameters:
+        arguments: The parsed arguments.
+        config: The configuration possibly containing the environment section.
+
+    Returns:
+        The log root.
+
+    Raises:
+        ValueError: If neither a log root nor a navigation results root can be
+            determined.
+    """
+    log_root_str = None
+    try:
+        log_root_str = arguments.log_root
+    except AttributeError:
+        pass
+    if log_root_str is None:
+        try:
+            log_root_str = config.environment.log_root
+        except AttributeError:
+            pass
+    if log_root_str is None:
+        log_root_str = os.getenv('NAV_LOG_ROOT')
+    if log_root_str is None:
+        log_root_str = os.path.join(get_nav_results_root(arguments, config), 'logs')
+    return str(log_root_str)
+
+
 def get_pds4_bundle_results_root(arguments: argparse.Namespace, config: Config) -> str:
     """Get the PDS4 bundle root from the arguments, configuration, or environment.
 

--- a/src/spindoctor/config/config_helper.py
+++ b/src/spindoctor/config/config_helper.py
@@ -1,6 +1,8 @@
 import argparse
 import os
 
+from filecache import FCPath
+
 from .config import Config
 from .logging_keys import validate_logging_config
 
@@ -113,7 +115,9 @@ def get_log_root(arguments: argparse.Namespace, config: Config) -> str:
     if log_root_str is None:
         log_root_str = os.getenv('NAV_LOG_ROOT')
     if log_root_str is None:
-        log_root_str = os.path.join(get_nav_results_root(arguments, config), 'logs')
+        # FCPath rather than os.path.join: a results root is routinely a cloud
+        # URL, and joining those must not depend on the local path separator.
+        log_root_str = (FCPath(get_nav_results_root(arguments, config)) / 'logs').as_posix()
     return str(log_root_str)
 
 

--- a/src/spindoctor/config/logging_config.py
+++ b/src/spindoctor/config/logging_config.py
@@ -39,7 +39,7 @@ stdout regardless of level.
 import argparse
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 import pdslogger
@@ -77,7 +77,7 @@ DEFAULT_LEVEL = 'INFO'
 """Level used when nothing in the arguments or configuration says otherwise."""
 
 LOG_TIMESTAMP_FORMAT = '%Y-%m-%dT%H-%M-%S'
-"""Suffix format distinguishing one run's log file from the next."""
+"""Suffix format distinguishing one run's log file from the next, in UTC."""
 
 BACKEND_NAMES = frozenset({'nav', 'backplane', 'reproj'})
 """Per-image backends, each owning a subtree of the log root."""
@@ -425,12 +425,17 @@ def image_log_path(
 
 
 def run_timestamp() -> str:
-    """Return the current local time formatted for a log file name.
+    """Return the current UTC time formatted for a log file name.
+
+    UTC rather than local time so that log names sort chronologically and
+    correlate across machines: cloud-task workers processing one batch may sit
+    in different zones, and a local-time name is ambiguous across a
+    daylight-saving fall-back.
 
     Returns:
         The timestamp in :data:`LOG_TIMESTAMP_FORMAT`.
     """
-    return datetime.now().strftime(LOG_TIMESTAMP_FORMAT)
+    return datetime.now(UTC).strftime(LOG_TIMESTAMP_FORMAT)
 
 
 def _handlers_for(*, console: bool, to_file: bool, path: FCPath | None, level: str) -> list[Any]:

--- a/src/spindoctor/config/logging_config.py
+++ b/src/spindoctor/config/logging_config.py
@@ -1,0 +1,463 @@
+"""Resolution and construction of the two SpinDoctor loggers.
+
+Two loggers exist.  The main logger covers one program run and reports what
+the program is doing at the top level.  The image logger covers one image
+inside one per-image backend and carries that image's processing detail.
+
+Each logger writes to a console sink, a file sink, or both.  Both sinks always
+share a level, so one level per module governs whatever sinks are enabled.
+That is what lets a module's verbosity be expressed as the ``level=`` argument
+of a single ``logger.open(...)`` call: pdslogger applies a section level as a
+floor before its handlers, so with both handlers at the same level the floor
+is the effective level and the two sinks cannot disagree.
+
+Levels resolve in two steps.  The top-level ``logging`` block is first merged
+with ``logging.programs.<program>``, the program block winning key by key;
+then, against that merged result, the most specific setting wins:
+
+    --log-level MODULE=LEVEL
+      > <category>.<module>
+      > <category>.default
+      > --log-level-main / --log-level-image
+      > --log-level LEVEL
+      > main / image
+      > INFO
+
+Building a logger attaches exactly the enabled sinks.  When neither is
+enabled the builder attaches ``NULL_HANDLER``, because a PdsLogger left with
+no handlers does not go quiet -- it falls back to printing every record to
+stdout regardless of level.
+"""
+
+import argparse
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+import pdslogger
+from filecache import FCPath
+from pdslogger import PdsLogger
+
+from .logging_keys import CATEGORY_KEYS, normalize_level
+
+if TYPE_CHECKING:
+    from .config import Config
+
+__all__ = [
+    'BACKEND_NAMES',
+    'DEFAULT_LEVEL',
+    'LOG_TIMESTAMP_FORMAT',
+    'LogLevels',
+    'LogSinks',
+    'build_image_log_handlers',
+    'build_main_logger',
+    'image_log_path',
+    'main_log_path',
+    'resolve_log_levels',
+    'run_timestamp',
+    'sinks_from_arguments',
+]
+
+
+DEFAULT_LEVEL = 'INFO'
+"""Level used when nothing in the arguments or configuration says otherwise."""
+
+LOG_TIMESTAMP_FORMAT = '%Y-%m-%dT%H-%M-%S'
+"""Suffix format distinguishing one run's log file from the next."""
+
+BACKEND_NAMES = frozenset({'nav', 'backplane', 'reproj'})
+"""Per-image backends, each owning a subtree of the log root."""
+
+_OFF = 'NONE'
+_CATEGORY_DEFAULT_KEY = 'default'
+_PROGRAMS_KEY = 'programs'
+
+
+@dataclass(frozen=True)
+class LogLevels:
+    """Resolved level for each logger and each module that overrides it.
+
+    Parameters:
+        main: Level for the main logger.
+        image: Level for the image logger, and for any image-scoped module
+            with no override of its own.
+        modules: Level per module key, for the modules that override the
+            image level.  Keys are the snake_case names validated by
+            :mod:`spindoctor.config.logging_keys`.
+    """
+
+    main: str = DEFAULT_LEVEL
+    image: str = DEFAULT_LEVEL
+    modules: dict[str, str] = field(default_factory=dict)
+
+    def for_module(self, log_key: str) -> str:
+        """Return the level governing ``log_key``.
+
+        Parameters:
+            log_key: A module's snake_case configuration key.
+
+        Returns:
+            The module's own level if it has one, else the image level.
+        """
+        return self.modules.get(log_key, self.image)
+
+
+@dataclass(frozen=True)
+class LogSinks:
+    """Which sinks each logger writes to, and where files are written.
+
+    Parameters:
+        log_root: Root directory for every log file this run produces.
+        main_console: Whether the main logger writes to stdout.
+        main_file: Whether the main logger writes to a file.
+        image_console: Whether the image logger writes to stdout.
+        image_file: Whether the image logger writes to a file.
+    """
+
+    log_root: FCPath
+    main_console: bool = True
+    main_file: bool = True
+    image_console: bool = False
+    image_file: bool = True
+
+
+def _level_or_none(value: Any) -> str | None:
+    """Return a canonicalized level name, or None when nothing was configured.
+
+    Parameters:
+        value: A configured or command-line level, possibly absent.
+
+    Returns:
+        The canonical level name, or None if ``value`` is absent.
+    """
+    if value is None:
+        return None
+    return normalize_level(str(value))
+
+
+def _merged_logging_block(program_name: str, config: 'Config') -> dict[str, Any]:
+    """Return the logging configuration in force for one program.
+
+    The top-level block is merged with that program's block under
+    ``programs``, the program's value winning key by key.  Categories merge a
+    level deeper, so a program can override one module without restating the
+    rest of the category.
+
+    Parameters:
+        program_name: The program's identity, as declared by its dispatch
+            module.
+        config: The loaded configuration.
+
+    Returns:
+        A mapping in the shape of the top-level ``logging`` block, with the
+        ``programs`` key removed.
+    """
+    section = config.logging
+    block: dict[str, Any] = {k: v for k, v in dict(section).items() if k != _PROGRAMS_KEY}
+    for key in CATEGORY_KEYS:
+        if isinstance(block.get(key), dict):
+            block[key] = dict(block[key])
+
+    overrides = dict(section).get(_PROGRAMS_KEY) or {}
+    program_block = overrides.get(program_name) or {}
+    for key, value in dict(program_block).items():
+        if key in CATEGORY_KEYS and isinstance(value, dict):
+            merged = dict(block.get(key) or {})
+            merged.update(dict(value))
+            block[key] = merged
+        else:
+            block[key] = value
+    return block
+
+
+def resolve_log_levels(
+    program_name: str,
+    arguments: argparse.Namespace | None,
+    config: 'Config',
+) -> LogLevels:
+    """Resolve the level governing each logger and each overriding module.
+
+    Applies the merge and precedence described in the module docstring.  A
+    module named on the command line beats one named in the configuration; a
+    module named anywhere beats its category default; a category default beats
+    the per-logger default.
+
+    Parameters:
+        program_name: The program's identity, used to select its block under
+            ``logging.programs``.
+        arguments: Parsed command-line arguments, or None to resolve from the
+            configuration alone.  Recognized attributes are ``log_level``,
+            ``log_level_main``, and ``log_level_image``.
+        config: The loaded configuration.
+
+    Returns:
+        The resolved :class:`LogLevels`.
+    """
+    block = _merged_logging_block(program_name, config)
+
+    cli_global, cli_modules = _parse_log_level_arguments(arguments)
+    cli_main = _level_or_none(getattr(arguments, 'log_level_main', None))
+    cli_image = _level_or_none(getattr(arguments, 'log_level_image', None))
+
+    main = cli_main or cli_global or _level_or_none(block.get('main')) or DEFAULT_LEVEL
+    image = cli_image or cli_global or _level_or_none(block.get('image')) or DEFAULT_LEVEL
+
+    modules: dict[str, str] = {}
+    for category in CATEGORY_KEYS:
+        entries = block.get(category)
+        if not isinstance(entries, dict):
+            continue
+        category_default = _level_or_none(entries.get(_CATEGORY_DEFAULT_KEY))
+        for key, value in entries.items():
+            if key == _CATEGORY_DEFAULT_KEY:
+                continue
+            level = _level_or_none(value)
+            if level is not None:
+                modules[key] = level
+        if category_default is not None:
+            # Applies to every module in the category that did not name itself.
+            # Recorded per known key rather than as a category-wide entry so
+            # LogLevels stays a flat lookup.
+            for key in _category_member_keys(category):
+                modules.setdefault(key, category_default)
+
+    modules.update(cli_modules)
+    return LogLevels(main=main, image=image, modules=modules)
+
+
+def _category_member_keys(category: str) -> frozenset[str]:
+    """Return every module key belonging to ``category``.
+
+    Parameters:
+        category: One of the categories in
+            :data:`spindoctor.config.logging_keys.CATEGORY_KEYS`.
+
+    Returns:
+        The category's valid module keys.
+    """
+    from .logging_keys import OTHER_LOG_KEYS, model_log_keys, technique_log_keys
+
+    if category == 'techniques':
+        return technique_log_keys()
+    if category == 'models':
+        return model_log_keys()
+    return OTHER_LOG_KEYS
+
+
+def _parse_log_level_arguments(
+    arguments: argparse.Namespace | None,
+) -> tuple[str | None, dict[str, str]]:
+    """Split the repeatable ``--log-level`` values into global and per-module.
+
+    A bare ``LEVEL`` sets the default for both loggers; a ``MODULE=LEVEL`` pair
+    sets one module.  The last bare value wins, so a later flag overrides an
+    earlier one rather than silently combining.
+
+    Parameters:
+        arguments: Parsed command-line arguments, or None.
+
+    Returns:
+        Tuple of the global level (or None) and a mapping of module key to
+        level.
+    """
+    values = getattr(arguments, 'log_level', None) or []
+    if isinstance(values, str):
+        values = [values]
+
+    global_level: str | None = None
+    modules: dict[str, str] = {}
+    for value in values:
+        text = str(value)
+        if '=' in text:
+            key, _, level = text.partition('=')
+            modules[key.strip()] = normalize_level(level)
+        else:
+            global_level = normalize_level(text)
+    return global_level, modules
+
+
+def main_log_path(log_root: FCPath, program_name: str, *, timestamp: str) -> FCPath:
+    """Return the path of a program run's main log file.
+
+    Parameters:
+        log_root: Root directory for this run's logs.
+        program_name: The program's identity, which names its directory.
+        timestamp: Run timestamp in :data:`LOG_TIMESTAMP_FORMAT`.
+
+    Returns:
+        ``{log_root}/{program_name}/main_{timestamp}.log``.
+    """
+    return log_root / program_name / f'main_{timestamp}.log'
+
+
+def image_log_path(
+    log_root: FCPath, backend: str, results_path_stub: str, *, timestamp: str
+) -> FCPath:
+    """Return the path of one image's log file for one backend.
+
+    The subtree is keyed by backend rather than by program, so an image's log
+    for a given stage is in one place whichever driver produced it.
+
+    Parameters:
+        log_root: Root directory for this run's logs.
+        backend: One of :data:`BACKEND_NAMES`.
+        results_path_stub: The image's results path stub.
+        timestamp: Run timestamp in :data:`LOG_TIMESTAMP_FORMAT`.
+
+    Returns:
+        ``{log_root}/{backend}/{results_path_stub}_{timestamp}.log``.
+
+    Raises:
+        ValueError: If ``backend`` is not a known backend.
+    """
+    if backend not in BACKEND_NAMES:
+        raise ValueError(f'Unknown backend {backend!r}; expected one of {sorted(BACKEND_NAMES)}')
+    return log_root / backend / f'{results_path_stub}_{timestamp}.log'
+
+
+def run_timestamp() -> str:
+    """Return the current local time formatted for a log file name.
+
+    Returns:
+        The timestamp in :data:`LOG_TIMESTAMP_FORMAT`.
+    """
+    return datetime.now().strftime(LOG_TIMESTAMP_FORMAT)
+
+
+def _handlers_for(*, console: bool, to_file: bool, path: FCPath | None, level: str) -> list[Any]:
+    """Build the handler list for one logger.
+
+    Parameters:
+        console: Whether to attach a stdout handler.
+        to_file: Whether to attach a file handler.
+        path: Destination for the file handler; required when ``to_file``.
+        level: Level shared by both sinks.
+
+    Returns:
+        The handlers to attach.  Never empty: with no sink enabled the list is
+        ``[NULL_HANDLER]``, because a PdsLogger with no handlers prints every
+        record to stdout regardless of level.
+
+    Raises:
+        ValueError: If ``to_file`` is set without a ``path``.
+    """
+    handlers: list[Any] = []
+    if level != _OFF:
+        if console:
+            handlers.append(pdslogger.stream_handler(level=level.lower()))
+        if to_file:
+            if path is None:
+                raise ValueError('A file sink was requested without a destination path')
+            path.parent.mkdir(parents=True, exist_ok=True)
+            handlers.append(pdslogger.file_handler(path, level=level.lower()))
+    if not handlers:
+        handlers.append(pdslogger.NULL_HANDLER)
+    return handlers
+
+
+def build_main_logger(
+    logger: PdsLogger,
+    program_name: str,
+    sinks: LogSinks,
+    levels: LogLevels,
+    *,
+    timestamp: str | None = None,
+) -> FCPath | None:
+    """Attach this run's sinks to the main logger.
+
+    Any handlers already present are removed first, so calling this twice does
+    not duplicate output.
+
+    Parameters:
+        logger: The main logger to configure.
+        program_name: The program's identity, which names its log directory.
+        sinks: Which sinks to attach and where files go.
+        levels: Resolved levels; the main level applies to both sinks.
+        timestamp: Run timestamp for the file name; defaults to now.
+
+    Returns:
+        The path written to, or None when no file sink is enabled.
+    """
+    # remove_all_handlers detaches but does not close, so a rebuild would leak
+    # the previous run's open log file.
+    for existing in list(logger.handlers):
+        existing.close()
+    logger.remove_all_handlers()
+    stamp = timestamp if timestamp is not None else run_timestamp()
+    path = main_log_path(sinks.log_root, program_name, timestamp=stamp) if sinks.main_file else None
+    for handler in _handlers_for(
+        console=sinks.main_console, to_file=sinks.main_file, path=path, level=levels.main
+    ):
+        logger.add_handler(handler)
+    return path
+
+
+def build_image_log_handlers(
+    backend: str,
+    results_path_stub: str,
+    sinks: LogSinks,
+    levels: LogLevels,
+    *,
+    timestamp: str | None = None,
+) -> tuple[list[Any], FCPath | None]:
+    """Build the handlers for one image, to be attached for that image only.
+
+    The handlers are returned rather than attached because the image logger
+    scopes them to a single ``logger.open(...)`` section, which removes them
+    when the image is done.
+
+    Parameters:
+        backend: The per-image backend, one of :data:`BACKEND_NAMES`.
+        results_path_stub: The image's results path stub.
+        sinks: Which sinks to attach and where files go.
+        levels: Resolved levels; the image level applies to both sinks.
+        timestamp: Run timestamp for the file name; defaults to now.
+
+    Returns:
+        Tuple of the handlers and the path written to, the latter None when no
+        file sink is enabled.
+
+    Raises:
+        ValueError: If ``backend`` is not a known backend.
+    """
+    # Validated up front so a typo fails the same way whether or not a file
+    # sink happens to be enabled.
+    if backend not in BACKEND_NAMES:
+        raise ValueError(f'Unknown backend {backend!r}; expected one of {sorted(BACKEND_NAMES)}')
+    stamp = timestamp if timestamp is not None else run_timestamp()
+    path = (
+        image_log_path(sinks.log_root, backend, results_path_stub, timestamp=stamp)
+        if sinks.image_file
+        else None
+    )
+    handlers = _handlers_for(
+        console=sinks.image_console, to_file=sinks.image_file, path=path, level=levels.image
+    )
+    return handlers, path
+
+
+def sinks_from_arguments(arguments: argparse.Namespace | None, log_root: FCPath) -> LogSinks:
+    """Build the sink selection from command-line arguments.
+
+    Each sink keeps its default unless the corresponding flag was given.
+
+    Parameters:
+        arguments: Parsed command-line arguments, or None for the defaults.
+        log_root: Resolved log root for this run.
+
+    Returns:
+        The resolved :class:`LogSinks`.
+    """
+    defaults = LogSinks(log_root=log_root)
+
+    def flag(name: str, default: bool) -> bool:
+        value = getattr(arguments, name, None)
+        return default if value is None else bool(value)
+
+    return LogSinks(
+        log_root=log_root,
+        main_console=flag('log_main_to_console', defaults.main_console),
+        main_file=flag('log_main_to_file', defaults.main_file),
+        image_console=flag('log_image_to_console', defaults.image_console),
+        image_file=flag('log_image_to_file', defaults.image_file),
+    )

--- a/src/spindoctor/config/logging_config.py
+++ b/src/spindoctor/config/logging_config.py
@@ -5,11 +5,18 @@ the program is doing at the top level.  The image logger covers one image
 inside one per-image backend and carries that image's processing detail.
 
 Each logger writes to a console sink, a file sink, or both.  Both sinks always
-share a level, so one level per module governs whatever sinks are enabled.
-That is what lets a module's verbosity be expressed as the ``level=`` argument
-of a single ``logger.open(...)`` call: pdslogger applies a section level as a
-floor before its handlers, so with both handlers at the same level the floor
-is the effective level and the two sinks cannot disagree.
+share a level, so one level per module governs whatever sinks are enabled, and
+a module's verbosity can be expressed as the ``level=`` argument of a single
+``logger.open(...)`` call.
+
+Making that work takes care.  A pdslogger section level is a floor applied
+before the handlers, and each handler then applies its own level, so what
+reaches a sink is the more severe of the two.  Handlers are therefore built at
+the most verbose level any module could ask for, and the per-section floor
+does all of the discrimination.  Building them at the plain image level would
+silently drop every module configured more verbose than it -- and the section
+summary would still count the dropped records, reporting output that was never
+written.
 
 Levels resolve in two steps.  The top-level ``logging`` block is first merged
 with ``logging.programs.<program>``, the program block winning key by key;
@@ -30,6 +37,7 @@ stdout regardless of level.
 """
 
 import argparse
+import logging
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
@@ -38,7 +46,12 @@ import pdslogger
 from filecache import FCPath
 from pdslogger import PdsLogger
 
-from .logging_keys import CATEGORY_KEYS, normalize_level
+from .logging_keys import (
+    CATEGORY_KEYS,
+    LOG_LEVEL_NAMES,
+    LOG_LEVEL_VALUES,
+    normalize_level,
+)
 
 if TYPE_CHECKING:
     from .config import Config
@@ -47,6 +60,7 @@ __all__ = [
     'BACKEND_NAMES',
     'DEFAULT_LEVEL',
     'LOG_TIMESTAMP_FORMAT',
+    'SILENT_LEVEL',
     'LogLevels',
     'LogSinks',
     'build_image_log_handlers',
@@ -69,6 +83,13 @@ BACKEND_NAMES = frozenset({'nav', 'backplane', 'reproj'})
 """Per-image backends, each owning a subtree of the log root."""
 
 _OFF = 'NONE'
+SILENT_LEVEL = LOG_LEVEL_VALUES[_OFF]
+"""Numeric level suppressing every record, for a module configured ``NONE``.
+
+pdslogger has no name for "off", so a section that must emit nothing is opened
+with this number rather than a level name.
+"""
+
 _CATEGORY_DEFAULT_KEY = 'default'
 _PROGRAMS_KEY = 'programs'
 
@@ -91,7 +112,7 @@ class LogLevels:
     modules: dict[str, str] = field(default_factory=dict)
 
     def for_module(self, log_key: str) -> str:
-        """Return the level governing ``log_key``.
+        """Return the level name governing ``log_key``.
 
         Parameters:
             log_key: A module's snake_case configuration key.
@@ -100,6 +121,36 @@ class LogLevels:
             The module's own level if it has one, else the image level.
         """
         return self.modules.get(log_key, self.image)
+
+    def section_level_for(self, log_key: str) -> str | int:
+        """Return the value to pass as ``logger.open(level=...)`` for a module.
+
+        pdslogger has no level named ``NONE``, so a module configured off is
+        expressed as :data:`SILENT_LEVEL` instead of a name it would reject.
+
+        Parameters:
+            log_key: A module's snake_case configuration key.
+
+        Returns:
+            A pdslogger level name, or :data:`SILENT_LEVEL` for a module
+            configured ``NONE``.
+        """
+        level = self.for_module(log_key)
+        return SILENT_LEVEL if level == _OFF else level.lower()
+
+    def most_verbose_image_level(self) -> str:
+        """Return the least severe level any image-scoped module can request.
+
+        Image handlers are built at this level rather than at :attr:`image`,
+        because a handler filters after the per-section floor: one built at
+        :attr:`image` would discard every record from a module configured more
+        verbose than it, while the section summary still counted them.
+
+        Returns:
+            The level name to build the image sinks at.
+        """
+        candidates = [self.image, *self.modules.values()]
+        return min(candidates, key=lambda name: LOG_LEVEL_VALUES[name])
 
 
 @dataclass(frozen=True)
@@ -121,18 +172,47 @@ class LogSinks:
     image_file: bool = True
 
 
-def _level_or_none(value: Any) -> str | None:
+def _level_or_none(value: Any, location: str) -> str | None:
     """Return a canonicalized level name, or None when nothing was configured.
 
     Parameters:
         value: A configured or command-line level, possibly absent.
+        location: What supplied the value, used in the error message.
 
     Returns:
         The canonical level name, or None if ``value`` is absent.
+
+    Raises:
+        ValueError: If ``value`` names no known level.  The configuration side
+            is checked at load; this catches the command-line side, which
+            would otherwise reach pdslogger as a bare ``KeyError``.
     """
     if value is None:
         return None
-    return normalize_level(str(value))
+    level = normalize_level(str(value))
+    if level not in LOG_LEVEL_NAMES:
+        raise ValueError(f'{location} is {value!r}; expected one of {sorted(LOG_LEVEL_NAMES)}')
+    return level
+
+
+def _first_set(*candidates: str | None) -> str:
+    """Return the first candidate that was actually supplied.
+
+    Written as an explicit None test rather than an ``or`` chain so that a
+    value which happens to be falsy is not skipped in favor of a less specific
+    source.
+
+    Parameters:
+        *candidates: Levels in order of decreasing precedence, the last of
+            which must be a fallback rather than None.
+
+    Returns:
+        The first non-None candidate.
+    """
+    for candidate in candidates:
+        if candidate is not None:
+            return candidate
+    return DEFAULT_LEVEL
 
 
 def _merged_logging_block(program_name: str, config: 'Config') -> dict[str, Any]:
@@ -196,22 +276,28 @@ def resolve_log_levels(
     block = _merged_logging_block(program_name, config)
 
     cli_global, cli_modules = _parse_log_level_arguments(arguments)
-    cli_main = _level_or_none(getattr(arguments, 'log_level_main', None))
-    cli_image = _level_or_none(getattr(arguments, 'log_level_image', None))
+    cli_main = _level_or_none(getattr(arguments, 'log_level_main', None), '--log-level-main')
+    cli_image = _level_or_none(getattr(arguments, 'log_level_image', None), '--log-level-image')
 
-    main = cli_main or cli_global or _level_or_none(block.get('main')) or DEFAULT_LEVEL
-    image = cli_image or cli_global or _level_or_none(block.get('image')) or DEFAULT_LEVEL
+    main = _first_set(
+        cli_main, cli_global, _level_or_none(block.get('main'), 'logging.main'), DEFAULT_LEVEL
+    )
+    image = _first_set(
+        cli_image, cli_global, _level_or_none(block.get('image'), 'logging.image'), DEFAULT_LEVEL
+    )
 
     modules: dict[str, str] = {}
     for category in CATEGORY_KEYS:
         entries = block.get(category)
         if not isinstance(entries, dict):
             continue
-        category_default = _level_or_none(entries.get(_CATEGORY_DEFAULT_KEY))
+        category_default = _level_or_none(
+            entries.get(_CATEGORY_DEFAULT_KEY), f'logging.{category}.default'
+        )
         for key, value in entries.items():
             if key == _CATEGORY_DEFAULT_KEY:
                 continue
-            level = _level_or_none(value)
+            level = _level_or_none(value, f'logging.{category}.{key}')
             if level is not None:
                 modules[key] = level
         if category_default is not None:
@@ -223,6 +309,15 @@ def resolve_log_levels(
 
     modules.update(cli_modules)
     return LogLevels(main=main, image=image, modules=modules)
+
+
+def _all_module_keys() -> frozenset[str]:
+    """Return every module key any category accepts.
+
+    Returns:
+        The union of the technique, model, and other key sets.
+    """
+    return frozenset().union(*(_category_member_keys(name) for name in CATEGORY_KEYS))
 
 
 def _category_member_keys(category: str) -> frozenset[str]:
@@ -264,15 +359,29 @@ def _parse_log_level_arguments(
     if isinstance(values, str):
         values = [values]
 
+    known_keys = _all_module_keys()
     global_level: str | None = None
     modules: dict[str, str] = {}
     for value in values:
         text = str(value)
         if '=' in text:
             key, _, level = text.partition('=')
-            modules[key.strip()] = normalize_level(level)
+            key = key.strip()
+            if not key:
+                raise ValueError(f'--log-level {text!r} names no module before the "="')
+            if key not in known_keys:
+                raise ValueError(
+                    f'--log-level {text!r} names unknown module {key!r}; '
+                    f'expected one of {sorted(known_keys)}'
+                )
+            resolved = _level_or_none(level, f'--log-level {key}')
+            if resolved is None:
+                raise ValueError(f'--log-level {text!r} names no level after the "="')
+            modules[key] = resolved
         else:
-            global_level = normalize_level(text)
+            resolved = _level_or_none(text, '--log-level')
+            if resolved is not None:
+                global_level = resolved
     return global_level, modules
 
 
@@ -341,14 +450,16 @@ def _handlers_for(*, console: bool, to_file: bool, path: FCPath | None, level: s
     Raises:
         ValueError: If ``to_file`` is set without a ``path``.
     """
-    handlers: list[Any] = []
+    handlers: list[logging.Handler] = []
     if level != _OFF:
         if console:
             handlers.append(pdslogger.stream_handler(level=level.lower()))
         if to_file:
             if path is None:
                 raise ValueError('A file sink was requested without a destination path')
-            path.parent.mkdir(parents=True, exist_ok=True)
+            # No mkdir here: pdslogger.file_handler creates missing parents
+            # itself, and FCPath.mkdir raises NotImplementedError on a remote
+            # root, which is exactly the cloud-task configuration.
             handlers.append(pdslogger.file_handler(path, level=level.lower()))
     if not handlers:
         handlers.append(pdslogger.NULL_HANDLER)
@@ -379,12 +490,15 @@ def build_main_logger(
         The path written to, or None when no file sink is enabled.
     """
     # remove_all_handlers detaches but does not close, so a rebuild would leak
-    # the previous run's open log file.
+    # the previous run's open log file.  NULL_HANDLER is a process-wide
+    # singleton this module does not own, so it is left alone.
     for existing in list(logger.handlers):
-        existing.close()
+        if existing is not pdslogger.NULL_HANDLER:
+            existing.close()
     logger.remove_all_handlers()
     stamp = timestamp if timestamp is not None else run_timestamp()
-    path = main_log_path(sinks.log_root, program_name, timestamp=stamp) if sinks.main_file else None
+    writes_a_file = sinks.main_file and levels.main != _OFF
+    path = main_log_path(sinks.log_root, program_name, timestamp=stamp) if writes_a_file else None
     for handler in _handlers_for(
         console=sinks.main_console, to_file=sinks.main_file, path=path, level=levels.main
     ):
@@ -403,8 +517,9 @@ def build_image_log_handlers(
     """Build the handlers for one image, to be attached for that image only.
 
     The handlers are returned rather than attached because the image logger
-    scopes them to a single ``logger.open(...)`` section, which removes them
-    when the image is done.
+    scopes them to a single ``logger.open(...)`` section.  Closing the section
+    detaches them but does not close them, so the caller owns disposal and must
+    close each handler once the image is done.
 
     Parameters:
         backend: The per-image backend, one of :data:`BACKEND_NAMES`.
@@ -425,13 +540,17 @@ def build_image_log_handlers(
     if backend not in BACKEND_NAMES:
         raise ValueError(f'Unknown backend {backend!r}; expected one of {sorted(BACKEND_NAMES)}')
     stamp = timestamp if timestamp is not None else run_timestamp()
+    # Built at the most verbose level any module can ask for; the per-section
+    # floor set from LogLevels.section_level_for then does the discrimination.
+    handler_level = levels.most_verbose_image_level()
+    writes_a_file = sinks.image_file and handler_level != _OFF
     path = (
         image_log_path(sinks.log_root, backend, results_path_stub, timestamp=stamp)
-        if sinks.image_file
+        if writes_a_file
         else None
     )
     handlers = _handlers_for(
-        console=sinks.image_console, to_file=sinks.image_file, path=path, level=levels.image
+        console=sinks.image_console, to_file=sinks.image_file, path=path, level=handler_level
     )
     return handlers, path
 

--- a/src/spindoctor/config/logging_keys.py
+++ b/src/spindoctor/config/logging_keys.py
@@ -26,6 +26,7 @@ __all__ = [
     'CATEGORY_KEYS',
     'LOGGER_KEYS',
     'LOG_LEVEL_NAMES',
+    'LOG_LEVEL_VALUES',
     'OTHER_LOG_KEYS',
     'log_key_for',
     'model_log_keys',
@@ -35,7 +36,22 @@ __all__ = [
 ]
 
 
-LOG_LEVEL_NAMES = frozenset({'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL', 'NONE'})
+LOG_LEVEL_VALUES = {
+    'DEBUG': 10,
+    'INFO': 20,
+    'WARNING': 30,
+    'ERROR': 40,
+    'CRITICAL': 50,
+    'NONE': 51,
+}
+"""Numeric severity of each level name, ordered least to most severe.
+
+``NONE`` sits above ``CRITICAL`` so that selecting it suppresses every record
+the library can emit, rather than relying on nothing happening to log at
+``CRITICAL``.
+"""
+
+LOG_LEVEL_NAMES = frozenset(LOG_LEVEL_VALUES)
 """Level names accepted anywhere in the ``logging`` section."""
 
 LOGGER_KEYS = frozenset({'main', 'image'})
@@ -130,6 +146,23 @@ def normalize_level(value: str) -> str:
     return value.strip().upper()
 
 
+def _is_shipped(cls: type) -> bool:
+    """Whether ``cls`` is part of the distributed package.
+
+    The technique and model registries are process-global, and test modules
+    register their own subclasses into them.  Filtering on the defining module
+    keeps the key namespace to what actually ships, so a configuration key set
+    cannot vary with which tests have been imported.
+
+    Parameters:
+        cls: A registered technique or model class.
+
+    Returns:
+        True when ``cls`` is defined inside the ``spindoctor`` package.
+    """
+    return cls.__module__.startswith('spindoctor.')
+
+
 def technique_log_keys() -> frozenset[str]:
     """Return the configuration key for every navigation technique.
 
@@ -143,7 +176,7 @@ def technique_log_keys() -> frozenset[str]:
     from spindoctor.nav_technique.nav_technique import NavTechnique
     from spindoctor.nav_technique.nav_technique_manual import NavTechniqueManual
 
-    keys = {log_key_for(cls) for cls in NavTechnique._registry}
+    keys = {log_key_for(cls) for cls in NavTechnique._registry if _is_shipped(cls)}
     keys.add(log_key_for(NavTechniqueManual))
     return frozenset(keys)
 
@@ -158,7 +191,7 @@ def model_log_keys() -> frozenset[str]:
     """
     from spindoctor.nav_model.nav_model import NavModel
 
-    return frozenset(log_key_for(cls) for cls in NavModel._registry)
+    return frozenset(log_key_for(cls) for cls in NavModel._registry if _is_shipped(cls))
 
 
 def _validate_level(value: Any, location: str) -> None:

--- a/src/spindoctor/config_files/config_015_logging.yaml
+++ b/src/spindoctor/config_files/config_015_logging.yaml
@@ -22,22 +22,24 @@ logging:
   main: INFO
   image: INFO
 
-  # Per-module overrides.  A category's "default" applies to every module in
-  # that category and overrides the "image" default above; a module key applies
-  # to that module alone.  Technique and model keys are the snake_case form of
-  # the class name with the NavTechnique / NavModel prefix, a trailing Nav, and
-  # a trailing Simulated removed, so TitanHazeNav is "titan_haze" and both
-  # NavModelRings and NavModelRingsSimulated are "rings".
-  techniques:
-    default: INFO
-  models:
-    default: INFO
+  # Per-module overrides.  A module with no entry here follows the "image"
+  # level above, so nothing is listed that would only restate it: writing
+  # "default: INFO" in a category would shadow "image", and a later
+  # "image: DEBUG" would then silently fail to reach that category.  A
+  # category's "default" is for deliberately holding one category away from
+  # the image level.
+  #
+  # Technique and model keys are the snake_case form of the class name with the
+  # NavTechnique / NavModel prefix, a trailing Nav, and a trailing Simulated
+  # removed, so TitanHazeNav is "titan_haze" and both NavModelRings and
+  # NavModelRingsSimulated are "rings".
+  techniques: {}
+  models: {}
 
   # Image-scoped components that are neither a technique nor a model.  There is
   # no key here for a per-image backend: a backend's verbosity is the "image"
   # level of whichever program drives it.
   other:
-    default: INFO
     annotate: ERROR
 
   # Per-program overrides, keyed by program identity (see

--- a/tests/spindoctor/config/test_logging_config.py
+++ b/tests/spindoctor/config/test_logging_config.py
@@ -1,0 +1,521 @@
+"""Tests for logging level resolution, sink selection, and logger construction."""
+
+import argparse
+import logging
+from pathlib import Path
+
+import pdslogger
+import pytest
+from filecache import FCPath
+
+from spindoctor.config.config import Config
+from spindoctor.config.logging_config import (
+    BACKEND_NAMES,
+    DEFAULT_LEVEL,
+    LogLevels,
+    LogSinks,
+    build_image_log_handlers,
+    build_main_logger,
+    image_log_path,
+    main_log_path,
+    resolve_log_levels,
+    sinks_from_arguments,
+)
+from spindoctor.config.program_names import SD_MOSAIC, SD_OFFSET
+
+_STAMP = '2026-07-29T12-00-00'
+
+
+def _config(tmp_path: Path, body: str = '') -> Config:
+    """Build a Config carrying the shipped defaults plus a logging override.
+
+    Parameters:
+        tmp_path: Directory to write the override file into.
+        body: YAML text placed under a ``logging:`` key; empty for defaults only.
+
+    Returns:
+        The loaded Config.
+    """
+    config = Config()
+    config.read_config()
+    if body:
+        override = tmp_path / 'override.yaml'
+        override.write_text(f'logging:\n{body}')
+        config.update_config(str(override))
+    return config
+
+
+def _args(**kwargs: object) -> argparse.Namespace:
+    """Build a Namespace carrying only the given logging arguments.
+
+    Parameters:
+        **kwargs: Argument names and values to set.
+
+    Returns:
+        The populated Namespace.
+    """
+    return argparse.Namespace(**kwargs)
+
+
+def _close(handlers: list[object]) -> None:
+    """Close any handlers holding an open file.
+
+    Parameters:
+        handlers: Handlers returned by a builder.
+    """
+    for handler in handlers:
+        close = getattr(handler, 'close', None)
+        if close is not None:
+            close()
+
+
+def _sinks(tmp_path: Path, **kwargs: bool) -> LogSinks:
+    """Build a LogSinks rooted at ``tmp_path``.
+
+    Parameters:
+        tmp_path: Directory used as the log root.
+        **kwargs: Sink flags to override.
+
+    Returns:
+        The constructed LogSinks.
+    """
+    return LogSinks(log_root=FCPath(str(tmp_path)), **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Level resolution: defaults and configuration
+# ---------------------------------------------------------------------------
+
+
+def test_defaults_resolve_to_info(tmp_path: Path) -> None:
+    """With nothing configured, both loggers resolve to the fallback level."""
+    levels = resolve_log_levels(SD_OFFSET, None, _config(tmp_path))
+    assert levels.main == DEFAULT_LEVEL
+
+
+def test_image_default_resolves_to_info(tmp_path: Path) -> None:
+    """The image logger shares the fallback level."""
+    levels = resolve_log_levels(SD_OFFSET, None, _config(tmp_path))
+    assert levels.image == DEFAULT_LEVEL
+
+
+def test_config_sets_the_main_level(tmp_path: Path) -> None:
+    """A configured main level is used."""
+    levels = resolve_log_levels(SD_OFFSET, None, _config(tmp_path, '  main: WARNING\n'))
+    assert levels.main == 'WARNING'
+
+
+def test_config_level_is_canonicalized(tmp_path: Path) -> None:
+    """A lower-case configured level resolves to its canonical spelling."""
+    levels = resolve_log_levels(SD_OFFSET, None, _config(tmp_path, '  main: warning\n'))
+    assert levels.main == 'WARNING'
+
+
+def test_module_override_beats_the_image_default(tmp_path: Path) -> None:
+    """A named module takes its own level rather than the image default."""
+    config = _config(tmp_path, '  image: WARNING\n  techniques:\n    titan_haze: DEBUG\n')
+    levels = resolve_log_levels(SD_OFFSET, None, config)
+    assert levels.for_module('titan_haze') == 'DEBUG'
+
+
+def test_unnamed_module_takes_the_image_default(tmp_path: Path) -> None:
+    """A module with no override of its own follows the image level."""
+    config = _config(tmp_path, '  image: WARNING\n  techniques:\n    titan_haze: DEBUG\n')
+    levels = resolve_log_levels(SD_OFFSET, None, config)
+    assert levels.for_module('body_limb') == 'WARNING'
+
+
+def test_category_default_applies_to_its_members(tmp_path: Path) -> None:
+    """A category default governs every module in that category."""
+    config = _config(tmp_path, '  techniques:\n    default: DEBUG\n')
+    levels = resolve_log_levels(SD_OFFSET, None, config)
+    assert levels.for_module('body_limb') == 'DEBUG'
+
+
+def test_category_default_does_not_cross_categories(tmp_path: Path) -> None:
+    """A technique category default leaves models alone."""
+    config = _config(tmp_path, '  techniques:\n    default: DEBUG\n')
+    levels = resolve_log_levels(SD_OFFSET, None, config)
+    assert levels.for_module('rings') == DEFAULT_LEVEL
+
+
+def test_module_override_beats_its_category_default(tmp_path: Path) -> None:
+    """A named module wins over the default of its own category."""
+    config = _config(tmp_path, '  techniques:\n    default: DEBUG\n    titan_haze: ERROR\n')
+    levels = resolve_log_levels(SD_OFFSET, None, config)
+    assert levels.for_module('titan_haze') == 'ERROR'
+
+
+def test_shipped_annotation_level_survives_resolution(tmp_path: Path) -> None:
+    """The shipped annotation override reaches the resolved levels."""
+    levels = resolve_log_levels(SD_OFFSET, None, _config(tmp_path))
+    assert levels.for_module('annotate') == 'ERROR'
+
+
+# ---------------------------------------------------------------------------
+# Level resolution: the program merge
+# ---------------------------------------------------------------------------
+
+
+def test_program_block_overrides_the_global_default(tmp_path: Path) -> None:
+    """A program's block wins over the top-level value for that program."""
+    config = _config(
+        tmp_path, f'  main: INFO\n  programs:\n    {SD_MOSAIC}:\n      main: WARNING\n'
+    )
+    levels = resolve_log_levels(SD_MOSAIC, None, config)
+    assert levels.main == 'WARNING'
+
+
+def test_program_block_does_not_affect_another_program(tmp_path: Path) -> None:
+    """One program's block leaves every other program untouched."""
+    config = _config(
+        tmp_path, f'  main: INFO\n  programs:\n    {SD_MOSAIC}:\n      main: WARNING\n'
+    )
+    levels = resolve_log_levels(SD_OFFSET, None, config)
+    assert levels.main == 'INFO'
+
+
+def test_program_block_inherits_unmentioned_keys(tmp_path: Path) -> None:
+    """Overriding one key leaves the rest of the global block in force."""
+    config = _config(
+        tmp_path, f'  image: WARNING\n  programs:\n    {SD_MOSAIC}:\n      main: ERROR\n'
+    )
+    levels = resolve_log_levels(SD_MOSAIC, None, config)
+    assert levels.image == 'WARNING'
+
+
+def test_program_block_merges_within_a_category(tmp_path: Path) -> None:
+    """A program overriding one module keeps the global entries for the others."""
+    config = _config(
+        tmp_path,
+        '  techniques:\n    titan_haze: DEBUG\n    body_limb: ERROR\n'
+        f'  programs:\n    {SD_MOSAIC}:\n      techniques:\n        titan_haze: WARNING\n',
+    )
+    levels = resolve_log_levels(SD_MOSAIC, None, config)
+    assert levels.for_module('body_limb') == 'ERROR'
+
+
+def test_program_block_wins_within_a_category(tmp_path: Path) -> None:
+    """The program's value for a module wins over the global one."""
+    config = _config(
+        tmp_path,
+        '  techniques:\n    titan_haze: DEBUG\n'
+        f'  programs:\n    {SD_MOSAIC}:\n      techniques:\n        titan_haze: WARNING\n',
+    )
+    levels = resolve_log_levels(SD_MOSAIC, None, config)
+    assert levels.for_module('titan_haze') == 'WARNING'
+
+
+# ---------------------------------------------------------------------------
+# Level resolution: command line
+# ---------------------------------------------------------------------------
+
+
+def test_bare_log_level_sets_both_loggers(tmp_path: Path) -> None:
+    """A bare --log-level sets the default for the main logger."""
+    levels = resolve_log_levels(SD_OFFSET, _args(log_level=['DEBUG']), _config(tmp_path))
+    assert levels.main == 'DEBUG'
+
+
+def test_bare_log_level_sets_the_image_logger_too(tmp_path: Path) -> None:
+    """A bare --log-level sets the default for the image logger as well."""
+    levels = resolve_log_levels(SD_OFFSET, _args(log_level=['DEBUG']), _config(tmp_path))
+    assert levels.image == 'DEBUG'
+
+
+def test_log_level_main_beats_the_bare_form(tmp_path: Path) -> None:
+    """The per-logger flag is more specific than the global one."""
+    args = _args(log_level=['DEBUG'], log_level_main='ERROR')
+    levels = resolve_log_levels(SD_OFFSET, args, _config(tmp_path))
+    assert levels.main == 'ERROR'
+
+
+def test_log_level_main_leaves_the_image_logger_alone(tmp_path: Path) -> None:
+    """Setting the main level does not change the image level."""
+    args = _args(log_level=['DEBUG'], log_level_main='ERROR')
+    levels = resolve_log_levels(SD_OFFSET, args, _config(tmp_path))
+    assert levels.image == 'DEBUG'
+
+
+def test_module_form_sets_one_module(tmp_path: Path) -> None:
+    """--log-level MODULE=LEVEL sets that module."""
+    args = _args(log_level=['titan_haze=DEBUG'])
+    levels = resolve_log_levels(SD_OFFSET, args, _config(tmp_path))
+    assert levels.for_module('titan_haze') == 'DEBUG'
+
+
+def test_module_form_leaves_other_modules_alone(tmp_path: Path) -> None:
+    """A per-module flag affects only the module it names."""
+    args = _args(log_level=['titan_haze=DEBUG'])
+    levels = resolve_log_levels(SD_OFFSET, args, _config(tmp_path))
+    assert levels.for_module('body_limb') == DEFAULT_LEVEL
+
+
+def test_module_form_beats_the_configuration(tmp_path: Path) -> None:
+    """A module named on the command line wins over the configured value."""
+    config = _config(tmp_path, '  techniques:\n    titan_haze: ERROR\n')
+    args = _args(log_level=['titan_haze=DEBUG'])
+    levels = resolve_log_levels(SD_OFFSET, args, config)
+    assert levels.for_module('titan_haze') == 'DEBUG'
+
+
+def test_bare_and_module_forms_combine(tmp_path: Path) -> None:
+    """The documented "debug everywhere except one" invocation works."""
+    args = _args(log_level=['debug', 'titan_haze=info'])
+    levels = resolve_log_levels(SD_OFFSET, args, _config(tmp_path))
+    assert levels.for_module('titan_haze') == 'INFO'
+
+
+def test_bare_form_still_applies_to_other_modules(tmp_path: Path) -> None:
+    """The bare form governs every module the per-module form did not name."""
+    args = _args(log_level=['debug', 'titan_haze=info'])
+    levels = resolve_log_levels(SD_OFFSET, args, _config(tmp_path))
+    assert levels.for_module('body_limb') == 'DEBUG'
+
+
+def test_a_later_bare_form_wins(tmp_path: Path) -> None:
+    """Repeating the bare form takes the last value rather than combining."""
+    args = _args(log_level=['debug', 'error'])
+    levels = resolve_log_levels(SD_OFFSET, args, _config(tmp_path))
+    assert levels.main == 'ERROR'
+
+
+def test_command_line_beats_a_program_block(tmp_path: Path) -> None:
+    """A per-logger flag wins over a per-program configured value."""
+    config = _config(tmp_path, f'  programs:\n    {SD_MOSAIC}:\n      main: WARNING\n')
+    levels = resolve_log_levels(SD_MOSAIC, _args(log_level_main='ERROR'), config)
+    assert levels.main == 'ERROR'
+
+
+def test_configured_module_beats_a_bare_command_line_level(tmp_path: Path) -> None:
+    """A configured module is more specific than a global command-line default."""
+    config = _config(tmp_path, '  techniques:\n    titan_haze: ERROR\n')
+    levels = resolve_log_levels(SD_OFFSET, _args(log_level=['DEBUG']), config)
+    assert levels.for_module('titan_haze') == 'ERROR'
+
+
+# ---------------------------------------------------------------------------
+# Sinks
+# ---------------------------------------------------------------------------
+
+
+def test_default_sinks_put_main_on_the_console(tmp_path: Path) -> None:
+    """The main logger writes to the console by default."""
+    assert sinks_from_arguments(None, FCPath(str(tmp_path))).main_console is True
+
+
+def test_default_sinks_keep_image_off_the_console(tmp_path: Path) -> None:
+    """The image logger stays off the console by default."""
+    assert sinks_from_arguments(None, FCPath(str(tmp_path))).image_console is False
+
+
+def test_default_sinks_write_both_log_files(tmp_path: Path) -> None:
+    """Both loggers write files by default."""
+    sinks = sinks_from_arguments(None, FCPath(str(tmp_path)))
+    assert (sinks.main_file, sinks.image_file) == (True, True)
+
+
+@pytest.mark.parametrize(
+    ('flag', 'attribute'),
+    [
+        ('log_main_to_console', 'main_console'),
+        ('log_main_to_file', 'main_file'),
+        ('log_image_to_console', 'image_console'),
+        ('log_image_to_file', 'image_file'),
+    ],
+)
+def test_each_sink_flag_is_honored(tmp_path: Path, flag: str, attribute: str) -> None:
+    """Each sink flag independently controls its own sink."""
+    sinks = sinks_from_arguments(_args(**{flag: True}), FCPath(str(tmp_path)))
+    assert getattr(sinks, attribute) is True
+
+
+@pytest.mark.parametrize(
+    ('flag', 'attribute'),
+    [
+        ('log_main_to_console', 'main_console'),
+        ('log_main_to_file', 'main_file'),
+        ('log_image_to_console', 'image_console'),
+        ('log_image_to_file', 'image_file'),
+    ],
+)
+def test_each_sink_flag_can_disable(tmp_path: Path, flag: str, attribute: str) -> None:
+    """Each sink flag can turn its sink off."""
+    sinks = sinks_from_arguments(_args(**{flag: False}), FCPath(str(tmp_path)))
+    assert getattr(sinks, attribute) is False
+
+
+# ---------------------------------------------------------------------------
+# Log paths
+# ---------------------------------------------------------------------------
+
+
+def test_main_log_path_is_under_the_program_directory(tmp_path: Path) -> None:
+    """A main log lands under a directory named for its program."""
+    path = main_log_path(FCPath(str(tmp_path)), SD_OFFSET, timestamp=_STAMP)
+    assert path.as_posix().endswith(f'{SD_OFFSET}/main_{_STAMP}.log')
+
+
+@pytest.mark.parametrize('backend', sorted(BACKEND_NAMES))
+def test_image_log_path_is_under_the_backend_directory(tmp_path: Path, backend: str) -> None:
+    """An image log lands under a directory named for its backend."""
+    path = image_log_path(
+        FCPath(str(tmp_path)), backend, 'COISS_2001/data/N123_1', timestamp=_STAMP
+    )
+    assert path.as_posix().endswith(f'{backend}/COISS_2001/data/N123_1_{_STAMP}.log')
+
+
+def test_image_log_path_rejects_an_unknown_backend(tmp_path: Path) -> None:
+    """A backend that is not one of the three is rejected."""
+    with pytest.raises(ValueError, match='Unknown backend'):
+        image_log_path(FCPath(str(tmp_path)), 'wibble', 'stub', timestamp=_STAMP)
+
+
+def test_two_backends_do_not_collide_for_one_image(tmp_path: Path) -> None:
+    """The same image logged by two backends lands in two distinct files."""
+    root = FCPath(str(tmp_path))
+    nav = image_log_path(root, 'nav', 'vol/N123', timestamp=_STAMP)
+    reproj = image_log_path(root, 'reproj', 'vol/N123', timestamp=_STAMP)
+    assert nav.as_posix() != reproj.as_posix()
+
+
+# ---------------------------------------------------------------------------
+# Logger construction
+# ---------------------------------------------------------------------------
+
+
+def test_main_logger_gets_both_handlers(tmp_path: Path) -> None:
+    """With both sinks enabled the main logger carries two handlers."""
+    logger = pdslogger.PdsLogger('test_main_both', lognames=False)
+    build_main_logger(logger, SD_OFFSET, _sinks(tmp_path), LogLevels(), timestamp=_STAMP)
+    count = len(logger.handlers)
+    _close(logger.handlers)
+    logger.remove_all_handlers()
+    assert count == 2
+
+
+def test_main_logger_writes_to_the_reported_path(tmp_path: Path) -> None:
+    """The returned path is the file the main logger actually writes."""
+    logger = pdslogger.PdsLogger('test_main_path', lognames=False)
+    path = build_main_logger(
+        logger, SD_OFFSET, _sinks(tmp_path, main_console=False), LogLevels(), timestamp=_STAMP
+    )
+    logger.info('a line')
+    _close(logger.handlers)
+    logger.remove_all_handlers()
+    assert path is not None
+    assert 'a line' in Path(path.as_posix()).read_text()
+
+
+def test_main_logger_reports_no_path_without_a_file_sink(tmp_path: Path) -> None:
+    """Disabling the file sink reports no path."""
+    logger = pdslogger.PdsLogger('test_main_nofile', lognames=False)
+    path = build_main_logger(
+        logger, SD_OFFSET, _sinks(tmp_path, main_file=False), LogLevels(), timestamp=_STAMP
+    )
+    assert path is None
+
+
+def test_rebuilding_does_not_duplicate_handlers(tmp_path: Path) -> None:
+    """Building twice replaces the handlers rather than accumulating them."""
+    logger = pdslogger.PdsLogger('test_main_twice', lognames=False)
+    build_main_logger(logger, SD_OFFSET, _sinks(tmp_path), LogLevels(), timestamp=_STAMP)
+    build_main_logger(logger, SD_OFFSET, _sinks(tmp_path), LogLevels(), timestamp=_STAMP)
+    count = len(logger.handlers)
+    _close(logger.handlers)
+    logger.remove_all_handlers()
+    assert count == 2
+
+
+def test_disabling_every_main_sink_attaches_the_null_handler(tmp_path: Path) -> None:
+    """A logger with no sink still has a handler, so it cannot fall back to printing."""
+    logger = pdslogger.PdsLogger('test_main_null', lognames=False)
+    build_main_logger(
+        logger,
+        SD_OFFSET,
+        _sinks(tmp_path, main_console=False, main_file=False),
+        LogLevels(),
+        timestamp=_STAMP,
+    )
+    assert isinstance(logger.handlers[0], logging.NullHandler)
+
+
+def test_a_silenced_main_logger_prints_nothing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """With every sink off, logging produces no terminal output at all."""
+    logger = pdslogger.PdsLogger('test_main_quiet', lognames=False)
+    build_main_logger(
+        logger,
+        SD_OFFSET,
+        _sinks(tmp_path, main_console=False, main_file=False),
+        LogLevels(),
+        timestamp=_STAMP,
+    )
+    logger.info('should not appear')
+    logger.error('should not appear either')
+    assert capsys.readouterr().out == ''
+
+
+def test_level_none_silences_the_logger(tmp_path: Path) -> None:
+    """A level of NONE attaches the null handler rather than a live sink."""
+    logger = pdslogger.PdsLogger('test_main_none', lognames=False)
+    build_main_logger(logger, SD_OFFSET, _sinks(tmp_path), LogLevels(main='NONE'), timestamp=_STAMP)
+    assert isinstance(logger.handlers[0], logging.NullHandler)
+
+
+def test_image_handlers_are_built_for_the_backend(tmp_path: Path) -> None:
+    """Image handlers report the backend-scoped path they will write."""
+    handlers, path = build_image_log_handlers(
+        'nav', 'vol/N123', _sinks(tmp_path), LogLevels(), timestamp=_STAMP
+    )
+    _close(handlers)
+    assert path is not None
+    assert '/nav/' in path.as_posix()
+
+
+def test_image_handlers_default_to_file_only(tmp_path: Path) -> None:
+    """With default sinks the image logger gets exactly one handler."""
+    handlers, _ = build_image_log_handlers(
+        'nav', 'vol/N123', _sinks(tmp_path), LogLevels(), timestamp=_STAMP
+    )
+    _close(handlers)
+    assert len(handlers) == 1
+
+
+def test_image_handlers_reject_an_unknown_backend(tmp_path: Path) -> None:
+    """An unknown backend is rejected even when no file sink is enabled."""
+    with pytest.raises(ValueError, match='Unknown backend'):
+        build_image_log_handlers(
+            'wibble', 'vol/N123', _sinks(tmp_path, image_file=False), LogLevels(), timestamp=_STAMP
+        )
+
+
+def test_image_handlers_fall_back_to_the_null_handler(tmp_path: Path) -> None:
+    """An image logger with no sink still gets a handler."""
+    handlers, _ = build_image_log_handlers(
+        'nav',
+        'vol/N123',
+        _sinks(tmp_path, image_console=False, image_file=False),
+        LogLevels(),
+        timestamp=_STAMP,
+    )
+    assert isinstance(handlers[0], logging.NullHandler)
+
+
+def test_no_builder_ever_returns_an_empty_handler_list(tmp_path: Path) -> None:
+    """Across every sink combination, a logger is never left able to print by fallback."""
+    empty = []
+    for console in (True, False):
+        for to_file in (True, False):
+            handlers, _ = build_image_log_handlers(
+                'nav',
+                'vol/N123',
+                _sinks(tmp_path, image_console=console, image_file=to_file),
+                LogLevels(),
+                timestamp=_STAMP,
+            )
+            _close(handlers)
+            if not handlers:
+                empty.append((console, to_file))
+    assert empty == []

--- a/tests/spindoctor/config/test_logging_config.py
+++ b/tests/spindoctor/config/test_logging_config.py
@@ -408,7 +408,8 @@ def test_main_logger_writes_to_the_reported_path(tmp_path: Path) -> None:
     _close(logger.handlers)
     logger.remove_all_handlers()
     assert path is not None
-    assert 'a line' in Path(path.as_posix()).read_text()
+    with path.open('r') as handle:
+        assert 'a line' in handle.read()
 
 
 def test_main_logger_reports_no_path_without_a_file_sink(tmp_path: Path) -> None:
@@ -553,7 +554,8 @@ def _emit_through_sections(
                 getattr(logger, method)(message)
     _close(handlers)
     assert path is not None
-    return Path(path.as_posix()).read_text()
+    with path.open('r') as handle:
+        return str(handle.read())
 
 
 def test_a_module_raised_above_the_image_level_reaches_the_sink(tmp_path: Path) -> None:

--- a/tests/spindoctor/config/test_logging_config.py
+++ b/tests/spindoctor/config/test_logging_config.py
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+from datetime import datetime
 from pathlib import Path
 
 import pdslogger
@@ -12,6 +13,8 @@ from spindoctor.config.config import Config
 from spindoctor.config.logging_config import (
     BACKEND_NAMES,
     DEFAULT_LEVEL,
+    LOG_TIMESTAMP_FORMAT,
+    SILENT_LEVEL,
     LogLevels,
     LogSinks,
     build_image_log_handlers,
@@ -19,6 +22,7 @@ from spindoctor.config.logging_config import (
     image_log_path,
     main_log_path,
     resolve_log_levels,
+    run_timestamp,
     sinks_from_arguments,
 )
 from spindoctor.config.program_names import SD_MOSAIC, SD_OFFSET
@@ -519,3 +523,279 @@ def test_no_builder_ever_returns_an_empty_handler_list(tmp_path: Path) -> None:
             if not handlers:
                 empty.append((console, to_file))
     assert empty == []
+
+
+# ---------------------------------------------------------------------------
+# Per-module levels must actually reach a sink
+# ---------------------------------------------------------------------------
+
+
+def _emit_through_sections(
+    tmp_path: Path, levels: LogLevels, emissions: list[tuple[str, str, str]]
+) -> str:
+    """Log through per-module sections and return what the image log file holds.
+
+    Parameters:
+        tmp_path: Directory used as the log root.
+        levels: Resolved levels governing the sections.
+        emissions: Tuples of module key, level-method name, and message.
+
+    Returns:
+        The text written to the image log.
+    """
+    handlers, path = build_image_log_handlers(
+        'nav', 'vol/N1', _sinks(tmp_path), levels, timestamp=_STAMP
+    )
+    logger = pdslogger.PdsLogger(f'emit_{tmp_path.name}', lognames=False)
+    with logger.open('IMAGE', handler=handlers):
+        for log_key, method, message in emissions:
+            with logger.open(f'MODULE: {log_key}', level=levels.section_level_for(log_key)):
+                getattr(logger, method)(message)
+    _close(handlers)
+    assert path is not None
+    return Path(path.as_posix()).read_text()
+
+
+def test_a_module_raised_above_the_image_level_reaches_the_sink(tmp_path: Path) -> None:
+    """A module configured more verbose than the image level actually writes."""
+    levels = LogLevels(image='INFO', modules={'titan_haze': 'DEBUG'})
+    text = _emit_through_sections(tmp_path, levels, [('titan_haze', 'debug', 'HAZE-DEBUG')])
+    assert 'HAZE-DEBUG' in text
+
+
+def test_an_unraised_module_still_honors_the_image_level(tmp_path: Path) -> None:
+    """Raising one module does not make every other module verbose."""
+    levels = LogLevels(image='INFO', modules={'titan_haze': 'DEBUG'})
+    text = _emit_through_sections(tmp_path, levels, [('ring_edge', 'debug', 'RING-DEBUG')])
+    assert 'RING-DEBUG' not in text
+
+
+def test_a_module_lowered_below_the_image_level_is_suppressed(tmp_path: Path) -> None:
+    """A module configured quieter than the image level drops its lesser records."""
+    levels = LogLevels(image='INFO', modules={'body_limb': 'ERROR'})
+    text = _emit_through_sections(tmp_path, levels, [('body_limb', 'info', 'LIMB-INFO')])
+    assert 'LIMB-INFO' not in text
+
+
+def test_a_lowered_module_still_reports_severe_records(tmp_path: Path) -> None:
+    """Quieting a module does not lose its errors."""
+    levels = LogLevels(image='INFO', modules={'body_limb': 'ERROR'})
+    text = _emit_through_sections(tmp_path, levels, [('body_limb', 'error', 'LIMB-ERROR')])
+    assert 'LIMB-ERROR' in text
+
+
+def test_handlers_are_built_at_the_most_verbose_module_level(tmp_path: Path) -> None:
+    """The sinks are opened wide enough for the most verbose module to pass."""
+    levels = LogLevels(image='WARNING', modules={'titan_haze': 'DEBUG'})
+    handlers, _ = build_image_log_handlers(
+        'nav', 'vol/N1', _sinks(tmp_path), levels, timestamp=_STAMP
+    )
+    level = handlers[0].level
+    _close(handlers)
+    assert level == logging.DEBUG
+
+
+def test_most_verbose_level_ignores_a_quieter_module(tmp_path: Path) -> None:
+    """A module quieter than the image level does not raise the handler level."""
+    levels = LogLevels(image='INFO', modules={'body_limb': 'ERROR'})
+    assert levels.most_verbose_image_level() == 'INFO'
+
+
+# ---------------------------------------------------------------------------
+# NONE
+# ---------------------------------------------------------------------------
+
+
+def test_section_level_for_a_silent_module_is_not_the_name() -> None:
+    """A NONE module resolves to a numeric level pdslogger will accept."""
+    levels = LogLevels(modules={'titan_haze': 'NONE'})
+    assert levels.section_level_for('titan_haze') == SILENT_LEVEL
+
+
+def test_a_silent_module_can_open_a_section(tmp_path: Path) -> None:
+    """Opening a section for a NONE module does not raise."""
+    levels = LogLevels(image='INFO', modules={'titan_haze': 'NONE'})
+    text = _emit_through_sections(tmp_path, levels, [('titan_haze', 'critical', 'HAZE-CRIT')])
+    assert 'HAZE-CRIT' not in text
+
+
+def test_a_silent_main_logger_reports_no_path(tmp_path: Path) -> None:
+    """A main logger at NONE writes no file, so it reports no path."""
+    logger = pdslogger.PdsLogger('test_none_path', lognames=False)
+    path = build_main_logger(
+        logger, SD_OFFSET, _sinks(tmp_path), LogLevels(main='NONE'), timestamp=_STAMP
+    )
+    logger.remove_all_handlers()
+    assert path is None
+
+
+def test_a_silent_image_logger_reports_no_path(tmp_path: Path) -> None:
+    """An image logger silenced everywhere writes no file, so it reports no path."""
+    handlers, path = build_image_log_handlers(
+        'nav', 'vol/N1', _sinks(tmp_path), LogLevels(image='NONE'), timestamp=_STAMP
+    )
+    _close(handlers)
+    assert path is None
+
+
+# ---------------------------------------------------------------------------
+# Command-line validation
+# ---------------------------------------------------------------------------
+
+
+def test_an_unknown_command_line_level_is_rejected(tmp_path: Path) -> None:
+    """A misspelled level fails with a named error rather than a later KeyError."""
+    with pytest.raises(ValueError, match='VERBOSE'):
+        resolve_log_levels(SD_OFFSET, _args(log_level=['VERBOSE']), _config(tmp_path))
+
+
+def test_an_unknown_per_logger_level_is_rejected(tmp_path: Path) -> None:
+    """A misspelled --log-level-main value is rejected."""
+    with pytest.raises(ValueError, match='log-level-main'):
+        resolve_log_levels(SD_OFFSET, _args(log_level_main='CHATTY'), _config(tmp_path))
+
+
+def test_an_unknown_command_line_module_is_rejected(tmp_path: Path) -> None:
+    """A module key naming nothing is rejected rather than silently ignored."""
+    with pytest.raises(ValueError, match='bogus_module'):
+        resolve_log_levels(SD_OFFSET, _args(log_level=['bogus_module=DEBUG']), _config(tmp_path))
+
+
+def test_a_hyphenated_module_key_is_rejected(tmp_path: Path) -> None:
+    """A near-miss spelling is rejected rather than quietly doing nothing."""
+    with pytest.raises(ValueError, match='titan-haze'):
+        resolve_log_levels(SD_OFFSET, _args(log_level=['titan-haze=DEBUG']), _config(tmp_path))
+
+
+def test_an_empty_module_key_is_rejected(tmp_path: Path) -> None:
+    """A value with nothing before the equals sign is rejected."""
+    with pytest.raises(ValueError, match='no module'):
+        resolve_log_levels(SD_OFFSET, _args(log_level=['=DEBUG']), _config(tmp_path))
+
+
+def test_an_empty_command_line_level_is_rejected(tmp_path: Path) -> None:
+    """A value with nothing after the equals sign is rejected."""
+    with pytest.raises(ValueError, match='expected one of'):
+        resolve_log_levels(SD_OFFSET, _args(log_level=['titan_haze=']), _config(tmp_path))
+
+
+def test_an_empty_per_logger_level_is_rejected(tmp_path: Path) -> None:
+    """An empty level is rejected rather than falling through to a lesser source."""
+    with pytest.raises(ValueError, match='log-level-main'):
+        resolve_log_levels(
+            SD_OFFSET, _args(log_level_main='', log_level=['ERROR']), _config(tmp_path)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Coverage the first pass missed
+# ---------------------------------------------------------------------------
+
+
+def test_log_level_image_beats_the_bare_form(tmp_path: Path) -> None:
+    """The per-logger image flag is more specific than the global one."""
+    args = _args(log_level=['DEBUG'], log_level_image='ERROR')
+    levels = resolve_log_levels(SD_OFFSET, args, _config(tmp_path))
+    assert levels.image == 'ERROR'
+
+
+def test_log_level_image_leaves_the_main_logger_alone(tmp_path: Path) -> None:
+    """Setting the image level does not change the main level."""
+    args = _args(log_level=['DEBUG'], log_level_image='ERROR')
+    levels = resolve_log_levels(SD_OFFSET, args, _config(tmp_path))
+    assert levels.main == 'DEBUG'
+
+
+def test_a_models_category_default_applies(tmp_path: Path) -> None:
+    """A models category default governs every model."""
+    config = _config(tmp_path, '  models:\n    default: DEBUG\n')
+    levels = resolve_log_levels(SD_OFFSET, None, config)
+    assert levels.for_module('rings') == 'DEBUG'
+
+
+def test_an_other_category_default_applies(tmp_path: Path) -> None:
+    """An other category default governs every module in that category."""
+    config = _config(tmp_path, '  other:\n    default: DEBUG\n')
+    levels = resolve_log_levels(SD_OFFSET, None, config)
+    assert levels.for_module('ensemble') == 'DEBUG'
+
+
+def test_run_timestamp_matches_the_documented_format(tmp_path: Path) -> None:
+    """A generated timestamp parses back under the documented format."""
+    datetime.strptime(run_timestamp(), LOG_TIMESTAMP_FORMAT)
+
+
+def test_resolution_is_stable_across_repeated_calls(tmp_path: Path) -> None:
+    """Resolving twice gives the same answer, so nothing is mutated in place."""
+    config = _config(tmp_path, f'  programs:\n    {SD_MOSAIC}:\n      main: WARNING\n')
+    first = resolve_log_levels(SD_MOSAIC, None, config)
+    second = resolve_log_levels(SD_MOSAIC, None, config)
+    assert first == second
+
+
+def test_resolving_one_program_does_not_leak_into_another(tmp_path: Path) -> None:
+    """A program's merge does not contaminate the shared configuration."""
+    config = _config(
+        tmp_path, f'  main: INFO\n  programs:\n    {SD_MOSAIC}:\n      main: WARNING\n'
+    )
+    resolve_log_levels(SD_MOSAIC, None, config)
+    assert resolve_log_levels(SD_OFFSET, None, config).main == 'INFO'
+
+
+def test_module_keys_exclude_test_registered_classes(tmp_path: Path) -> None:
+    """Stub classes other tests register do not enter the resolved key set."""
+    config = _config(tmp_path, '  techniques:\n    default: DEBUG\n')
+    levels = resolve_log_levels(SD_OFFSET, None, config)
+    offenders = [key for key in levels.modules if key.startswith('_')]
+    assert offenders == []
+
+
+def test_a_cloud_log_root_is_not_mkdired(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Building against a remote root never attempts a directory creation.
+
+    FCPath.mkdir raises NotImplementedError on a remote path, and a cloud
+    results root is exactly the cloud-task configuration, so the builder must
+    leave parent creation to the handler factory.  The factory is stubbed so
+    the test needs no credentials.
+    """
+    seen: list[str] = []
+
+    def fake_file_handler(path: FCPath, level: object = None, **kwargs: object) -> logging.Handler:
+        seen.append(FCPath(path).as_posix())
+        return logging.NullHandler()
+
+    def exploding_mkdir(*args: object, **kwargs: object) -> None:
+        raise AssertionError('the builder must not mkdir a log root')
+
+    monkeypatch.setattr(pdslogger, 'file_handler', fake_file_handler)
+    monkeypatch.setattr(FCPath, 'mkdir', exploding_mkdir)
+
+    sinks = LogSinks(log_root=FCPath('gs://example-bucket/run/logs'), main_console=False)
+    logger = pdslogger.PdsLogger('test_cloud_root', lognames=False)
+    build_main_logger(logger, SD_OFFSET, sinks, LogLevels(), timestamp=_STAMP)
+    logger.remove_all_handlers()
+    assert seen == [f'gs://example-bucket/run/logs/{SD_OFFSET}/main_{_STAMP}.log']
+
+
+def test_rebuilding_reattaches_the_shared_null_handler(tmp_path: Path) -> None:
+    """A rebuild leaves the process-wide NULL_HANDLER attached, not discarded."""
+    logger = pdslogger.PdsLogger('test_null_reuse', lognames=False)
+    silent = _sinks(tmp_path, main_console=False, main_file=False)
+    build_main_logger(logger, SD_OFFSET, silent, LogLevels(), timestamp=_STAMP)
+    build_main_logger(logger, SD_OFFSET, silent, LogLevels(), timestamp=_STAMP)
+    attached = list(logger.handlers)
+    logger.remove_all_handlers()
+    assert attached == [pdslogger.NULL_HANDLER]
+
+
+def test_a_silenced_logger_stays_silent_after_a_rebuild(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Rebuilding a fully silenced logger does not restore output."""
+    logger = pdslogger.PdsLogger('test_null_quiet', lognames=False)
+    silent = _sinks(tmp_path, main_console=False, main_file=False)
+    build_main_logger(logger, SD_OFFSET, silent, LogLevels(), timestamp=_STAMP)
+    build_main_logger(logger, SD_OFFSET, silent, LogLevels(), timestamp=_STAMP)
+    logger.info('should not appear')
+    logger.remove_all_handlers()
+    assert capsys.readouterr().out == ''


### PR DESCRIPTION
Phase 2 of `plans/LOGGING_REDESIGN_PLAN.md`: the logging core. Adds `spindoctor/config/logging_config.py` and `get_log_root`.

## What this adds

`LogLevels` and `LogSinks`; `resolve_log_levels`, implementing the two-step resolution — merge the program's block over the global one, then apply most-specific-wins across command line, per-module config, category default, per-logger flag, global flag, and per-logger config; the `{log_root}/{program}/main_{ts}.log` and `{log_root}/{backend}/{stub}_{ts}.log` path layout; and the builders that attach exactly the enabled sinks.

`get_log_root` follows the established argument / configuration / environment order, defaulting to `{nav_results_root}/logs` so a run never told where to put logs still puts them somewhere predictable.

## Not yet wired

Nothing calls this yet. Phases 5 through 7 replace the eight call sites still on `setup_logging` / `image_log_handlers`, and Phase 6 — which removes the last of them — deletes `_resolve_level` and the nine `log_level_*` keys. The plan previously put that removal here; it moved because deleting the resolver while its callers remain would break them, and a PR whose net effect is only dropping configurability is not independently reviewable.

## The bug the second commit fixes

Worth reading if you review nothing else. The first commit built the image handlers at the image level, on the premise that a pdslogger section level *is* the effective level. It is not: a section level is a floor applied before the handlers, and each handler then applies its own level, so what reaches a sink is the **more severe** of the two.

The consequence was that every module configured *more verbose* than the image level had its records counted and then silently dropped by the handler — while the section summary still reported them. `techniques: {titan_haze: DEBUG}` with `image: INFO` produced a log claiming "1 DEBUG message" and containing none. Per-module verbosity increases, which is the point of this whole redesign, did nothing. Only the *quieter* direction worked, which is why the shipped `other.annotate: ERROR` looked fine and hid it.

Handlers are now built at the most verbose level any module can request, leaving the per-section floor to discriminate. Regression tests cover both directions plus the handler level itself.

## Also from review

Removed the `mkdir` on the log directory: `FCPath.mkdir` raises `NotImplementedError` on a remote root — the cloud-task configuration — and `pdslogger.file_handler` creates parents itself. Added command-line level and module-key validation, which the configuration side had and the command line did not. Added `SILENT_LEVEL` / `section_level_for`, because `NONE` is a level this design introduced that pdslogger has no name for, so every `open()` site Phase 4 wires would have raised `KeyError`. A silent logger now reports no path instead of naming a file it never created. Replaced the `or` chains with an explicit presence check. Filtered the process-global technique and model registries to shipped classes, so resolution cannot vary with which tests have been imported. Left the shared `NULL_HANDLER` open on rebuild. Joined the default log root with `FCPath` rather than `os.path.join`.

## Verification

Full suite 4604 passed, 7 xfailed. `ruff`, `mypy --strict` (540 files), and `sphinx-build -W` clean. 111 tests in `test_logging_config.py`, including one per adjacent pair in the precedence chain, every sink combination against the no-empty-handler invariant, and a hermetic check that a remote log root is never `mkdir`ed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qfv91zHoSgvYFhnosuZeDS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive logging configuration for main and image logs.
  * Added configurable log levels, module overrides, console/file sinks, timestamps, and log locations.
  * Added support for disabling logging with the `NONE` level.
  * Added validation for logging settings and command-line options.

* **Documentation**
  * Expanded API documentation and clarified logging behavior and rollout plans.

* **Tests**
  * Added extensive coverage for log resolution, outputs, paths, overrides, validation, and silent logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->