### PR TITLE
docs: document logging for operators and contributors (phase 9)

### DIFF
--- a/docs/dev_guide/dev_guide_logging.rst
+++ b/docs/dev_guide/dev_guide_logging.rst
@@ -100,6 +100,57 @@ audience and the consequence of the line, not the call site's depth:
   un-importable extension) that abort the whole run before any image is processed.
   Reserve for setup errors that no per-image fallback can recover from.
 
+Writing a component that logs
+=============================
+
+Which logger a class writes to is declared, not inferred. Most components work
+on one image and keep the default :attr:`LogRole.IMAGE
+<spindoctor.config.log_scope.LogRole>`; one whose work spans a run -- enumerating a
+dataset, tallying totals -- sets ``log_role = LogRole.MAIN`` on the class, and
+:class:`~spindoctor.support.nav_base.NavBase` binds ``self.logger`` accordingly.
+
+Open sections with :meth:`~spindoctor.support.nav_base.NavBase.log_section`
+rather than ``self.logger.open``. A level is applied when a section is opened,
+so the section is where a component's configured level takes effect; calling
+``open`` directly silently ignores it::
+
+    with self.log_section(f'TECHNIQUE: {self.name}'):
+        ...
+
+A component that is a module-level function rather than a class gets the same
+treatment from the :func:`~spindoctor.config.log_scope.logged_section`
+decorator, which is what makes it independently configurable at all.
+
+The name a component is configured under is its ``log_key``, defaulting to the
+snake_case form of the class name with the ``Nav`` prefix and suffix stripped
+(``TitanHazeNav`` becomes ``titan_haze``). A family that should share one key
+-- every body model, say -- declares it once on their base, since ``log_key``
+is inherited normally. Adding a technique or model therefore adds a
+configuration key automatically; adding a function-shaped component means
+adding its key to ``OTHER_LOG_KEYS`` in
+:mod:`spindoctor.config.logging_keys`, or the configuration will reject it.
+
+Every dispatch module that has a logger declares ``PROGRAM_NAME`` from
+:mod:`spindoctor.config.program_names`. It names the program's main log
+directory and selects its block under ``logging.programs``, so a program
+without one has no way to be configured separately and no place to put its
+main log.
+
+The scope rule
+==============
+
+An image-role component that logs when no image scope is open is a bug. The
+record is routed to the main logger so it is never lost, and a warning names
+the call site, deduplicated so a loop cannot flood the log. Under
+``logging.strict_scope`` it raises instead.
+
+There is no legitimate case for it in production code: a component logging
+about one image should be running inside that image's section, and one whose
+work spans the run belongs on the main logger. Strict scope is opt-in per test
+rather than on suite-wide, because a unit test that drives a model or technique
+directly is correct isolation testing, not a mis-binding -- request the
+``strict_log_scope`` fixture from a test that drives a real pipeline.
+
 Cloud tasks
 ===========
 

--- a/docs/dev_guide/dev_guide_logging.rst
+++ b/docs/dev_guide/dev_guide_logging.rst
@@ -28,7 +28,7 @@ Every navigation produces a top-level INFO line per per-image phase
 plus a final ``status_reason``-keyed verdict:
 
 * **Per technique.** Each technique opens a section with
-  ``with self.logger.open(f'TECHNIQUE: {self.name}'):`` so per-image
+  ``with self.log_section(f'TECHNIQUE: {self.name}'):`` so per-image
   logs delimit each technique's contribution unambiguously.
 * **Per status reason.** The orchestrator emits one INFO line per item
   in :data:`spindoctor.nav_orchestrator.status_reason_info.STATUS_REASON_INFO_TEMPLATE`
@@ -104,9 +104,10 @@ Writing a component that logs
 =============================
 
 Which logger a class writes to is declared, not inferred. Most components work
-on one image and keep the default :attr:`LogRole.IMAGE
-<spindoctor.config.log_scope.LogRole>`; one whose work spans a run -- enumerating a
-dataset, tallying totals -- sets ``log_role = LogRole.MAIN`` on the class, and
+on one image and keep the default
+:attr:`~spindoctor.config.log_scope.LogRole.IMAGE`; one whose work spans a run
+-- enumerating a dataset, tallying totals -- sets ``log_role = LogRole.MAIN``
+on the class, and
 :class:`~spindoctor.support.nav_base.NavBase` binds ``self.logger`` accordingly.
 
 Open sections with :meth:`~spindoctor.support.nav_base.NavBase.log_section`
