### PR TITLE
test: cover the logging claims no single phase could (phase 8)

### DIFF
--- a/plans/LOGGING_REDESIGN_PLAN.md
+++ b/plans/LOGGING_REDESIGN_PLAN.md
@@ -637,9 +637,15 @@ Left open and filed as #418: whether a task's `status` should reflect its per-im
 
 ### Phase 8 — Tests
 
-New `tests/spindoctor/config/test_logger.py` plus additions to the CLI tests.
+Most of this list arrived with the phase that introduced the behavior, which is where a test belongs: level resolution, sinks, paths, validation and `--log-level` parsing in `test_logging_config.py` and `test_logging_keys.py`; role binding and scope enforcement in `test_log_scope.py` and `test_nav_base_log_section.py`; program identity in `test_logging_keys.py`; cloud-task isolation in `test_cloud_task_logging.py`. Phase 8 is what none of them could cover from inside a single phase:
+
+- **Argument-surface consistency** (`tests/spindoctor/cli/test_logging_argument_surface.py`), which is a claim about the whole set of programs rather than any one of them. Each program's parser is driven the way the program builds it, by running `main` with `--help`, so what is asserted is the surface a user meets rather than a reconstruction of it.
+- **Static invariants** (`tests/spindoctor/config/test_logging_static_invariants.py`), because what this design guarantees for the print-only programs is an *absence*, and an absence is not observable by exercising the code. Reading the source covers whole packages, so a file added to one tomorrow is covered without being named, and covers the GUI packages without importing PyQt6. Includes a guard that every path these search actually exists — every assertion is that a search came back empty, so a moved target would pass by finding nothing.
+- **Cloud-task silence at the file-descriptor level** (`tests/spindoctor/cli/test_cloud_task_silence.py`), in a real subprocess with `logging.basicConfig` installed as a worker installs it. The rest of the suite uses `capsys`, which replaces `sys.stdout` inside the test process; the guarantee is about the descriptors a worker's terminal actually is.
+
 Per `CLAUDE.md`, pdslogger writes through its own stream handler, so tests
-capture with `capsys`, not `caplog`. Coverage:
+capture with `capsys`, not `caplog`. The original coverage list, now spread
+across the phases above:
 
 - Level precedence at each of the six tiers in section 2.6, and the
   top-level / `programs` merge, including a program block overriding one key
@@ -655,7 +661,9 @@ capture with `capsys`, not `caplog`. Coverage:
 - Role binding: a main-role component's output lands in the main log and not
   the image log, and the reverse.
 - Scope enforcement: out-of-scope image logging warns once per call site and
-  raises under strict scope; the suite runs with strict scope on.
+  raises under strict scope. Strict scope is opt-in per test rather than on
+  suite-wide; see section 2.9 for why that premise did not survive contact
+  with the suite.
 - Argument-surface consistency: a parametrized test asserting every
   logger-carrying program in section 2.1 accepts the same logging flags with
   the same defaults, and that the statistics and GUI programs accept none

