### PR TITLE
feat: scope-aware image logger proxy and logger roles (phase 3)

### DIFF
--- a/.cursor/rules/logging_nav.mdc
+++ b/.cursor/rules/logging_nav.mdc
@@ -40,8 +40,11 @@ class DataSet(ABC, NavBase):
 
 Logging through `IMAGE_LOGGER` with no image scope open is a defect, not a
 mode. The record is routed to `MAIN_LOGGER` and the call site is reported once;
-under `logging.strict_scope`, which the test suite enables, it raises
-`LogScopeError` instead. If a component trips this, it is bound to the wrong
+under `logging.strict_scope` it raises `LogScopeError` instead. That is off by
+default; a test that drives a real pipeline turns it on with the
+`strict_log_scope` fixture. It is deliberately not enabled suite-wide, because
+a unit test exercising a model or technique in isolation calls it outside any
+image scope by design. If a component trips this, it is bound to the wrong
 logger — give it `LogRole.MAIN`.
 
 **Programs that carry no logger.** The statistics programs (`sd_stats_ingest`,
@@ -98,6 +101,6 @@ Per the `filecache` rule, `image_log_path` is an `FCPath`; never
 |------|---------|
 | Import loggers | `from spindoctor.config import MAIN_LOGGER, IMAGE_LOGGER` |
 | Top-level events | `MAIN_LOGGER.info(...)` |
-| Per-image events | `self._logger.info(...)` (`self._logger` is `IMAGE_LOGGER`) |
+| Per-image events | `self._logger.info(...)` (follows the class's `log_role`) |
 | Set up `MAIN_LOGGER` | `setup_logging(arguments, config, results_root)` once in `main()` |
 | Per-image handlers | `image_log_handlers(path, arguments, config)` passed to `open()` |

--- a/.cursor/rules/logging_nav.mdc
+++ b/.cursor/rules/logging_nav.mdc
@@ -19,15 +19,40 @@ project config system and imported from `spindoctor.config`:
 from spindoctor.config import MAIN_LOGGER, IMAGE_LOGGER
 ```
 
-| Logger | Name | Purpose |
-|--------|------|---------|
-| `MAIN_LOGGER` | `"sd_offset"` | Top-level program events; stdout + timestamped file handler attached at startup via `setup_logging()` |
-| `IMAGE_LOGGER` | `"nav_image"` | Per-image events; handlers are attached only inside an `IMAGE_LOGGER.open()` context via `image_log_handlers()` |
+| Logger | Purpose |
+|--------|---------|
+| `MAIN_LOGGER` | One per program run: top-level events, per-image progress, totals |
+| `IMAGE_LOGGER` | One image inside one backend: models, techniques, reprojection, annotation |
 
-Navigation components (subclasses of `NavBase`) receive `IMAGE_LOGGER` via
-`self._logger`. The main driver modules use `MAIN_LOGGER` directly. Log levels
-for both loggers come from the config system (CLI arguments override config
-keys override the `"INFO"` default).
+`IMAGE_LOGGER` is a proxy, not a logger. Opening a section on it enters an
+image scope; while that scope is open every nested section resolves to the same
+real logger, so one image's records land in one file.
+
+**A component declares which logger it belongs to.** `NavBase` subclasses carry
+`log_role`, defaulting to `LogRole.IMAGE`. A component whose work spans a run
+rather than an image sets `LogRole.MAIN` — `DataSet` does, because enumeration
+belongs to no single image:
+
+```python
+class DataSet(ABC, NavBase):
+    log_role: ClassVar[LogRole] = LogRole.MAIN
+```
+
+Logging through `IMAGE_LOGGER` with no image scope open is a defect, not a
+mode. The record is routed to `MAIN_LOGGER` and the call site is reported once;
+under `logging.strict_scope`, which the test suite enables, it raises
+`LogScopeError` instead. If a component trips this, it is bound to the wrong
+logger — give it `LogRole.MAIN`.
+
+**Programs that carry no logger.** The statistics programs (`sd_stats_ingest`,
+`sd_stats_report`) and the graphical programs (`sd_backplane_viewer`,
+`sd_mosaic_display`, `sd_create_simulated_image`) write to the terminal with
+`print()` and take no logging configuration. Neither is a batch pipeline, and a
+GUI surfaces problems through dialogs. This is the one documented exception to
+"never bare `print()` in library code", and it extends to the
+`spindoctor.ui.mosaic_viewer` widgets those programs drive. Where a converted
+call previously used `logger.exception`, follow the `print()` with
+`traceback.print_exc()` so the stack trace is not silently lost.
 
 ## 2. Setting Up `MAIN_LOGGER`
 

--- a/docs/api_reference/api_config.rst
+++ b/docs/api_reference/api_config.rst
@@ -18,6 +18,11 @@ spindoctor.config
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: spindoctor.config.log_scope
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: spindoctor.config.logging_config
    :members:
    :undoc-members:

--- a/docs/dev_guide/dev_guide_class_hierarchy.rst
+++ b/docs/dev_guide/dev_guide_class_hierarchy.rst
@@ -320,11 +320,12 @@ properties:
 - :attr:`~spindoctor.support.nav_base.NavBase.logger` — the logger this
   component belongs to, selected by its
   :attr:`~spindoctor.support.nav_base.NavBase.log_role`. The default,
-  ``LogRole.IMAGE``, gives ``IMAGE_LOGGER`` from
-  :mod:`spindoctor.config.log_scope`, a proxy resolving to whichever image
-  scope is open. A component whose work spans a run rather than an image, as
-  :class:`~spindoctor.dataset.dataset.DataSet` does, declares
-  ``LogRole.MAIN`` and gets ``MAIN_LOGGER``. Subclasses log through this
+  :attr:`~spindoctor.config.log_scope.LogRole.IMAGE`, gives
+  :data:`~spindoctor.config.log_scope.IMAGE_LOGGER`, a proxy resolving to
+  whichever image scope is open. A component whose work spans a run rather
+  than an image, as :class:`~spindoctor.dataset.dataset.DataSet` does,
+  declares :attr:`~spindoctor.config.log_scope.LogRole.MAIN` and gets
+  :data:`~spindoctor.config.logger.MAIN_LOGGER`. Subclasses log through this
   property; never through the stdlib :mod:`logging` module.
 
 Construction follows a single contract: every subclass takes a

--- a/docs/dev_guide/dev_guide_class_hierarchy.rst
+++ b/docs/dev_guide/dev_guide_class_hierarchy.rst
@@ -317,10 +317,15 @@ properties:
   :data:`~spindoctor.config.config.DEFAULT_CONFIG` singleton when none is
   supplied. Subclasses read every YAML-driven tunable through this
   property so per-instance overrides flow naturally for tests.
-- :attr:`~spindoctor.support.nav_base.NavBase.logger` — the project-wide
-  ``IMAGE_LOGGER`` (a :class:`pdslogger.PdsLogger`) loaded from
-  :mod:`spindoctor.config.logger`. Subclasses log through this property; never
-  through the stdlib :mod:`logging` module.
+- :attr:`~spindoctor.support.nav_base.NavBase.logger` — the logger this
+  component belongs to, selected by its
+  :attr:`~spindoctor.support.nav_base.NavBase.log_role`. The default,
+  ``LogRole.IMAGE``, gives ``IMAGE_LOGGER`` from
+  :mod:`spindoctor.config.log_scope`, a proxy resolving to whichever image
+  scope is open. A component whose work spans a run rather than an image, as
+  :class:`~spindoctor.dataset.dataset.DataSet` does, declares
+  ``LogRole.MAIN`` and gets ``MAIN_LOGGER``. Subclasses log through this
+  property; never through the stdlib :mod:`logging` module.
 
 Construction follows a single contract: every subclass takes a
 keyword-only ``config`` parameter and forwards it via

--- a/docs/dev_guide/dev_guide_logging.rst
+++ b/docs/dev_guide/dev_guide_logging.rst
@@ -3,7 +3,7 @@ Developer Guide: Logging
 ========================
 
 The autonomous-navigation pipeline routes every per-image log line
-through ``pdslogger`` (``spindoctor.config.logger.IMAGE_LOGGER``). The standard
+through ``pdslogger`` (``spindoctor.config.log_scope.IMAGE_LOGGER``). The standard
 library ``logging`` module is intentionally **not used** anywhere in the
 ``spindoctor.feature``, ``spindoctor.nav_model``, ``spindoctor.nav_orchestrator``,
 ``spindoctor.nav_technique``, or ``spindoctor.support`` packages.

--- a/docs/dev_guide/dev_guide_logging.rst
+++ b/docs/dev_guide/dev_guide_logging.rst
@@ -3,7 +3,7 @@ Developer Guide: Logging
 ========================
 
 The autonomous-navigation pipeline routes every per-image log line
-through ``pdslogger`` (``spindoctor.config.log_scope.IMAGE_LOGGER``). The standard
+through ``pdslogger`` (:data:`~spindoctor.config.log_scope.IMAGE_LOGGER`). The standard
 library ``logging`` module is intentionally **not used** anywhere in the
 ``spindoctor.feature``, ``spindoctor.nav_model``, ``spindoctor.nav_orchestrator``,
 ``spindoctor.nav_technique``, or ``spindoctor.support`` packages.

--- a/plans/LOGGING_REDESIGN_PLAN.md
+++ b/plans/LOGGING_REDESIGN_PLAN.md
@@ -391,11 +391,23 @@ Behavior when it happens anyway:
 - A `WARNING` is emitted to the main logger naming the module and function
   that logged out of scope, **deduplicated per call site** so a loop cannot
   flood the log.
-- Under `logging.strict_scope: true` (default `false` in production, `true`
-  in the test suite) the violation raises instead.
+- Under `logging.strict_scope: true` (default `false`) the violation raises
+  instead.
 
-The test suite runs with strict scope on, so any newly-introduced violation
-fails CI rather than quietly appearing in a main log.
+Strict scope is **opt-in for tests, not suite-wide**. The original intent was
+to enable it everywhere so a new violation failed CI, but that premise does not
+survive contact with the suite: enabling it globally fails 497 tests, and
+essentially none of them are mis-bindings. A unit test exercising
+`NavModelTitan.to_annotations()` calls it directly, outside any pipeline, which
+is correct isolation testing — the component is properly image-role and the
+test is properly written. "An image-role component only logs inside an image
+scope" holds for production paths, not for tests that drive components
+individually.
+
+Enforcement therefore belongs where a scope genuinely should be open: tests
+that drive a real pipeline. A `strict_log_scope` fixture makes that a one-line
+request, and the pipeline-level tests adopt it as Phases 5 through 7 wire the
+drivers. In production the warning remains the signal.
 
 ---
 

--- a/src/spindoctor/cli/sd_backplane_viewer.py
+++ b/src/spindoctor/cli/sd_backplane_viewer.py
@@ -2,6 +2,7 @@
 import argparse
 import os
 import sys
+import traceback
 from collections.abc import Callable
 from typing import Any, cast
 
@@ -42,7 +43,6 @@ from matplotlib import colormaps as mpl_colormaps
 
 from spindoctor.config import (
     DEFAULT_CONFIG,
-    MAIN_LOGGER,
     Config,
     get_backplane_results_root,
     get_nav_results_root,
@@ -206,7 +206,6 @@ class NavBackplaneViewer(QDialog):
         self._nav_results_root = nav_results_root
         self._backplane_results_root = backplane_results_root
         self._config = config or DEFAULT_CONFIG
-        self._logger = MAIN_LOGGER
 
         self._obs_class = inst_name_to_obs_class(inst_name)
 
@@ -645,7 +644,10 @@ class NavBackplaneViewer(QDialog):
             return
         group = self._image_groups[index]
         if len(group.image_files) != 1:
-            self._logger.error('Expected single image per group; got %d', len(group.image_files))
+            print(
+                f'Expected single image per group; got {len(group.image_files)}',
+                file=sys.stderr,
+            )
             return
         image_file = group.image_files[0]
         image_path = image_file.image_file_path.absolute()
@@ -659,7 +661,8 @@ class NavBackplaneViewer(QDialog):
             if not isinstance(snapshot, ObsSnapshot):
                 raise ValueError('Expected ObsSnapshot')
         except Exception as e:
-            self._logger.exception('Failed to read image %s', image_path)
+            print(f'Failed to read image {image_path}', file=sys.stderr)
+            traceback.print_exc()
             self._status_label.setText(f'Image read error: {e}')
             return
 
@@ -704,14 +707,17 @@ class NavBackplaneViewer(QDialog):
                     rgba = im.convert('RGBA')
                     self._summary_rgba = np.array(rgba)
                 if self._summary_rgba is not None:
-                    self._logger.info(
-                        'Loaded summary overlay "%s" size=%dx%d',
-                        png_local,
-                        self._summary_rgba.shape[1],
-                        self._summary_rgba.shape[0],
+                    print(
+                        f'Loaded summary overlay "{png_local}" '
+                        f'size={self._summary_rgba.shape[1]}x'
+                        f'{self._summary_rgba.shape[0]}'
                     )
             except Exception:
-                self._logger.exception('Failed to load summary overlay from %s', summary_png_file)
+                print(
+                    f'Failed to load summary overlay from {summary_png_file}',
+                    file=sys.stderr,
+                )
+                traceback.print_exc()
                 self._summary_rgba = None
         # Enable/disable summary checkbox based on availability
         has_summary = self._summary_rgba is not None
@@ -729,10 +735,8 @@ class NavBackplaneViewer(QDialog):
             local_path = cast(str, fits_file.get_local_path())
             with fits.open(local_path) as hdul:
                 self._fits_hdus = list(hdul)
-                self._logger.info(
-                    'Opened backplanes FITS file "%s" with %d HDUs',
-                    local_path,
-                    len(self._fits_hdus),
+                print(
+                    f'Opened backplanes FITS file "{local_path}" with {len(self._fits_hdus)} HDUs'
                 )
                 # Parse HDUs: locate BODY_ID_MAP and backplanes
                 for hdu in self._fits_hdus[1:]:
@@ -741,18 +745,22 @@ class NavBackplaneViewer(QDialog):
                         try:
                             self._body_id_map = np.asarray(hdu.data, dtype=np.int32)
                         except Exception:
-                            self._logger.exception(
-                                f'Failed to parse BODY_ID_MAP from HDU for {fits_file}'
+                            print(
+                                f'Failed to parse BODY_ID_MAP from HDU for {fits_file}',
+                                file=sys.stderr,
                             )
+                            traceback.print_exc()
                             self._body_id_map = None
                     else:
                         arr: np.ndarray | None = None
                         try:
                             arr = np.asarray(hdu.data, dtype=np.float64)
                         except Exception:
-                            self._logger.exception(
-                                f'Failed to parse {name} from HDU for {fits_file}'
+                            print(
+                                f'Failed to parse {name} from HDU for {fits_file}',
+                                file=sys.stderr,
                             )
+                            traceback.print_exc()
                             arr = None
                         if arr is None:
                             continue
@@ -769,13 +777,14 @@ class NavBackplaneViewer(QDialog):
                 f'Backplane FITS file not found:\n{fits_file}\n\n'
                 'All backplane data will be unavailable.',
             )
-            self._logger.warning('FITS file not found: %s', fits_file)
+            print(f'FITS file not found: {fits_file}', file=sys.stderr)
             self._fits_hdus = []
             self._bp_body_map.clear()
             self._bp_ring_map.clear()
             self._body_id_map = None
         except Exception:
-            self._logger.exception('Failed to read FITS backplane file')
+            print('Failed to read FITS backplane file', file=sys.stderr)
+            traceback.print_exc()
             self._fits_hdus = []
             self._bp_body_map.clear()
             self._bp_ring_map.clear()

--- a/src/spindoctor/cli/sd_backplane_viewer.py
+++ b/src/spindoctor/cli/sd_backplane_viewer.py
@@ -46,6 +46,7 @@ from spindoctor.config import (
     Config,
     get_backplane_results_root,
     get_nav_results_root,
+    image_scope,
     load_default_and_user_config,
 )
 from spindoctor.dataset import dataset_name_to_class, dataset_name_to_inst_name, dataset_names
@@ -655,9 +656,13 @@ class NavBackplaneViewer(QDialog):
         self._current_image_name = image_path.name
         self.setWindowTitle(f'Backplane Viewer - {self._current_image_name}')
 
-        # Load observation (science image)
+        # Load observation (science image).  The observation classes are
+        # image-scoped library code and log while reading, so the load runs
+        # inside an image scope even though the viewer itself keeps no logger;
+        # without one every load would report a scope violation per record.
         try:
-            snapshot = self._obs_class.from_file(image_path)
+            with image_scope():
+                snapshot = self._obs_class.from_file(image_path)
             if not isinstance(snapshot, ObsSnapshot):
                 raise ValueError('Expected ObsSnapshot')
         except Exception as e:

--- a/src/spindoctor/cli/stats/ingest.py
+++ b/src/spindoctor/cli/stats/ingest.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import math
 import sqlite3
+import sys
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, cast
@@ -12,7 +13,6 @@ from filecache import FCPath
 
 from spindoctor.cli.stats.classify import date_from_image_et
 from spindoctor.cli.stats.schema import open_stats_db, upsert_image
-from spindoctor.config import MAIN_LOGGER
 
 __all__ = ['ingest_metadata_files', 'main_ingest', 'rows_from_metadata']
 
@@ -233,7 +233,7 @@ def ingest_metadata_files(
                         metadata, source_file=source
                     )
                 except (OSError, ValueError) as exc:
-                    MAIN_LOGGER.warning('Skipping %s: %s', source, exc)
+                    print(f'Skipping {source}: {exc}', file=sys.stderr)
                     n_errors += 1
                     continue
                 upsert_image(
@@ -273,10 +273,5 @@ def main_ingest(cmdline: list[str] | None = None) -> int:
         n_ingested, n_errors = ingest_metadata_files(conn, arguments.roots)
     finally:
         conn.close()
-    MAIN_LOGGER.info(
-        'Ingested %d metadata file(s) into %s (%d error(s))',
-        n_ingested,
-        arguments.db,
-        n_errors,
-    )
+    print(f'Ingested {n_ingested} metadata file(s) into {arguments.db} ({n_errors} error(s))')
     return 0 if n_ingested > 0 else 1

--- a/src/spindoctor/cli/stats/report.py
+++ b/src/spindoctor/cli/stats/report.py
@@ -38,7 +38,6 @@ from spindoctor.cli.stats.report_sections import (
     write_csv_export,
 )
 from spindoctor.cli.stats.schema import open_stats_db
-from spindoctor.config import MAIN_LOGGER
 
 __all__ = ['build_report', 'main_report']
 
@@ -779,5 +778,5 @@ def main_report(cmdline: list[str] | None = None) -> int:
         parser.error(str(exc))
     finally:
         conn.close()
-    MAIN_LOGGER.info('Wrote %s', report_path)
+    print(f'Wrote {report_path}')
     return 0

--- a/src/spindoctor/config/__init__.py
+++ b/src/spindoctor/config/__init__.py
@@ -15,6 +15,7 @@ from .log_scope import (
     image_scope_is_open,
     set_strict_scope,
     strict_scope,
+    strict_scope_override,
 )
 from .logger import (
     MAIN_LOGGER,
@@ -71,5 +72,6 @@ __all__ = [
     'setup_logging',
     'sinks_from_arguments',
     'strict_scope',
+    'strict_scope_override',
     'validate_logging_config',
 ]

--- a/src/spindoctor/config/__init__.py
+++ b/src/spindoctor/config/__init__.py
@@ -6,8 +6,17 @@ from .config_helper import (
     get_pds4_bundle_results_root,
     load_default_and_user_config,
 )
-from .logger import (
+from .log_scope import (
     IMAGE_LOGGER,
+    ImageLoggerProxy,
+    LogRole,
+    LogScopeError,
+    image_scope,
+    image_scope_is_open,
+    set_strict_scope,
+    strict_scope,
+)
+from .logger import (
     MAIN_LOGGER,
     image_log_handlers,
     setup_logging,
@@ -38,7 +47,10 @@ __all__ = [
     'MAIN_LOGGER',
     'SILENT_LEVEL',
     'Config',
+    'ImageLoggerProxy',
     'LogLevels',
+    'LogRole',
+    'LogScopeError',
     'LogSinks',
     'build_image_log_handlers',
     'build_main_logger',
@@ -48,12 +60,16 @@ __all__ = [
     'get_pds4_bundle_results_root',
     'image_log_handlers',
     'image_log_path',
+    'image_scope',
+    'image_scope_is_open',
     'load_default_and_user_config',
     'log_key_for',
     'main_log_path',
     'resolve_log_levels',
     'run_timestamp',
+    'set_strict_scope',
     'setup_logging',
     'sinks_from_arguments',
+    'strict_scope',
     'validate_logging_config',
 ]

--- a/src/spindoctor/config/log_scope.py
+++ b/src/spindoctor/config/log_scope.py
@@ -44,6 +44,7 @@ __all__ = [
     'image_scope_is_open',
     'set_strict_scope',
     'strict_scope',
+    'strict_scope_override',
 ]
 
 
@@ -51,10 +52,10 @@ class LogRole(Enum):
     """Which logger a component's records belong to."""
 
     MAIN = 'main'
-    """Work spanning a whole run: enumeration, totals, per-image progress."""
+    """For work spanning a whole run, such as enumeration and totals."""
 
     IMAGE = 'image'
-    """Work on one image: models, techniques, reprojection, annotation."""
+    """For work on one image, such as models, techniques and annotation."""
 
 
 class LogScopeError(RuntimeError):
@@ -84,6 +85,19 @@ def set_strict_scope(enabled: bool | None) -> None:
     """
     global _strict_scope_override
     _strict_scope_override = enabled
+
+
+def strict_scope_override() -> bool | None:
+    """Return the override in force, distinct from the resolved behavior.
+
+    :func:`strict_scope` collapses "no override" into the configured value, so
+    a caller saving and restoring state must read the override itself; saving
+    the resolved boolean would pin it and lose the deferral.
+
+    Returns:
+        The override, or None when behavior defers to the configuration.
+    """
+    return _strict_scope_override
 
 
 def strict_scope() -> bool:
@@ -333,4 +347,4 @@ class ImageLoggerProxy:
 
 
 IMAGE_LOGGER = ImageLoggerProxy()
-"""The image logger: a proxy resolving to whichever image scope is open."""
+"""A proxy resolving to whichever image scope is currently open."""

--- a/src/spindoctor/config/log_scope.py
+++ b/src/spindoctor/config/log_scope.py
@@ -1,0 +1,258 @@
+"""Routing of log records to the main or the image logger.
+
+Two loggers exist, and every component belongs to exactly one.  Components
+whose work spans a run -- enumerating a dataset, tallying totals -- belong to
+the main logger.  Components working on one image belong to the image logger.
+
+The image logger is reached through :data:`IMAGE_LOGGER`, a proxy rather than
+a logger.  Opening a section on it enters an image scope; while that scope is
+open the proxy forwards to the real logger underneath, and every nested
+section, model and technique writes into the same per-image log.  Outside any
+scope there is nothing sensible to forward to, so the proxy routes the record
+to the main logger, warns once about the call site, and -- with strict scope
+enabled, as the test suite does -- raises instead.
+
+Logging from an image-scoped component with no image open is a defect rather
+than a mode to support.  Every occurrence found while this was written was
+either correctly scoped or a component bound to the wrong logger.
+"""
+
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from enum import Enum
+from typing import Any
+
+import pdslogger
+from pdslogger import PdsLogger
+
+from .logger import MAIN_LOGGER
+
+__all__ = [
+    'IMAGE_LOGGER',
+    'ImageLoggerProxy',
+    'LogRole',
+    'LogScopeError',
+    'image_scope',
+    'image_scope_is_open',
+    'set_strict_scope',
+    'strict_scope',
+]
+
+
+class LogRole(Enum):
+    """Which logger a component's records belong to."""
+
+    MAIN = 'main'
+    """Work spanning a whole run: enumeration, totals, per-image progress."""
+
+    IMAGE = 'image'
+    """Work on one image: models, techniques, reprojection, annotation."""
+
+
+class LogScopeError(RuntimeError):
+    """An image-scoped component logged with no image scope open."""
+
+
+_ACTIVE_IMAGE_LOGGER: ContextVar[PdsLogger | None] = ContextVar(
+    'spindoctor_active_image_logger', default=None
+)
+
+_DEFAULT_IMAGE_LOGGER = pdslogger.PdsLogger('nav_image', lognames=False, digits=3)
+
+_strict_scope = False
+_reported_call_sites: set[tuple[str, str, int]] = set()
+
+
+def set_strict_scope(enabled: bool) -> None:
+    """Choose whether an out-of-scope image log raises or only warns.
+
+    Production warns, so one mis-scoped call cannot abort a batch over a log
+    line.  The test suite raises, so a newly introduced one fails rather than
+    appearing quietly in a main log.
+
+    Parameters:
+        enabled: True to raise on an out-of-scope image log.
+    """
+    global _strict_scope
+    _strict_scope = enabled
+
+
+def strict_scope() -> bool:
+    """Whether an out-of-scope image log currently raises.
+
+    Returns:
+        True when strict scope is enabled.
+    """
+    return _strict_scope
+
+
+def image_scope_is_open() -> bool:
+    """Whether an image scope is currently open on this task.
+
+    Returns:
+        True when :func:`image_scope` is active.
+    """
+    return _ACTIVE_IMAGE_LOGGER.get() is not None
+
+
+def _caller_site() -> tuple[str, str, int]:
+    """Identify the first frame outside this module.
+
+    Returns:
+        Tuple of module name, function name, and line number of the code that
+        logged, used both to name the offender and to deduplicate the warning.
+    """
+    frame = sys._getframe(1)
+    while frame is not None and frame.f_globals.get('__name__') == __name__:
+        frame = frame.f_back  # type: ignore[assignment]
+    if frame is None:  # pragma: no cover - a frame outside this module always exists
+        return ('<unknown>', '<unknown>', 0)
+    return (frame.f_globals.get('__name__', '<unknown>'), frame.f_code.co_name, frame.f_lineno)
+
+
+def _report_out_of_scope() -> None:
+    """Handle an image-scoped record logged with no image scope open.
+
+    Raises:
+        LogScopeError: When strict scope is enabled.
+    """
+    module, function, line = _caller_site()
+    where = f'{module}.{function} (line {line})'
+    if _strict_scope:
+        raise LogScopeError(
+            f'{where} logged to the image logger with no image scope open. '
+            f'A component scoped to one image must log inside an image scope; '
+            f'if its work spans the run, bind it to the main logger instead.'
+        )
+    site = (module, function, line)
+    if site not in _reported_call_sites:
+        _reported_call_sites.add(site)
+        MAIN_LOGGER.warning(
+            'Log routed to the main logger: %s logged to the image logger with no '
+            'image scope open. Reported once per call site.',
+            where,
+        )
+
+
+def _reset_reported_call_sites() -> None:
+    """Forget which call sites have been warned about.
+
+    Exposed for tests, which need each case to warn independently rather than
+    inheriting the deduplication state of an earlier one.
+    """
+    _reported_call_sites.clear()
+
+
+@contextmanager
+def image_scope(logger: PdsLogger | None = None) -> Iterator[PdsLogger]:
+    """Make ``logger`` the image logger for the duration of the block.
+
+    Nesting is a no-op: an inner scope keeps the logger the outer one
+    established, so a model or technique opening its own section does not
+    displace the image it is running under.
+
+    Parameters:
+        logger: The real logger to route image records to.  None uses the
+            default image logger.
+
+    Yields:
+        The logger image records will reach.
+    """
+    active = _ACTIVE_IMAGE_LOGGER.get()
+    if active is not None:
+        yield active
+        return
+    target = logger if logger is not None else _DEFAULT_IMAGE_LOGGER
+    token = _ACTIVE_IMAGE_LOGGER.set(target)
+    try:
+        yield target
+    finally:
+        _ACTIVE_IMAGE_LOGGER.reset(token)
+
+
+class ImageLoggerProxy:
+    """Forwards image-scoped records to whichever logger the scope selected.
+
+    Presents the part of the ``PdsLogger`` interface SpinDoctor uses, so a
+    component can hold this object wherever it would have held a logger.
+    Records arriving outside an image scope are routed to the main logger and
+    reported; see the module docstring.
+    """
+
+    def _target(self) -> PdsLogger:
+        """Return the logger this record should reach.
+
+        Returns:
+            The scope's logger, or the main logger when none is open.
+        """
+        active = _ACTIVE_IMAGE_LOGGER.get()
+        if active is not None:
+            return active
+        _report_out_of_scope()
+        return MAIN_LOGGER
+
+    def debug(self, message: str, *args: Any, **kwargs: Any) -> None:
+        """Log at DEBUG. See :meth:`pdslogger.PdsLogger.debug`."""
+        self._target().debug(message, *args, **kwargs)
+
+    def info(self, message: str, *args: Any, **kwargs: Any) -> None:
+        """Log at INFO. See :meth:`pdslogger.PdsLogger.info`."""
+        self._target().info(message, *args, **kwargs)
+
+    def warning(self, message: str, *args: Any, **kwargs: Any) -> None:
+        """Log at WARNING. See :meth:`pdslogger.PdsLogger.warning`."""
+        self._target().warning(message, *args, **kwargs)
+
+    def error(self, message: str, *args: Any, **kwargs: Any) -> None:
+        """Log at ERROR. See :meth:`pdslogger.PdsLogger.error`."""
+        self._target().error(message, *args, **kwargs)
+
+    def critical(self, message: str, *args: Any, **kwargs: Any) -> None:
+        """Log at CRITICAL. See :meth:`pdslogger.PdsLogger.critical`."""
+        self._target().critical(message, *args, **kwargs)
+
+    def exception(self, message: str, *args: Any, **kwargs: Any) -> None:
+        """Log an exception with its stack trace.
+
+        See :meth:`pdslogger.PdsLogger.exception`.
+        """
+        self._target().exception(message, *args, **kwargs)
+
+    def log(self, level: Any, message: str, *args: Any, **kwargs: Any) -> None:
+        """Log at an explicit level. See :meth:`pdslogger.PdsLogger.log`."""
+        self._target().log(level, message, *args, **kwargs)
+
+    def set_level(self, level: Any) -> None:
+        """Set the level of the current tier. See ``PdsLogger.set_level``."""
+        self._target().set_level(level)
+
+    @property
+    def handlers(self) -> Any:
+        """The handlers of the logger records currently reach."""
+        return self._target().handlers
+
+    @contextmanager
+    def open(self, title: str, *args: Any, **kwargs: Any) -> Iterator[Any]:
+        """Open a section, entering an image scope if none is open.
+
+        Opening a section on the image logger is what establishes an image
+        scope, so the outermost such call selects the logger every nested
+        section, model and technique will write to.  A nested call passes
+        straight through to the scope's logger.
+
+        Parameters:
+            title: Title of the section.
+            *args: Passed to ``PdsLogger.open``.
+            **kwargs: Passed to ``PdsLogger.open``.
+
+        Yields:
+            Whatever ``PdsLogger.open`` yields.
+        """
+        with image_scope() as target, target.open(title, *args, **kwargs) as section:
+            yield section
+
+
+IMAGE_LOGGER = ImageLoggerProxy()
+"""The image logger: a proxy resolving to whichever image scope is open."""

--- a/src/spindoctor/config/log_scope.py
+++ b/src/spindoctor/config/log_scope.py
@@ -9,8 +9,14 @@ a logger.  Opening a section on it enters an image scope; while that scope is
 open the proxy forwards to the real logger underneath, and every nested
 section, model and technique writes into the same per-image log.  Outside any
 scope there is nothing sensible to forward to, so the proxy routes the record
-to the main logger, warns once about the call site, and -- with strict scope
-enabled, as the test suite does -- raises instead.
+to the main logger and warns once about the call site.  With
+``logging.strict_scope`` enabled it raises instead; that is off by default,
+because one mis-scoped call should not abort a batch over a log line.
+
+Configuring the image logger -- setting a level, attaching a handler -- is not
+the same as logging to it, and is a reasonable thing to do before any image is
+open.  Those calls reach the image logger directly and never report a
+violation.
 
 Logging from an image-scoped component with no image open is a defect rather
 than a mode to support.  Every occurrence found while this was written was
@@ -61,31 +67,43 @@ _ACTIVE_IMAGE_LOGGER: ContextVar[PdsLogger | None] = ContextVar(
 
 _DEFAULT_IMAGE_LOGGER = pdslogger.PdsLogger('nav_image', lognames=False, digits=3)
 
-_strict_scope = False
+_strict_scope_override: bool | None = None
 _reported_call_sites: set[tuple[str, str, int]] = set()
 
 
-def set_strict_scope(enabled: bool) -> None:
-    """Choose whether an out-of-scope image log raises or only warns.
+def set_strict_scope(enabled: bool | None) -> None:
+    """Override whether an out-of-scope image log raises or only warns.
 
     Production warns, so one mis-scoped call cannot abort a batch over a log
-    line.  The test suite raises, so a newly introduced one fails rather than
-    appearing quietly in a main log.
+    line.  A caller that wants the stricter behavior for a bounded stretch --
+    a test driving a real pipeline, say -- turns it on here.
 
     Parameters:
-        enabled: True to raise on an out-of-scope image log.
+        enabled: True to raise, False to warn, or None to defer to
+            ``logging.strict_scope`` in the configuration.
     """
-    global _strict_scope
-    _strict_scope = enabled
+    global _strict_scope_override
+    _strict_scope_override = enabled
 
 
 def strict_scope() -> bool:
     """Whether an out-of-scope image log currently raises.
 
+    Falls back to ``logging.strict_scope`` in the configuration when no
+    override is in force, so the shipped key is what actually governs
+    behavior rather than being a setting nothing reads.
+
     Returns:
         True when strict scope is enabled.
     """
-    return _strict_scope
+    if _strict_scope_override is not None:
+        return _strict_scope_override
+    from .config import DEFAULT_CONFIG
+
+    try:
+        return bool(DEFAULT_CONFIG.logging.get('strict_scope', False))
+    except (AttributeError, KeyError):  # pragma: no cover - config always loads
+        return False
 
 
 def image_scope_is_open() -> bool:
@@ -120,7 +138,7 @@ def _report_out_of_scope() -> None:
     """
     module, function, line = _caller_site()
     where = f'{module}.{function} (line {line})'
-    if _strict_scope:
+    if strict_scope():
         raise LogScopeError(
             f'{where} logged to the image logger with no image scope open. '
             f'A component scoped to one image must log inside an image scope; '
@@ -193,6 +211,22 @@ class ImageLoggerProxy:
         _report_out_of_scope()
         return MAIN_LOGGER
 
+    def _configured(self) -> PdsLogger:
+        """Return the logger that configuration should act on.
+
+        Configuring the image logger is not the same as logging to it.  A
+        caller adjusting a level or attaching a handler is preparing the image
+        logger, which is a sensible thing to do before any image is open, so
+        this resolves to the default image logger rather than reporting a
+        scope violation and redirecting the change onto the main logger --
+        where it would silently fail to have the intended effect.
+
+        Returns:
+            The scope's logger if one is open, else the default image logger.
+        """
+        active = _ACTIVE_IMAGE_LOGGER.get()
+        return active if active is not None else _DEFAULT_IMAGE_LOGGER
+
     def debug(self, message: str, *args: Any, **kwargs: Any) -> None:
         """Log at DEBUG. See :meth:`pdslogger.PdsLogger.debug`."""
         self._target().debug(message, *args, **kwargs)
@@ -226,12 +260,56 @@ class ImageLoggerProxy:
 
     def set_level(self, level: Any) -> None:
         """Set the level of the current tier. See ``PdsLogger.set_level``."""
-        self._target().set_level(level)
+        self._configured().set_level(level)
+
+    def add_handler(self, *handlers: Any, **kwargs: Any) -> None:
+        """Attach handlers. See ``PdsLogger.add_handler``."""
+        self._configured().add_handler(*handlers, **kwargs)
+
+    def remove_handler(self, *handlers: Any) -> None:
+        """Detach handlers. See ``PdsLogger.remove_handler``."""
+        self._configured().remove_handler(*handlers)
+
+    def remove_all_handlers(self) -> None:
+        """Detach every handler. See ``PdsLogger.remove_all_handlers``."""
+        self._configured().remove_all_handlers()
+
+    def replace_handler(self, *handlers: Any, **kwargs: Any) -> None:
+        """Replace the attached handlers. See ``PdsLogger.replace_handler``."""
+        self._configured().replace_handler(*handlers, **kwargs)
+
+    @property
+    def level(self) -> Any:
+        """The minimum level of the logger being configured."""
+        return self._configured().level
 
     @property
     def handlers(self) -> Any:
-        """The handlers of the logger records currently reach."""
-        return self._target().handlers
+        """The handlers of the logger being configured.
+
+        Reading this is introspection rather than logging, so it does not
+        report a scope violation; a diagnostic must not be able to raise.
+        """
+        return self._configured().handlers
+
+    def __getattr__(self, name: str) -> Any:
+        """Reject a PdsLogger member this proxy does not implement.
+
+        The proxy covers the interface SpinDoctor uses rather than all of
+        ``PdsLogger``.  Failing here names the missing member and says why,
+        instead of surfacing a bare AttributeError from an unexpected place.
+
+        Parameters:
+            name: The attribute that was requested.
+
+        Raises:
+            AttributeError: Always.
+        """
+        raise AttributeError(
+            f'{type(self).__name__} does not implement {name!r}. The image logger is a '
+            f'proxy over whichever image scope is open, and forwards only the interface '
+            f'SpinDoctor uses; add {name!r} to it if it is genuinely needed.'
+        )
 
     @contextmanager
     def open(self, title: str, *args: Any, **kwargs: Any) -> Iterator[Any]:

--- a/src/spindoctor/config/logger.py
+++ b/src/spindoctor/config/logger.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from .config import Config
 
 MAIN_LOGGER = pdslogger.PdsLogger('sd_offset', lognames=False, digits=3)
+"""The run's logger, carrying top-level program events for one execution."""
 
 _FALLBACK_LEVEL = 'INFO'
 _ALLOWED_LOG_LEVELS = frozenset({'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'})

--- a/src/spindoctor/config/logger.py
+++ b/src/spindoctor/config/logger.py
@@ -1,12 +1,10 @@
 """Logger instances and setup for the SpinDoctor pipeline.
 
-Provides two PdsLogger instances:
+Provides ``MAIN_LOGGER``, which carries top-level program events and is written
+to stdout and to a timestamped logfile under ``NAV_RESULTS_ROOT/logs/sd_offset/``.
 
-- ``MAIN_LOGGER`` (``"sd_offset"``) -- top-level program events, written to stdout
-  and to a timestamped logfile under ``NAV_RESULTS_ROOT/logs/sd_offset/``.
-- ``IMAGE_LOGGER`` (``"nav_image"``) -- per-image processing events; both its stdout
-  handler and its per-image logfile handler are attached as local handlers inside each
-  ``logger.open()`` context so they are active only while that image is being processed.
+The image logger lives in :mod:`spindoctor.config.log_scope`, which routes
+per-image records to whichever image scope is open.
 
 Call ``setup_logging()`` from ``main()`` after the nav-results root and CLI
 arguments have been resolved. It is safe to call more than once: existing
@@ -31,7 +29,6 @@ if TYPE_CHECKING:
     from .config import Config
 
 MAIN_LOGGER = pdslogger.PdsLogger('sd_offset', lognames=False, digits=3)
-IMAGE_LOGGER = pdslogger.PdsLogger('nav_image', lognames=False, digits=3)
 
 _FALLBACK_LEVEL = 'INFO'
 _ALLOWED_LOG_LEVELS = frozenset({'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'})

--- a/src/spindoctor/config_files/config_015_logging.yaml
+++ b/src/spindoctor/config_files/config_015_logging.yaml
@@ -13,9 +13,9 @@
 logging:
 
   # Raise, rather than warn, when a component scoped to one image logs while no
-  # image scope is open.  That situation is a programming error either way; the
-  # test suite turns this on so a new occurrence fails rather than being routed
-  # quietly to the main log.
+  # image scope is open.  That situation is a programming error either way;
+  # warning keeps one mis-scoped call from aborting a batch over a log line.
+  # Turn this on to make such a call fail loudly instead.
   strict_scope: false
 
   # Global default for each logger.

--- a/src/spindoctor/dataset/dataset.py
+++ b/src/spindoctor/dataset/dataset.py
@@ -3,11 +3,11 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 from filecache import FCPath
 
-from spindoctor.config import MAIN_LOGGER, Config
+from spindoctor.config import MAIN_LOGGER, Config, LogRole
 from spindoctor.support.nav_base import NavBase
 
 
@@ -144,6 +144,17 @@ class ImageFiles:
 
 
 class DataSet(ABC, NavBase):
+    """Enumerates the images a run will process.
+
+    Class attributes:
+        log_role: ``LogRole.MAIN``.  Enumeration spans the whole run rather
+            than belonging to any one image, so its records go to the run's
+            log; routing them to the image logger would file them under
+            whichever image happened to be open, or none at all.
+    """
+
+    log_role: ClassVar[LogRole] = LogRole.MAIN
+
     def __init__(self, *, config: Config | None = None) -> None:
         """Initializes a dataset.
 

--- a/src/spindoctor/navigate_image_files.py
+++ b/src/spindoctor/navigate_image_files.py
@@ -136,7 +136,9 @@ def navigate_image_files(
     run_start = datetime.now(UTC)
 
     if len(image_files.image_files) != 1:
-        logger.error(
+        # A malformed batch is a caller error, reported before any image scope
+        # exists and belonging to no image, so it goes to the run's log.
+        MAIN_LOGGER.error(
             'Expected exactly one image per batch; got %d',
             len(image_files.image_files),
         )

--- a/src/spindoctor/support/nav_base.py
+++ b/src/spindoctor/support/nav_base.py
@@ -1,8 +1,8 @@
-from typing import Any
+from typing import Any, ClassVar
 
 from pdslogger import PdsLogger
 
-from spindoctor.config import DEFAULT_CONFIG, IMAGE_LOGGER, Config
+from spindoctor.config import DEFAULT_CONFIG, IMAGE_LOGGER, MAIN_LOGGER, Config, LogRole
 
 
 class NavBase:
@@ -11,9 +11,20 @@ class NavBase:
     Serves as the foundation for navigation-related classes by providing common functionality
     for configuration management and logging.
 
+    Which logger a subclass writes to is declared, not inferred.  Most
+    navigation components work on one image and keep the default
+    ``LogRole.IMAGE``; a component whose work spans a whole run, such as
+    enumerating a dataset, sets ``log_role = LogRole.MAIN`` so its records go
+    to the run's log rather than into whichever image happens to be open.
+
+    Class attributes:
+        log_role: Which logger this component's records belong to.
+
     Parameters:
         config: Configuration object for this instance. Uses DEFAULT_CONFIG if not provided.
     """
+
+    log_role: ClassVar[LogRole] = LogRole.IMAGE
 
     def __init__(self, *, config: Config | None = None, **kwargs: Any) -> None:
         """Initializes a new NavBase instance.
@@ -24,7 +35,7 @@ class NavBase:
         """
 
         self._config = config or DEFAULT_CONFIG
-        self._logger = IMAGE_LOGGER
+        self._logger = MAIN_LOGGER if self.log_role is LogRole.MAIN else IMAGE_LOGGER
 
     @property
     def config(self) -> Config:

--- a/src/spindoctor/ui/mosaic_viewer/body_window.py
+++ b/src/spindoctor/ui/mosaic_viewer/body_window.py
@@ -1,6 +1,8 @@
 """BodyMosaicWindow: PyQt6 window for browsing body reprojections and mosaics."""
 
 import math
+import sys
+import traceback
 from pathlib import Path
 from typing import Any
 
@@ -33,7 +35,6 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from spindoctor.config import IMAGE_LOGGER
 from spindoctor.support.time import et_to_utc
 from spindoctor.ui.common import build_stretch_controls
 from spindoctor.ui.mosaic_viewer.common import (
@@ -48,8 +49,6 @@ from spindoctor.ui.mosaic_viewer.projections import ProjectionKind
 from spindoctor.ui.mosaic_viewer.tiled_image_widget import (
     TiledImageWidget,
 )
-
-logger = IMAGE_LOGGER
 
 _STATUS_HINTS: dict[ProjectionKind, str] = {
     ProjectionKind.RECT: (
@@ -696,7 +695,8 @@ class BodyMosaicWindow(QMainWindow):
         try:
             dd = load_body_file(path)
         except Exception as exc:
-            logger.exception('Error loading %s', path)
+            print(f'Error loading {path}', file=sys.stderr)
+            traceback.print_exc()
             self.statusBar().showMessage(f'Error loading {path}: {exc}', 5000)
             return
 

--- a/src/spindoctor/ui/mosaic_viewer/body_window.py
+++ b/src/spindoctor/ui/mosaic_viewer/body_window.py
@@ -35,6 +35,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from spindoctor.config import image_scope
 from spindoctor.support.time import et_to_utc
 from spindoctor.ui.common import build_stretch_controls
 from spindoctor.ui.mosaic_viewer.common import (
@@ -686,14 +687,15 @@ class BodyMosaicWindow(QMainWindow):
     def _load_file(self, idx: int) -> None:
         """Load body data at index ``idx``, refresh UI, overlays, and stretch.
 
-        No-op if ``idx`` is out of range. On ``load_body_file`` failure, logs the
+        No-op if ``idx`` is out of range. On ``load_body_file`` failure, prints the
         exception and shows a status-bar message without changing the current file.
         """
         if not (0 <= idx < len(self._file_paths)):
             return
         path = self._file_paths[idx]
         try:
-            dd = load_body_file(path)
+            with image_scope():
+                dd = load_body_file(path)
         except Exception as exc:
             print(f'Error loading {path}', file=sys.stderr)
             traceback.print_exc()

--- a/src/spindoctor/ui/mosaic_viewer/common.py
+++ b/src/spindoctor/ui/mosaic_viewer/common.py
@@ -7,6 +7,7 @@ reprojection / mosaic dataclasses (``RingReprojResult``, ``RingMosaicData``,
 """
 
 import math
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -18,14 +19,11 @@ import numpy.ma as ma
 from filecache import FCPath
 from PyQt6.QtWidgets import QLineEdit, QSlider
 
-from spindoctor.config import IMAGE_LOGGER
 from spindoctor.reproj._serialization import infer_format
 from spindoctor.reproj.bodies import BodyMosaicData, BodyReprojResult
 from spindoctor.reproj.ring_orbit_model import RingOrbitModel, get_orbit_model_by_name
 from spindoctor.reproj.rings import RingMosaicData, RingReprojResult
 from spindoctor.ui.mosaic_viewer.tiled_image_widget import slider_to_zoom, zoom_to_slider
-
-logger = IMAGE_LOGGER
 
 
 class _SyncedSlider:
@@ -199,11 +197,11 @@ def _ring_longitude_column_origin_and_extent_hi_deg(
         return 0.0, float(n_cols * lon_res_deg), None
     global_bins = np.flatnonzero(longitude_antimask)
     if global_bins.size != n_cols:
-        logger.warning(
-            'Ring longitude antimask length %s does not match image columns %s; '
-            'assuming longitudes start at 0 deg for display.',
-            int(global_bins.size),
-            int(n_cols),
+        print(
+            f'Ring longitude antimask length {int(global_bins.size)} does not match '
+            f'image columns {int(n_cols)}; assuming longitudes start at 0 deg for '
+            f'display.',
+            file=sys.stderr,
         )
         return 0.0, float(n_cols * lon_res_deg), None
     # Check for contiguous bins: diff should be all-ones.

--- a/src/spindoctor/ui/mosaic_viewer/ring_window.py
+++ b/src/spindoctor/ui/mosaic_viewer/ring_window.py
@@ -42,6 +42,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from spindoctor.config import image_scope
 from spindoctor.support.time import et_to_utc
 from spindoctor.ui.common import build_stretch_controls
 from spindoctor.ui.mosaic_viewer.common import (
@@ -332,8 +333,11 @@ class RingMosaicWindow(QMainWindow):
             pass
         try:
             c.draw()
-        except RuntimeError as e:
-            print(f'radial canvas draw failed: {e}', file=sys.stderr)
+        except RuntimeError:
+            # Repaint failures here are recoverable and were filed at DEBUG;
+            # with no logger to file them under, printing every one would turn
+            # a silent diagnostic into permanent noise on a repaint loop.
+            pass
 
     # ------------------------------------------------------------------
     #  UI
@@ -1175,7 +1179,8 @@ class RingMosaicWindow(QMainWindow):
         QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
         try:
             try:
-                dd = load_ring_file(path)
+                with image_scope():
+                    dd = load_ring_file(path)
             except Exception as exc:
                 print(f'Error loading {path}', file=sys.stderr)
                 traceback.print_exc()

--- a/src/spindoctor/ui/mosaic_viewer/ring_window.py
+++ b/src/spindoctor/ui/mosaic_viewer/ring_window.py
@@ -6,6 +6,8 @@ Info grid and Color By controls in the lower strip, and status-bar readouts.
 """
 
 import math
+import sys
+import traceback
 from pathlib import Path
 from typing import Any, cast
 
@@ -40,7 +42,6 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from spindoctor.config import IMAGE_LOGGER
 from spindoctor.support.time import et_to_utc
 from spindoctor.ui.common import build_stretch_controls
 from spindoctor.ui.mosaic_viewer.common import (
@@ -55,8 +56,6 @@ from spindoctor.ui.mosaic_viewer.photometric_display import compute_ring_display
 from spindoctor.ui.mosaic_viewer.tiled_image_widget import (
     TiledImageWidget,
 )
-
-logger = IMAGE_LOGGER
 
 EW_PROFILE_LEFT_GUTTER_PX = 58
 
@@ -334,7 +333,7 @@ class RingMosaicWindow(QMainWindow):
         try:
             c.draw()
         except RuntimeError as e:
-            logger.debug('radial canvas draw failed: %s', e)
+            print(f'radial canvas draw failed: {e}', file=sys.stderr)
 
     # ------------------------------------------------------------------
     #  UI
@@ -1178,7 +1177,8 @@ class RingMosaicWindow(QMainWindow):
             try:
                 dd = load_ring_file(path)
             except Exception as exc:
-                logger.exception('Error loading %s', path)
+                print(f'Error loading {path}', file=sys.stderr)
+                traceback.print_exc()
                 self.statusBar().showMessage(f'Error loading {path}: {exc}', 5000)
                 return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,10 @@ def strict_log_scope() -> Iterator[None]:
     it for the whole suite would fail hundreds of legitimate tests.  Request it
     from a test that drives a real pipeline, where a scope genuinely should be
     open.
+
+    Clears the override on exit rather than forcing it off, so behavior returns
+    to whatever the configuration says.
     """
     set_strict_scope(True)
     yield
-    set_strict_scope(False)
+    set_strict_scope(None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,29 @@
 """Pytest configuration and shared fixtures."""
 
+from collections.abc import Iterator
+
 import pytest
 
-from spindoctor.config import DEFAULT_CONFIG
+from spindoctor.config import DEFAULT_CONFIG, set_strict_scope
 
 
 @pytest.fixture(autouse=True)
 def config_fixture() -> None:
     """Load bundled default config before each test if not already loaded."""
     DEFAULT_CONFIG.ensure_loaded()
+
+
+@pytest.fixture
+def strict_log_scope() -> Iterator[None]:
+    """Make an out-of-scope image log raise for the duration of a test.
+
+    Opt-in rather than automatic.  A unit test exercising a model or technique
+    in isolation calls it outside any image scope by design, which is correct
+    practice and not the mis-binding this switch exists to catch, so enabling
+    it for the whole suite would fail hundreds of legitimate tests.  Request it
+    from a test that drives a real pipeline, where a scope genuinely should be
+    open.
+    """
+    set_strict_scope(True)
+    yield
+    set_strict_scope(False)

--- a/tests/spindoctor/config/test_log_scope.py
+++ b/tests/spindoctor/config/test_log_scope.py
@@ -1,12 +1,19 @@
 """Tests for image-scope routing, logger roles, and scope enforcement."""
 
+import importlib
 import logging
 from collections.abc import Iterator
 
 import pdslogger
 import pytest
 
-from spindoctor.config import IMAGE_LOGGER, MAIN_LOGGER, LogRole, LogScopeError
+from spindoctor.config import (
+    DEFAULT_CONFIG,
+    IMAGE_LOGGER,
+    MAIN_LOGGER,
+    LogRole,
+    LogScopeError,
+)
 from spindoctor.config.log_scope import (
     _DEFAULT_IMAGE_LOGGER,
     _reset_reported_call_sites,
@@ -14,7 +21,9 @@ from spindoctor.config.log_scope import (
     image_scope_is_open,
     set_strict_scope,
     strict_scope,
+    strict_scope_override,
 )
+from spindoctor.dataset.dataset import DataSet
 from spindoctor.support.nav_base import NavBase
 
 
@@ -22,11 +31,16 @@ from spindoctor.support.nav_base import NavBase
 def _isolate_scope_state() -> Iterator[None]:
     """Restore the strict-scope switch and warning memory around each test.
 
+    Saves the override rather than the resolved value: strict_scope() collapses
+    "no override" into the configured boolean, so restoring that would pin the
+    global and quietly break a later test that expects the configuration to
+    govern.
+
     The warning is deduplicated per call site for the life of the process, so
     without this reset a test asserting on the warning would pass or fail
     depending on whether an earlier test had already reported the same line.
     """
-    previous = strict_scope()
+    previous = strict_scope_override()
     _reset_reported_call_sites()
     yield
     set_strict_scope(previous)
@@ -40,8 +54,6 @@ def recording_logger() -> Iterator[tuple[pdslogger.PdsLogger, list[str]]]:
     Yields:
         Tuple of the logger and the list its records accumulate in.
     """
-    import logging
-
     records: list[str] = []
 
     class _Capture(logging.Handler):
@@ -241,8 +253,6 @@ def test_the_suite_is_permissive_by_default() -> None:
 
 def test_the_dataset_is_main_role() -> None:
     """Enumeration spans the run, so DataSet logs to the main logger."""
-    from spindoctor.dataset.dataset import DataSet
-
     assert DataSet.log_role is LogRole.MAIN
 
 
@@ -277,8 +287,6 @@ def test_a_main_role_component_never_trips_scope_enforcement(
 )
 def test_no_logger_survives_in_a_print_only_module(module_name: str) -> None:
     """The statistics and GUI modules hold no logger to trip scope enforcement."""
-    import importlib
-
     module = importlib.import_module(module_name)
     offenders = [
         name
@@ -397,8 +405,6 @@ def test_an_out_of_scope_exception_keeps_its_traceback(
 
 def test_the_config_key_enables_strict_scope(monkeypatch: pytest.MonkeyPatch) -> None:
     """logging.strict_scope is read, not merely shipped and validated."""
-    from spindoctor.config import DEFAULT_CONFIG
-
     DEFAULT_CONFIG.ensure_loaded()
     monkeypatch.setitem(DEFAULT_CONFIG.logging, 'strict_scope', True)
     set_strict_scope(None)
@@ -407,8 +413,6 @@ def test_the_config_key_enables_strict_scope(monkeypatch: pytest.MonkeyPatch) ->
 
 def test_the_config_key_can_disable_strict_scope(monkeypatch: pytest.MonkeyPatch) -> None:
     """The configured value governs in both directions."""
-    from spindoctor.config import DEFAULT_CONFIG
-
     DEFAULT_CONFIG.ensure_loaded()
     monkeypatch.setitem(DEFAULT_CONFIG.logging, 'strict_scope', False)
     set_strict_scope(None)

--- a/tests/spindoctor/config/test_log_scope.py
+++ b/tests/spindoctor/config/test_log_scope.py
@@ -1,0 +1,286 @@
+"""Tests for image-scope routing, logger roles, and scope enforcement."""
+
+from collections.abc import Iterator
+
+import pdslogger
+import pytest
+
+from spindoctor.config import IMAGE_LOGGER, MAIN_LOGGER, LogRole, LogScopeError
+from spindoctor.config.log_scope import (
+    _reset_reported_call_sites,
+    image_scope,
+    image_scope_is_open,
+    set_strict_scope,
+    strict_scope,
+)
+from spindoctor.support.nav_base import NavBase
+
+
+@pytest.fixture(autouse=True)
+def _isolate_scope_state() -> Iterator[None]:
+    """Restore the strict-scope switch and warning memory around each test.
+
+    The warning is deduplicated per call site for the life of the process, so
+    without this reset a test asserting on the warning would pass or fail
+    depending on whether an earlier test had already reported the same line.
+    """
+    previous = strict_scope()
+    _reset_reported_call_sites()
+    yield
+    set_strict_scope(previous)
+    _reset_reported_call_sites()
+
+
+@pytest.fixture
+def recording_logger() -> Iterator[tuple[pdslogger.PdsLogger, list[str]]]:
+    """Provide a logger capturing its records into a list.
+
+    Yields:
+        Tuple of the logger and the list its records accumulate in.
+    """
+    import logging
+
+    records: list[str] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record.getMessage())
+
+    logger = pdslogger.PdsLogger.get_logger('test_scope_target', lognames=False)
+    logger.remove_all_handlers()
+    logger.add_handler(_Capture())
+    yield logger, records
+    logger.remove_all_handlers()
+
+
+# ---------------------------------------------------------------------------
+# Scope state
+# ---------------------------------------------------------------------------
+
+
+def test_no_scope_is_open_by_default() -> None:
+    """Outside any image, no scope is reported open."""
+    assert image_scope_is_open() is False
+
+
+def test_a_scope_reports_itself_open() -> None:
+    """Inside an image scope, the scope reports open."""
+    with image_scope():
+        assert image_scope_is_open() is True
+
+
+def test_a_scope_closes_on_exit() -> None:
+    """Leaving an image scope restores the outside state."""
+    with image_scope():
+        pass
+    assert image_scope_is_open() is False
+
+
+def test_a_scope_closes_after_an_exception() -> None:
+    """An exception inside a scope does not leave it open."""
+    with pytest.raises(RuntimeError), image_scope():
+        raise RuntimeError('boom')
+    assert image_scope_is_open() is False
+
+
+def test_a_nested_scope_keeps_the_outer_logger(
+    recording_logger: tuple[pdslogger.PdsLogger, list[str]],
+) -> None:
+    """An inner scope does not displace the image the outer one established."""
+    logger, _ = recording_logger
+    with image_scope(logger) as outer, image_scope() as inner:
+        assert inner is outer
+
+
+def test_leaving_a_nested_scope_leaves_the_outer_open(
+    recording_logger: tuple[pdslogger.PdsLogger, list[str]],
+) -> None:
+    """Closing an inner scope does not end the image."""
+    logger, _ = recording_logger
+    with image_scope(logger):
+        with image_scope():
+            pass
+        assert image_scope_is_open() is True
+
+
+# ---------------------------------------------------------------------------
+# Routing through the proxy
+# ---------------------------------------------------------------------------
+
+
+def test_a_record_in_scope_reaches_the_scope_logger(
+    recording_logger: tuple[pdslogger.PdsLogger, list[str]],
+) -> None:
+    """Inside a scope, image records go to that scope's logger."""
+    logger, records = recording_logger
+    with image_scope(logger):
+        IMAGE_LOGGER.info('in scope')
+    assert any('in scope' in record for record in records)
+
+
+def test_opening_a_section_on_the_proxy_enters_a_scope() -> None:
+    """The outermost open on the image logger is what establishes the scope."""
+    with IMAGE_LOGGER.open('IMAGE'):
+        assert image_scope_is_open() is True
+
+
+def test_a_section_opened_on_the_proxy_closes_its_scope() -> None:
+    """Leaving the outermost section ends the image scope."""
+    with IMAGE_LOGGER.open('IMAGE'):
+        pass
+    assert image_scope_is_open() is False
+
+
+def test_nested_sections_stay_in_one_scope(
+    recording_logger: tuple[pdslogger.PdsLogger, list[str]],
+) -> None:
+    """A model or technique section writes into the image already open."""
+    logger, records = recording_logger
+    with image_scope(logger), IMAGE_LOGGER.open('TECHNIQUE: titan_haze'):
+        IMAGE_LOGGER.info('technique detail')
+    assert any('technique detail' in record for record in records)
+
+
+# ---------------------------------------------------------------------------
+# Out-of-scope handling
+# ---------------------------------------------------------------------------
+
+
+def test_an_out_of_scope_record_is_not_lost(capsys: pytest.CaptureFixture[str]) -> None:
+    """A record logged with no scope open still reaches the main logger."""
+    set_strict_scope(False)
+    IMAGE_LOGGER.info('orphan record')
+    assert 'orphan record' in capsys.readouterr().out
+
+
+def test_an_out_of_scope_record_warns(capsys: pytest.CaptureFixture[str]) -> None:
+    """The warning names the offending call site."""
+    set_strict_scope(False)
+    IMAGE_LOGGER.info('orphan record')
+    assert 'no image scope open' in capsys.readouterr().out
+
+
+def test_the_warning_names_the_calling_module(capsys: pytest.CaptureFixture[str]) -> None:
+    """The report identifies where the stray call came from, not the proxy."""
+    set_strict_scope(False)
+    IMAGE_LOGGER.info('orphan record')
+    assert 'test_log_scope' in capsys.readouterr().out
+
+
+def test_the_warning_is_reported_once_per_call_site(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A loop logging out of scope does not flood the log with warnings."""
+    set_strict_scope(False)
+    for _ in range(5):
+        IMAGE_LOGGER.info('orphan record')
+    assert capsys.readouterr().out.count('no image scope open') == 1
+
+
+def test_strict_scope_raises_instead(capsys: pytest.CaptureFixture[str]) -> None:
+    """With strict scope on, an out-of-scope record is an error."""
+    set_strict_scope(True)
+    with pytest.raises(LogScopeError, match='no image scope open'):
+        IMAGE_LOGGER.info('orphan record')
+
+
+def test_strict_scope_names_the_offender() -> None:
+    """The raised error identifies the call site so it can be fixed."""
+    set_strict_scope(True)
+    with pytest.raises(LogScopeError, match='test_log_scope'):
+        IMAGE_LOGGER.warning('orphan record')
+
+
+def test_strict_scope_allows_an_in_scope_record(
+    recording_logger: tuple[pdslogger.PdsLogger, list[str]],
+) -> None:
+    """Strict scope does not interfere with correctly scoped logging."""
+    logger, records = recording_logger
+    set_strict_scope(True)
+    with image_scope(logger):
+        IMAGE_LOGGER.info('properly scoped')
+    assert any('properly scoped' in record for record in records)
+
+
+# ---------------------------------------------------------------------------
+# Role binding
+# ---------------------------------------------------------------------------
+
+
+def test_the_default_role_is_image() -> None:
+    """A navigation component logs to the image logger unless it says otherwise."""
+    assert NavBase.log_role is LogRole.IMAGE
+
+
+def test_an_image_role_component_gets_the_proxy() -> None:
+    """An image-role component holds the image logger."""
+    assert NavBase().logger is IMAGE_LOGGER
+
+
+def test_a_main_role_component_gets_the_main_logger() -> None:
+    """Declaring the main role binds the component to the run's logger."""
+
+    class _RunScoped(NavBase):
+        log_role = LogRole.MAIN
+
+    assert _RunScoped().logger is MAIN_LOGGER
+
+
+def test_the_opt_in_fixture_enables_strict_scope(strict_log_scope: None) -> None:
+    """Requesting the fixture makes an out-of-scope image log raise."""
+    with pytest.raises(LogScopeError):
+        IMAGE_LOGGER.info('orphan record')
+
+
+def test_the_suite_is_permissive_by_default() -> None:
+    """Without the fixture the suite matches production and only warns."""
+    assert strict_scope() is False
+
+
+def test_the_dataset_is_main_role() -> None:
+    """Enumeration spans the run, so DataSet logs to the main logger."""
+    from spindoctor.dataset.dataset import DataSet
+
+    assert DataSet.log_role is LogRole.MAIN
+
+
+def test_a_main_role_component_never_trips_scope_enforcement(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A main-role component logs outside any image without being reported."""
+
+    class _RunScoped(NavBase):
+        log_role = LogRole.MAIN
+
+    set_strict_scope(True)
+    _RunScoped().logger.info('run-level record')
+    assert 'no image scope open' not in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Programs that carry no logger
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'module_name',
+    [
+        'spindoctor.cli.stats.ingest',
+        'spindoctor.cli.stats.report',
+        'spindoctor.cli.sd_backplane_viewer',
+        'spindoctor.ui.mosaic_viewer.common',
+        'spindoctor.ui.mosaic_viewer.body_window',
+        'spindoctor.ui.mosaic_viewer.ring_window',
+    ],
+)
+def test_no_logger_survives_in_a_print_only_module(module_name: str) -> None:
+    """The statistics and GUI modules hold no logger to trip scope enforcement."""
+    import importlib
+
+    module = importlib.import_module(module_name)
+    offenders = [
+        name
+        for name in ('IMAGE_LOGGER', 'MAIN_LOGGER', 'logger')
+        if getattr(module, name, None) is not None
+    ]
+    assert offenders == []

--- a/tests/spindoctor/config/test_log_scope.py
+++ b/tests/spindoctor/config/test_log_scope.py
@@ -1,5 +1,6 @@
 """Tests for image-scope routing, logger roles, and scope enforcement."""
 
+import logging
 from collections.abc import Iterator
 
 import pdslogger
@@ -7,6 +8,7 @@ import pytest
 
 from spindoctor.config import IMAGE_LOGGER, MAIN_LOGGER, LogRole, LogScopeError
 from spindoctor.config.log_scope import (
+    _DEFAULT_IMAGE_LOGGER,
     _reset_reported_call_sites,
     image_scope,
     image_scope_is_open,
@@ -284,3 +286,136 @@ def test_no_logger_survives_in_a_print_only_module(module_name: str) -> None:
         if getattr(module, name, None) is not None
     ]
     assert offenders == []
+
+
+# ---------------------------------------------------------------------------
+# Configuring the image logger is not logging to it
+# ---------------------------------------------------------------------------
+
+
+def test_set_level_reaches_the_image_logger() -> None:
+    """A level set outside any scope configures the image logger, not the main one."""
+    IMAGE_LOGGER.set_level('WARNING')
+    try:
+        assert _DEFAULT_IMAGE_LOGGER.level == logging.WARNING
+    finally:
+        IMAGE_LOGGER.set_level('INFO')
+
+
+def test_set_level_outside_a_scope_does_not_warn(capsys: pytest.CaptureFixture[str]) -> None:
+    """Preparing the image logger before any image is open is not a violation."""
+    set_strict_scope(False)
+    IMAGE_LOGGER.set_level('INFO')
+    assert 'no image scope open' not in capsys.readouterr().out
+
+
+def test_set_level_outside_a_scope_does_not_raise(strict_log_scope: None) -> None:
+    """Configuration is allowed even under strict scope."""
+    IMAGE_LOGGER.set_level('INFO')
+
+
+def test_handlers_can_be_attached_outside_a_scope() -> None:
+    """A worker silencing the image logger at startup can do so before any image."""
+    IMAGE_LOGGER.add_handler(pdslogger.NULL_HANDLER)
+    try:
+        assert pdslogger.NULL_HANDLER in IMAGE_LOGGER.handlers
+    finally:
+        IMAGE_LOGGER.remove_all_handlers()
+
+
+def test_reading_handlers_does_not_raise_under_strict_scope(strict_log_scope: None) -> None:
+    """Introspection must not be able to crash the program."""
+    assert IMAGE_LOGGER.handlers == []
+
+
+def test_an_unimplemented_member_names_itself() -> None:
+    """A PdsLogger member the proxy lacks fails with an explanatory error."""
+    with pytest.raises(AttributeError, match='summarize'):
+        IMAGE_LOGGER.summarize()
+
+
+# ---------------------------------------------------------------------------
+# The remaining forwarding methods
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('method', ['debug', 'info', 'warning', 'error', 'critical'])
+def test_each_level_method_reaches_the_scope_logger(
+    recording_logger: tuple[pdslogger.PdsLogger, list[str]], method: str
+) -> None:
+    """Every level method forwards to the scope's logger."""
+    logger, records = recording_logger
+    logger.set_level('debug')
+    with image_scope(logger):
+        getattr(IMAGE_LOGGER, method)(f'{method} record')
+    assert any(f'{method} record' in record for record in records)
+
+
+def test_log_forwards_an_explicit_level(
+    recording_logger: tuple[pdslogger.PdsLogger, list[str]],
+) -> None:
+    """The generic log method forwards like the named ones."""
+    logger, records = recording_logger
+    with image_scope(logger):
+        IMAGE_LOGGER.log('info', 'explicit level record')
+    assert any('explicit level record' in record for record in records)
+
+
+def test_an_out_of_scope_exception_reaches_the_main_logger(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A routed exception carries its message, not only the scope warning."""
+    set_strict_scope(False)
+    try:
+        raise ValueError('the original failure')
+    except ValueError:
+        IMAGE_LOGGER.exception('while doing the thing')
+    assert 'while doing the thing' in capsys.readouterr().out
+
+
+def test_an_out_of_scope_exception_keeps_its_traceback(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Routing preserves the traceback frames, so the stack is not lost.
+
+    pdslogger records ``traceback.format_tb``, which carries the frames but
+    omits the trailing ``ValueError: ...`` line; the assertion is on a frame
+    rather than the exception text for that reason.
+    """
+    set_strict_scope(False)
+    try:
+        raise ValueError('the original failure')
+    except ValueError:
+        IMAGE_LOGGER.exception('while doing the thing')
+    assert 'test_log_scope.py' in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# The configuration key governs behavior
+# ---------------------------------------------------------------------------
+
+
+def test_the_config_key_enables_strict_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """logging.strict_scope is read, not merely shipped and validated."""
+    from spindoctor.config import DEFAULT_CONFIG
+
+    DEFAULT_CONFIG.ensure_loaded()
+    monkeypatch.setitem(DEFAULT_CONFIG.logging, 'strict_scope', True)
+    set_strict_scope(None)
+    assert strict_scope() is True
+
+
+def test_the_config_key_can_disable_strict_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The configured value governs in both directions."""
+    from spindoctor.config import DEFAULT_CONFIG
+
+    DEFAULT_CONFIG.ensure_loaded()
+    monkeypatch.setitem(DEFAULT_CONFIG.logging, 'strict_scope', False)
+    set_strict_scope(None)
+    assert strict_scope() is False
+
+
+def test_an_override_beats_the_config_key() -> None:
+    """An explicit override takes precedence over the configured value."""
+    set_strict_scope(False)
+    assert strict_scope() is False

--- a/util/agreement/collect.py
+++ b/util/agreement/collect.py
@@ -399,7 +399,7 @@ def _init_worker() -> None:
     """
     import pdslogger
 
-    from spindoctor.config.logger import IMAGE_LOGGER, MAIN_LOGGER
+    from spindoctor.config import IMAGE_LOGGER, MAIN_LOGGER
 
     null_handler = pdslogger.NULL_HANDLER
     for logger in (IMAGE_LOGGER, MAIN_LOGGER):

--- a/util/calibration/collect.py
+++ b/util/calibration/collect.py
@@ -159,7 +159,7 @@ def _init_worker() -> None:
     """
     import pdslogger
 
-    from spindoctor.config.logger import IMAGE_LOGGER, MAIN_LOGGER
+    from spindoctor.config import IMAGE_LOGGER, MAIN_LOGGER
 
     null_handler = pdslogger.NULL_HANDLER
     for logger in (IMAGE_LOGGER, MAIN_LOGGER):

--- a/util/calibration/library_crosscheck.py
+++ b/util/calibration/library_crosscheck.py
@@ -145,7 +145,7 @@ def _init_worker() -> None:
         os.environ[var] = '1'
     import pdslogger
 
-    from spindoctor.config.logger import IMAGE_LOGGER, MAIN_LOGGER
+    from spindoctor.config import IMAGE_LOGGER, MAIN_LOGGER
 
     for logger in (IMAGE_LOGGER, MAIN_LOGGER):
         logger.remove_all_handlers()

--- a/util/fov_distortion/run.py
+++ b/util/fov_distortion/run.py
@@ -65,7 +65,7 @@ def _init_worker() -> None:
         os.environ[var] = '1'
     import pdslogger
 
-    from spindoctor.config.logger import IMAGE_LOGGER, MAIN_LOGGER
+    from spindoctor.config import IMAGE_LOGGER, MAIN_LOGGER
 
     for logger in (IMAGE_LOGGER, MAIN_LOGGER):
         logger.remove_all_handlers()

--- a/util/titan_cohort/build_nominations.py
+++ b/util/titan_cohort/build_nominations.py
@@ -212,7 +212,7 @@ def main(argv: list[str] | None = None) -> int:
 
     import pdslogger
 
-    from spindoctor.config.logger import IMAGE_LOGGER, MAIN_LOGGER
+    from spindoctor.config import IMAGE_LOGGER, MAIN_LOGGER
 
     for logger in (IMAGE_LOGGER, MAIN_LOGGER):
         logger.remove_all_handlers()

--- a/util/titan_cohort/collect.py
+++ b/util/titan_cohort/collect.py
@@ -136,7 +136,7 @@ def _init_worker() -> None:
     """Silence the per-image and main loggers in a pool worker."""
     import pdslogger
 
-    from spindoctor.config.logger import IMAGE_LOGGER, MAIN_LOGGER
+    from spindoctor.config import IMAGE_LOGGER, MAIN_LOGGER
 
     for logger in (IMAGE_LOGGER, MAIN_LOGGER):
         logger.remove_all_handlers()

--- a/util/titan_truth/collect.py
+++ b/util/titan_truth/collect.py
@@ -237,7 +237,7 @@ def _init_worker() -> None:
     """
     import pdslogger
 
-    from spindoctor.config.logger import IMAGE_LOGGER, MAIN_LOGGER
+    from spindoctor.config import IMAGE_LOGGER, MAIN_LOGGER
 
     for logger in (IMAGE_LOGGER, MAIN_LOGGER):
         logger.remove_all_handlers()


### PR DESCRIPTION
Phase 3 of `plans/LOGGING_REDESIGN_PLAN.md`: routing. Makes `IMAGE_LOGGER` a scope-aware proxy, gives components an explicit logger role, and takes the statistics and GUI programs out of the logging system.

## What this does

`IMAGE_LOGGER` becomes a proxy rather than a logger. Opening a section on it enters an image scope; while that scope is open, every nested section, model and technique resolves to the same real logger, so one image's records land in one file. **None of the 57 existing call sites changed.**

Components declare which logger they belong to. `NavBase` carries `log_role`, defaulting to `LogRole.IMAGE`; `DataSet` declares `LogRole.MAIN`, because enumerating a run's images belongs to no single image and was previously filed under whichever image happened to be open, or none at all.

Logging through the image logger with no scope open is treated as a defect: the record is routed to the main logger so it is not lost, the call site is reported once, and under `logging.strict_scope` it raises.

The statistics and GUI programs leave the logging system — seventeen call sites converted to `print()`, with `traceback.print_exc()` wherever `logger.exception` would otherwise drop the stack trace. Without this they would log outside any image scope by construction. The `.cursor/rules` no-print exception for `spindoctor.ui` lands with them.

## A plan premise that did not survive contact

The plan said the suite runs with strict scope on so a new violation fails CI. Enabling it produces **497 failures**, and essentially none are mis-bindings: a unit test calling `NavModelTitan.to_annotations()` directly is correct isolation testing, and that component is correctly image-role. "An image-role component only logs inside an image scope" holds for production paths, not for tests that drive components individually.

Strict scope is therefore opt-in via a `strict_log_scope` fixture, and enforcement moves to tests that drive a real pipeline — which arrive with the wiring in Phases 5 through 7. Section 2.9 of the plan records this, including the figure, so the abandoned premise is not quietly reinstated.

## The second commit

An adversarial review pass found three things that would have shipped broken:

**`sd_mosaic --log-level` silently stopped working.** Its startup `IMAGE_LOGGER.set_level(...)` runs before any image exists, so the proxy treated it as a stray record, routed it to the main logger, and warned. The level never reached the image logger, and every run opened with a warning. Root cause: I had not distinguished *configuring* the image logger from *logging to* it. Configuration now reaches the image logger directly and never reports a violation.

**Seven `util/` worker-pool initializers died at spawn** — the calibration campaign, Titan cohort and truth collection, agreement collection, and the FOV distortion tool. They silence both loggers with `NULL_HANDLER`, which needs `remove_all_handlers`/`add_handler`; the proxy had neither, and their import path had moved. `util/` being out of scope for modification is not the same as being allowed to break.

**`logging.strict_scope` was shipped, validated, documented, and never read.** Setting it had no effect — precisely the dead-key failure this whole design exists to prevent.

Also fixed: the viewers printed six scope warnings per image load, because the obs classes are image-scoped library code that logs while reading; an unimplemented `PdsLogger` member now fails by name, since mypy cannot catch the difference with pdslogger untyped; a malformed batch reports on the main logger where it belongs; a DEBUG repaint diagnostic is dropped rather than printed unconditionally; and the rules file, config comment and dev guide no longer contradict the plan.

## Verification

Full suite 4651 passed, 7 xfailed. `ruff`, `mypy --strict` (542 files), `sphinx-build -W`, `pymarkdown` clean. Proxy coverage 97%.

A real Cassini navigation produces a byte-for-byte identical per-image log to the base branch — same sections, same `135 INFO / 142 DEBUG` counts, nothing leaking to the main logger — and zero violations under strict scope. A real `sd_mosaic` run emits zero scope warnings. All seven `util/` initializers execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qfv91zHoSgvYFhnosuZeDS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced image-scoped logging so navigation components can route messages to per-image or run-level logs via configurable log roles.
  * Added strict scope controls that can fail loudly when image-scoped logging occurs without an active image scope.
* **Bug Fixes**
  * Improved user-facing error reporting in viewers and stats tools with stderr messages and full tracebacks; ingestion/reporting now prints clearer progress.
* **Documentation**
  * Expanded API and developer guide coverage for logging scopes, roles, and strict-scope behavior.
* **Tests**
  * Added coverage for scope routing, nesting, strict enforcement, proxy forwarding, and exception handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->