@@ -190,9 +191,9 @@ Conventions
 * Never ``import logging`` in ``nav.*`` core code.
 * Never ``print(...)`` in library code; route through ``self.logger``.
 * Every :meth:`~spindoctor.nav_technique.nav_technique.NavTechnique.navigate` body
-  wraps its work in
-  ``with self.logger.open(f'TECHNIQUE: {self.name}'):`` for log
-  scoping.
+  wraps its work in ``with self.log_section(f'TECHNIQUE: {self.name}'):``
+  for log scoping. Not ``self.logger.open``, which would skip the level
+  configured for that technique; see `Writing a component that logs`_.
 * The orchestrator captures every per-technique exception and emits an
   ``EXCEPTION``-level pdslogger line via ``self._logger.exception(...)``;
   the technique's failure surfaces on the returned

--- a/docs/introduction_configuration.rst
+++ b/docs/introduction_configuration.rst
@@ -77,7 +77,9 @@ Logging is configured by the top-level ``logging`` section, described under
 Two loggers write during a run: the main logger, covering one program run, and
 the image logger, covering one image inside one processing stage. A component
 can be given its own level, so one technique or model can be made verbose or
-quiet without affecting the rest.
+quiet without affecting the rest. For the full component list, where the log
+files are written, and the precedence between the configuration and the
+command line, see :doc:`user_guide/user_guide_logging`.
 
 Example -- enable verbose output for star and ring models while keeping other
 components at the default level:
@@ -206,7 +208,8 @@ loggers, or ``MODULE=LEVEL`` for one component, repeatable),
 ``--log-level-main``, ``--log-level-image``, and the four sink switches
 ``--log-main-to-console``, ``--log-main-to-file``, ``--log-image-to-console``
 and ``--log-image-to-file``, each with a ``--no-`` form. A program that does
-not process images individually accepts only the main-logger options.
+not process images individually accepts only the main-logger options, and the
+cloud-task drivers accept none: see :doc:`user_guide/user_guide_logging`.
 
 These command-line options provide the highest priority override mechanism,
 taking precedence over all configuration files, including those specified with

--- a/docs/introduction_configuration.rst
+++ b/docs/introduction_configuration.rst
@@ -79,7 +79,7 @@ the image logger, covering one image inside one processing stage. A component
 can be given its own level, so one technique or model can be made verbose or
 quiet without affecting the rest. For the full component list, where the log
 files are written, and the precedence between the configuration and the
-command line, see :doc:`user_guide/user_guide_logging`.
+command line, see :doc:`/user_guide/user_guide_logging`.
 
 Example -- enable verbose output for star and ring models while keeping other
 components at the default level:
@@ -209,7 +209,7 @@ loggers, or ``MODULE=LEVEL`` for one component, repeatable),
 ``--log-main-to-console``, ``--log-main-to-file``, ``--log-image-to-console``
 and ``--log-image-to-file``, each with a ``--no-`` form. A program that does
 not process images individually accepts only the main-logger options, and the
-cloud-task drivers accept none: see :doc:`user_guide/user_guide_logging`.
+cloud-task drivers accept none: see :doc:`/user_guide/user_guide_logging`.
 
 These command-line options provide the highest priority override mechanism,
 taking precedence over all configuration files, including those specified with

--- a/docs/user_guide/user_guide.rst
+++ b/docs/user_guide/user_guide.rst
@@ -3,14 +3,15 @@ User Guide
 ==========
 
 This guide provides comprehensive documentation for using SpinDoctor, including
-navigation workflows, backplanes, PDS4 bundle creation, and instrument-specific
-appendices.
+navigation workflows, logging, backplanes, PDS4 bundle creation, and
+instrument-specific appendices.
 
 .. toctree::
    :maxdepth: 2
    :caption: User Guide:
 
    user_guide_navigation
+   user_guide_logging
    user_guide_reprojection
    user_guide_backplanes
    user_guide_statistics

--- a/docs/user_guide/user_guide_backplanes.rst
+++ b/docs/user_guide/user_guide_backplanes.rst
@@ -142,6 +142,16 @@ For each processed image, ``sd_backplanes`` writes two files under
   inventory information and per-backplane ``min``/``max`` statistics
   (consumed by ``sd_create_bundle`` when generating PDS4 labels).
 
+Logs are written under the log root rather than beside these products: the
+run's own log to ``{log_root}/sd_backplanes/main_{timestamp}.log`` and one per
+image to ``{log_root}/backplanes/{results_path_stub}_{timestamp}.log``.
+``sd_backplanes`` accepts the same logging options as every other pipeline
+program; see :doc:`user_guide_logging`.
+
+An image whose navigation did not succeed is skipped and gets no backplanes.
+The run's log says which images those were, and reports the navigation status
+that caused each skip.
+
 Backplane Viewer GUI
 ====================
 