--- a/tests/spindoctor/cli/test_cloud_task_silence.py
+++ b/tests/spindoctor/cli/test_cloud_task_silence.py
@@ -1,0 +1,131 @@
+"""Tests that a cloud task emits nothing on a real terminal.
+
+The rest of the logging tests capture with ``capsys``, which replaces
+``sys.stdout`` and ``sys.stderr`` inside the test process.  That is enough for
+records written through Python, but the guarantee here is about the file
+descriptors a worker's terminal actually is, and the handler that
+``cloud_tasks`` installs on the root logger binds a stream at construction.
+So this one runs a real subprocess, with ``logging.basicConfig`` installed
+exactly as a worker installs it, and measures the bytes on each descriptor.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Every level, so nothing is passing merely for being below a threshold, and
+# an exception, whose traceback is the bulkiest thing a per-image log carries.
+_CHILD = """
+import logging
+import sys
+
+logging.basicConfig(level=logging.DEBUG)
+
+from filecache import FCPath
+from spindoctor.config import IMAGE_LOGGER, MAIN_LOGGER
+from spindoctor.config.config import Config
+from spindoctor.config.logging_config import (
+    build_cloud_task_logging,
+    build_image_log_handlers,
+)
+import argparse
+
+config = Config()
+config.read_config()
+log_root = FCPath(sys.argv[1])
+
+run_logging = build_cloud_task_logging(
+    'sd_offset',
+    argparse.Namespace(log_root=log_root.as_posix(), log_level=['DEBUG']),
+    config,
+)
+handlers, path = build_image_log_handlers(
+    'nav', 'vol/N1', run_logging.sinks, run_logging.levels, timestamp='STAMP'
+)
+try:
+    with IMAGE_LOGGER.open('IMAGE', handler=handlers):
+        IMAGE_LOGGER.debug('CANARY-DEBUG')
+        IMAGE_LOGGER.info('CANARY-INFO')
+        IMAGE_LOGGER.warning('CANARY-WARNING')
+        IMAGE_LOGGER.error('CANARY-ERROR')
+        IMAGE_LOGGER.critical('CANARY-CRITICAL')
+        try:
+            raise RuntimeError('CANARY-EXCEPTION')
+        except RuntimeError:
+            IMAGE_LOGGER.exception('CANARY-EXCEPTION')
+    MAIN_LOGGER.info('CANARY-MAIN')
+    IMAGE_LOGGER.warning('CANARY-OUT-OF-SCOPE')
+finally:
+    for handler in handlers:
+        handler.close()
+
+with open(sys.argv[2], 'w') as stream:
+    stream.write(path.as_posix())
+"""
+
+
+@pytest.fixture(scope='module')
+def task_output(tmp_path_factory: pytest.TempPathFactory) -> tuple[str, str, str]:
+    """Run one cloud task in a worker-like subprocess.
+
+    Module-scoped: the subprocess costs a full interpreter start and every
+    assertion below reads the same run.
+
+    Parameters:
+        tmp_path_factory: Fixture used to make the run's directory.
+
+    Yields:
+        Tuple of the child's stdout, its stderr, and its image log text.
+    """
+    directory = tmp_path_factory.mktemp('cloud_task_silence')
+    script = directory / 'child.py'
+    script.write_text(_CHILD)
+    path_file = directory / 'log_path.txt'
+
+    completed = subprocess.run(
+        [sys.executable, str(script), str(directory / 'logs'), str(path_file)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+    assert completed.returncode == 0, completed.stderr
+    log_text = Path(path_file.read_text()).read_text()
+    return completed.stdout, completed.stderr, log_text
+
+
+def test_a_cloud_task_writes_nothing_to_stdout(task_output: tuple[str, str, str]) -> None:
+    """Not one byte reaches the descriptor the worker reports progress on."""
+    assert task_output[0] == ''
+
+
+def test_a_cloud_task_writes_nothing_to_stderr(task_output: tuple[str, str, str]) -> None:
+    """Nor to stderr, where the root handler would otherwise re-emit it all."""
+    assert task_output[1] == ''
+
+
+@pytest.mark.parametrize(
+    'canary',
+    [
+        'CANARY-DEBUG',
+        'CANARY-INFO',
+        'CANARY-WARNING',
+        'CANARY-ERROR',
+        'CANARY-CRITICAL',
+        'CANARY-EXCEPTION',
+    ],
+)
+def test_the_image_log_is_complete(task_output: tuple[str, str, str], canary: str) -> None:
+    """Silence on the terminal is not silence everywhere.
+
+    Every level reaches the per-image file, so what the terminal is spared is
+    duplication rather than the record itself.
+    """
+    assert canary in task_output[2]
+
+
+def test_the_exception_keeps_its_traceback(task_output: tuple[str, str, str]) -> None:
+    """The traceback survives too, since the image log is where it now lives."""
+    assert 'RuntimeError' in task_output[2]

--- a/tests/spindoctor/cli/test_cloud_task_silence.py
+++ b/tests/spindoctor/cli/test_cloud_task_silence.py
@@ -11,9 +11,9 @@ exactly as a worker installs it, and measures the bytes on each descriptor.
 
 import subprocess
 import sys
-from pathlib import Path
 
 import pytest
+from filecache import FCPath
 
 # Every level, so nothing is passing merely for being below a threshold, and
 # an exception, whose traceback is the bulkiest thing a per-image log carries.
@@ -61,8 +61,7 @@ finally:
     for handler in handlers:
         handler.close()
 
-with open(sys.argv[2], 'w') as stream:
-    stream.write(path.as_posix())
+FCPath(sys.argv[2]).write_text(path.as_posix())
 """
 
 