--- a/docs/user_guide/user_guide_logging.rst
+++ b/docs/user_guide/user_guide_logging.rst
@@ -1,0 +1,280 @@
+=======
+Logging
+=======
+
+Every SpinDoctor pipeline program writes two kinds of record, and keeps them
+apart. This page covers what goes where, how to change it, and where the files
+land.
+
+The two loggers
+===============
+
+**The main log** covers one run of one program. It reports what the program is
+doing at the top level: which image it is about to process, counts and totals,
+elapsed time, and the path of each image log it wrote. There is one for the
+life of the run.
+
+**An image log** covers one image inside one processing stage. It carries the
+detail of that image's processing -- which models were built, which techniques
+ran, what each of them found. A new one is started for each image.
+
+A record belongs to exactly one of them, so the two never repeat each other.
+When you want to know what a run did, read the main log; when you want to know
+what happened to one image, read that image's log.
+
+Not every program has both. A program that does not process images
+individually has only a main log, and the statistics and GUI programs have
+neither -- they write to the terminal directly, because both are read as they
+run rather than afterwards.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 15 35
+
+   * - Program
+     - Main log
+     - Image log
+   * - ``sd_offset``
+     - yes
+     - ``nav``
+   * - ``sd_backplanes``
+     - yes
+     - ``backplanes``
+   * - ``sd_mosaic`` (and ``sd_mosaic_rings`` / ``sd_mosaic_body``)
+     - yes
+     - ``reproj``
+   * - ``sd_create_bundle``
+     - yes
+     - none
+   * - ``sd_consolidate_metadata``
+     - yes
+     - none
+   * - ``sd_offset_cloud_tasks``
+     - no
+     - ``nav``
+   * - ``sd_backplanes_cloud_tasks``
+     - no
+     - ``backplanes``
+   * - ``sd_mosaic_cloud_tasks``
+     - no
+     - ``reproj``
+   * - ``sd_stats_ingest``, ``sd_stats_report``
+     - no
+     - none
+   * - ``sd_create_simulated_image``
+     - no
+     - none
+   * - ``sd_backplane_viewer``, ``sd_mosaic_display``
+     - no
+     - none
+
+Where the files go
+==================
+
+Both kinds live under one log root. By default that is a ``logs`` directory
+under the navigation results root; ``--log-root`` overrides it, as do the
+``environment.log_root`` configuration variable and the ``NAV_LOG_ROOT``
+environment variable.
+
+.. code-block:: text
+
+   {log_root}/{program}/main_{timestamp}.log
+   {log_root}/{backend}/{results_path_stub}_{timestamp}.log
+
+The main log is filed under the program that wrote it. An image log is filed
+under the *stage* rather than the program, so an image's navigation log sits
+beside every other navigation log whether an interactive run or a cloud task
+produced it. The three stages are ``nav``, ``backplanes`` and ``reproj``.
+
+Every file from one run shares a single timestamp, in UTC and in
+``YYYY-MM-DDTHH-MM-SS`` form. UTC rather than local time so the names sort
+chronologically and can be compared across machines, which matters when a
+batch is spread over workers in different time zones.
+
+Reprojection logs are keyed by mosaic subject as well, since one image may be
+reprojected onto more than one body::
+
+   {log_root}/reproj/{subject}/{results_path_stub}_{timestamp}.log
+
+.. note::
+
+   Reprojection logs live under the log root, not under the mosaic output
+   directory. If you have a script or a habit that reads them from
+   ``<output-dir>/logs``, it needs updating.
+
+What appears on the terminal
+============================
+
+By default the main log goes to both the terminal and a file, and image logs go
+to a file only.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 33 33
+
+   * - Logger
+     - Terminal
+     - File
+   * - Main
+     - yes
+     - yes
+   * - Image
+     - no
+     - yes
+
+.. note::
+
+   An interactive run therefore shows top-level progress rather than
+   per-component detail. The detail is not lost -- it is in the per-image log
+   file. Pass ``--log-image-to-console`` to see it on screen as well.
+
+Turning every sink off produces no output at all, rather than falling back to
+the terminal.
+
+Command-line options
+====================
+
+Every program that has a logger accepts the same options, so what you learn for
+one works for the next. A program with no image log accepts only the
+main-logger options, and rejects the image ones by name rather than accepting
+and ignoring them.
+
+``--log-root PATH``
+    Where this run's log files go.
+
+``--log-level LEVEL``
+    The default level for both loggers.
+
+``--log-level MODULE=LEVEL``
+    The level for one component. Repeatable, and combines with the bare form.
+
+``--log-level-main LEVEL``, ``--log-level-image LEVEL``
+    The level for one logger, taking precedence over a bare ``--log-level``.
+
+``--log-main-to-console`` / ``--no-log-main-to-console``
+    Whether the main log reaches the terminal. Default on.
+
+``--log-main-to-file`` / ``--no-log-main-to-file``
+    Whether the main log is written to a file. Default on.
+
+``--log-image-to-console`` / ``--no-log-image-to-console``
+    Whether image logs reach the terminal. Default off.
+
+``--log-image-to-file`` / ``--no-log-image-to-file``
+    Whether image logs are written to files. Default on.
+
+Levels are ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, ``CRITICAL`` and
+``NONE``. Both sinks of a logger always share a level, so there is one level to
+set per component rather than one per sink.
+
+Worked examples
+---------------
+
+Quiet the run but keep one technique verbose, which is the usual shape of
+investigating a single technique across many images:
+
+.. code-block:: bash
+
+   sd_offset coiss_saturn --volumes COISS_2001 \
+       --log-level WARNING --log-level titan_haze=DEBUG
+
+Watch one image's detail on screen instead of opening its file:
+
+.. code-block:: bash
+
+   sd_offset coiss N1234567890 --log-image-to-console --log-level DEBUG
+
+Keep the terminal clean and the files complete, for a long batch:
+
+.. code-block:: bash
+
+   sd_offset coiss_saturn --no-log-main-to-console --log-level-image DEBUG
+
+Silence one noisy component without lowering anything else:
+
+.. code-block:: bash
+
+   sd_offset coiss_saturn --log-level annotate=NONE
+
+Configuring levels
+==================
+
+Anything settable on the command line is settable in the configuration, under
+the top-level ``logging`` section:
+
+.. code-block:: yaml
+
+   logging:
+     main: INFO            # the run's logger
+     image: INFO           # image logs, and any component not named below
+     techniques:
+       titan_haze: DEBUG   # one technique
+       default: WARNING    # every other technique
+     models:
+       rings: WARNING      # one model family
+     other:
+       annotate: ERROR
+     programs:
+       sd_mosaic:          # applies to that program only
+         main: WARNING
+
+The most specific setting wins:
+
+.. code-block:: text
+
+   --log-level MODULE=LEVEL
+     > a component named in the configuration
+     > its category's "default"
+     > --log-level-main / --log-level-image
+     > --log-level LEVEL
+     > logging.main / logging.image
+     > INFO
+
+A ``programs`` block applies to that program alone and is merged key by key
+with the settings above it, so a program can override one value while
+inheriting the rest.
+
+An unrecognized component name, program name or level is rejected when the
+configuration loads, naming the offending key. A setting that does nothing is
+worse than one that errors, because it looks like it worked.
+
+Component names
+---------------
+
+A component is named by the technique or model it is, in snake_case.
+
+**Techniques** -- ``body_blob``, ``body_disc_correlate``, ``body_limb``,
+``body_terminator``, ``manual``, ``ring_annulus``, ``ring_edge``,
+``star_field_from_catalog``, ``star_refine``, ``star_unique_match``,
+``titan_haze``
+
+**Models** -- ``body``, ``rings``, ``stars``, ``titan``. One name covers a
+whole family: ``body`` governs every body model regardless of which body it
+renders, and a simulated model is named with the model it stands in for.
+
+**Everything else** -- ``annotate``, ``correlate``, ``ensemble``,
+``image_derivatives``, ``obs``, ``orchestrator``, ``provenance``
+
+Cloud tasks
+===========
+
+The ``_cloud_tasks`` drivers write **nothing** to the terminal. A worker's
+console belongs to ``cloud_tasks``, which reports task progress there under its
+own configuration, and interleaving per-image navigation detail with it would
+make both harder to read.
+
+The per-image logs are written exactly as an interactive run writes them, to
+the same ``{log_root}/{backend}/`` tree and at the same levels, so an image's
+log reads the same whichever driver produced it. There is no main log: with
+many workers writing to one log root, a single shared main log is not something
+they can all append to sensibly.
+
+These drivers accept no logging command-line options, because every one of them
+configures a logger they do not have or a terminal they must not write to. Set
+their levels in the configuration instead -- with a ``programs`` block if they
+should differ from an interactive run.
+
+Because a cloud task has no main log, an outcome that an interactive run would
+report there is returned in the task result instead. A backplanes task reports
+whether the image was processed or skipped, and a reprojection task returns how
+many images it completed, skipped and failed.

--- a/docs/user_guide/user_guide_logging.rst
+++ b/docs/user_guide/user_guide_logging.rst
@@ -71,10 +71,17 @@ run rather than afterwards.
 Where the files go
 ==================
 
-Both kinds live under one log root. By default that is a ``logs`` directory
-under the navigation results root; ``--log-root`` overrides it, as do the
-``environment.log_root`` configuration variable and the ``NAV_LOG_ROOT``
-environment variable.
+Both kinds live under one log root, named by ``--log-root``, the
+``environment.log_root`` configuration variable or the ``NAV_LOG_ROOT``
+environment variable, in that order of precedence.
+
+With none of those set, the root is derived: a ``logs`` directory under the
+navigation results root. A cloud-task worker is not required to have a
+navigation results root, so each falls back to a ``logs`` directory under the
+root it does have -- the backplane results root for
+``sd_backplanes_cloud_tasks``, and the task's own output directory for
+``sd_mosaic_cloud_tasks`` -- rather than dropping its logs for want of a
+setting that does not apply to it.
 
 .. code-block:: text
 
@@ -134,10 +141,11 @@ the terminal.
 Command-line options
 ====================
 
-Every program that has a logger accepts the same options, so what you learn for
+Every program you run yourself accepts the same options, so what you learn for
 one works for the next. A program with no image log accepts only the
 main-logger options, and rejects the image ones by name rather than accepting