@@ -76,24 +75,29 @@ def task_output(tmp_path_factory: pytest.TempPathFactory) -> tuple[str, str, str
     Parameters:
         tmp_path_factory: Fixture used to make the run's directory.
 
-    Yields:
+    Returns:
         Tuple of the child's stdout, its stderr, and its image log text.
     """
-    directory = tmp_path_factory.mktemp('cloud_task_silence')
+    directory = FCPath(tmp_path_factory.mktemp('cloud_task_silence'))
     script = directory / 'child.py'
     script.write_text(_CHILD)
     path_file = directory / 'log_path.txt'
 
     completed = subprocess.run(
-        [sys.executable, str(script), str(directory / 'logs'), str(path_file)],
+        [
+            sys.executable,
+            script.as_posix(),
+            (directory / 'logs').as_posix(),
+            path_file.as_posix(),
+        ],
         capture_output=True,
         text=True,
         check=False,
         timeout=300,
     )
     assert completed.returncode == 0, completed.stderr
-    log_text = Path(path_file.read_text()).read_text()
-    return completed.stdout, completed.stderr, log_text
+    log_text = FCPath(path_file.read_text()).read_text()
+    return completed.stdout, completed.stderr, str(log_text)
 
 
 def test_a_cloud_task_writes_nothing_to_stdout(task_output: tuple[str, str, str]) -> None:
@@ -126,6 +130,22 @@ def test_the_image_log_is_complete(task_output: tuple[str, str, str], canary: st
     assert canary in task_output[2]
 
 
-def test_the_exception_keeps_its_traceback(task_output: tuple[str, str, str]) -> None:
-    """The traceback survives too, since the image log is where it now lives."""
+def test_the_exception_keeps_its_type(task_output: tuple[str, str, str]) -> None:
+    """The exception survives, since the image log is where it now lives."""
     assert 'RuntimeError' in task_output[2]
+
+
+def test_the_exception_keeps_its_traceback(task_output: tuple[str, str, str]) -> None:
+    """And so does the traceback, which is the part worth having.
+
+    Naming the exception type alone would be satisfied by a one-line record.
+    The frame is what tells a reader where the image failed, and it is the
+    bulkiest thing a per-image log carries -- so if isolation were going to
+    lose anything to a size or formatting difference, it would lose this.
+    """
+    assert f'in <module>{chr(10)}' in task_output[2]
+
+
+def test_the_traceback_names_the_failing_line(task_output: tuple[str, str, str]) -> None:
+    """The frame carries the source line, not just the file it came from."""
+    assert "raise RuntimeError('CANARY-EXCEPTION')" in task_output[2]

--- a/tests/spindoctor/cli/test_logging_argument_surface.py
+++ b/tests/spindoctor/cli/test_logging_argument_surface.py
@@ -1,0 +1,162 @@
+"""Tests that the logging command-line surface is the same everywhere.
+
+Someone who learns these flags for one program should not have to relearn
+them for the next, so the check is over the whole set of programs rather than
+one at a time: every program with a logger accepts the same four main flags,
+every program that processes images individually accepts the three image
+flags as well, and a program with no logger accepts none of them.
+
+Each program's parser is driven the way the program itself builds it, by
+running ``main`` with ``--help``, so what is asserted is the surface a user
+actually meets rather than a reconstruction of it.
+"""
+
+import contextlib
+import importlib
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+_MAIN_FLAGS = ('--log-root', '--log-main-to-console', '--log-main-to-file', '--log-level')
+_IMAGE_FLAGS = ('--log-image-to-console', '--log-image-to-file', '--log-level-image')
+
+_CLI_DIR = Path(__file__).resolve().parents[3] / 'src' / 'spindoctor' / 'cli'
+
+# Programs with a logger, and the argv that reaches their parser.  A program
+# reading its dataset or mode from argv before parsing needs it supplied.
+_WITH_IMAGE_LOGGER = [
+    ('sd_offset', ['coiss_saturn']),
+    ('sd_backplanes', ['coiss_saturn']),
+    ('sd_mosaic', ['rings', 'coiss_saturn']),
+    ('sd_mosaic', ['body', 'coiss_saturn']),
+]
+
+_WITHOUT_IMAGE_LOGGER = [
+    ('sd_consolidate_metadata', ['coiss_saturn']),
+    ('sd_create_bundle', ['labels', 'coiss_saturn']),
+    ('sd_create_bundle', ['summary', 'coiss_saturn']),
+]
+
+_WITH_ANY_LOGGER = _WITH_IMAGE_LOGGER + _WITHOUT_IMAGE_LOGGER
+
+# Programs that carry no logger and write to the terminal with print().  These
+# are checked by source rather than by running them: the GUI programs import
+# PyQt6 at module scope, and importing it to prove a program has no logging
+# flags is a poor trade.
+_WITHOUT_LOGGER = [
+    'sd_stats_ingest',
+    'sd_stats_report',
+    'sd_create_simulated_image',
+    'sd_backplane_viewer',
+    'sd_mosaic_display',
+]
+
+# The cloud-task drivers deliberately have no logging surface: every flag here
+# configures a logger they are not allowed to have, or a console they must not
+# write to.
+_CLOUD_TASK_DRIVERS = [
+    'sd_offset_cloud_tasks',
+    'sd_backplanes_cloud_tasks',
+    'sd_mosaic_cloud_tasks',
+]
+
+
+def _help_text(program: str, argv: list[str]) -> str:
+    """Return what ``program --help`` prints.
+
+    Parameters:
+        program: Dispatch module name under ``spindoctor.cli``.
+        argv: Arguments preceding ``--help``, for a program that reads its
+            dataset or mode from argv before parsing.
+
+    Returns:
+        The help text.
+    """
+    module = importlib.import_module(f'spindoctor.cli.{program}')
+    buffer = io.StringIO()
+    saved = sys.argv
+    sys.argv = [program, *argv, '--help']
+    try:
+        with contextlib.redirect_stdout(buffer), contextlib.suppress(SystemExit):
+            module.main()
+    finally:
+        sys.argv = saved
+    return buffer.getvalue()
+
+
+def _source(program: str) -> str:
+    """Return the source of a dispatch module.
+
+    Parameters:
+        program: Dispatch module name under ``spindoctor.cli``.
+
+    Returns:
+        The module's text.
+    """
+    return (_CLI_DIR / f'{program}.py').read_text()
+
+
+@pytest.mark.parametrize(('program', 'argv'), _WITH_ANY_LOGGER)
+@pytest.mark.parametrize('flag', _MAIN_FLAGS)
+def test_a_program_with_a_logger_accepts_the_main_flags(
+    program: str, argv: list[str], flag: str
+) -> None:
+    """Every program that logs accepts the same main-logger flags."""
+    assert flag in _help_text(program, argv)
+
+
+@pytest.mark.parametrize(('program', 'argv'), _WITH_IMAGE_LOGGER)
+@pytest.mark.parametrize('flag', _IMAGE_FLAGS)
+def test_a_program_that_processes_images_accepts_the_image_flags(
+    program: str, argv: list[str], flag: str
+) -> None:
+    """A program with a per-image backend accepts the image-logger flags."""
+    assert flag in _help_text(program, argv)
+
+
+@pytest.mark.parametrize(('program', 'argv'), _WITHOUT_IMAGE_LOGGER)
+@pytest.mark.parametrize('flag', _IMAGE_FLAGS)
+def test_a_program_without_images_rejects_the_image_flags(
+    program: str, argv: list[str], flag: str
+) -> None:
+    """A program with no image backend does not offer the image flags.
+
+    Offering them would leave someone believing they had changed something.
+    """
+    assert flag not in _help_text(program, argv)
+
+
+@pytest.mark.parametrize(('program', 'argv'), _WITH_ANY_LOGGER)
+def test_a_logging_flag_defaults_to_unset(program: str, argv: list[str]) -> None:
+    """The flags default to nothing, so the configuration decides.
+
+    A flag defaulting to a concrete value would override the configuration
+    just by existing, and there would be no way to ask for the configured
+    behavior on the command line.
+    """
+    assert '--log-level-main LEVEL' in _help_text(program, argv)
+
+
+@pytest.mark.parametrize(('program', 'argv'), _WITH_IMAGE_LOGGER)
+def test_the_console_flags_are_negatable(program: str, argv: list[str]) -> None:
+    """Each sink can be turned off as well as on, from the command line."""
+    text = _help_text(program, argv)
+    assert '--no-log-image-to-console' in text
+
+
+@pytest.mark.parametrize('program', _WITHOUT_LOGGER)
+def test_a_program_with_no_logger_has_no_logging_flags(program: str) -> None:
+    """The statistics and GUI programs take none of the logging surface."""
+    assert 'add_logging_arguments' not in _source(program)
+
+
+@pytest.mark.parametrize('program', _CLOUD_TASK_DRIVERS)
+def test_a_cloud_task_driver_has_no_logging_flags(program: str) -> None:
+    """A worker's logging is not the operator's to configure per invocation.
+
+    Every flag configures a main logger a cloud task must not have, or a
+    console it must not write to.
+    """
+    assert 'add_logging_arguments' not in _source(program)

--- a/tests/spindoctor/cli/test_logging_argument_surface.py
+++ b/tests/spindoctor/cli/test_logging_argument_surface.py
@@ -11,6 +11,7 @@ running ``main`` with ``--help``, so what is asserted is the surface a user
 actually meets rather than a reconstruction of it.
 """
 
+import argparse
 import contextlib
 import importlib
 import io
@@ -18,11 +19,22 @@ import sys
 from pathlib import Path
 
 import pytest
+from filecache import FCPath
+
+from spindoctor.cli.logging_args import add_logging_arguments
 
 _MAIN_FLAGS = ('--log-root', '--log-main-to-console', '--log-main-to-file', '--log-level')
 _IMAGE_FLAGS = ('--log-image-to-console', '--log-image-to-file', '--log-level-image')
 
-_CLI_DIR = Path(__file__).resolve().parents[3] / 'src' / 'spindoctor' / 'cli'
+# The sink flags, which argparse gives a --no- form; the level and root flags
+# take a value and have none.
+_NEGATABLE_MAIN_FLAGS = ('--log-main-to-console', '--log-main-to-file')
+_NEGATABLE_IMAGE_FLAGS = ('--log-image-to-console', '--log-image-to-file')
+
+_MAIN_DESTINATIONS = ('log_root', 'log_main_to_console', 'log_main_to_file', 'log_level')
+_IMAGE_DESTINATIONS = ('log_image_to_console', 'log_image_to_file', 'log_level_image')
+
+_CLI_DIR = FCPath(Path(__file__).resolve().parents[3]) / 'src' / 'spindoctor' / 'cli'
 
 # Programs with a logger, and the argv that reaches their parser.  A program
 # reading its dataset or mode from argv before parsing needs it supplied.
@@ -95,7 +107,7 @@ def _source(program: str) -> str:
     Returns:
         The module's text.
     """
-    return (_CLI_DIR / f'{program}.py').read_text()
+    return str((_CLI_DIR / f'{program}.py').read_text())
 
 
 @pytest.mark.parametrize(('program', 'argv'), _WITH_ANY_LOGGER)
@@ -128,22 +140,46 @@ def test_a_program_without_images_rejects_the_image_flags(
     assert flag not in _help_text(program, argv)
 
 
-@pytest.mark.parametrize(('program', 'argv'), _WITH_ANY_LOGGER)
-def test_a_logging_flag_defaults_to_unset(program: str, argv: list[str]) -> None:
-    """The flags default to nothing, so the configuration decides.
+@pytest.mark.parametrize('destination', [*_MAIN_DESTINATIONS, *_IMAGE_DESTINATIONS])
+def test_a_logging_flag_defaults_to_unset(destination: str) -> None:
+    """Naming no flag leaves every destination None, so the configuration decides.
 
     A flag defaulting to a concrete value would override the configuration
-    just by existing, and there would be no way to ask for the configured
-    behavior on the command line.
+    just by existing, and there would be no way to ask on the command line for
+    the behavior the configuration was set up to give.  Parsed rather than read
+    out of the help text: a default that silently overrode the configuration
+    would be spelled the same way in ``--help`` as one that did not.
     """
-    assert '--log-level-main LEVEL' in _help_text(program, argv)
+    parser = argparse.ArgumentParser()
+    add_logging_arguments(parser)
+    assert getattr(parser.parse_args([]), destination) is None
+
+
+@pytest.mark.parametrize(('program', 'argv'), _WITH_ANY_LOGGER)
+@pytest.mark.parametrize('flag', _NEGATABLE_MAIN_FLAGS)
+def test_a_main_sink_can_be_turned_off(program: str, argv: list[str], flag: str) -> None:
+    """Each main sink can be turned off as well as on, from the command line."""
+    assert f'--no-{flag.removeprefix("--")}' in _help_text(program, argv)
 
 
 @pytest.mark.parametrize(('program', 'argv'), _WITH_IMAGE_LOGGER)
-def test_the_console_flags_are_negatable(program: str, argv: list[str]) -> None:
-    """Each sink can be turned off as well as on, from the command line."""
-    text = _help_text(program, argv)
-    assert '--no-log-image-to-console' in text
+@pytest.mark.parametrize('flag', _NEGATABLE_IMAGE_FLAGS)
+def test_an_image_sink_can_be_turned_off(program: str, argv: list[str], flag: str) -> None:
+    """So can each image sink, on the programs that have one."""
+    assert f'--no-{flag.removeprefix("--")}' in _help_text(program, argv)
+
+
+@pytest.mark.parametrize('flag', [*_NEGATABLE_MAIN_FLAGS, *_NEGATABLE_IMAGE_FLAGS])
+def test_turning_a_sink_off_is_distinguishable_from_saying_nothing(flag: str) -> None:
+    """The negated form resolves to False rather than back to None.
+
+    None means "the configuration decides", so a negation that produced it
+    would silently ask for the default it was trying to override.
+    """
+    parser = argparse.ArgumentParser()
+    add_logging_arguments(parser)
+    destination = flag.removeprefix('--').replace('-', '_')
+    assert getattr(parser.parse_args([f'--no-{flag.removeprefix("--")}']), destination) is False
 
 
 @pytest.mark.parametrize('program', _WITHOUT_LOGGER)

--- a/tests/spindoctor/config/test_logging_static_invariants.py
+++ b/tests/spindoctor/config/test_logging_static_invariants.py
@@ -1,0 +1,138 @@
+"""Tests for logging invariants that hold across the source rather than in one run.
+
+Some of what this design guarantees is an absence, and an absence is not
+observable by exercising the code: a logger that should not be there does
+nothing until the day something logs to it. These read the source instead, so
+a conversion cannot be quietly undone.
+
+Reading the source rather than importing the module is what lets these cover
+whole packages, so a file added to one of them tomorrow is covered without
+being named here, and lets them cover the GUI packages without importing
+PyQt6 to do it. The complement is in ``test_log_scope.py``, which imports a
+handful of named modules and inspects their attributes: that catches a logger
+bound at run time, which no amount of reading imports will find.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).resolve().parents[3] / 'src' / 'spindoctor'
+
+# The statistics and GUI programs carry no logger and write to the terminal
+# with print(): neither is a batch pipeline, and both are read as they run.
+_PRINT_ONLY = [
+    'cli/stats',
+    'cli/sd_backplane_viewer.py',
+    'cli/sd_create_simulated_image.py',
+    'cli/sim_editor',
+    'cli/sd_mosaic_display.py',
+    'ui/mosaic_viewer',
+]
+
+_LOGGER_NAMES = frozenset({'IMAGE_LOGGER', 'MAIN_LOGGER'})
+
+# Core packages route through NavBase.logger; the stdlib logging module is
+# never imported there.
+_NO_STDLIB_LOGGING = [
+    'feature',
+    'nav_model',
+    'nav_orchestrator',
+    'nav_technique',
+    'support',
+]
+
+
+def _python_files(relative: str) -> list[Path]:
+    """Return the Python files a target names.
+
+    Parameters:
+        relative: Path under the package, either a module or a directory.
+
+    Returns:
+        The files to inspect.
+    """
+    target = _SRC / relative
+    return sorted(target.rglob('*.py')) if target.is_dir() else [target]
+
+
+def _imported_names(path: Path) -> set[str]:
+    """Return every name a module imports.
+
+    Parsed rather than matched textually, so a name in a docstring or a
+    comment explaining why it is absent does not count as a use.
+
+    Parameters:
+        path: The module to read.
+
+    Returns:
+        The imported names, including module names.
+    """
+    tree = ast.parse(path.read_text())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            names.update(alias.name for alias in node.names)
+            if node.module is not None:
+                names.add(node.module)
+        elif isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+    return names
+
+
+@pytest.mark.parametrize('relative', _PRINT_ONLY + _NO_STDLIB_LOGGING)
+def test_every_target_of_these_checks_exists(relative: str) -> None:
+    """A target that has moved would make its check pass by finding nothing.
+
+    Every assertion in this module is that a search came back empty, so a path
+    that names nothing is indistinguishable from a path that is clean.
+    """
+    assert (_SRC / relative).exists()
+
+
+@pytest.mark.parametrize('relative', _PRINT_ONLY)
+def test_a_print_only_program_imports_no_logger(relative: str) -> None:
+    """A program that reports through print() holds no logger to drift back to."""
+    offenders = [
+        f'{path.name}:{sorted(_LOGGER_NAMES & _imported_names(path))}'
+        for path in _python_files(relative)
+        if _LOGGER_NAMES & _imported_names(path)
+    ]
+    assert offenders == []
+
+
+@pytest.mark.parametrize('relative', _PRINT_ONLY)
+def test_a_print_only_program_imports_no_pdslogger(relative: str) -> None:
+    """Nor does it reach around the loggers to pdslogger itself."""
+    offenders = [
+        path.name for path in _python_files(relative) if 'pdslogger' in _imported_names(path)
+    ]
+    assert offenders == []
+
+
+@pytest.mark.parametrize('package', _NO_STDLIB_LOGGING)
+def test_core_code_does_not_import_stdlib_logging(package: str) -> None:
+    """Core navigation code logs through pdslogger, never the stdlib module.
+
+    The two do not share a level ladder or a handler set, so a stdlib logger
+    here would be configured by nothing this design controls -- and in a cloud
+    task it would reach the worker's terminal by a path isolation never sees.
+    """
+    offenders = [path.name for path in _python_files(package) if 'logging' in _imported_names(path)]
+    assert offenders == []
+
+
+def test_the_loggers_are_the_only_two() -> None:
+    """No third logger has been constructed anywhere in the package.
+
+    Every record belongs to the run or to one image.  A logger outside those
+    two is configured by none of the command line, the configuration, or the
+    cloud-task isolation.
+    """
+    constructed = sorted(
+        path.relative_to(_SRC).as_posix()
+        for path in _SRC.rglob('*.py')
+        if 'PdsLogger(' in path.read_text()
+    )
+    assert constructed == ['config/log_scope.py', 'config/logger.py']

--- a/tests/spindoctor/config/test_logging_static_invariants.py
+++ b/tests/spindoctor/config/test_logging_static_invariants.py
@@ -17,8 +17,9 @@ import ast
 from pathlib import Path
 
 import pytest
+from filecache import FCPath
 
-_SRC = Path(__file__).resolve().parents[3] / 'src' / 'spindoctor'
+_SRC = FCPath(Path(__file__).resolve().parents[3]) / 'src' / 'spindoctor'
 
 # The statistics and GUI programs carry no logger and write to the terminal
 # with print(): neither is a batch pipeline, and both are read as they run.
@@ -44,7 +45,7 @@ _NO_STDLIB_LOGGING = [
 ]
 
 
-def _python_files(relative: str) -> list[Path]:
+def _python_files(relative: str) -> list[FCPath]:
     """Return the Python files a target names.
 
     Parameters:
@@ -57,7 +58,7 @@ def _python_files(relative: str) -> list[Path]:
     return sorted(target.rglob('*.py')) if target.is_dir() else [target]
 
 
-def _imported_names(path: Path) -> set[str]:
+def _imported_names(path: FCPath) -> set[str]:
     """Return every name a module imports.
 
     Parsed rather than matched textually, so a name in a docstring or a
@@ -107,6 +108,20 @@ def test_a_print_only_program_imports_no_pdslogger(relative: str) -> None:
     """Nor does it reach around the loggers to pdslogger itself."""
     offenders = [
         path.name for path in _python_files(relative) if 'pdslogger' in _imported_names(path)
+    ]
+    assert offenders == []
+
+
+@pytest.mark.parametrize('relative', _PRINT_ONLY)
+def test_a_print_only_program_imports_no_stdlib_logging(relative: str) -> None:
+    """Nor the stdlib module, which is the third way back to having a logger.
+
+    Checking only for the two loggers and for pdslogger would let
+    ``logging.getLogger(__name__)`` reintroduce exactly what these programs
+    were converted away from, configured by nothing this design controls.
+    """
+    offenders = [
+        path.name for path in _python_files(relative) if 'logging' in _imported_names(path)
     ]
     assert offenders == []
 


### PR DESCRIPTION
Phase 8 of the logging redesign. Most of what the plan listed here arrived with the phase that introduced the behavior, which is where a test belongs — level resolution, sinks, paths and validation in `test_logging_config.py` / `test_logging_keys.py`, role binding and scope enforcement in `test_log_scope.py` / `test_nav_base_log_section.py`, program identity in `test_logging_keys.py`, cloud-task isolation in `test_cloud_task_logging.py`. I audited each bullet against the existing suite rather than re-covering it; three were genuinely uncovered, and each is a claim no phase could assert from the inside.

## Argument-surface consistency

`tests/spindoctor/cli/test_logging_argument_surface.py` — the promise is that someone who learns these flags for one program does not relearn them for the next, which is a statement about the *set* of programs. Every program with a logger accepts the same four main flags; every program with a per-image backend accepts the three image flags; a program without one rejects them by name rather than accepting and ignoring them; and the statistics, GUI and cloud-task drivers accept none of the surface at all.

Each program's parser is driven the way the program builds it — running `main` with `--help`, with the dataset or mode a program reads from argv before parsing — so what is asserted is the surface a user actually meets. That turned out to cost ~0ms per program in-process, so no subprocess was needed and no reconstruction of the parsers was involved.

## Static invariants

`tests/spindoctor/config/test_logging_static_invariants.py` — what this design guarantees for the print-only programs is an **absence**, and an absence is not observable by exercising the code: a logger that should not be there does nothing until the day something logs to it.

Reading the source (via AST, so a name in a comment explaining its own absence does not count as a use) covers whole packages rather than named modules, so a file added to `cli/stats`, `cli/sim_editor` or `ui/mosaic_viewer` tomorrow is covered without being named here — and covers the GUI packages without importing PyQt6 to do it. Also asserts no stdlib `logging` import in the five core packages, and that `PdsLogger(` is constructed in exactly two files.

This complements rather than duplicates `test_log_scope.py::test_no_logger_survives_in_a_print_only_module`, which imports six named modules and inspects their attributes — that catches a logger bound at *run* time, which reading imports never will. The module docstring says so, so the next reader does not mistake one for a copy of the other.

Includes a guard that every path these search actually exists: every assertion here is that a search came back empty, so a target that moved would pass by finding nothing.

## Cloud-task silence, on real file descriptors

`tests/spindoctor/cli/test_cloud_task_silence.py` — the rest of the suite captures with `capsys`, which replaces `sys.stdout` and `sys.stderr` inside the test process. The Phase 7 guarantee is about the descriptors a worker's terminal actually is, and the root handler `cloud_tasks` installs binds its stream at construction. So this runs a real subprocess with `logging.basicConfig(level=DEBUG)` installed exactly as a worker installs it, and measures the bytes on each descriptor: both empty, while every level from DEBUG to CRITICAL plus an exception traceback is present in the per-image log.

## Mutation-checked

Each group was verified to fail when the behavior it names regresses, rather than trusted for being green:

| Mutation | Fails |
|---|---|
| image flags removed from the shared helper | 16 |
| a logger imported into a print-only module | its check |
| stdlib `logging` imported into `support` | its check |
| `isolate_cloud_task_logging()` call dropped | both silence assertions |

Suite 4846 passed / 7 xfailed, parallel and serial; ruff, mypy (550 files), sphinx `-W` clean.

The plan's Phase 8 section is reconciled to record where each original bullet actually landed, and the "the suite runs with strict scope on" line is corrected — that premise was revised in Phase 3 and section 2.9 already explains why.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming cloud-task operations produce no terminal output while preserving complete image logs in log files.
  * Added checks for consistent logging options and help text across command-line programs.
  * Added safeguards ensuring logging remains limited to approved application areas and follows configured invariants.

* **Documentation**
  * Updated the logging redesign plan to clarify test coverage, strict-scope behavior, and Phase 8 responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->