-and ignoring them.
+and ignoring them. The ``_cloud_tasks`` drivers accept none of these and are
+configured through the configuration file alone; see `Cloud tasks`_ below.
 
 ``--log-root PATH``
     Where this run's log files go.

--- a/docs/user_guide/user_guide_navigation.rst
+++ b/docs/user_guide/user_guide_navigation.rst
@@ -193,42 +193,29 @@ Miscellaneous
 Logging options
 ^^^^^^^^^^^^^^^
 
-Two loggers write during a run. The main logger reports what the program is
-doing at the top level and writes to the terminal and to a file. The image
-logger carries the detail of processing one image and writes to a file by
-default, though it can write to the console as well.
-Both sinks of a logger always share a level, so there is one level to set per
-component rather than one per sink.
+``sd_offset`` writes a main log reporting what the run is doing, and one log
+per image carrying the detail of navigating it:
 
-Levels are ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, ``CRITICAL`` and
-``NONE``. For the configuration-file equivalents see
-:doc:`/introduction_configuration`.
+.. code-block:: text
 
-* ``--log-root PATH``: where this run's log files go. Defaults to a ``logs``
-  directory under the navigation results root. The main log is written to
-  ``{log_root}/sd_offset/main_{timestamp}.log`` and each image's log to
-  ``{log_root}/nav/{results_path_stub}_{timestamp}.log``, with one UTC
-  timestamp shared by every file a run produces.
+   {log_root}/sd_offset/main_{timestamp}.log
+   {log_root}/nav/{results_path_stub}_{timestamp}.log
 
-* ``--log-level LEVEL``: the default level for both loggers.
+``--log-root`` says where those go, defaulting to a ``logs`` directory under
+the navigation results root. The main log goes to the terminal as well as a
+file; image logs go to a file only, so the per-technique detail is on disk
+rather than on screen unless ``--log-image-to-console`` asks for it.
 
-* ``--log-level MODULE=LEVEL``: the level for one component, repeatable. For
-  example ``--log-level WARNING --log-level titan_haze=DEBUG`` quiets the run
-  but keeps the haze technique verbose. Components are named by the technique
-  or model they are, in snake_case: ``titan_haze``, ``body_limb``, ``rings``,
-  ``stars``, and so on, plus ``annotate``, ``correlate``, ``ensemble``,
-  ``image_derivatives``, ``obs``, ``orchestrator`` and ``provenance``. An
-  unrecognized name is rejected at startup rather than ignored.
+The level of any one component can be raised or lowered on its own, which is
+the usual way to investigate a single technique across many images:
 
-* ``--log-level-main LEVEL`` and ``--log-level-image LEVEL``: the level for one
-  logger, taking precedence over a bare ``--log-level``.
+.. code-block:: bash
 
-* ``--log-main-to-console`` / ``--no-log-main-to-console`` (default on),
-  ``--log-main-to-file`` / ``--no-log-main-to-file`` (default on),
-  ``--log-image-to-console`` / ``--no-log-image-to-console`` (default off),
-  ``--log-image-to-file`` / ``--no-log-image-to-file`` (default on): which
-  sinks each logger writes to. Turning every sink off produces no output at
-  all rather than falling back to the terminal.
+   sd_offset coiss_saturn --volumes COISS_2001 \
+       --log-level WARNING --log-level titan_haze=DEBUG
+
+The full set of options, the component names, the configuration-file
+equivalents and the precedence between them are in :doc:`user_guide_logging`.
 
 Example Commands
 ----------------

--- a/docs/user_guide/user_guide_reprojection.rst
+++ b/docs/user_guide/user_guide_reprojection.rst
@@ -512,6 +512,9 @@ of its own falls back to ``<output-dir>/logs``:
 
 If ``--prefix`` is empty (the default), the leading underscore is omitted.
 
+``sd_mosaic`` accepts the same logging options as every other pipeline
+program; see :doc:`user_guide_logging`.
+
 Cloud-tasks entry point
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/plans/LOGGING_REDESIGN_PLAN.md
+++ b/plans/LOGGING_REDESIGN_PLAN.md
@@ -680,15 +680,13 @@ across the phases above:
 
 ### Phase 9 — Documentation
 
-New `docs/user_guide/user_guide_logging.rst`, referenced from
-`docs/user_guide.rst`, covering the two loggers and what belongs in each, the
-sink defaults, log file locations and naming for all three backends, the
-`logging` section schema including `programs` and the full module key table,
-the precedence order, the command-line arguments with worked examples, and
-cloud-task behavior. Update `docs/introduction_configuration.rst` for the new
-section, the per-program user-guide pages for the flags, and the developer
-guide for `PROGRAM_NAME`, `log_key`, `NavBase.log_section`, and the scope
-rule.
+New `docs/user_guide/user_guide_logging.rst`, in the `docs/user_guide/user_guide.rst` toctree, covering the two loggers and what belongs in each, the sink defaults, log file locations and naming for all three backends, the `logging` section schema including `programs` and the full module key table, the precedence order, the command-line arguments with worked examples, and cloud-task behavior. It carries the two operator-visible changes flagged in section 6 as notes: image detail no longer reaching the console by default, and reprojection logs moving out of `{output_dir}/logs/`.
+
+The page is the single place these are written down. The per-program guides keep only what is specific to that program — its backend, its log paths, one worked example — and link here for the rest, rather than repeating a flag table four times and letting the copies drift.
+
+`docs/introduction_configuration.rst` gains cross-references from both its logging sections. The developer guide gains `PROGRAM_NAME`, `log_key`, `NavBase.log_section` and the scope rule, under a "writing a component that logs" section, since those are the four things a contributor adding a technique or model has to get right.
+
+Every factual claim on the page was checked against the code rather than against the plan: the log paths from `main_log_path` and `image_log_path`, the sink defaults from `LogSinks`, the component names from the key registries, the precedence from `resolve_log_levels`, the `programs` isolation, and the three startup rejections. That found one broken example — `--image-full-path` does not exist — which the guide's own idiom, a bare positional image name, replaced.
 
 ---
 
@@ -713,14 +711,19 @@ rule.
 7. Each of the four sink toggles independently controls its sink, and
    disabling every sink produces no output at all.
 8. No PdsLogger anywhere in the codebase can reach the `print()` fallback.
-   Enforced by a test that walks every logger the builders produce and
-   asserts a non-empty handler list.
-9. No image-role component logs outside an image scope anywhere in the suite,
-   enforced by strict scope being on in tests.
+   Enforced by a test over all sixteen sink combinations at three levels,
+   asserting a non-empty handler list for each.
+9. No image-role component logs outside an image scope in production code.
+   **Revised**: the original wording said "anywhere in the suite, enforced by
+   strict scope being on in tests", which does not survive contact with the
+   suite — see section 2.9. Enforcement is the `strict_log_scope` fixture in
+   tests that drive a real pipeline, and the deduplicated warning in
+   production.
 10. An unknown module key, program name, or level name in the configuration
    fails at startup with a message naming the offending key.
 11. No `_LOOKUP` growth proportional to image count: a run over N images
-    leaves the registry size unchanged from a run over one.
+    leaves the registry size unchanged from a run over one. Enforced by a
+    test over fifty images.
 12. `ruff check`, `ruff format --check`, `mypy --strict`, `sphinx-build -W`,
     and `pymarkdown scan` all pass; suite coverage stays at or above 90%.
 

--- a/plans/LOGGING_REDESIGN_PLAN.md
+++ b/plans/LOGGING_REDESIGN_PLAN.md
@@ -711,8 +711,11 @@ Every factual claim on the page was checked against the code rather than against
 7. Each of the four sink toggles independently controls its sink, and
    disabling every sink produces no output at all.
 8. No PdsLogger anywhere in the codebase can reach the `print()` fallback.
-   Enforced by a test over all sixteen sink combinations at three levels,
-   asserting a non-empty handler list for each.
+   Enforced by tests over every sink combination at three levels, for both
+   loggers, asserting a non-empty handler list for each. `NONE` is the case
+   worth having: it creates no real sink even where a file sink was asked
+   for, reaching the null handler by a different route than turning the
+   sinks off does.
 9. No image-role component logs outside an image scope in production code.
    **Revised**: the original wording said "anywhere in the suite, enforced by
    strict scope being on in tests", which does not survive contact with the

--- a/tests/spindoctor/config/test_logging_config.py
+++ b/tests/spindoctor/config/test_logging_config.py
@@ -1,6 +1,7 @@
 """Tests for logging level resolution, sink selection, and logger construction."""
 
 import argparse
+import itertools
 import logging
 from datetime import datetime
 from pathlib import Path
@@ -9,6 +10,7 @@ import pdslogger
 import pytest
 from filecache import FCPath
 
+from spindoctor.config import IMAGE_LOGGER
 from spindoctor.config.config import Config
 from spindoctor.config.logging_config import (
     BACKEND_NAMES,
@@ -911,3 +913,92 @@ def test_without_a_fallback_the_file_sinks_are_dropped(
         SD_OFFSET, argparse.Namespace(), _config(tmp_path), build_main=False
     )
     assert (run_logging.sinks.main_file, run_logging.sinks.image_file) == (False, False)
+
+
+# ---------------------------------------------------------------------------
+# No logger can reach the print fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ('main_console', 'main_file', 'image_console', 'image_file'),
+    list(itertools.product([True, False], repeat=4)),
+)
+@pytest.mark.parametrize('level', ['DEBUG', 'INFO', 'NONE'])
+def test_image_handlers_are_never_empty(
+    tmp_path: Path,
+    main_console: bool,
+    main_file: bool,
+    image_console: bool,
+    image_file: bool,
+    level: str,
+) -> None:
+    """No combination of sinks and levels leaves a logger with no handlers.
+
+    A PdsLogger with an empty handler list does not go quiet: it prints every
+    record to stdout regardless of level.  Asking for no output must therefore
+    produce the null handler rather than nothing, and that has to hold for
+    every combination rather than the ones a driver happens to use.
+    """
+    sinks = LogSinks(
+        log_root=FCPath(tmp_path),
+        main_console=main_console,
+        main_file=main_file,
+        image_console=image_console,
+        image_file=image_file,
+    )
+    handlers, _ = build_image_log_handlers(
+        'nav',
+        f'vol/{main_console}{main_file}{image_console}{image_file}{level}',
+        sinks,
+        LogLevels(main=level, image=level),
+        timestamp=_STAMP,
+    )
+    try:
+        assert handlers != []
+    finally:
+        _close(handlers)
+
+
+@pytest.mark.parametrize(
+    ('main_console', 'main_file'), list(itertools.product([True, False], repeat=2))
+)
+def test_the_main_logger_is_never_left_empty(
+    tmp_path: Path, main_console: bool, main_file: bool
+) -> None:
+    """The same holds for the main logger, however its sinks are set."""
+    logger = pdslogger.PdsLogger.get_logger(
+        f'never_empty_{main_console}_{main_file}', lognames=False
+    )
+    sinks = LogSinks(log_root=FCPath(tmp_path), main_console=main_console, main_file=main_file)
+    build_main_logger(logger, SD_OFFSET, sinks, LogLevels(), timestamp=_STAMP)
+    try:
+        assert logger.handlers != []
+    finally:
+        _close(list(logger.handlers))
+        logger.remove_all_handlers()
+
+
+# ---------------------------------------------------------------------------
+# The logger registry does not grow with the batch
+# ---------------------------------------------------------------------------
+
+
+def test_the_registry_does_not_grow_with_the_image_count(tmp_path: Path) -> None:
+    """Navigating many images leaves the logger registry the size it was.
+
+    pdslogger keeps every logger it is asked for in a process-wide table and
+    never frees one, so a logger per image would leak for the length of a
+    batch.  One image logger is reused with its handlers swapped instead.
+    """
+    before = len(pdslogger._LOOKUP)
+    for index in range(50):
+        handlers, _ = build_image_log_handlers(
+            'nav', f'vol/N{index}', _sinks(tmp_path), LogLevels(), timestamp=_STAMP
+        )
+        try:
+            with IMAGE_LOGGER.open(f'IMAGE {index}', handler=handlers):
+                IMAGE_LOGGER.info('processing')
+        finally:
+            _close(handlers)
+    assert len(pdslogger._LOOKUP) == before

--- a/tests/spindoctor/config/test_logging_config.py
+++ b/tests/spindoctor/config/test_logging_config.py
@@ -963,15 +963,21 @@ def test_image_handlers_are_never_empty(
 @pytest.mark.parametrize(
     ('main_console', 'main_file'), list(itertools.product([True, False], repeat=2))
 )
+@pytest.mark.parametrize('level', ['DEBUG', 'INFO', 'NONE'])
 def test_the_main_logger_is_never_left_empty(
-    tmp_path: Path, main_console: bool, main_file: bool
+    tmp_path: Path, main_console: bool, main_file: bool, level: str
 ) -> None:
-    """The same holds for the main logger, however its sinks are set."""
+    """The same holds for the main logger, however its sinks and level are set.
+
+    ``NONE`` is the case worth having here: it creates no real sink even when a
+    file sink was asked for, so it reaches the null handler by a different route
+    than turning the sinks off does.
+    """
     logger = pdslogger.PdsLogger.get_logger(
-        f'never_empty_{main_console}_{main_file}', lognames=False
+        f'never_empty_{main_console}_{main_file}_{level}', lognames=False
     )
     sinks = LogSinks(log_root=FCPath(tmp_path), main_console=main_console, main_file=main_file)
-    build_main_logger(logger, SD_OFFSET, sinks, LogLevels(), timestamp=_STAMP)
+    build_main_logger(logger, SD_OFFSET, sinks, LogLevels(main=level), timestamp=_STAMP)
     try:
         assert logger.handlers != []
     finally:


### PR DESCRIPTION
The last phase of the logging redesign.

## A single place, not four copies

`docs/user_guide/user_guide_logging.rst` is new and is where the logging surface is written down: the two loggers and what belongs in each, where files land for all three stages, the sink defaults, the configuration schema with the full component list, the precedence order, the command-line options with worked examples, and cloud-task behavior.

The per-program guides keep only what is specific to them — their backend, their log paths, one example — and link here for the rest. Repeating a flag table across four guides is how the copies drift apart, and the navigation guide already had a full one. It now has its own two paths and a single worked example.

Two operator-visible changes from the plan's risk list are carried as notes on the page, since neither is discoverable by reading the flags: **image detail no longer reaches the console by default** (it is in the per-image file; `--log-image-to-console` restores it), and **reprojection logs moved out of `<output-dir>/logs`**, which breaks any script that reads them there.

## Claims checked against the code, not the plan

A documentation page is the one artifact where a wrong claim is invisible until someone follows it, so I verified each factual statement against the implementation: log paths from `main_log_path` / `image_log_path`, sink defaults from `LogSinks`, component names from the key registries, precedence from `resolve_log_levels`, `programs` isolation, and the three startup rejections (each fires and names the offending key).

That found one broken example — `--image-full-path` does not exist. The guide's own established idiom, a bare positional image name, replaced it.

## Two acceptance criteria that said "enforced by a test" and had none

Criterion 8 (no `PdsLogger` can reach the `print()` fallback) and criterion 11 (no `_LOOKUP` growth with image count) were both true but unasserted. Now:

- All sixteen sink combinations at three levels, asserting a non-empty handler list. Removing the `NULL_HANDLER` guarantee fails 32 tests.
- Fifty images leave the pdslogger registry the size it started.

Criterion 9 is marked **revised** rather than met: it said strict scope would be on suite-wide, which Phase 3 found does not survive contact with the suite — section 2.9 already explains why, and the criteria list now says so instead of implying a promise that was quietly dropped.

## Developer guide

Gains a "writing a component that logs" section covering the four things a contributor adding a technique or model has to get right: `log_role`, using `log_section` rather than `logger.open` (a level is applied when a section opens, so calling `open` directly silently ignores the component's configured level), `log_key` and where a function-shaped component's key must be registered, and `PROGRAM_NAME`. Plus the scope rule and why strict scope is opt-in.

Suite 4929 passed / 7 xfailed; ruff, mypy (550 files), sphinx `-W`, pymarkdown all clean. Logging-module coverage 95%, against the plan's 90% bar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive logging guide covering log files, locations, formats, levels, configuration, component logging, command-line options, and cloud-task behavior.
  - Clarified backplane logging, navigation outcomes, reprojection logging, and configuration limitations.
  - Added developer guidance and updated navigation links throughout the documentation.

- **Tests**
  - Expanded coverage for logging configurations across sink and log-level combinations.
  - Added checks ensuring image logger reuse remains stable during repeated processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->