### PR TITLE
Record corrected pointing as a C-matrix

### DIFF
--- a/docs/api_reference/api_support.rst
+++ b/docs/api_reference/api_support.rst
@@ -13,6 +13,11 @@ spindoctor.support
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: spindoctor.support.cmatrix
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: spindoctor.support.constants
    :members:
    :undoc-members:

--- a/docs/dev_guide/dev_guide_orchestrator_curator.rst
+++ b/docs/dev_guide/dev_guide_orchestrator_curator.rst
@@ -34,6 +34,28 @@ The constants are chosen tighter than the per-image tolerance budget so the JSON
 is byte-identical across runs of the same input — a regression-baseline comparator can
 diff the JSON directly.
 
+Corrected pointing
+------------------
+
+When the orchestrator could determine the observation's attitude, the
+:class:`~spindoctor.nav_orchestrator.nav_result.NavResult` carries a
+:class:`~spindoctor.support.cmatrix.PointingSolution` and the curator emits two further
+blocks under ``navigation_result``:
+
+- ``pointing`` — ``cmatrix_original`` (the uncorrected J2000-to-camera rotation the
+  furnished kernels gave at navigation time), ``cmatrix`` (the same rotation corrected
+  by the navigated offset), ``camera_frame``, ``camera_frame_id`` and ``ck_frame_id``.
+  Both matrices are nine row-major floats in the SPICE camera-frame convention at the
+  exposure midtime. ``cmatrix`` is present only when the navigation produced an offset
+  and fitted no camera rotation.
+- ``times`` — ``start_et``, ``stop_et``, ``midtime_et``, ``exposure_s`` and the three
+  spacecraft-clock strings ``sclk_start``, ``sclk_midtime`` and ``sclk_stop``.
+
+Both blocks are written unrounded, against the policy above. A consumer identifies the
+kernel an image navigated against by reproducing ``cmatrix_original`` to within a
+nanoradian and defines a segment interval from the exact exposure epochs, and rounding
+would put the recorded values outside those bounds.
+
 Allow-list discipline
 ---------------------
 

--- a/docs/user_guide/user_guide_navigation.rst
+++ b/docs/user_guide/user_guide_navigation.rst
@@ -512,7 +512,10 @@ These JSON files contain the navigation results, including:
   and ``image_et`` there; that needs no SPICE and never opens the image, so
   a frame whose navigation dies for want of a kernel is still placed in
   time and attributed to its camera. An image navigated by explicit path
-  rather than enumerated from an index has neither.
+  rather than enumerated from an index has neither.  ``shutter_mode`` records
+  the mode the image was taken in for an instrument whose label carries one
+  (Cassini ISS reports ``BOTSIM`` when both cameras were exposed at once);
+  instruments whose labels carry no such field omit it.
 * The calculated pointing offset (dv, du)
 * Uncertainty estimates (sigma_v, sigma_u)
 * Confidence scores
@@ -524,6 +527,16 @@ These JSON files contain the navigation results, including:
 * ``excluded_from_consensus`` — technique names the ensemble left out of the
   reported combine (outliers rejected against a multi-technique consensus, or
   the runner-up alternative on a conflicted result)
+* ``pointing`` — the image's attitude as a C-matrix: ``cmatrix_original``, the
+  uncorrected J2000-to-camera rotation the furnished kernels gave, and
+  ``cmatrix``, the same rotation corrected by the navigated offset, alongside
+  the SPICE ``camera_frame``, ``camera_frame_id``, and the ``ck_frame_id`` of
+  the object a corrected C-kernel targets.  Both matrices are nine row-major
+  floats at the exposure midtime.  ``cmatrix`` is present only when the
+  navigation produced an offset and fitted no camera rotation
+* ``times`` — the exposure window the attitude belongs to: ``start_et``,
+  ``stop_et``, ``midtime_et``, ``exposure_s``, and the spacecraft-clock
+  strings ``sclk_start``, ``sclk_midtime`` and ``sclk_stop``
 * Timestamps
 
 .. note::

--- a/plans/CK_KERNEL_PLAN.md
+++ b/plans/CK_KERNEL_PLAN.md
@@ -150,7 +150,7 @@ M . d = los_from_xy(xy_from_uv(uv_los))
 
 **Step 2 -- construct `M`.** `M` is the minimal rotation taking `d` to the
 boresight direction `b = los_from_xy(xy_from_uv(uv_los))`: axis
-`d x b` normalized, angle `arccos(d . b)`, realized with
+`d x b` normalized, angle `arctan2(|d x b|, d . b)`, realized with
 `cspyce.axisar(axis, angle)` -- which is the **active** vector rotation
 (`M . d = b`); `cspyce.rotate` is the frame rotation and gives the
 transpose. Guard: when `|d x b| < 1e-12` (a zero or sub-nanoradian offset),
@@ -158,11 +158,60 @@ transpose. Guard: when `|d x b| < 1e-12` (a zero or sub-nanoradian offset),
 `rotation_deg` on the result means no `cmatrix` is computed at all (section
 1); there is no twist term in `M`.
 
+The angle is `arctan2(|d x b|, d . b)` and not the mathematically
+equivalent `arccos(d . b)` this plan first specified, because for unit
+vectors `arccos` loses all relative precision as the angle goes to zero,
+which is exactly the regime a sub-pixel offset lives in. Measured against a
+Cassini NAC pixel scale of 6e-6 rad/px: at 0.01 px `arccos` returns
+5.9605e-08 rad against a true 6.0000e-08 (0.7% low), and at 0.001 px it
+returns **exactly 0.0** -- `cos` of 6e-9 rad rounds to 1.0 in float64, so
+the correction would be silently dropped altogether. `arctan2` returns the
+true angle in every one of those cases. This is a correction of a defect in
+the formula, not a change of method: the two forms agree wherever `arccos`
+has any precision left.
+
 An exact rigid rotation is not exactly a uniform tangent-plane shift; the
-difference is second order in field angle -- about 1e-9 radians on a
-Cassini NAC and at most ~0.04 px at the corner of a WAC for a 50 px offset,
-measured. This bounds what the round trip in Phase D can be expected to
-recover and is part of its error budget.
+difference is second order in field angle. Measured over a 17x17 pixel grid
+across each full frame, worst case over eight offset directions, for **50
+pixels of total boresight displacement**, comparing `M` applied to oops's
+own `OffsetFOV` line of sight against the unmodified FOV:
+
+| Instrument | worst residual (rad) | in tangent-plane px | in pixel space |
+|---|---|---|---|
+| Cassini NAC | 6.01e-9 | 1.00e-3 px | 1.24e-3 px |
+| Cassini WAC | 5.91e-6 | 9.89e-2 px | 7.86e-2 px |
+| New Horizons LORRI | 1.62e-8 | 8.15e-4 px | 1.23e-3 px |
+| Galileo SSI | 1.82e-8 | 1.79e-3 px | 1.79e-3 px |
+| Voyager 2 NAC | 1.29e-8 | 1.64e-3 px | 1.64e-3 px |
+
+These replace this plan's earlier figures of "about 1e-9 radians on a
+Cassini NAC" and "at most ~0.04 px at the corner of a WAC", which were low
+by roughly 6x and 2.5x respectively; the 0.04 px figure corresponds to an
+offset closer to 20 px than to 50.
+
+**The residual is essentially linear in the offset**, not quadratic.
+Measured across 12.5 / 25 / 50 / 100 px of total displacement, each
+doubling multiplies it by 2.034, 2.067, 2.129 -- on both the NAC and the
+WAC, identically. The two figures above confirm it independently: 8.72e-9
+rad at 70.71 px against 6.01e-9 at 50 px is a ratio of 1.452, where linear
+predicts 1.414 and quadratic 2.000. The term is second order in *field
+angle* and first order in the offset -- it goes as offset times field angle
+squared -- and an earlier revision of this plan conflated the two
+variables. Quoting the residual without the offset it was measured at is
+still meaningless, but halving the offset only halves the residual.
+
+**The WAC case sits essentially at Phase D's 0.1 px decision boundary.**
+9.89e-2 px of total displacement at a 50 px total offset, against a target
+stated as 0.1 px *per axis* -- so the comparison is conservative (a total
+displacement is at most sqrt(2) times the larger per-axis component), but
+the two are not in the same units and Phase D must convert before deciding.
+That is a fact to confront with the rule as written, not a reason to move
+the bound: a WAC round trip at a 50 px offset should be expected to consume
+nearly the whole budget from this term alone. Because the term is linear,
+buying headroom costs proportionally more offset than a quadratic rule
+would suggest: a Phase D WAC frame at about 10 px of total offset lands
+near a fifth of budget, where a quadratic reading would have promised that
+at ~22 px.
 
 **Step 3 -- express both attitudes in the SPICE convention.** With
 `C_oops` the observation frame's J2000-to-camera matrix at midtime
@@ -179,7 +228,7 @@ cmatrix          = (R^T . M . R) . cmatrix_original
 instrument, and asserted epoch-independent by recomputing at `start_et` and
 `stop_et`; a violation raises rather than being absorbed. For **Voyager**,
 oops builds the observation frame as
-`P . ckgp(ck_id, sce2c(scid, et_mid), 800 + texp/48, 'J2000')` with
+`P . ckgp(ck_id, sce2t(scid, et_mid), 800 + texp/48, 'J2000')` with
 `P = pxform('VGn_SCAN_PLATFORM', camera_frame, 0)` -- frozen,
 time-independent, and tolerance-snapped, so `pxform` at midtime does not
 reproduce it. For Voyager, `cmatrix_original = C_oops` itself (already the
@@ -188,9 +237,25 @@ construction, and the writer must reproduce the baseline with the same
 snapped `ckgp` call (section 3.3) -- which is why `exposure_s` is a
 recorded field.
 
-Sanity check on the result: `|det(cmatrix) - 1| < 1e-9` and
-`max|cmatrix . cmatrix^T - I| < 1e-9`, both raising on violation -- a
-non-proper rotation here is a defect, not something to repair.
+The tick conversion is `sce2t`, not the `sce2c` this plan first named:
+`oops/hosts/voyager/iss.py` calls `cspyce.sce2t(scid, tstart + texp/2.)`.
+The two differ. On `C1205021_GEOMED` (Voyager 2, texp 0.48 s), `sce2t`
+returns 6349696766.0 and `sce2c` returns 6349696766.186253 -- 0.19 ticks
+apart against a tolerance of 800.01, so on this frame both find the same
+pointing record (found tick 6349696815.0). It is nonetheless the wrong
+call, and section 3.3's reproduction step must use `sce2t` to be sure of
+matching oops on every frame.
+
+Sanity check on the result: `|det(cmatrix) - 1| < 1e-9`,
+`max|cmatrix . cmatrix^T - I| < 1e-9`, and every element finite, all three
+raising on violation -- a non-proper rotation here is a defect, not
+something to repair. The finiteness check is not redundant with the other
+two: `NaN` fails every inequality, so a `NaN` matrix passes both tolerance
+guards silently, and the metadata writer emits the C-matrices and epochs
+unrounded (they must reproduce to 1e-9 rad, which rounding would break),
+bypassing the rounding helper that maps non-finite floats onto the JSON
+sentinel. An unchecked `NaN` therefore reaches the file as a bare `NaN`
+token, which is not valid JSON and which the results-index ingest rejects.
 
 ### 2.3 Metadata fields
 
@@ -246,13 +311,53 @@ interface stays. A `#` comment records that intent.
 
 `NavResult` is constructed inside the ensemble, which never sees the
 observation, and it is a frozen dataclass -- so the wiring is: `NavResult`
-gains an optional `pointing` field (default None), populated in
-`_navigate_pipeline` in `nav_orchestrator/orchestrator.py` via
-`dataclasses.replace` at the point where `context.obs` is in hand (the same
-neighborhood that builds provenance from `obs.midtime`), and
-`curator.build_metadata_dict` serializes it. Phase A states this as the
-insertion point so the implementer does not go looking for an `obs`
-argument inside `ensemble()` that does not exist.
+gains an optional `pointing` field (default None), populated via
+`dataclasses.replace` where the observation is in hand, and
+`curator.build_metadata_dict` serializes it. This is stated explicitly so
+the implementer does not go looking for an `obs` argument inside
+`ensemble()` that does not exist.
+
+The stamping site is `NavOrchestrator.navigate` in
+`nav_orchestrator/orchestrator.py`, not `_navigate_pipeline` as this plan
+first said. `_navigate_pipeline` has five early failure returns and
+`navigate` has two more of its own -- the hard-failure image-class
+short-circuit, which never enters the pipeline at all, and the
+`NavContractError` path -- so stamping the pipeline's final return alone
+would leave the uncorrected matrix and the times off every failed result,
+against this section's own "whenever a `NavResult` exists". `navigate`
+routes all three of its returns through one `with_pointing(result, obs)`
+method instead.
+
+That method is **public**, because the manual-navigation driver needs it:
+`run_manual_nav` in `nav_technique/nav_technique_manual.py` builds its
+`NavResult` directly from the operator's pick and never calls `navigate`,
+so it calls `with_pointing` itself. Operator-ratified offsets are the
+highest-quality pointing in the corpus; leaving them unstamped would make
+them the one subset excluded from every generated kernel.
+
+`with_pointing` never raises. `navigate` is documented never to raise
+through to its caller, and a pointing solution is recorded metadata rather
+than the navigation itself, so a failure is reported and the field is left
+unset -- no wrong C-matrix is ever recorded, which is the property the
+raises in section 2.2 exist to guarantee. Two constraints on how it
+absorbs:
+
+- The caught set is only what the computation can legitimately raise: its
+  own `ValueError` guards, plus the `LookupError` / `OSError` /
+  `RuntimeError` / `ValueError` family cspyce raises for a missing frame,
+  an unreadable kernel, or a SPICE error. A `TypeError` or `AttributeError`
+  from a defect in the computation itself is deliberately **not** caught,
+  so a broken build fails on the first image instead of quietly dropping
+  pointing from a 50,000-image batch while every image still reports
+  `status=success`.
+- Anything that degrades or omits a solution goes to **both** logs: detail
+  to the image log, one line to the run log. An operator watching a batch
+  must not have to open every per-image log to learn that pointing stopped
+  being recorded. The same applies to a registered instrument that reaches
+  navigation with no entry in the frame table (section 2.1): that is a
+  build defect and warns to both logs, where a simulated image, which has
+  no spacecraft and no furnished camera frame, is expected and logs at
+  debug.
 
 ---
 
@@ -347,6 +452,23 @@ silently). The SCLK kernel furnished must be the one navigation used,
 resolved from `provenance.spice_kernels`; a different SCLK is a silent
 time-tag error.
 
+**`ckmeta` will not catch a wrong CK id either.** It computes rather than
+validates: `ckmeta(-999999, 'SCLK')` returns `-999` and `ckmeta(-12345,
+'SCLK')` returns `-12`, neither raising. A `ck_frame_id` that is wrong for
+any reason therefore yields a plausible-looking clock id, a successful
+`sce2c`, and silently wrong time tags on every record. Validate the
+resolved `sclk_id` against the expected set for the mission rather than
+trusting the round trip.
+
+**Both attitudes are evaluated at the exposure midtime**, and Phase A's
+integration tier pins that against a moving attitude on LORRI alone -- the
+only frame in the cohort with an exposure (5 s) long enough for the
+attitude to move measurably between start and midtime. That is adequate but
+thin. It matters most here: a midtime/start mix-up in the reproduction step
+would fail every baseline at the 1e-9 rad bound, so an unexplained
+across-the-board `no_reproducing_baseline` should be checked against this
+first.
+
 **Angular velocity: copied unchanged, never rotated.** CK angular velocity
 is expressed in the segment's **base reference frame** (J2000), per the CK
 Required Reading, and the corrected frame differs from the original by a
@@ -383,8 +505,9 @@ accumulates kernels from earlier images -- a superset. So:
    per group, not per image): furnish the supporting kernels (LSK, SCLK,
    FK) plus one candidate CK at a time, evaluate the original attitude at
    midtime -- for Voyager via the snapped
-   `ckgp(ck_id, sce2c(scid, mid), 800 + exposure_s/48, 'J2000')`, composed
-   with `P`, matching section 2.2; otherwise via `pxform` -- and keep
+   `ckgp(ck_id, sce2t(scid, mid), 800 + exposure_s/48, 'J2000')`, composed
+   with `P`, matching section 2.2 (`sce2t`, not `sce2c`; see the evidence
+   there); otherwise via `pxform` -- and keep
    candidates that reproduce the recorded `cmatrix_original` to within
    **1e-9 radians** (an angular tolerance on the rotation between the two
    matrices; this is a reproduction bound, far tighter than any navigation
@@ -401,6 +524,19 @@ accumulates kernels from earlier images -- a superset. So:
    the kernel set changed since navigation, reproduction fails and the
    image is refused rather than corrected against a baseline that no
    longer exists.
+
+**Voyager has a second tolerance to try.** When the snapped `ckgp` above
+raises `LookupError`, `oops/hosts/voyager/iss.py` does not fail the image:
+it warns and falls back to the FK-registered frame
+`VOYAGER<n>_ISS_<NAC|WAC>`, which chains on
+`SpiceType1Frame('VG<n>_SCAN_PLATFORM', -3<n>, TOL_TICKS)` with
+`TOL_TICKS = 80000.` (raised from 800 in oops "to deal with very long
+exposures"). The recorded `cmatrix_original` is the observation frame's
+attitude at midtime either way, so Phase A needs no special case, but a
+Voyager image navigated through that fallback is reproduced only at the
+80000-tick tolerance. The reproduction step should try `800 + exposure_s/48`
+first and 80000 second; an image that reproduces under neither is a genuine
+`no_reproducing_baseline`.
 
 **Omission reasons**, the complete set: `not_eligible`, `botsim_loser`,
 `rotation_unsupported`, `no_reproducing_baseline`, `degenerate_exposure`
@@ -471,7 +607,7 @@ and shared with oops; the writer assumes the exceptions regime
 ### Phase A — C-matrix in the metadata
 
 `spindoctor/support/cmatrix.py` per section 2.2; the `NavResult.pointing`
-field and the `_navigate_pipeline` wiring per section 2.4; curator
+field and the `navigate` / `run_manual_nav` wiring per section 2.4; curator
 serialization of `pointing`, `times`, and `observation.shutter_mode` per
 section 2.3.
 
@@ -480,20 +616,62 @@ Hermetic tests (synthetic FOV and frames):
 - A planted offset produces a `cmatrix` whose correction, inverted,
   recovers that offset; the test fails if the sign of `xy_offset` flips.
 - A zero offset produces `cmatrix == cmatrix_original` exactly, through
-  the `M = I` guard.
+  the `M = I` guard. **This holds only for a FOV whose boresight pixel maps
+  to `xy` exactly `(0, 0)`**, which a synthetic `FlatFOV` does, and which
+  Galileo SSI and Voyager ISS also do. It does not hold on a real
+  `PolynomialFOV`: `oops.fov.OffsetFOV(fov, uv_offset=(0, 0))` is itself
+  not the identity there, because its `xy_offset` is `fov.xy_from_uv(
+  fov.uv_los)` rather than zero. Measured `|xy_from_uv(uv_los)|`, which is
+  exactly the residual correction angle a zero offset produces, each
+  converted at its own frame's pixel scale:
+
+  | Frame | scale (rad/px) | residual (rad) | in px |
+  |---|---|---|---|
+  | Cassini WAC, 1024x1024 | 5.977e-5 | 5.427585e-08 | 9.08e-4 |
+  | LORRI, 256x256 (4x4 binned) | 1.986e-5 | 6.842953e-10 | 3.45e-5 |
+  | Cassini NAC, 1024x1024 | 5.992e-6 | 1.149029e-10 | 1.92e-5 |
+  | Galileo SSI | 1.015e-5 | exactly 0 | 0 |
+  | Voyager 2 NAC | 7.842e-6 | exactly 0 | 0 |
+
+  The WAC is the worst case by a factor of ~470 over the NAC and must not
+  be left off this list. The LORRI conversion uses the binned scale of the
+  actual test frame; quoting it at the unbinned 4.96e-6 rad/px understates
+  it by 4x. The non-zero cases are faithful, not a defect -- the recorded
+  attitude reproduces what a consumer applying the offset through
+  `OffsetFOV` actually sees -- but Phase D must not assume `offset == 0`
+  implies `cmatrix == cmatrix_original` on a real frame.
+- A small-but-real offset (0.05 px) still produces a non-identity
+  correction that recovers that offset, so the `|d x b| < 1e-12` guard is
+  pinned from below as well as above.
 - The Cassini-style flip: with a synthetic `R = diag(-1,-1,1)` between the
   "oops" and "SPICE" frames, the recorded `cmatrix` reproduces the offset
   in the SPICE convention; the test fails if the `R` conjugation is
   dropped (the un-conjugated result negates both tangent components).
+- The conjugation **direction** with a synthetic non-involutory `R` (a
+  quarter turn about Z). Every `R` in the section 2.1 table is diagonal
+  and therefore its own inverse, so `R^T M R` and `R M R^T` agree on all
+  real data and no real-frame test can tell them apart.
 - A result carrying a fitted rotation records `cmatrix_original` but no
   `cmatrix`.
-- Determinant/orthonormality violations raise.
+- Determinant, orthonormality and finiteness violations raise.
+- A measured flip that is not the instrument's constant raises.
 
 Integration tests (real frames, marked `integration`): for one Cassini
 NAC, one Cassini WAC, one LORRI, and one Galileo frame, the measured `R`
 equals the section 2.1 constant to 1e-9 and is identical at start, mid and
 stop; for one Voyager frame, `cmatrix_original` equals the frozen oops
 attitude.
+
+Every one of those frames must additionally recover its planted `(dv, du)`
+**exactly**, by inverting the recorded `cmatrix` back through the recorded
+flip on the instrument's own distorted FOV. A magnitude check -- the
+rotation angle of `cmatrix . cmatrix_original^T` against the offset's field
+angle -- is **not** sufficient and must not be substituted: a rotation
+magnitude is invariant under a sign flip, an `R` conjugation, and a
+reversed composition, so such a test passes unchanged against every
+directional error this section exists to catch. The recovery tolerance
+follows from the step-2 error budget above; 1e-2 px is comfortable at a
+~19 px offset, and a directional error is off by twice the offset.
 
 ### Phase B — Writer core, one image
 
@@ -558,8 +736,12 @@ pixel scale. Decision rule: when the measured residual is at or below
 0.1 px, pin the test at measured-plus-margin; when it is above, **stop and
 diagnose** -- a larger residual is a defect (most likely a section 2
 convention error), never a tolerance to raise. The section 2.2
-rotation-vs-shift bound (~0.04 px worst case, WAC corner) is part of the
-budget.
+rotation-vs-shift bound is part of the budget, and on a WAC it very nearly
+**is** the budget: 9.89e-2 px of total displacement, worst case across the
+frame, at a 50 px total offset, against a 0.1 px per-axis target -- convert
+before comparing. Choose the WAC cohort frame accordingly, remembering the
+bound is **linear** in the offset, not quadratic: about 10 px of total
+offset buys a fifth of budget.
 
 Cohort: one star-navigated Cassini NAC frame (best-constrained truth), one
 Cassini WAC frame, and one frame from each other instrument that has a

--- a/src/spindoctor/cli/sd_offset.py
+++ b/src/spindoctor/cli/sd_offset.py
@@ -307,6 +307,7 @@ def _run_manual_pass(
                     image_name,
                     instrument=obs_class_to_inst_name(obs_class),
                     camera=obs.camera,
+                    shutter_mode=obs.shutter_mode,
                     image_shape=(int(obs.data.shape[0]), int(obs.data.shape[1])),
                     timing=build_timing_section(run_start, datetime.now(UTC)),
                 )

--- a/src/spindoctor/nav_orchestrator/curator.py
+++ b/src/spindoctor/nav_orchestrator/curator.py
@@ -14,6 +14,8 @@ import dataclasses
 import math
 from typing import Any
 
+import numpy as np
+
 from spindoctor.feature.constants import JSON_INF_SENTINEL
 from spindoctor.feature.feature import NavReliabilityBreakdown
 from spindoctor.nav_orchestrator.feature_summary import NavFeatureSummary
@@ -21,6 +23,8 @@ from spindoctor.nav_orchestrator.image_classifier_result import NavImageClassifi
 from spindoctor.nav_orchestrator.nav_result import NavResult
 from spindoctor.nav_orchestrator.provenance import Provenance
 from spindoctor.nav_technique.technique_result import NavTechniqueResult
+from spindoctor.support.cmatrix import AttitudeBaseline, PointingSolution
+from spindoctor.support.types import NDArrayFloatType
 
 __all__ = [
     'assert_diagnostic_fields_present',
@@ -214,6 +218,50 @@ def _curate_provenance(provenance: Provenance) -> dict[str, Any]:
     }
 
 
+def _flatten_rotation(matrix: NDArrayFloatType) -> list[float]:
+    """Flatten a 3x3 rotation into nine row-major floats.
+
+    Deliberately unrounded: a C-kernel writer identifies the baseline kernel
+    an image navigated against by reproducing this matrix to within a
+    nanoradian, and rounding would put the recorded value outside that bound.
+    """
+    return [float(v) for v in np.asarray(matrix, np.float64).reshape(9)]
+
+
+def _curate_pointing(solution: PointingSolution) -> dict[str, Any]:
+    """Return a JSON-friendly entry for a corrected-attitude solution.
+
+    ``cmatrix`` is present only when one was computed; ``cmatrix_original``
+    and the frame identities are always present.
+    """
+    baseline = solution.baseline
+    out: dict[str, Any] = {}
+    if solution.cmatrix is not None:
+        out['cmatrix'] = _flatten_rotation(solution.cmatrix)
+    out['cmatrix_original'] = _flatten_rotation(baseline.cmatrix_original)
+    out['camera_frame'] = baseline.camera_frame
+    out['camera_frame_id'] = baseline.camera_frame_id
+    out['ck_frame_id'] = baseline.ck_frame_id
+    return out
+
+
+def _curate_times(baseline: AttitudeBaseline) -> dict[str, Any]:
+    """Return a JSON-friendly entry for an observation's exposure times.
+
+    Deliberately unrounded, for the same reason as the C-matrices: the epochs
+    define a C-kernel segment's interpolation interval exactly.
+    """
+    return {
+        'start_et': baseline.start_et,
+        'stop_et': baseline.stop_et,
+        'midtime_et': baseline.midtime_et,
+        'exposure_s': baseline.exposure_s,
+        'sclk_start': baseline.sclk_start,
+        'sclk_midtime': baseline.sclk_midtime,
+        'sclk_stop': baseline.sclk_stop,
+    }
+
+
 def build_metadata_dict(result: NavResult) -> dict[str, Any]:
     """Build the additive ``navigation_result`` metadata block.
 
@@ -275,4 +323,7 @@ def build_metadata_dict(result: NavResult) -> dict[str, Any]:
         out['sigma_rotation_deg'] = _round_float(
             math.degrees(result.sigma_rotation_rad), CONFIDENCE_DECIMALS
         )
+    if result.pointing is not None:
+        out['pointing'] = _curate_pointing(result.pointing)
+        out['times'] = _curate_times(result.pointing.baseline)
     return out

--- a/src/spindoctor/nav_orchestrator/nav_result.py
+++ b/src/spindoctor/nav_orchestrator/nav_result.py
@@ -16,6 +16,7 @@ from spindoctor.nav_orchestrator.feature_summary import NavFeatureSummary
 from spindoctor.nav_orchestrator.image_classifier_result import NavImageClassifierResult
 from spindoctor.nav_orchestrator.provenance import Provenance
 from spindoctor.nav_technique.technique_result import NavTechniqueResult
+from spindoctor.support.cmatrix import PointingSolution
 from spindoctor.support.status_reason import NavStatusReason
 from spindoctor.support.types import NDArrayFloatType
 
@@ -72,6 +73,11 @@ class NavResult:
         rotation_rad: Optional fitted camera rotation (radians); ``None``
             when ``fit_camera_rotation`` is False.
         sigma_rotation_rad: Optional 1-sigma rotation uncertainty.
+        pointing: Optional corrected-attitude solution: the uncorrected and
+            corrected C-matrices, the SPICE frame identities, and the
+            exposure times.  Stamped by the orchestrator once the
+            observation is in hand; ``None`` for a host whose SPICE frames
+            are unknown, or when the attitude could not be computed.
     """
 
     status: Status
@@ -92,6 +98,7 @@ class NavResult:
     annotations: Annotations = field(default_factory=Annotations)
     rotation_rad: float | None = None
     sigma_rotation_rad: float | None = None
+    pointing: PointingSolution | None = None
 
     def __post_init__(self) -> None:
         """Validate consistency between status, offset, and reason."""

--- a/src/spindoctor/nav_orchestrator/orchestrator.py
+++ b/src/spindoctor/nav_orchestrator/orchestrator.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from spindoctor.annotation import Annotations
-from spindoctor.config import Config, logged_section
+from spindoctor.config import MAIN_LOGGER, Config, logged_section
 from spindoctor.feature.feature import NavFeature
 from spindoctor.feature.feature_type import NavFeatureType
 from spindoctor.feature.reliability import FeatureReliabilityGate, GatedFeatureRecord
@@ -62,6 +62,8 @@ from spindoctor.nav_technique.nav_technique import (
     technique_tier,
 )
 from spindoctor.nav_technique.technique_result import NavTechniqueResult
+from spindoctor.obs import obs_class_to_inst_name
+from spindoctor.support.cmatrix import compute_pointing
 from spindoctor.support.exceptions import NavContractError
 from spindoctor.support.filters import NavFilterKind, NavFilterSpec, apply_filter
 from spindoctor.support.image_quality import cosmic_ray_mask, saturation_mask
@@ -131,6 +133,17 @@ _HARD_FAILURE_TO_REASON: dict[ImageClass, NavStatusReason] = {
 Maps each hard-failure ``ImageClass`` to the matching ``NavStatusReason``
 returned by the orchestrator's preflight.  Reading from this dict is the
 sole admission test for the hard-failure short-circuit.
+"""
+
+_INSTRUMENTS_WITHOUT_SPICE_FRAMES = frozenset({'sim'})
+"""Instruments that are expected to record no corrected attitude.
+
+A simulated image has no spacecraft and no furnished camera frame, so it is
+the one case where recording no attitude is the right outcome.  Everything
+else reaching the same path is missing its frame mapping, which is a build
+defect and is reported as such rather than passing silently -- including an
+observation class the registry cannot identify at all, which carries the
+least information of any case and is the last one that should be silenced.
 """
 
 
@@ -346,11 +359,14 @@ class NavOrchestrator(NavBase):
     def navigate(self, obs: ObsSnapshotInst) -> NavResult:
         """Run the full pipeline on one observation.
 
-        Never raises through to the caller: plugin failures are sandboxed
-        (see ``_extract_features`` / ``_run_pass``), and a
+        No image-data problem raises through to the caller: plugin failures
+        are sandboxed (see ``_extract_features`` / ``_run_pass``), and a
         ``NavContractError`` (an internal invariant violated by upstream
         code) is logged at error level and converted into a failed
         ``NavResult`` with ``NavStatusReason.CONTRACT_VIOLATION``.
+
+        A programming error inside :meth:`with_pointing`'s attitude
+        computation does propagate, by design: see that method.
 
         Parameters:
             obs: The observation snapshot to navigate.
@@ -362,13 +378,16 @@ class NavOrchestrator(NavBase):
         context, image_classifier = self._make_context(obs, provenance)
         self._log_classifier_verdict(image_classifier)
         if image_classifier.image_class in _HARD_FAILURE_TO_REASON:
-            return self._fail(
-                status_reason=_HARD_FAILURE_TO_REASON[image_classifier.image_class],
-                image_classifier=image_classifier,
-                provenance=provenance,
+            return self.with_pointing(
+                self._fail(
+                    status_reason=_HARD_FAILURE_TO_REASON[image_classifier.image_class],
+                    image_classifier=image_classifier,
+                    provenance=provenance,
+                ),
+                obs,
             )
         try:
-            return self._navigate_pipeline(
+            result = self._navigate_pipeline(
                 context=context,
                 image_classifier=image_classifier,
                 provenance=provenance,
@@ -380,11 +399,94 @@ class NavOrchestrator(NavBase):
                 'failing this image with status_reason=contract_violation',
                 str(exc),
             )
-            return self._fail(
+            result = self._fail(
                 status_reason=NavStatusReason.CONTRACT_VIOLATION,
                 image_classifier=image_classifier,
                 provenance=provenance,
             )
+        return self.with_pointing(result, obs)
+
+    def with_pointing(self, result: NavResult, obs: ObsSnapshotInst) -> NavResult:
+        """Stamp a result with the corrected-attitude solution for its image.
+
+        :meth:`navigate` applies this to every result it returns.  The
+        manual-navigation driver, which builds its own ``NavResult`` outside
+        the autonomous pipeline, calls it directly so an operator-picked
+        offset carries the same recorded attitude.
+
+        The uncorrected attitude, frame identities and exposure times are
+        recorded for every result; a corrected C-matrix additionally requires
+        an offset and no fitted camera rotation.
+
+        A host with no SPICE camera frame this build knows records nothing:
+        that is expected for a simulated image, and reported as a warning for
+        any other instrument, which means the instrument was added without
+        its frame mapping.
+
+        A pointing solution is recorded metadata rather than the navigation
+        itself, so an attitude the environment cannot supply is reported to
+        both logs and simply not recorded, and no wrong C-matrix ever
+        reaches a kernel.  The absorbed set is ``LookupError``, ``OSError``,
+        ``RuntimeError`` and ``ValueError`` -- the computation's own guards
+        plus what cspyce raises for a missing frame, an unreadable kernel or
+        a SPICE error.  Anything else, an ``AttributeError`` or
+        ``TypeError`` from a defect in the computation itself, propagates by
+        design, so a broken build fails on the first image rather than
+        silently dropping pointing from a whole batch.
+
+        Parameters:
+            result: The result to stamp.
+            obs: The observation it was produced from.
+
+        Returns:
+            ``result`` with its ``pointing`` field populated, or ``result``
+            unchanged when no attitude could be computed.
+        """
+        instrument = obs_class_to_inst_name(type(obs))
+        try:
+            pointing = compute_pointing(
+                obs,
+                offset_px=result.offset_px,
+                rotation_fitted=result.rotation_rad is not None,
+            )
+        except (LookupError, OSError, RuntimeError, ValueError) as exc:
+            # The exception set is exactly what the computation can legitimately
+            # raise: its own ValueError guards, and the LookupError / OSError /
+            # RuntimeError / ValueError family cspyce raises for a missing
+            # frame, an unreadable kernel or a SPICE error.  A TypeError or
+            # AttributeError from a defect in the computation itself is
+            # deliberately not caught, so a broken build fails loudly on the
+            # first image instead of quietly dropping pointing from a whole
+            # batch.
+            self._logger.exception('Could not compute the corrected pointing: %s', exc)
+            MAIN_LOGGER.error(
+                'Corrected pointing not recorded for this %s image: %s', instrument, exc
+            )
+            return result
+        if pointing is None:
+            if instrument in _INSTRUMENTS_WITHOUT_SPICE_FRAMES:
+                self._logger.debug(
+                    'Instrument %s has no SPICE camera frame; pointing not recorded', instrument
+                )
+            else:
+                self._logger.warning(
+                    'No SPICE camera frame is mapped for instrument %s; pointing not recorded',
+                    instrument,
+                )
+                MAIN_LOGGER.warning(
+                    'No SPICE camera frame is mapped for instrument %s; no image of it can '
+                    'carry a corrected attitude',
+                    instrument,
+                )
+            return result
+        self._logger.info(
+            'Recorded pointing: camera frame %s (%d), CK object %d, corrected cmatrix %s',
+            pointing.baseline.camera_frame,
+            pointing.baseline.camera_frame_id,
+            pointing.baseline.ck_frame_id,
+            'present' if pointing.cmatrix is not None else 'withheld',
+        )
+        return dataclasses.replace(result, pointing=pointing)
 
     def _navigate_pipeline(
         self,

--- a/src/spindoctor/nav_technique/nav_technique_manual.py
+++ b/src/spindoctor/nav_technique/nav_technique_manual.py
@@ -222,8 +222,9 @@ def run_manual_nav(
             to :data:`~spindoctor.config.DEFAULT_CONFIG`.
 
     Returns:
-        A :class:`NavResult` with ``status='success'`` on accept, or
-        ``None`` when the operator cancels or no supported overlay
+        A :class:`NavResult` with ``status='success'`` on accept, carrying
+        the same recorded corrected-pointing solution an autonomous result
+        does, or ``None`` when the operator cancels or no supported overlay
         feature paints any pixels into the ext-FOV composite.
         Supported overlay types match
         :meth:`NavTechniqueManual.is_feasible`: template-bearing
@@ -283,7 +284,7 @@ def run_manual_nav(
         # PNG write step.  The cancel reason has already been logged by
         # ``NavTechniqueManual.navigate``.
         return None
-    return NavResult.success(
+    result = NavResult.success(
         offset_px=technique_result.offset_px,
         covariance_px2=technique_result.covariance_px2,
         confidence=technique_result.confidence,
@@ -300,3 +301,8 @@ def run_manual_nav(
         model_metadata=prep.model_metadata,
         annotations=prep.annotations,
     )
+    # Operator-picked offsets are the highest-quality pointing in the corpus,
+    # so they carry the same recorded attitude an autonomous result does; the
+    # orchestrator's own navigate() is bypassed here, so the stamping is
+    # applied explicitly.
+    return orchestrator.with_pointing(result, obs)

--- a/src/spindoctor/navigate_image_files.py
+++ b/src/spindoctor/navigate_image_files.py
@@ -273,6 +273,7 @@ def navigate_image_files(
                 image_name,
                 instrument=instrument,
                 camera=snapshot_inst.camera,
+                shutter_mode=snapshot_inst.shutter_mode,
                 image_shape=(int(data_shape[0]), int(data_shape[1])),
                 timing=build_timing_section(run_start, datetime.now(UTC)),
             )
@@ -340,6 +341,7 @@ def build_metadata_from_result(
     *,
     instrument: str,
     camera: str | None = None,
+    shutter_mode: str | None = None,
     image_shape: tuple[int, int] | None = None,
     timing: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -360,6 +362,9 @@ def build_metadata_from_result(
         camera: The camera that took the image (``ObsInst.camera``, e.g.
             ``'NAC'``); written to the ``observation.camera`` field.  None
             omits the field.
+        shutter_mode: The shutter mode the image was taken in
+            (``ObsInst.shutter_mode``, e.g. ``'BOTSIM'``); written to the
+            ``observation.shutter_mode`` field.  None omits the field.
         image_shape: ``(v, u)`` pixel dimensions of the loaded image data;
             written to the ``observation.image_shape`` field.  None omits
             the field.
@@ -374,6 +379,8 @@ def build_metadata_from_result(
     }
     if camera is not None:
         observation['camera'] = camera
+    if shutter_mode is not None:
+        observation['shutter_mode'] = shutter_mode
     if image_shape is not None:
         observation['image_shape'] = [int(image_shape[0]), int(image_shape[1])]
     metadata: dict[str, Any] = {

--- a/src/spindoctor/obs/obs_inst.py
+++ b/src/spindoctor/obs/obs_inst.py
@@ -45,6 +45,21 @@ class ObsInst(ABC):
         """
         ...
 
+    @property
+    def shutter_mode(self) -> str | None:
+        """The shutter mode this observation was taken in.
+
+        Instruments that can expose more than one camera at once name the
+        mode here, because two cameras exposed simultaneously share one
+        spacecraft attitude and a consumer cannot tell that from the times
+        alone.  Instruments whose labels carry no such field return None.
+
+        Returns:
+            The instrument's shutter mode string, or None when the host
+            exposes none.
+        """
+        return None
+
     @staticmethod
     @abstractmethod
     def from_file(

--- a/src/spindoctor/obs/obs_inst_cassini_iss.py
+++ b/src/spindoctor/obs/obs_inst_cassini_iss.py
@@ -142,6 +142,23 @@ class ObsCassiniISS(ObsSnapshotInst):
         """
         return str(self.detector)
 
+    @property
+    def shutter_mode(self) -> str | None:
+        """The shutter mode this observation was taken in.
+
+        Cassini ISS can expose both cameras at once; the label records that
+        as ``'BOTSIM'``, against ``'NACONLY'`` or ``'WACONLY'`` for a single
+        camera.  Two BOTSIM frames share one spacecraft attitude, so a
+        consumer correcting that attitude can honor only one of them.
+
+        Returns:
+            The ``SHUTTER_MODE_ID`` label value, or None when the label
+            carries none.
+        """
+        if 'SHUTTER_MODE_ID' not in self.dict:
+            return None
+        return str(self.dict['SHUTTER_MODE_ID'])
+
     def get_public_metadata(self) -> dict[str, Any]:
         """Returns the public metadata for Cassini ISS.
 

--- a/src/spindoctor/obs/obs_inst_voyager_iss.py
+++ b/src/spindoctor/obs/obs_inst_voyager_iss.py
@@ -192,6 +192,23 @@ class ObsVoyagerISS(ObsSnapshotInst):
         """
         return str(self.detector)
 
+    @property
+    def spacecraft_digit(self) -> str:
+        """Which Voyager took this observation.
+
+        Read from the VICAR ``LAB02`` record, whose 5th character is the
+        spacecraft digit.  SPICE frame, kernel and clock identifiers are all
+        keyed per spacecraft, so consumers that must name one derive it here.
+
+        Returns:
+            ``'1'`` for Voyager 1 or ``'2'`` for Voyager 2.
+
+        Raises:
+            ValueError: If ``LAB02`` is missing, too short, or names neither
+                spacecraft.
+        """
+        return _voyager_spacecraft_digit(self.dict.get('LAB02', None))
+
     def get_public_metadata(self) -> dict[str, Any]:
         """Returns the public metadata for Voyager ISS.
 
@@ -202,7 +219,7 @@ class ObsVoyagerISS(ObsSnapshotInst):
         # scet_start = float(obs.dict["SPACECRAFT_CLOCK_START_COUNT"])
         # scet_end = float(obs.dict["SPACECRAFT_CLOCK_STOP_COUNT"])
 
-        spacecraft = _voyager_spacecraft_digit(self.dict.get('LAB02', None))
+        spacecraft = self.spacecraft_digit
 
         # The instrument LID and `camera` field encode the camera as iss{n,w};
         # guard against an unexpected detector so a malformed LID never reaches

--- a/src/spindoctor/support/__init__.py
+++ b/src/spindoctor/support/__init__.py
@@ -12,6 +12,9 @@ Modules:
     ``image``
         Two-dimensional array helpers: shifting, padding, cropping, normalization,
         and FFT-related image operations.
+    ``cmatrix``
+        ``compute_pointing`` and its supporting types: the corrected and uncorrected
+        C-matrices a navigated offset implies, in the SPICE camera-frame convention.
     ``correlate``
         Fourier-domain and template-matching utilities (e.g. normalized
         cross-correlation) built on ``image`` and ``misc``.
@@ -55,6 +58,7 @@ Modules:
 
 __all__ = [
     'attrdict',
+    'cmatrix',
     'constants',
     'correlate',
     'distance_transform',

--- a/src/spindoctor/support/cmatrix.py
+++ b/src/spindoctor/support/cmatrix.py
@@ -1,0 +1,554 @@
+"""Corrected-attitude C-matrices for a navigated observation.
+
+A C-matrix is the rotation taking a vector expressed in J2000 to the same vector
+expressed in a camera frame::
+
+    v_frame = C . v_J2000
+
+which is what ``cspyce.pxform('J2000', frame_name, et)`` returns.  Navigation
+measures a pixel offset; this module converts that offset into the corrected
+attitude the camera actually had, so the same measurement can later be written
+into a C-kernel and consumed by any SPICE-aware tool without applying a pixel
+offset by hand.
+
+Two matrices are produced per navigated image, both in the SPICE camera frame
+convention and both at the exposure midtime:
+
+``cmatrix_original``
+    The attitude the furnished kernels gave at navigation time, before any
+    correction.
+``cmatrix``
+    The corrected attitude, the one a kernel should carry.
+
+The oops observation frame is **not** the SPICE camera frame.  For three of the
+four supported instruments oops builds its frame with a constant flip ``R`` on
+top of the SPICE frame, so that ``C_oops = R . C_spice``:
+
+============================  ==========================
+Instrument                    ``R``
+============================  ==========================
+Cassini ISS (NAC, WAC)        ``diag(-1, -1, +1)``
+New Horizons LORRI            ``diag(+1, -1, -1)``
+Galileo SSI                   identity
+Voyager ISS                   identity by construction
+============================  ==========================
+
+A correction built in the oops frame and composed onto a ``pxform``-derived
+matrix without conjugating through ``R`` is a proper rotation of the right
+magnitude pointing the wrong way, so ``R`` is measured at runtime and checked
+against the value above rather than assumed.
+
+Voyager is the exception to everything: oops freezes the observation frame from
+a tolerance-snapped ``ckgp`` lookup rather than evaluating a frame chain, so
+``pxform`` at the midtime does not reproduce it.  For Voyager the observation
+frame attitude already **is** the SPICE camera frame attitude, and ``R`` is the
+identity by construction.
+
+The offset-to-rotation conversion lives here, behind one entry point, so that
+when oops grows its own corrected-attitude API this module's body is replaced
+and its interface stays.
+"""
+
+from dataclasses import dataclass
+
+import cspyce
+import numpy as np
+import oops
+
+from spindoctor.obs import (
+    ObsCassiniISS,
+    ObsGalileoSSI,
+    ObsNewHorizonsLORRI,
+    ObsSnapshotInst,
+    ObsVoyagerISS,
+)
+from spindoctor.support.types import NDArrayFloatType
+
+# The offset-to-attitude conversion is deliberately behind one public
+# function: when oops grows its own corrected-attitude API this module's body
+# is replaced and only ``compute_pointing`` has to survive the swap.  The
+# helpers below it are private for that reason, not because they are trivial.
+__all__ = [
+    'AttitudeBaseline',
+    'PointingSolution',
+    'compute_pointing',
+]
+
+
+# The object each mission's C-kernels describe.  The correction is measured at
+# the camera but written at the bus or platform the existing kernels already
+# cover, so a corrected kernel targets one of these.  Voyager's is derived per
+# spacecraft instead, because one instrument key serves two spacecraft.
+_CASSINI_CK_FRAME_ID = -82000
+_GALILEO_CK_FRAME_ID = -77001
+_LORRI_CK_FRAME_ID = -98000
+
+_IDENTITY: NDArrayFloatType = np.eye(3)
+_IDENTITY.setflags(write=False)
+
+# oops rotates the Cassini ISS camera frames 180 degrees about the boresight
+# because the instrument's internal coordinate system is turned that way.
+_CASSINI_OOPS_FROM_SPICE: NDArrayFloatType = np.diag([-1.0, -1.0, 1.0])
+_CASSINI_OOPS_FROM_SPICE.setflags(write=False)
+
+# The LORRI SPICE boresight is -Z; oops flips Y and Z to put it on +Z.
+_LORRI_OOPS_FROM_SPICE: NDArrayFloatType = np.diag([1.0, -1.0, -1.0])
+_LORRI_OOPS_FROM_SPICE.setflags(write=False)
+
+# Angular tolerance, in matrix-element terms, for the measured flip matching
+# its expected constant value and for that value being epoch-independent.
+_FLIP_TOL = 1e-9
+
+# A C-matrix must be a proper rotation to this tolerance; anything looser is a
+# defect in the frame chain rather than something to orthonormalize away.
+_ROTATION_TOL = 1e-9
+
+# Below this cross-product norm the corrected and uncorrected boresights are
+# the same direction to sub-nanoradian precision and the correction is exactly
+# the identity.
+_DEGENERATE_AXIS_NORM = 1e-12
+
+
+@dataclass(frozen=True)
+class _FrameIdentity:
+    """Per-instrument frame facts needed to place a correction in SPICE terms.
+
+    Parameters:
+        camera_frame: SPICE name of the frame the observation's boresight is
+            expressed in.
+        ck_frame_id: SPICE id of the object a corrected C-kernel targets.
+        oops_from_spice: The constant rotation ``R`` relating the oops
+            observation frame to the SPICE camera frame.
+        frozen_oops_attitude: True when oops freezes the observation frame
+            from a tolerance-snapped pointing lookup, so the SPICE baseline is
+            the observation frame itself rather than a ``pxform`` evaluation.
+    """
+
+    camera_frame: str
+    ck_frame_id: int
+    oops_from_spice: NDArrayFloatType
+    frozen_oops_attitude: bool
+
+
+@dataclass(frozen=True)
+class AttitudeBaseline:
+    """The SPICE-derived facts about one observation, independent of any offset.
+
+    Parameters:
+        cmatrix_original: Uncorrected J2000-to-camera rotation at the exposure
+            midtime, in the SPICE camera frame convention.
+        oops_from_spice: The measured constant rotation ``R`` satisfying
+            ``C_oops = R . C_spice``.
+        camera_frame: SPICE name of the camera frame.
+        camera_frame_id: SPICE id of the camera frame.
+        ck_frame_id: SPICE id of the object a corrected C-kernel targets.
+        start_et: Exposure start, TDB seconds past J2000.
+        stop_et: Exposure stop, TDB seconds past J2000.
+        midtime_et: Exposure midtime, TDB seconds past J2000.
+        exposure_s: Exposure duration in seconds.
+        sclk_start: Spacecraft clock string at ``start_et``.
+        sclk_midtime: Spacecraft clock string at ``midtime_et``.
+        sclk_stop: Spacecraft clock string at ``stop_et``.
+    """
+
+    cmatrix_original: NDArrayFloatType
+    oops_from_spice: NDArrayFloatType
+    camera_frame: str
+    camera_frame_id: int
+    ck_frame_id: int
+    start_et: float
+    stop_et: float
+    midtime_et: float
+    exposure_s: float
+    sclk_start: str
+    sclk_midtime: str
+    sclk_stop: str
+
+    def __post_init__(self) -> None:
+        """Store both matrices as read-only 3x3 float arrays."""
+        object.__setattr__(self, 'cmatrix_original', _as_readonly_3x3(self.cmatrix_original))
+        object.__setattr__(self, 'oops_from_spice', _as_readonly_3x3(self.oops_from_spice))
+
+
+@dataclass(frozen=True)
+class PointingSolution:
+    """A navigated image's baseline attitude plus its corrected attitude.
+
+    Parameters:
+        baseline: The uncorrected attitude, frame identities, and times.
+        cmatrix: Corrected J2000-to-camera rotation at the exposure midtime,
+            in the SPICE camera frame convention.  ``None`` when the result
+            carried no offset, or carried a fitted camera rotation whose pivot
+            is not recorded and therefore cannot be expressed as an attitude.
+    """
+
+    baseline: AttitudeBaseline
+    cmatrix: NDArrayFloatType | None
+
+    def __post_init__(self) -> None:
+        """Store the corrected matrix as a read-only 3x3 float array."""
+        if self.cmatrix is not None:
+            object.__setattr__(self, 'cmatrix', _as_readonly_3x3(self.cmatrix))
+
+
+def _as_readonly_3x3(matrix: NDArrayFloatType) -> NDArrayFloatType:
+    """Copy ``matrix`` into a read-only 3x3 float64 array.
+
+    Parameters:
+        matrix: Any 3x3 array-like of numbers.
+
+    Returns:
+        A read-only float64 copy.
+
+    Raises:
+        ValueError: if the input is not 3x3.
+    """
+    out = np.array(matrix, dtype=np.float64)
+    if out.shape != (3, 3):
+        raise ValueError(f'expected a 3x3 matrix; got shape {out.shape}')
+    out.setflags(write=False)
+    return out
+
+
+def _validate_rotation(matrix: NDArrayFloatType, label: str) -> None:
+    """Raise unless ``matrix`` is a proper rotation to ``_ROTATION_TOL``.
+
+    Parameters:
+        matrix: The 3x3 matrix to check.
+        label: Name used in the exception message.
+
+    Raises:
+        ValueError: if the matrix holds a non-finite value, or if its
+            determinant differs from 1, or it is not orthonormal, by more than
+            the tolerance.
+    """
+    # NaN fails every inequality below, so both tolerance guards would pass a
+    # NaN matrix silently; and a non-finite value serialized into the metadata
+    # is written as a bare NaN / Infinity token that strict JSON parsers
+    # reject.  Reject it here, where the defect is still attributable.
+    if not bool(np.all(np.isfinite(matrix))):
+        raise ValueError(f'{label} holds a non-finite value: {np.asarray(matrix).tolist()!r}')
+    det = float(np.linalg.det(matrix))
+    if abs(det - 1.0) > _ROTATION_TOL:
+        raise ValueError(
+            f'{label} is not a proper rotation: determinant {det!r} differs from 1 by more '
+            f'than {_ROTATION_TOL}'
+        )
+    residual = float(np.max(np.abs(matrix @ matrix.T - np.eye(3))))
+    if residual > _ROTATION_TOL:
+        raise ValueError(
+            f'{label} is not orthonormal: max|C C^T - I| = {residual!r} exceeds {_ROTATION_TOL}'
+        )
+
+
+def _oops_correction_matrix(fov: oops.fov.FOV, offset_px: tuple[float, float]) -> NDArrayFloatType:
+    """Build the pointing correction a navigated offset implies, in oops terms.
+
+    The offset is applied downstream as ``oops.fov.OffsetFOV(fov,
+    uv_offset=(du, dv))``, which maps pixels to tangent-plane coordinates as
+    ``fov.xy_from_uv(uv) - xy_offset`` with ``xy_offset =
+    fov.xy_from_uv(fov.uv_los + (du, dv))``.  Under the corrected pointing the
+    true direction seen by pixel ``uv`` in the *original* frame is therefore
+    ``fov.los_from_xy(fov.xy_from_uv(uv) - xy_offset)``, and the corrected
+    frame is the one in which the unmodified FOV holds.  Evaluating that at
+    the boresight gives the returned rotation ``M``, the minimal rotation
+    taking the uncorrected boresight direction to the corrected one.
+
+    ``M`` is an active vector rotation: ``M . d`` is the corrected direction
+    ``b``, where ``d`` is the direction the uncorrected FOV assigns to the
+    boresight pixel.  It is exact by construction; nothing is orthonormalized.
+    An exact rigid rotation is not exactly a uniform tangent-plane shift, so
+    away from the boresight the rotation and the pixel offset differ at second
+    order in field angle.
+
+    Parameters:
+        fov: The observation's unmodified oops FOV.
+        offset_px: The navigated ``(dv, du)`` offset in pixels.
+
+    Returns:
+        The 3x3 rotation ``M`` in oops observation frame coordinates.  Exactly
+        the identity when the offset moves the boresight by less than a
+        sub-nanoradian.
+    """
+    dv, du = float(offset_px[0]), float(offset_px[1])
+    uv_los = fov.uv_los
+    xy_los = fov.xy_from_uv(uv_los)
+    xy_offset = fov.xy_from_uv(oops.Pair((uv_los.vals[0] + du, uv_los.vals[1] + dv)))
+    uncorrected = np.asarray(fov.los_from_xy(xy_los - xy_offset).unit().vals, dtype=np.float64)
+    corrected = np.asarray(fov.los_from_xy(xy_los).unit().vals, dtype=np.float64)
+    axis = np.cross(uncorrected, corrected)
+    axis_norm = float(np.linalg.norm(axis))
+    if axis_norm < _DEGENERATE_AXIS_NORM:
+        return _IDENTITY
+    # arctan2(|d x b|, d . b) is the well-conditioned form of arccos(d . b)
+    # for unit vectors: arccos loses relative precision as the angle goes to
+    # zero, which is exactly the regime a sub-pixel offset lives in.
+    angle = float(np.arctan2(axis_norm, float(np.dot(uncorrected, corrected))))
+    correction: NDArrayFloatType = np.asarray(
+        cspyce.axisar(axis / axis_norm, angle), dtype=np.float64
+    )
+    return correction
+
+
+def _spice_cmatrix(
+    cmatrix_original: NDArrayFloatType,
+    correction: NDArrayFloatType,
+    oops_from_spice: NDArrayFloatType,
+) -> NDArrayFloatType:
+    """Apply an oops-frame correction to a SPICE-convention C-matrix.
+
+    With ``R`` the constant rotation satisfying ``C_oops = R . C_spice`` and
+    ``M`` the correction expressed in oops observation frame coordinates, the
+    corrected attitude in the SPICE convention is ``(R^T . M . R) . C``.
+    Skipping the conjugation yields a proper rotation of the right magnitude
+    pointing the wrong way.
+
+    Parameters:
+        cmatrix_original: Uncorrected J2000-to-camera rotation, SPICE
+            convention.
+        correction: The oops-frame correction ``M``.
+        oops_from_spice: The constant rotation ``R``.
+
+    Returns:
+        The corrected 3x3 J2000-to-camera rotation in the SPICE convention.
+        Bit-identical to ``cmatrix_original`` when the correction is exactly
+        the identity, since no correction must mean no change.
+
+    Raises:
+        ValueError: if ``cmatrix_original`` or the corrected result is not a
+            proper orthonormal rotation.
+    """
+    original = np.asarray(cmatrix_original, dtype=np.float64)
+    _validate_rotation(original, 'cmatrix_original')
+    if np.array_equal(correction, np.eye(3)):
+        return original
+    rotation = np.asarray(oops_from_spice, dtype=np.float64)
+    conjugated = rotation.T @ np.asarray(correction, dtype=np.float64) @ rotation
+    corrected: NDArrayFloatType = conjugated @ original
+    _validate_rotation(corrected, 'cmatrix')
+    return corrected
+
+
+def _build_pointing_solution(
+    baseline: AttitudeBaseline,
+    fov: oops.fov.FOV,
+    *,
+    offset_px: tuple[float, float] | None,
+    rotation_fitted: bool,
+) -> PointingSolution:
+    """Combine a SPICE baseline and a navigated offset into a PointingSolution.
+
+    The baseline is always carried through.  A corrected ``cmatrix`` is
+    produced only when the navigation yielded an offset and did not fit a
+    camera rotation: a fitted rotation turns about a per-technique pivot that
+    no result records, so the correction it implies is not expressible from
+    the recorded data and no corrected attitude is claimed.
+
+    Parameters:
+        baseline: The observation's uncorrected attitude, frames, and times.
+        fov: The observation's unmodified oops FOV.
+        offset_px: The navigated ``(dv, du)`` offset, or ``None`` when the
+            navigation produced no offset.
+        rotation_fitted: True when the result carries a fitted camera
+            rotation.
+
+    Returns:
+        A PointingSolution whose ``cmatrix`` is ``None`` unless an offset was
+        supplied with no fitted rotation.
+
+    Raises:
+        ValueError: if the baseline or the corrected matrix is not a proper
+            orthonormal rotation.
+    """
+    if offset_px is None or rotation_fitted:
+        _validate_rotation(np.asarray(baseline.cmatrix_original, np.float64), 'cmatrix_original')
+        return PointingSolution(baseline=baseline, cmatrix=None)
+    correction = _oops_correction_matrix(fov, offset_px)
+    cmatrix = _spice_cmatrix(baseline.cmatrix_original, correction, baseline.oops_from_spice)
+    return PointingSolution(baseline=baseline, cmatrix=cmatrix)
+
+
+def compute_pointing(
+    obs: ObsSnapshotInst,
+    *,
+    offset_px: tuple[float, float] | None,
+    rotation_fitted: bool,
+) -> PointingSolution | None:
+    """Compute the recorded and corrected attitudes for one navigated image.
+
+    This is the single entry point for the offset-to-attitude conversion.  It
+    reads the observation's own frame and FOV, measures the constant rotation
+    between the oops observation frame and the SPICE camera frame, checks that
+    rotation against the constant expected for the instrument, and returns
+    both attitudes in the SPICE convention along with the frame identities and
+    the exposure times a C-kernel writer needs.
+
+    Parameters:
+        obs: The navigated observation.
+        offset_px: The navigated ``(dv, du)`` offset, or ``None``.
+        rotation_fitted: True when the result carries a fitted camera
+            rotation.
+
+    Returns:
+        A PointingSolution, or ``None`` when the observation's host is not one
+        whose SPICE frames this module knows (a simulated image, for example).
+
+    Raises:
+        ValueError: if the measured flip between the oops and SPICE frames
+            differs from the constant expected for the instrument, varies
+            across the exposure, or if either C-matrix is not a proper
+            orthonormal rotation.
+    """
+    identity = _frame_identity(obs)
+    if identity is None:
+        return None
+    baseline = _attitude_baseline(obs, identity)
+    return _build_pointing_solution(
+        baseline, obs.fov, offset_px=offset_px, rotation_fitted=rotation_fitted
+    )
+
+
+def _frame_identity(obs: ObsSnapshotInst) -> _FrameIdentity | None:
+    """Return the SPICE frame facts for an observation's instrument.
+
+    Parameters:
+        obs: The observation to identify.
+
+    Returns:
+        The instrument's ``_FrameIdentity``, or ``None`` for a host with no
+        SPICE camera frame this module knows.
+    """
+    if isinstance(obs, ObsCassiniISS):
+        return _FrameIdentity(
+            camera_frame=f'CASSINI_ISS_{obs.camera}',
+            ck_frame_id=_CASSINI_CK_FRAME_ID,
+            oops_from_spice=_CASSINI_OOPS_FROM_SPICE,
+            frozen_oops_attitude=False,
+        )
+    if isinstance(obs, ObsGalileoSSI):
+        return _FrameIdentity(
+            camera_frame='GLL_SCAN_PLATFORM',
+            ck_frame_id=_GALILEO_CK_FRAME_ID,
+            oops_from_spice=_IDENTITY,
+            frozen_oops_attitude=False,
+        )
+    if isinstance(obs, ObsNewHorizonsLORRI):
+        return _FrameIdentity(
+            camera_frame='NH_LORRI',
+            ck_frame_id=_LORRI_CK_FRAME_ID,
+            oops_from_spice=_LORRI_OOPS_FROM_SPICE,
+            frozen_oops_attitude=False,
+        )
+    if isinstance(obs, ObsVoyagerISS):
+        digit = obs.spacecraft_digit
+        spacecraft_id = -(30 + int(digit))
+        # The Voyager FK spells the cameras ISSNA and ISSWA, so the oops
+        # detector names NAC and WAC contribute only their first letter.
+        return _FrameIdentity(
+            camera_frame=f'VG{digit}_ISS{obs.camera[0]}A',
+            ck_frame_id=spacecraft_id * 1000 - 100,
+            oops_from_spice=_IDENTITY,
+            frozen_oops_attitude=True,
+        )
+    return None
+
+
+def _observation_attitude(obs: ObsSnapshotInst, et: float) -> NDArrayFloatType:
+    """Return the observation frame's J2000-to-frame rotation at one epoch.
+
+    Parameters:
+        obs: The observation whose frame is evaluated.
+        et: TDB seconds past J2000.
+
+    Returns:
+        The 3x3 rotation in the oops observation frame convention.
+    """
+    transform = obs.frame.wrt(oops.frame.Frame.J2000).transform_at_time(et)
+    return np.asarray(transform.matrix.vals, dtype=np.float64).reshape(3, 3)
+
+
+def _attitude_baseline(obs: ObsSnapshotInst, identity: _FrameIdentity) -> AttitudeBaseline:
+    """Read the uncorrected attitude, frame ids, and exposure times from SPICE.
+
+    Parameters:
+        obs: The observation to read.
+        identity: The instrument's frame facts.
+
+    Returns:
+        The observation's AttitudeBaseline.
+
+    Raises:
+        ValueError: if the measured flip between the oops observation frame
+            and the SPICE camera frame differs from the instrument's expected
+            constant or varies across the exposure.
+    """
+    start_et = float(obs.time[0])
+    stop_et = float(obs.time[1])
+    midtime_et = float(obs.midtime)
+    if identity.frozen_oops_attitude:
+        # oops froze this frame from a tolerance-snapped pointing lookup, so a
+        # pxform at the midtime does not reproduce it; the observation frame
+        # attitude already is the SPICE camera attitude that was navigated.
+        cmatrix_original = _observation_attitude(obs, midtime_et)
+        oops_from_spice = _IDENTITY
+    else:
+        cmatrix_original = _pxform(identity.camera_frame, midtime_et)
+        oops_from_spice = _observation_attitude(obs, midtime_et) @ cmatrix_original.T
+        _check_flip(oops_from_spice, identity)
+        for et in (start_et, stop_et):
+            at_epoch = _observation_attitude(obs, et) @ _pxform(identity.camera_frame, et).T
+            if not np.allclose(at_epoch, oops_from_spice, rtol=0.0, atol=_FLIP_TOL):
+                raise ValueError(
+                    f'the rotation between the oops and SPICE {identity.camera_frame} frames '
+                    f'is not constant across the exposure: it differs by up to '
+                    f'{float(np.max(np.abs(at_epoch - oops_from_spice)))!r} between et {et!r} '
+                    f'and the midtime {midtime_et!r}'
+                )
+    sclk_id = int(cspyce.ckmeta(identity.ck_frame_id, 'SCLK'))
+    return AttitudeBaseline(
+        cmatrix_original=cmatrix_original,
+        oops_from_spice=oops_from_spice,
+        camera_frame=identity.camera_frame,
+        camera_frame_id=int(cspyce.namfrm(identity.camera_frame)),
+        ck_frame_id=identity.ck_frame_id,
+        start_et=start_et,
+        stop_et=stop_et,
+        midtime_et=midtime_et,
+        exposure_s=float(obs.texp),
+        sclk_start=str(cspyce.sce2s(sclk_id, start_et)),
+        sclk_midtime=str(cspyce.sce2s(sclk_id, midtime_et)),
+        sclk_stop=str(cspyce.sce2s(sclk_id, stop_et)),
+    )
+
+
+def _pxform(camera_frame: str, et: float) -> NDArrayFloatType:
+    """Evaluate the J2000-to-camera rotation from the furnished kernels.
+
+    Parameters:
+        camera_frame: SPICE name of the camera frame.
+        et: TDB seconds past J2000.
+
+    Returns:
+        The 3x3 rotation ``pxform('J2000', camera_frame, et)`` as float64.
+    """
+    return np.asarray(cspyce.pxform('J2000', camera_frame, et), dtype=np.float64)
+
+
+def _check_flip(measured: NDArrayFloatType, identity: _FrameIdentity) -> None:
+    """Raise unless the measured oops-to-SPICE flip is the expected constant.
+
+    Parameters:
+        measured: The rotation ``R`` measured from the observation.
+        identity: The instrument's frame facts, carrying the expected ``R``.
+
+    Raises:
+        ValueError: if the two differ by more than ``_FLIP_TOL``.
+    """
+    expected = np.asarray(identity.oops_from_spice, dtype=np.float64)
+    if not np.allclose(measured, expected, rtol=0.0, atol=_FLIP_TOL):
+        raise ValueError(
+            f'the rotation between the oops observation frame and the SPICE '
+            f'{identity.camera_frame} frame is {measured.tolist()!r}, which differs from the '
+            f'expected {expected.tolist()!r} by up to '
+            f'{float(np.max(np.abs(measured - expected)))!r}'
+        )

--- a/tests/integration/test_cmatrix_frames.py
+++ b/tests/integration/test_cmatrix_frames.py
@@ -1,0 +1,425 @@
+"""Real-frame integration tests for ``spindoctor.support.cmatrix``.
+
+The relation between an oops observation frame and the SPICE camera frame it
+is built on cannot be checked hermetically: it only exists once the mission's
+kernels are furnished and the host has built its frame.  These tests measure
+that relation on one frame per instrument and pin it to the constant the
+implementation asserts, at the exposure start, midtime and stop.
+
+Voyager gets its own test because oops does not build its frame from a frame
+chain at all: it freezes a tolerance-snapped pointing lookup, so ``pxform``
+at the midtime does not reproduce it and the recorded uncorrected attitude
+must be the frozen one.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import cast
+
+import numpy as np
+import pytest
+from filecache import FCPath
+
+pytestmark = pytest.mark.integration
+
+if 'PDS3_HOLDINGS_DIR' not in os.environ:
+    pytest.skip(
+        'PDS3_HOLDINGS_DIR is not set; skipping C-matrix frame integration tests',
+        allow_module_level=True,
+    )
+
+import cspyce  # noqa: E402  (guarded import)
+import oops  # noqa: E402  (guarded import)
+
+from spindoctor.obs import (  # noqa: E402
+    ObsCassiniISS,
+    ObsGalileoSSI,
+    ObsNewHorizonsLORRI,
+    ObsSnapshotInst,
+    ObsVoyagerISS,
+)
+from spindoctor.support.cmatrix import (  # noqa: E402
+    _attitude_baseline,
+    _FrameIdentity,
+    compute_pointing,
+)
+
+_CASSINI_NAC = 'calibrated/COISS_2xxx/COISS_2038/data/1572094226_1572114418/N1572105349_1_CALIB.IMG'
+_CASSINI_WAC = 'volumes/COISS_2xxx/COISS_2099/data/1822057149_1822284412/W1822132529_1.IMG'
+_GALILEO_SSI = 'volumes/GO_0xxx/GO_0003/RAW_CAL/C0059897400R.IMG'
+_LORRI = 'volumes/NHxxLO_xxxx/NHJULO_2001/data/20070110_003071/lor_0030713597_0x633_sci.fit'
+_VOYAGER_NAC = 'volumes/VGISS_8xxx/VGISS_8210/DATA/C12050XX/C1205021_GEOMED.IMG'
+
+_FLIP_TOL = 1e-9
+
+# A deliberately asymmetric offset, so a sign or axis error cannot cancel.
+_OFFSET = (8.68, -17.37)
+
+# A sub-pixel offset, well above the degenerate-axis guard but far below one
+# pixel, so the guard cannot be widened without this failing.
+_SMALL_OFFSET = (0.05, -0.02)
+
+# Tolerance on recovering a planted offset back out of a recorded C-matrix.
+# The exact rigid rotation is not exactly a uniform tangent-plane shift, so the
+# inverse carries the second-order difference.  Measured across these five
+# frames at both offsets below, the largest residual is 9.1e-4 px (Cassini
+# WAC); every directional error these tests guard against is off by twice the
+# offset, so a 1e-2 px bound separates the two by four orders of magnitude.
+_RECOVERY_TOL_PX = 1.0e-2
+
+_CASSINI_FLIP = [[-1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0]]
+_LORRI_FLIP = [[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0]]
+_NO_FLIP = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+
+_CASSINI_FLIP_ARRAY = np.asarray(_CASSINI_FLIP)
+
+
+def _url(relative: str) -> FCPath:
+    """Resolve a holdings-relative path against ``PDS3_HOLDINGS_DIR``."""
+    return FCPath(f'{os.environ["PDS3_HOLDINGS_DIR"].rstrip("/")}/{relative}')
+
+
+def _load(obs_class: type[ObsSnapshotInst], relative: str) -> ObsSnapshotInst:
+    """Load one holdings image through its instrument class."""
+    return cast(ObsSnapshotInst, obs_class.from_file(_url(relative)))
+
+
+def _observation_attitude(obs: ObsSnapshotInst, et: float) -> np.ndarray:
+    """Read the oops observation frame's J2000-to-frame rotation at one epoch."""
+    transform = obs.frame.wrt(oops.frame.Frame.J2000).transform_at_time(et)
+    return np.asarray(transform.matrix.vals, np.float64).reshape(3, 3)
+
+
+def _measured_flip(obs: ObsSnapshotInst, camera_frame: str, et: float) -> np.ndarray:
+    """Measure ``R = C_oops . C_spice^T`` directly from SPICE at one epoch."""
+    spice = np.asarray(cspyce.pxform('J2000', camera_frame, et), np.float64)
+    flip: np.ndarray = _observation_attitude(obs, et) @ spice.T
+    return flip
+
+
+def _offset_from_correction(fov: oops.fov.FOV, correction: np.ndarray) -> tuple[float, float]:
+    """Recover the ``(dv, du)`` offset an oops-frame correction rotation encodes.
+
+    The independent inverse of the production forward model: it maps the
+    corrected boresight direction back through the rotation, reads off the
+    tangent-plane point that direction came from, and converts the implied
+    ``xy_offset`` back into pixels.  Derived from the offset model rather than
+    from the forward code, so it does not reproduce a sign error the forward
+    code might contain.
+    """
+    xy_los = fov.xy_from_uv(fov.uv_los)
+    corrected = np.asarray(fov.los_from_xy(xy_los).unit().vals, np.float64)
+    uncorrected = np.asarray(correction, np.float64).T @ corrected
+    xy_uncorrected = oops.Pair((uncorrected[0] / uncorrected[2], uncorrected[1] / uncorrected[2]))
+    uv = fov.uv_from_xy(xy_los - xy_uncorrected)
+    return (
+        float(uv.vals[1] - fov.uv_los.vals[1]),
+        float(uv.vals[0] - fov.uv_los.vals[0]),
+    )
+
+
+def _rotation_about_z(angle_rad: float) -> np.ndarray:
+    """Build a small proper rotation about the Z axis."""
+    cos, sin = np.cos(angle_rad), np.sin(angle_rad)
+    return np.array([[cos, sin, 0.0], [-sin, cos, 0.0], [0.0, 0.0, 1.0]])
+
+
+def _cassini_nac_identity() -> _FrameIdentity:
+    """The Cassini NAC frame facts, for driving the baseline guards directly."""
+    return _FrameIdentity(
+        camera_frame='CASSINI_ISS_NAC',
+        ck_frame_id=-82000,
+        oops_from_spice=_CASSINI_FLIP_ARRAY,
+        frozen_oops_attitude=False,
+    )
+
+
+class _StubTransform:
+    """Stands in for an oops ``Transform``, carrying only its matrix."""
+
+    def __init__(self, matrix: np.ndarray) -> None:
+        self.matrix = SimpleNamespace(vals=matrix)
+
+
+class _StubFrame:
+    """Stands in for an oops frame whose attitude a test dictates per epoch."""
+
+    def __init__(self, attitude: Callable[[float], np.ndarray]) -> None:
+        self._attitude = attitude
+
+    def wrt(self, reference: object) -> _StubFrame:
+        """Return self; the stub is always expressed relative to J2000."""
+        return self
+
+    def transform_at_time(self, et: float) -> _StubTransform:
+        """Return the attitude the test dictated for this epoch."""
+        return _StubTransform(self._attitude(float(et)))
+
+
+class _StubObs:
+    """A real observation's times wrapped around a test-dictated frame.
+
+    Only the attributes ``_attitude_baseline`` reads are provided.  The times
+    come from a real frame so the SPICE clock and frame lookups it also makes
+    resolve against the furnished kernels.
+    """
+
+    def __init__(self, attitude: Callable[[float], np.ndarray], obs: ObsSnapshotInst) -> None:
+        self.frame = _StubFrame(attitude)
+        self.time = (float(obs.time[0]), float(obs.time[1]))
+        self.midtime = float(obs.midtime)
+        self.texp = float(obs.texp)
+
+
+@pytest.mark.parametrize(
+    ('obs_class', 'relative', 'camera_frame', 'expected_flip', 'ck_frame_id'),
+    [
+        (ObsCassiniISS, _CASSINI_NAC, 'CASSINI_ISS_NAC', _CASSINI_FLIP, -82000),
+        (ObsCassiniISS, _CASSINI_WAC, 'CASSINI_ISS_WAC', _CASSINI_FLIP, -82000),
+        (ObsNewHorizonsLORRI, _LORRI, 'NH_LORRI', _LORRI_FLIP, -98000),
+        (ObsGalileoSSI, _GALILEO_SSI, 'GLL_SCAN_PLATFORM', _NO_FLIP, -77001),
+    ],
+    ids=['cassini_nac', 'cassini_wac', 'lorri', 'galileo_ssi'],
+)
+def test_measured_flip_matches_the_expected_constant(
+    obs_class: type[ObsSnapshotInst],
+    relative: str,
+    camera_frame: str,
+    expected_flip: list[list[float]],
+    ck_frame_id: int,
+) -> None:
+    """The recorded flip is the instrument's documented constant.
+
+    Also pins the frame name and CK object the solution records, since a
+    correct flip against the wrong frame would be a silent mis-attribution.
+    """
+    obs = _load(obs_class, relative)
+    solution = compute_pointing(obs, offset_px=_OFFSET, rotation_fitted=False)
+    assert solution is not None
+    assert solution.baseline.camera_frame == camera_frame
+    assert solution.baseline.ck_frame_id == ck_frame_id
+    measured = np.asarray(solution.baseline.oops_from_spice, np.float64)
+    assert float(np.max(np.abs(measured - np.asarray(expected_flip)))) < _FLIP_TOL
+
+
+@pytest.mark.parametrize(
+    ('obs_class', 'relative', 'camera_frame'),
+    [
+        (ObsCassiniISS, _CASSINI_NAC, 'CASSINI_ISS_NAC'),
+        (ObsCassiniISS, _CASSINI_WAC, 'CASSINI_ISS_WAC'),
+        (ObsNewHorizonsLORRI, _LORRI, 'NH_LORRI'),
+        (ObsGalileoSSI, _GALILEO_SSI, 'GLL_SCAN_PLATFORM'),
+    ],
+    ids=['cassini_nac', 'cassini_wac', 'lorri', 'galileo_ssi'],
+)
+def test_measured_flip_is_identical_at_start_mid_and_stop(
+    obs_class: type[ObsSnapshotInst], relative: str, camera_frame: str
+) -> None:
+    """The flip does not vary across the exposure.
+
+    The correction is applied as a constant conjugation, which is only valid
+    if the two frames really are rigidly attached to each other.
+    """
+    obs = _load(obs_class, relative)
+    at_mid = _measured_flip(obs, camera_frame, float(obs.midtime))
+    at_start = _measured_flip(obs, camera_frame, float(obs.time[0]))
+    at_stop = _measured_flip(obs, camera_frame, float(obs.time[1]))
+    assert float(np.max(np.abs(at_start - at_mid))) < _FLIP_TOL
+    assert float(np.max(np.abs(at_stop - at_mid))) < _FLIP_TOL
+
+
+def test_voyager_records_the_frozen_oops_attitude() -> None:
+    """Voyager's uncorrected attitude is the frozen observation frame itself."""
+    obs = _load(ObsVoyagerISS, _VOYAGER_NAC)
+    solution = compute_pointing(obs, offset_px=_OFFSET, rotation_fitted=False)
+    assert solution is not None
+    frozen = _observation_attitude(obs, float(obs.midtime))
+    recorded = np.asarray(solution.baseline.cmatrix_original, np.float64)
+    assert float(np.max(np.abs(recorded - frozen))) == 0.0
+
+
+def test_voyager_pxform_cannot_reproduce_the_frozen_attitude() -> None:
+    """A plain ``pxform`` at the Voyager midtime does not resolve at all.
+
+    Pins the reason Voyager takes its own path: the scan-platform CK is
+    sparse, so the frame chain has no data at the exact midtime and only a
+    tolerance-snapped lookup succeeds.
+    """
+    obs = _load(ObsVoyagerISS, _VOYAGER_NAC)
+    with pytest.raises(RuntimeError, match='insufficient information'):
+        cspyce.pxform('J2000', 'VG2_ISSNA', float(obs.midtime))
+
+
+def test_voyager_records_its_per_spacecraft_frames() -> None:
+    """Voyager frame identities are derived per spacecraft, not per instrument."""
+    obs = _load(ObsVoyagerISS, _VOYAGER_NAC)
+    solution = compute_pointing(obs, offset_px=_OFFSET, rotation_fitted=False)
+    assert solution is not None
+    assert solution.baseline.camera_frame == 'VG2_ISSNA'
+    assert solution.baseline.camera_frame_id == -32101
+    assert solution.baseline.ck_frame_id == -32100
+
+
+def test_voyager_flip_is_the_identity() -> None:
+    """No flip is applied on the Voyager path, by construction."""
+    obs = _load(ObsVoyagerISS, _VOYAGER_NAC)
+    solution = compute_pointing(obs, offset_px=_OFFSET, rotation_fitted=False)
+    assert solution is not None
+    measured = np.asarray(solution.baseline.oops_from_spice, np.float64)
+    assert float(np.max(np.abs(measured - np.eye(3)))) == 0.0
+
+
+@pytest.mark.parametrize(
+    ('obs_class', 'relative'),
+    [
+        (ObsCassiniISS, _CASSINI_NAC),
+        (ObsNewHorizonsLORRI, _LORRI),
+        (ObsGalileoSSI, _GALILEO_SSI),
+        (ObsVoyagerISS, _VOYAGER_NAC),
+    ],
+    ids=['cassini_nac', 'lorri', 'galileo_ssi', 'voyager_nac'],
+)
+def test_recorded_times_bracket_the_midtime(
+    obs_class: type[ObsSnapshotInst], relative: str
+) -> None:
+    """The recorded epochs are the observation's own exposure window."""
+    obs = _load(obs_class, relative)
+    solution = compute_pointing(obs, offset_px=_OFFSET, rotation_fitted=False)
+    assert solution is not None
+    baseline = solution.baseline
+    assert baseline.start_et == float(obs.time[0])
+    assert baseline.stop_et == float(obs.time[1])
+    assert baseline.midtime_et == float(obs.midtime)
+    assert baseline.exposure_s == pytest.approx(float(obs.texp))
+
+
+@pytest.mark.parametrize(
+    ('obs_class', 'relative'),
+    [
+        (ObsCassiniISS, _CASSINI_NAC),
+        (ObsNewHorizonsLORRI, _LORRI),
+        (ObsGalileoSSI, _GALILEO_SSI),
+        (ObsVoyagerISS, _VOYAGER_NAC),
+    ],
+    ids=['cassini_nac', 'lorri', 'galileo_ssi', 'voyager_nac'],
+)
+def test_recorded_clock_strings_are_distinct_and_ordered(
+    obs_class: type[ObsSnapshotInst], relative: str
+) -> None:
+    """Start, midtime and stop encode to three different clock readings."""
+    obs = _load(obs_class, relative)
+    solution = compute_pointing(obs, offset_px=_OFFSET, rotation_fitted=False)
+    assert solution is not None
+    baseline = solution.baseline
+    assert baseline.sclk_start < baseline.sclk_midtime
+    assert baseline.sclk_midtime < baseline.sclk_stop
+
+
+@pytest.mark.parametrize(
+    ('obs_class', 'relative'),
+    [
+        (ObsCassiniISS, _CASSINI_NAC),
+        (ObsCassiniISS, _CASSINI_WAC),
+        (ObsNewHorizonsLORRI, _LORRI),
+        (ObsGalileoSSI, _GALILEO_SSI),
+        (ObsVoyagerISS, _VOYAGER_NAC),
+    ],
+    ids=['cassini_nac', 'cassini_wac', 'lorri', 'galileo_ssi', 'voyager_nac'],
+)
+def test_recorded_cmatrix_recovers_the_planted_offset(
+    obs_class: type[ObsSnapshotInst], relative: str
+) -> None:
+    """The recorded C-matrix returns the exact ``(dv, du)`` that produced it.
+
+    The inverse runs on the real distorted FOV of each instrument and against
+    the real measured flip, so every directional convention in the chain is
+    pinned at once: a flipped ``xy_offset``, a transposed correction, a
+    dropped or reversed ``R`` conjugation, and a reversed composition all
+    return a different offset.
+    """
+    obs = _load(obs_class, relative)
+    solution = compute_pointing(obs, offset_px=_OFFSET, rotation_fitted=False)
+    assert solution is not None
+    assert solution.cmatrix is not None
+    flip = np.asarray(solution.baseline.oops_from_spice, np.float64)
+    corrected_oops = flip @ np.asarray(solution.cmatrix, np.float64)
+    original_oops = flip @ np.asarray(solution.baseline.cmatrix_original, np.float64)
+    recovered = _offset_from_correction(obs.fov, corrected_oops @ original_oops.T)
+    assert recovered[0] == pytest.approx(_OFFSET[0], abs=_RECOVERY_TOL_PX)
+    assert recovered[1] == pytest.approx(_OFFSET[1], abs=_RECOVERY_TOL_PX)
+
+
+@pytest.mark.parametrize(
+    ('obs_class', 'relative'),
+    [
+        (ObsCassiniISS, _CASSINI_NAC),
+        (ObsCassiniISS, _CASSINI_WAC),
+        (ObsNewHorizonsLORRI, _LORRI),
+        (ObsGalileoSSI, _GALILEO_SSI),
+        (ObsVoyagerISS, _VOYAGER_NAC),
+    ],
+    ids=['cassini_nac', 'cassini_wac', 'lorri', 'galileo_ssi', 'voyager_nac'],
+)
+def test_recorded_cmatrix_recovers_a_sub_pixel_offset(
+    obs_class: type[ObsSnapshotInst], relative: str
+) -> None:
+    """A sub-pixel offset survives the round trip on a real FOV too.
+
+    The degenerate-axis guard must not absorb a real measurement, and the
+    second-order rotation-versus-shift difference is proportional to the
+    offset, so a small offset recovers tighter than a large one.
+    """
+    obs = _load(obs_class, relative)
+    solution = compute_pointing(obs, offset_px=_SMALL_OFFSET, rotation_fitted=False)
+    assert solution is not None
+    assert solution.cmatrix is not None
+    flip = np.asarray(solution.baseline.oops_from_spice, np.float64)
+    corrected_oops = flip @ np.asarray(solution.cmatrix, np.float64)
+    original_oops = flip @ np.asarray(solution.baseline.cmatrix_original, np.float64)
+    recovered = _offset_from_correction(obs.fov, corrected_oops @ original_oops.T)
+    assert recovered[0] == pytest.approx(_SMALL_OFFSET[0], abs=_RECOVERY_TOL_PX)
+    assert recovered[1] == pytest.approx(_SMALL_OFFSET[1], abs=_RECOVERY_TOL_PX)
+
+
+def test_epoch_varying_flip_is_refused() -> None:
+    """A flip that changes across the exposure is refused, not averaged away.
+
+    The correction is applied to a kernel as one constant body-fixed
+    rotation, which is only valid while the two frames are rigidly attached.
+    A stub observation whose frame drifts against the real SPICE camera frame
+    exercises the guard that would otherwise let a drifting frame through.
+    """
+    obs = _load(ObsCassiniISS, _CASSINI_NAC)
+    midtime = float(obs.midtime)
+    drift = _rotation_about_z(1.0e-6)
+
+    def attitude(et: float) -> np.ndarray:
+        spice = np.asarray(cspyce.pxform('J2000', 'CASSINI_ISS_NAC', et), np.float64)
+        flip = _CASSINI_FLIP_ARRAY if et == midtime else drift @ _CASSINI_FLIP_ARRAY
+        product: np.ndarray = flip @ spice
+        return product
+
+    stub = cast(ObsSnapshotInst, _StubObs(attitude, obs))
+    with pytest.raises(ValueError, match='is not constant across the exposure'):
+        _attitude_baseline(stub, _cassini_nac_identity())
+
+
+def test_a_wrong_flip_measured_from_the_frame_is_refused() -> None:
+    """An observation frame that is not the expected flip of the SPICE frame raises.
+
+    Pins the direction the flip is measured in as well as its value: measuring
+    ``C_spice^T . C_oops`` instead of ``C_oops . C_spice^T`` produces a matrix
+    that is not the instrument's constant and lands here.
+    """
+    obs = _load(ObsCassiniISS, _CASSINI_NAC)
+
+    def attitude(et: float) -> np.ndarray:
+        spice: np.ndarray = np.asarray(cspyce.pxform('J2000', 'CASSINI_ISS_NAC', et), np.float64)
+        return spice
+
+    stub = cast(ObsSnapshotInst, _StubObs(attitude, obs))
+    with pytest.raises(ValueError, match='differs from the expected'):
+        _attitude_baseline(stub, _cassini_nac_identity())

--- a/tests/spindoctor/inst/test_inst_cassini_iss.py
+++ b/tests/spindoctor/inst/test_inst_cassini_iss.py
@@ -30,3 +30,13 @@ def test_cassini_iss_calib_filename_selects_calib_inst_config() -> None:
     assert 'saturation_threshold_if' not in iqt
     assert 'blank_max_if' in iqt
     assert 'noisy_threshold_if' in iqt
+
+
+def test_cassini_iss_reports_shutter_mode() -> None:
+    """The shutter mode is read from the image label.
+
+    The Rhea test frame was taken with both cameras exposed at once, so it
+    reports the simultaneous mode rather than a single-camera one.
+    """
+    obs = obstcoiss.ObsCassiniISS.from_file(URL_CASSINI_ISS_RHEA_01)
+    assert obs.shutter_mode == 'BOTSIM'

--- a/tests/spindoctor/inst/test_inst_voyager_iss.py
+++ b/tests/spindoctor/inst/test_inst_voyager_iss.py
@@ -138,3 +138,9 @@ def test_star_max_usable_vmag_non_positive_exposure_returns_anchor() -> None:
     """A non-positive exposure falls back to the anchor magnitude."""
     obs = _make_obs('NAC', 0.0)
     assert obs.star_max_usable_vmag() == pytest.approx(_VOYAGER_NAC_ANCHOR, abs=1e-6)
+
+
+def test_voyager_iss_reports_spacecraft_digit() -> None:
+    """The spacecraft digit is read from the image label."""
+    obs = obstvgiss.ObsVoyagerISS.from_file(URL_VOYAGER_ISS_IO_01)
+    assert obs.spacecraft_digit == '2'

--- a/tests/spindoctor/nav_orchestrator/test_curator.py
+++ b/tests/spindoctor/nav_orchestrator/test_curator.py
@@ -1,5 +1,6 @@
 """Tests for ``spindoctor.nav_orchestrator.curator.build_metadata_dict``."""
 
+import dataclasses
 import json
 import math
 
@@ -18,6 +19,7 @@ from spindoctor.nav_orchestrator.nav_result import NavResult
 from spindoctor.nav_orchestrator.provenance import Provenance
 from spindoctor.nav_technique.diagnostics import BodyLimbDiagnostics
 from spindoctor.nav_technique.technique_result import NavTechniqueResult
+from spindoctor.support.cmatrix import AttitudeBaseline, PointingSolution
 from spindoctor.support.status_reason import NavStatusReason
 
 
@@ -298,3 +300,131 @@ def test_breakdown_is_empty_when_no_component_was_populated() -> None:
     """A feature whose model populated no component reports an empty mapping."""
     md = json.loads(json.dumps(build_metadata_dict(_ok_result_with_one_technique())))
     assert md['feature_inventory'][0]['reliability_reasons'] == {}
+
+
+def _pointing(*, corrected: bool) -> PointingSolution:
+    """Build a PointingSolution with recognizable, non-symmetric matrices."""
+    original = np.array(
+        [
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0],
+        ]
+    )
+    baseline = AttitudeBaseline(
+        cmatrix_original=original,
+        oops_from_spice=np.eye(3),
+        camera_frame='CASSINI_ISS_NAC',
+        camera_frame_id=-82360,
+        ck_frame_id=-82000,
+        start_et=246684087.05644953,
+        stop_et=246684087.23644954,
+        midtime_et=246684087.14644954,
+        exposure_s=0.18,
+        sclk_start='1/1572105349.077',
+        sclk_midtime='1/1572105349.100',
+        sclk_stop='1/1572105349.123',
+    )
+    cmatrix = None
+    if corrected:
+        cmatrix = np.array(
+            [
+                [0.0, 0.0, 1.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+            ]
+        )
+    return PointingSolution(baseline=baseline, cmatrix=cmatrix)
+
+
+def _result_with_pointing(*, corrected: bool) -> NavResult:
+    return dataclasses.replace(
+        _ok_result_with_one_technique(), pointing=_pointing(corrected=corrected)
+    )
+
+
+def test_metadata_dict_omits_pointing_when_none_was_computed() -> None:
+    """A result with no pointing solution writes no pointing block."""
+    md = build_metadata_dict(_ok_result_with_one_technique())
+    assert 'pointing' not in md
+
+
+def test_metadata_dict_omits_times_when_none_was_computed() -> None:
+    """A result with no pointing solution writes no times block."""
+    md = build_metadata_dict(_ok_result_with_one_technique())
+    assert 'times' not in md
+
+
+def test_pointing_block_has_the_declared_key_set() -> None:
+    """A corrected result's pointing block carries exactly the declared keys."""
+    md = json.loads(json.dumps(build_metadata_dict(_result_with_pointing(corrected=True))))
+    assert set(md['pointing']) == {
+        'cmatrix',
+        'cmatrix_original',
+        'camera_frame',
+        'camera_frame_id',
+        'ck_frame_id',
+    }
+
+
+def test_times_block_has_the_declared_key_set() -> None:
+    """The times block carries exactly the declared keys."""
+    md = json.loads(json.dumps(build_metadata_dict(_result_with_pointing(corrected=True))))
+    assert set(md['times']) == {
+        'start_et',
+        'stop_et',
+        'midtime_et',
+        'exposure_s',
+        'sclk_start',
+        'sclk_midtime',
+        'sclk_stop',
+    }
+
+
+def test_cmatrix_is_serialized_as_nine_row_major_floats() -> None:
+    """The corrected C-matrix flattens row by row, not column by column."""
+    md = json.loads(json.dumps(build_metadata_dict(_result_with_pointing(corrected=True))))
+    assert md['pointing']['cmatrix'] == [0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
+
+
+def test_cmatrix_original_is_serialized_as_nine_row_major_floats() -> None:
+    """The uncorrected C-matrix flattens row by row too."""
+    md = json.loads(json.dumps(build_metadata_dict(_result_with_pointing(corrected=True))))
+    assert md['pointing']['cmatrix_original'] == [0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0]
+
+
+def test_frame_identities_are_serialized_as_recorded() -> None:
+    """The camera frame name and both frame ids travel unchanged."""
+    md = json.loads(json.dumps(build_metadata_dict(_result_with_pointing(corrected=True))))
+    assert md['pointing']['camera_frame'] == 'CASSINI_ISS_NAC'
+    assert md['pointing']['camera_frame_id'] == -82360
+    assert md['pointing']['ck_frame_id'] == -82000
+
+
+def test_times_are_serialized_unrounded() -> None:
+    """Epochs keep full precision, since they define a segment interval exactly."""
+    md = json.loads(json.dumps(build_metadata_dict(_result_with_pointing(corrected=True))))
+    assert md['times']['start_et'] == 246684087.05644953
+    assert md['times']['midtime_et'] == 246684087.14644954
+    assert md['times']['stop_et'] == 246684087.23644954
+
+
+def test_sclk_strings_are_serialized_as_recorded() -> None:
+    """The three spacecraft-clock strings travel unchanged."""
+    md = json.loads(json.dumps(build_metadata_dict(_result_with_pointing(corrected=True))))
+    assert md['times']['sclk_start'] == '1/1572105349.077'
+    assert md['times']['sclk_midtime'] == '1/1572105349.100'
+    assert md['times']['sclk_stop'] == '1/1572105349.123'
+
+
+def test_uncorrectable_result_omits_cmatrix_but_keeps_the_original() -> None:
+    """A solution with no corrected attitude still records the uncorrected one."""
+    md = json.loads(json.dumps(build_metadata_dict(_result_with_pointing(corrected=False))))
+    assert 'cmatrix' not in md['pointing']
+    assert md['pointing']['cmatrix_original'] == [0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0]
+
+
+def test_uncorrectable_result_still_records_its_times() -> None:
+    """A solution with no corrected attitude still records the exposure times."""
+    md = json.loads(json.dumps(build_metadata_dict(_result_with_pointing(corrected=False))))
+    assert md['times']['exposure_s'] == 0.18

--- a/tests/spindoctor/nav_orchestrator/test_orchestrator.py
+++ b/tests/spindoctor/nav_orchestrator/test_orchestrator.py
@@ -32,6 +32,7 @@ from spindoctor.nav_technique.diagnostics import StarFieldDiagnostics
 from spindoctor.nav_technique.feasibility import NavFeasibilityReport
 from spindoctor.nav_technique.nav_technique import NavTechnique
 from spindoctor.nav_technique.technique_result import NavTechniqueResult
+from spindoctor.support.cmatrix import AttitudeBaseline, PointingSolution
 from spindoctor.support.exceptions import NavContractError
 from spindoctor.support.filters import NavFilterKind, NavFilterSpec
 from spindoctor.support.status_reason import NavStatusReason
@@ -209,6 +210,21 @@ class _FakeStarTechnique(NavTechnique):
 def fake_obs() -> _FakeObs:
     """Provide a clean fake observation."""
     return _FakeObs()
+
+
+@pytest.fixture(autouse=True)
+def _fakes_report_as_simulated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Report this module's fake observations as simulated.
+
+    ``obs_class_to_inst_name`` cannot identify a test fake and returns
+    ``'unknown'``, which the orchestrator treats as a build defect and
+    warns about.  These fakes stand in for an observation carrying no SPICE
+    camera frame, which is exactly what a simulated image is, so they report
+    that instead of shaping the production set around the test suite.
+    """
+    monkeypatch.setattr(
+        'spindoctor.nav_orchestrator.orchestrator.obs_class_to_inst_name', lambda cls: 'sim'
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -1248,3 +1264,191 @@ def test_feasible_technique_report_logged_at_debug(
     captured = capsys.readouterr()
     assert result.status == 'success'
     assert 'Technique _FakeStarTechnique feasible: would consume 3 feature(s)' in captured.out
+
+
+def _sentinel_pointing() -> PointingSolution:
+    """Build a PointingSolution a wiring test can identify by reference."""
+    baseline = AttitudeBaseline(
+        cmatrix_original=np.eye(3),
+        oops_from_spice=np.eye(3),
+        camera_frame='CASSINI_ISS_NAC',
+        camera_frame_id=-82360,
+        ck_frame_id=-82000,
+        start_et=1.0,
+        stop_et=2.0,
+        midtime_et=1.5,
+        exposure_s=1.0,
+        sclk_start='1/1.000',
+        sclk_midtime='1/1.500',
+        sclk_stop='1/2.000',
+    )
+    return PointingSolution(baseline=baseline, cmatrix=np.eye(3))
+
+
+def test_orchestrator_records_no_pointing_without_a_spice_camera_frame(
+    fake_obs: _FakeObs,
+) -> None:
+    """An observation with no known SPICE camera frame records no pointing."""
+    obs = fake_obs
+    model = _FakeStarModel(obs, feature_count=3)
+    orch = NavOrchestrator([model], only_techniques=['_FakeStarTechnique'])
+    result = orch.navigate(obs)  # type: ignore[arg-type]
+    assert result.pointing is None
+
+
+def test_orchestrator_stamps_pointing_on_a_successful_result(
+    fake_obs: _FakeObs, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A computed pointing solution is carried on the returned NavResult.
+
+    The SPICE lookups behind the real computation need furnished kernels, so
+    the wiring is exercised with a stand-in solution.
+    """
+    pointing = _sentinel_pointing()
+    monkeypatch.setattr(
+        'spindoctor.nav_orchestrator.orchestrator.compute_pointing',
+        lambda obs, *, offset_px, rotation_fitted: pointing,
+    )
+    obs = fake_obs
+    model = _FakeStarModel(obs, feature_count=3)
+    orch = NavOrchestrator([model], only_techniques=['_FakeStarTechnique'])
+    result = orch.navigate(obs)  # type: ignore[arg-type]
+    assert result.status == 'success'
+    assert result.pointing is pointing
+
+
+def test_orchestrator_stamps_pointing_on_a_short_circuited_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hard-failure image still records its uncorrected attitude and times."""
+    pointing = _sentinel_pointing()
+    monkeypatch.setattr(
+        'spindoctor.nav_orchestrator.orchestrator.compute_pointing',
+        lambda obs, *, offset_px, rotation_fitted: pointing,
+    )
+    obs = _FakeObs(image=np.zeros((64, 64), np.float64))
+    model = _FakeStarModel(obs, feature_count=3)
+    orch = NavOrchestrator([model])
+    result = orch.navigate(obs)  # type: ignore[arg-type]
+    assert result.status == 'failed'
+    assert result.pointing is pointing
+
+
+def test_orchestrator_passes_the_fitted_rotation_flag_through(
+    fake_obs: _FakeObs, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fitted-rotation flag reflects whether the result carries a rotation."""
+    seen: dict[str, Any] = {}
+
+    def _record(obs: Any, *, offset_px: Any, rotation_fitted: bool) -> None:
+        seen['offset_px'] = offset_px
+        seen['rotation_fitted'] = rotation_fitted
+        return None
+
+    monkeypatch.setattr('spindoctor.nav_orchestrator.orchestrator.compute_pointing', _record)
+    obs = fake_obs
+    model = _FakeStarModel(obs, feature_count=3)
+    orch = NavOrchestrator([model], only_techniques=['_FakeStarTechnique'])
+    result = orch.navigate(obs)  # type: ignore[arg-type]
+    assert seen['offset_px'] == result.offset_px
+    assert seen['rotation_fitted'] is False
+
+
+def test_orchestrator_reports_but_survives_a_failed_pointing_computation(
+    fake_obs: _FakeObs, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A pointing computation that raises is logged and leaves the result usable."""
+
+    def _boom(obs: Any, *, offset_px: Any, rotation_fitted: bool) -> None:
+        raise ValueError('cmatrix is not a proper rotation')
+
+    monkeypatch.setattr('spindoctor.nav_orchestrator.orchestrator.compute_pointing', _boom)
+    obs = fake_obs
+    model = _FakeStarModel(obs, feature_count=3)
+    orch = NavOrchestrator([model], only_techniques=['_FakeStarTechnique'])
+    result = orch.navigate(obs)  # type: ignore[arg-type]
+    assert result.status == 'success'
+    assert result.pointing is None
+    assert 'Could not compute the corrected pointing' in capsys.readouterr().out
+
+
+def test_orchestrator_reports_a_failed_pointing_to_the_run_log(
+    fake_obs: _FakeObs, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A failed pointing computation reaches the run log, not only the image log.
+
+    A batch operator watching the run log must not have to open every
+    per-image log to learn that pointing stopped being recorded.
+    """
+
+    def _boom(obs: Any, *, offset_px: Any, rotation_fitted: bool) -> None:
+        raise RuntimeError('SPICE(NOFRAMECONNECT)')
+
+    monkeypatch.setattr('spindoctor.nav_orchestrator.orchestrator.compute_pointing', _boom)
+    obs = fake_obs
+    model = _FakeStarModel(obs, feature_count=3)
+    orch = NavOrchestrator([model], only_techniques=['_FakeStarTechnique'])
+    orch.navigate(obs)  # type: ignore[arg-type]
+    assert 'Corrected pointing not recorded' in capsys.readouterr().out
+
+
+def test_orchestrator_does_not_swallow_a_defect_in_the_pointing_computation(
+    fake_obs: _FakeObs, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A programming error in the computation is not caught.
+
+    Catching everything would let one typo silently drop pointing from an
+    entire batch while every image still reported success.
+    """
+
+    def _typo(obs: Any, *, offset_px: Any, rotation_fitted: bool) -> None:
+        raise AttributeError("'NoneType' object has no attribute 'vals'")
+
+    monkeypatch.setattr('spindoctor.nav_orchestrator.orchestrator.compute_pointing', _typo)
+    obs = fake_obs
+    model = _FakeStarModel(obs, feature_count=3)
+    orch = NavOrchestrator([model], only_techniques=['_FakeStarTechnique'])
+    with pytest.raises(AttributeError, match='has no attribute'):
+        orch.navigate(obs)  # type: ignore[arg-type]
+
+
+def test_orchestrator_warns_when_a_registered_instrument_has_no_frame_mapping(
+    fake_obs: _FakeObs, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An instrument that navigates but maps to no SPICE frame is reported.
+
+    A fifth instrument added without its frame mapping would otherwise
+    produce no corrected attitude for any of its images, with nothing above
+    debug to say so.
+    """
+    monkeypatch.setattr(
+        'spindoctor.nav_orchestrator.orchestrator.obs_class_to_inst_name', lambda cls: 'newinst'
+    )
+    monkeypatch.setattr(
+        'spindoctor.nav_orchestrator.orchestrator.compute_pointing',
+        lambda obs, *, offset_px, rotation_fitted: None,
+    )
+    obs = fake_obs
+    model = _FakeStarModel(obs, feature_count=3)
+    orch = NavOrchestrator([model], only_techniques=['_FakeStarTechnique'])
+    result = orch.navigate(obs)  # type: ignore[arg-type]
+    assert result.pointing is None
+    assert 'No SPICE camera frame is mapped for instrument newinst' in capsys.readouterr().out
+
+
+def test_orchestrator_does_not_warn_for_a_simulated_image(
+    fake_obs: _FakeObs, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A simulated image records no attitude without raising a warning."""
+    monkeypatch.setattr(
+        'spindoctor.nav_orchestrator.orchestrator.obs_class_to_inst_name', lambda cls: 'sim'
+    )
+    monkeypatch.setattr(
+        'spindoctor.nav_orchestrator.orchestrator.compute_pointing',
+        lambda obs, *, offset_px, rotation_fitted: None,
+    )
+    obs = fake_obs
+    model = _FakeStarModel(obs, feature_count=3)
+    orch = NavOrchestrator([model], only_techniques=['_FakeStarTechnique'])
+    orch.navigate(obs)  # type: ignore[arg-type]
+    assert 'No SPICE camera frame is mapped' not in capsys.readouterr().out

--- a/tests/spindoctor/nav_technique/test_nav_technique_manual.py
+++ b/tests/spindoctor/nav_technique/test_nav_technique_manual.py
@@ -24,6 +24,7 @@ from spindoctor.feature.geometry import StarGeometry
 from spindoctor.nav_model import NavModel
 from spindoctor.nav_technique import NavTechniqueManual
 from spindoctor.nav_technique.nav_technique_manual import run_manual_nav
+from spindoctor.support.cmatrix import AttitudeBaseline, PointingSolution
 from spindoctor.support.filters import NavFilterKind, NavFilterSpec
 
 
@@ -114,6 +115,21 @@ def _patch_build_models(monkeypatch: pytest.MonkeyPatch) -> None:
     import spindoctor.nav_model as nav_model_pkg
 
     monkeypatch.setattr(nav_model_pkg, 'build_models_for_obs', _stub_builder, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _fakes_report_as_simulated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Report this module's fake observations as simulated.
+
+    ``obs_class_to_inst_name`` cannot identify a test fake and returns
+    ``'unknown'``, which the orchestrator treats as a build defect and
+    warns about.  These fakes stand in for an observation carrying no SPICE
+    camera frame, which is exactly what a simulated image is, so they report
+    that instead of shaping the production set around the test suite.
+    """
+    monkeypatch.setattr(
+        'spindoctor.nav_orchestrator.orchestrator.obs_class_to_inst_name', lambda cls: 'sim'
+    )
 
 
 def _make_fake_dialog(
@@ -335,3 +351,60 @@ def test_titan_only_feature_set_composes_a_non_empty_overlay(
     feature = _titan_feature(make_titan_feature)
     _image, mask = compose_dialog_overlay([feature], (48, 48))
     assert bool(mask.any()) is True
+
+
+def test_run_manual_nav_stamps_the_corrected_pointing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An operator-picked offset carries the same recorded attitude as an autonomous one.
+
+    Operator-ratified offsets are the highest-quality pointing in the corpus,
+    so they must not be the one subset a generated C-kernel omits.  The SPICE
+    lookups behind the real computation need furnished kernels, so the wiring
+    is exercised with a stand-in solution.
+    """
+    baseline = AttitudeBaseline(
+        cmatrix_original=np.eye(3),
+        oops_from_spice=np.eye(3),
+        camera_frame='CASSINI_ISS_NAC',
+        camera_frame_id=-82360,
+        ck_frame_id=-82000,
+        start_et=1.0,
+        stop_et=2.0,
+        midtime_et=1.5,
+        exposure_s=1.0,
+        sclk_start='1/1.000',
+        sclk_midtime='1/1.500',
+        sclk_stop='1/2.000',
+    )
+    pointing = PointingSolution(baseline=baseline, cmatrix=np.eye(3))
+    monkeypatch.setattr(
+        'spindoctor.nav_orchestrator.orchestrator.compute_pointing',
+        lambda obs, *, offset_px, rotation_fitted: pointing,
+    )
+    obs = _FakeObsForRunManual()
+    obs.with_template = True  # type: ignore[attr-defined]
+    fake_dialog, _instances = _make_fake_dialog((True, (3.0, -2.0), 0.92))
+    with patch('spindoctor.ui.manual_nav_dialog.ManualNavDialog', fake_dialog):
+        result = run_manual_nav(obs)  # type: ignore[arg-type]
+    assert result is not None
+    assert result.pointing is pointing
+
+
+def test_run_manual_nav_passes_the_operator_offset_to_the_pointing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The attitude is computed from the offset the operator actually picked."""
+    seen: dict[str, Any] = {}
+
+    def _record(obs: Any, *, offset_px: Any, rotation_fitted: bool) -> None:
+        seen['offset_px'] = offset_px
+        seen['rotation_fitted'] = rotation_fitted
+        return None
+
+    monkeypatch.setattr('spindoctor.nav_orchestrator.orchestrator.compute_pointing', _record)
+    obs = _FakeObsForRunManual()
+    obs.with_template = True  # type: ignore[attr-defined]
+    fake_dialog, _instances = _make_fake_dialog((True, (3.0, -2.0), 0.92))
+    with patch('spindoctor.ui.manual_nav_dialog.ManualNavDialog', fake_dialog):
+        run_manual_nav(obs)  # type: ignore[arg-type]
+    assert seen['offset_px'] == (3.0, -2.0)
+    assert seen['rotation_fitted'] is False

--- a/tests/spindoctor/obs/test_obs_inst.py
+++ b/tests/spindoctor/obs/test_obs_inst.py
@@ -76,3 +76,8 @@ def test_star_psf_size_wrong_length_raises() -> None:
     inst._inst_config = {'star_psf_sizes': {10: [7, 7, 7]}}
     with pytest.raises(AssertionError, match='must have 2 elements'):
         inst.star_psf_size(_make_star(4.0))
+
+
+def test_shutter_mode_defaults_to_none() -> None:
+    """An instrument whose host exposes no shutter mode reports None."""
+    assert _ConcreteObsInst().shutter_mode is None

--- a/tests/spindoctor/support/test_cmatrix.py
+++ b/tests/spindoctor/support/test_cmatrix.py
@@ -1,0 +1,448 @@
+"""Hermetic tests for ``spindoctor.support.cmatrix``.
+
+Every test here builds its own FOV and its own attitudes, so nothing depends
+on SPICE kernels or on a real observation.  The conventions under test are
+the ones a hermetic test can silently get wrong in both directions at once:
+the sign of the tangent-plane offset, the direction of the rotation
+``cspyce.axisar`` builds, and the conjugation of the oops-frame correction
+into the SPICE frame.  Each is pinned by recovering the planted offset back
+out of the recorded C-matrix with an independent inverse.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import cast
+
+import numpy as np
+import oops
+import pytest
+
+from spindoctor.obs import ObsSnapshotInst
+from spindoctor.support.cmatrix import (
+    AttitudeBaseline,
+    _build_pointing_solution,
+    _check_flip,
+    _FrameIdentity,
+    _oops_correction_matrix,
+    _spice_cmatrix,
+    _validate_rotation,
+    compute_pointing,
+)
+
+# A Cassini-NAC-like square camera: 1024 pixels at 6 microradians each.  A
+# FlatFOV maps its boresight pixel to xy exactly (0, 0), which is what makes
+# the zero-offset identity guard exercisable.
+_PIXEL_RAD = 6.0e-6
+_SHAPE = (1024, 1024)
+
+# A planted offset with two distinct, non-zero, opposite-signed components,
+# so a sign flip or an axis swap cannot go unnoticed.
+_PLANTED_OFFSET = (8.68, -17.37)
+
+# The 180-degree flip oops applies on top of the SPICE Cassini ISS frames.
+_CASSINI_FLIP = np.diag([-1.0, -1.0, 1.0])
+
+_IDENTITY = np.eye(3)
+
+
+def _fov() -> oops.fov.FOV:
+    """Build the synthetic camera every test in this module points."""
+    return oops.fov.FlatFOV((_PIXEL_RAD, _PIXEL_RAD), _SHAPE)
+
+
+def _some_attitude() -> np.ndarray:
+    """Return an arbitrary, deliberately non-axis-aligned J2000-to-camera rotation."""
+    ra, dec, twist = 0.7, -0.4, 1.9
+    rot_z = np.array(
+        [[np.cos(ra), np.sin(ra), 0.0], [-np.sin(ra), np.cos(ra), 0.0], [0.0, 0.0, 1.0]]
+    )
+    rot_y = np.array(
+        [[np.cos(dec), 0.0, -np.sin(dec)], [0.0, 1.0, 0.0], [np.sin(dec), 0.0, np.cos(dec)]]
+    )
+    rot_x = np.array(
+        [[1.0, 0.0, 0.0], [0.0, np.cos(twist), np.sin(twist)], [0.0, -np.sin(twist), np.cos(twist)]]
+    )
+    attitude: np.ndarray = rot_x @ rot_y @ rot_z
+    return attitude
+
+
+def _outcome_of(check: Callable[[], None]) -> str:
+    """Report whether a validator accepted or refused its input.
+
+    The validators under test signal acceptance by returning and refusal by
+    raising, so a test that only calls one asserts nothing.  This turns the
+    two outcomes into a value a test can assert on.
+    """
+    try:
+        check()
+    except ValueError:
+        return 'refused'
+    return 'accepted'
+
+
+def _baseline(
+    cmatrix_original: np.ndarray, oops_from_spice: np.ndarray = _IDENTITY
+) -> AttitudeBaseline:
+    """Build a synthetic AttitudeBaseline around a given attitude and flip."""
+    return AttitudeBaseline(
+        cmatrix_original=cmatrix_original,
+        oops_from_spice=oops_from_spice,
+        camera_frame='TEST_CAMERA',
+        camera_frame_id=-999999,
+        ck_frame_id=-999000,
+        start_et=100.0,
+        stop_et=100.5,
+        midtime_et=100.25,
+        exposure_s=0.5,
+        sclk_start='1/100.000',
+        sclk_midtime='1/100.250',
+        sclk_stop='1/100.500',
+    )
+
+
+def _offset_from_correction(fov: oops.fov.FOV, correction: np.ndarray) -> tuple[float, float]:
+    """Recover the ``(dv, du)`` offset a correction rotation encodes.
+
+    The independent inverse of :func:`_oops_correction_matrix`: it maps the
+    corrected boresight direction back through the rotation, reads off the
+    tangent-plane point that direction came from, and converts the implied
+    ``xy_offset`` back into pixels.  Written from the offset model rather
+    than from the forward implementation, so it does not reproduce a sign
+    error the forward code might contain.
+    """
+    xy_los = fov.xy_from_uv(fov.uv_los)
+    corrected = np.asarray(fov.los_from_xy(xy_los).unit().vals, np.float64)
+    uncorrected = np.asarray(correction, np.float64).T @ corrected
+    xy_uncorrected = oops.Pair((uncorrected[0] / uncorrected[2], uncorrected[1] / uncorrected[2]))
+    uv = fov.uv_from_xy(xy_los - xy_uncorrected)
+    return (
+        float(uv.vals[1] - fov.uv_los.vals[1]),
+        float(uv.vals[0] - fov.uv_los.vals[0]),
+    )
+
+
+def test_correction_maps_the_uncorrected_boresight_onto_the_corrected_one() -> None:
+    """``M . d`` is the direction the unmodified FOV assigns to the boresight."""
+    fov = _fov()
+    correction = _oops_correction_matrix(fov, _PLANTED_OFFSET)
+    xy_los = fov.xy_from_uv(fov.uv_los)
+    uv_los = fov.uv_los
+    xy_offset = fov.xy_from_uv(
+        oops.Pair((uv_los.vals[0] + _PLANTED_OFFSET[1], uv_los.vals[1] + _PLANTED_OFFSET[0]))
+    )
+    uncorrected = np.asarray(fov.los_from_xy(xy_los - xy_offset).unit().vals, np.float64)
+    corrected = np.asarray(fov.los_from_xy(xy_los).unit().vals, np.float64)
+    assert correction @ uncorrected == pytest.approx(corrected, abs=1e-15)
+
+
+def test_correction_is_a_proper_rotation() -> None:
+    """The correction matrix has unit determinant."""
+    correction = _oops_correction_matrix(_fov(), _PLANTED_OFFSET)
+    assert float(np.linalg.det(correction)) == pytest.approx(1.0, abs=1e-14)
+
+
+def test_planted_offset_is_recovered_from_the_recorded_cmatrix() -> None:
+    """A planted offset survives the round trip through the recorded C-matrix.
+
+    With no flip between the oops and SPICE frames, inverting the recorded
+    correction must return the planted ``(dv, du)``.  A flipped ``xy_offset``
+    sign, or a transposed correction, returns the negated offset instead.
+    """
+    fov = _fov()
+    original = _some_attitude()
+    solution = _build_pointing_solution(
+        _baseline(original), fov, offset_px=_PLANTED_OFFSET, rotation_fitted=False
+    )
+    assert solution.cmatrix is not None
+    correction = np.asarray(solution.cmatrix, np.float64) @ original.T
+    recovered = _offset_from_correction(fov, correction)
+    assert recovered[0] == pytest.approx(_PLANTED_OFFSET[0], abs=1e-9)
+    assert recovered[1] == pytest.approx(_PLANTED_OFFSET[1], abs=1e-9)
+
+
+def test_zero_offset_leaves_the_cmatrix_identical_to_the_original() -> None:
+    """A zero offset takes the identity guard and changes nothing at all."""
+    original = _some_attitude()
+    solution = _build_pointing_solution(
+        _baseline(original), _fov(), offset_px=(0.0, 0.0), rotation_fitted=False
+    )
+    assert solution.cmatrix is not None
+    assert np.array_equal(solution.cmatrix, solution.baseline.cmatrix_original)
+
+
+def test_zero_offset_correction_is_exactly_the_identity() -> None:
+    """The correction for a zero offset is the identity matrix, bit for bit."""
+    assert np.array_equal(_oops_correction_matrix(_fov(), (0.0, 0.0)), _IDENTITY)
+
+
+def test_cassini_style_flip_reproduces_the_offset_in_the_spice_convention() -> None:
+    """The recorded C-matrix carries the planted offset through a 180-degree flip.
+
+    With ``R = diag(-1, -1, 1)`` between the oops observation frame and the
+    SPICE camera frame, converting both recorded attitudes back into the oops
+    convention must yield exactly the correction the offset implies.  Dropping
+    the ``R`` conjugation leaves a correction of the right magnitude whose
+    tangent-plane components are both negated.
+    """
+    fov = _fov()
+    original = _some_attitude()
+    solution = _build_pointing_solution(
+        _baseline(original, _CASSINI_FLIP), fov, offset_px=_PLANTED_OFFSET, rotation_fitted=False
+    )
+    assert solution.cmatrix is not None
+    corrected_oops = _CASSINI_FLIP @ np.asarray(solution.cmatrix, np.float64)
+    original_oops = _CASSINI_FLIP @ original
+    recovered = _offset_from_correction(fov, corrected_oops @ original_oops.T)
+    assert recovered[0] == pytest.approx(_PLANTED_OFFSET[0], abs=1e-9)
+    assert recovered[1] == pytest.approx(_PLANTED_OFFSET[1], abs=1e-9)
+
+
+def test_flip_conjugation_changes_the_recorded_cmatrix() -> None:
+    """Conjugating through the flip is not a no-op for a Cassini-style flip.
+
+    Guards the test above: if ``R^T M R`` happened to equal ``M`` here, that
+    test would pass with the conjugation dropped.
+    """
+    fov = _fov()
+    original = _some_attitude()
+    correction = _oops_correction_matrix(fov, _PLANTED_OFFSET)
+    conjugated = _spice_cmatrix(original, correction, _CASSINI_FLIP)
+    unconjugated = correction @ original
+    assert float(np.max(np.abs(conjugated - unconjugated))) > 1e-6
+
+
+def test_fitted_rotation_records_the_original_but_no_corrected_cmatrix() -> None:
+    """A result carrying a fitted camera rotation gets no corrected attitude."""
+    original = _some_attitude()
+    solution = _build_pointing_solution(
+        _baseline(original), _fov(), offset_px=_PLANTED_OFFSET, rotation_fitted=True
+    )
+    assert solution.cmatrix is None
+    assert np.array_equal(solution.baseline.cmatrix_original, original)
+
+
+def test_missing_offset_records_the_original_but_no_corrected_cmatrix() -> None:
+    """A result with no offset gets no corrected attitude."""
+    original = _some_attitude()
+    solution = _build_pointing_solution(
+        _baseline(original), _fov(), offset_px=None, rotation_fitted=False
+    )
+    assert solution.cmatrix is None
+    assert np.array_equal(solution.baseline.cmatrix_original, original)
+
+
+def test_baseline_with_a_bad_determinant_raises() -> None:
+    """A baseline attitude that is not a proper rotation is refused."""
+    reflected = _some_attitude()
+    reflected[0] = -reflected[0]
+    with pytest.raises(ValueError, match='cmatrix_original is not a proper rotation'):
+        _build_pointing_solution(
+            _baseline(reflected), _fov(), offset_px=_PLANTED_OFFSET, rotation_fitted=False
+        )
+
+
+def test_baseline_that_is_not_orthonormal_raises() -> None:
+    """A unit-determinant baseline that is not orthonormal is refused."""
+    sheared = np.array([[1.0, 1.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+    with pytest.raises(ValueError, match='cmatrix_original is not orthonormal'):
+        _build_pointing_solution(
+            _baseline(sheared), _fov(), offset_px=_PLANTED_OFFSET, rotation_fitted=False
+        )
+
+
+def test_baseline_with_a_bad_determinant_raises_without_an_offset() -> None:
+    """The baseline is checked even when no corrected attitude is produced."""
+    reflected = _some_attitude()
+    reflected[0] = -reflected[0]
+    with pytest.raises(ValueError, match='cmatrix_original is not a proper rotation'):
+        _build_pointing_solution(
+            _baseline(reflected), _fov(), offset_px=None, rotation_fitted=False
+        )
+
+
+def test_corrected_cmatrix_that_is_not_a_rotation_raises() -> None:
+    """A correction that is not a rotation is refused by the result check."""
+    with pytest.raises(ValueError, match='cmatrix is not a proper rotation'):
+        _spice_cmatrix(_some_attitude(), np.diag([1.0, 1.0, 2.0]), _IDENTITY)
+
+
+def test_attitude_baseline_rejects_a_matrix_of_the_wrong_shape() -> None:
+    """A baseline built from a non-3x3 matrix is refused at construction."""
+    with pytest.raises(ValueError, match='expected a 3x3 matrix'):
+        _baseline(np.eye(4))
+
+
+def test_recorded_matrices_are_read_only() -> None:
+    """Recorded C-matrices cannot be mutated through the returned solution."""
+    solution = _build_pointing_solution(
+        _baseline(_some_attitude()), _fov(), offset_px=_PLANTED_OFFSET, rotation_fitted=False
+    )
+    assert solution.cmatrix is not None
+    with pytest.raises(ValueError, match='read-only'):
+        solution.cmatrix[0, 0] = 0.0
+
+
+def test_a_sub_pixel_offset_still_produces_a_real_correction() -> None:
+    """A small but genuine offset is corrected, not swallowed by the guard.
+
+    Pins the degenerate-axis threshold from below: raising it far enough to
+    absorb a real sub-pixel offset would silently record every such image as
+    needing no correction at all.
+    """
+    fov = _fov()
+    small = (0.05, -0.02)
+    correction = _oops_correction_matrix(fov, small)
+    assert not np.array_equal(correction, _IDENTITY)
+    recovered = _offset_from_correction(fov, correction)
+    assert recovered[0] == pytest.approx(small[0], abs=1e-9)
+    assert recovered[1] == pytest.approx(small[1], abs=1e-9)
+
+
+def _quarter_turn_about_z() -> np.ndarray:
+    """A 90-degree rotation about Z: a proper rotation that is not involutory."""
+    return np.array([[0.0, 1.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+
+
+def test_conjugation_direction_is_pinned_by_a_non_involutory_flip() -> None:
+    """The conjugation is ``R^T M R``, not ``R M R^T``.
+
+    Every flip in the instrument table is diagonal and therefore its own
+    inverse, so the two orders agree on real data and no real-frame test can
+    tell them apart.  A quarter turn about Z can.
+    """
+    fov = _fov()
+    flip = _quarter_turn_about_z()
+    original = _some_attitude()
+    solution = _build_pointing_solution(
+        _baseline(original, flip), fov, offset_px=_PLANTED_OFFSET, rotation_fitted=False
+    )
+    assert solution.cmatrix is not None
+    recovered = _offset_from_correction(
+        fov, (flip @ np.asarray(solution.cmatrix, np.float64)) @ (flip @ original).T
+    )
+    assert recovered[0] == pytest.approx(_PLANTED_OFFSET[0], abs=1e-9)
+    assert recovered[1] == pytest.approx(_PLANTED_OFFSET[1], abs=1e-9)
+
+
+def test_the_two_conjugation_orders_differ_under_a_non_involutory_flip() -> None:
+    """Guards the test above: the quarter turn really does tell them apart."""
+    flip = _quarter_turn_about_z()
+    correction = _oops_correction_matrix(_fov(), _PLANTED_OFFSET)
+    forward = flip.T @ correction @ flip
+    reversed_order = flip @ correction @ flip.T
+    assert float(np.max(np.abs(forward - reversed_order))) > 1e-6
+
+
+def test_a_nan_baseline_is_rejected() -> None:
+    """A NaN attitude is refused rather than serialized as an invalid JSON token."""
+    corrupted = _some_attitude()
+    corrupted[1, 1] = np.nan
+    with pytest.raises(ValueError, match='cmatrix_original holds a non-finite value'):
+        _build_pointing_solution(
+            _baseline(corrupted), _fov(), offset_px=_PLANTED_OFFSET, rotation_fitted=False
+        )
+
+
+def test_an_infinite_baseline_is_rejected() -> None:
+    """An infinite attitude entry is refused for the same reason."""
+    corrupted = _some_attitude()
+    corrupted[0, 2] = np.inf
+    with pytest.raises(ValueError, match='cmatrix_original holds a non-finite value'):
+        _build_pointing_solution(
+            _baseline(corrupted), _fov(), offset_px=None, rotation_fitted=False
+        )
+
+
+def test_a_nan_correction_is_rejected_by_the_result_check() -> None:
+    """A NaN reaching the corrected matrix is refused too."""
+    corrupted = np.eye(3) * np.nan
+    with pytest.raises(ValueError, match='cmatrix holds a non-finite value'):
+        _spice_cmatrix(_some_attitude(), corrupted, _IDENTITY)
+
+
+def _cassini_identity() -> _FrameIdentity:
+    """The Cassini NAC frame identity, for the flip-check tests."""
+    return _FrameIdentity(
+        camera_frame='CASSINI_ISS_NAC',
+        ck_frame_id=-82000,
+        oops_from_spice=_CASSINI_FLIP,
+        frozen_oops_attitude=False,
+    )
+
+
+def test_a_mismatched_flip_is_refused() -> None:
+    """A measured flip that is not the instrument's constant raises."""
+    with pytest.raises(ValueError, match='differs from the expected'):
+        _check_flip(_IDENTITY, _cassini_identity())
+
+
+def test_the_mismatched_flip_message_names_the_camera_frame() -> None:
+    """The refusal says which frame disagreed, so it is attributable."""
+    with pytest.raises(ValueError, match='CASSINI_ISS_NAC'):
+        _check_flip(_IDENTITY, _cassini_identity())
+
+
+def test_a_flip_within_tolerance_is_accepted() -> None:
+    """A flip differing by less than the tolerance is accepted silently."""
+    perturbed = _CASSINI_FLIP + np.full((3, 3), 1e-12)
+    assert _outcome_of(lambda: _check_flip(perturbed, _cassini_identity())) == 'accepted'
+
+
+def test_a_flip_just_outside_tolerance_is_refused() -> None:
+    """A flip differing by more than the tolerance raises."""
+    perturbed = _CASSINI_FLIP.copy()
+    perturbed[0, 1] = 1e-8
+    with pytest.raises(ValueError, match='differs from the expected'):
+        _check_flip(perturbed, _cassini_identity())
+
+
+def test_a_host_with_no_spice_camera_frame_records_nothing() -> None:
+    """An observation whose instrument has no frame mapping yields no solution.
+
+    A simulated image has no spacecraft and no furnished camera frame; it is
+    returned as "nothing to record" rather than raising, so a simulated
+    navigation runs unchanged.
+    """
+    unmapped = cast(ObsSnapshotInst, object())
+    assert compute_pointing(unmapped, offset_px=_PLANTED_OFFSET, rotation_fitted=False) is None
+
+
+def test_a_determinant_just_inside_tolerance_is_accepted() -> None:
+    """A matrix whose determinant is within the tolerance of 1 is accepted.
+
+    Pins the rotation tolerance from below.  Scaling a rotation by
+    ``1 + 1e-11`` moves its determinant by about ``3e-11``, comfortably
+    inside the documented ``1e-9``.
+    """
+    nearly = _some_attitude() * (1.0 + 1e-11)
+    assert _outcome_of(lambda: _validate_rotation(nearly, 'test matrix')) == 'accepted'
+
+
+def test_a_determinant_just_outside_tolerance_is_refused() -> None:
+    """A determinant further than the tolerance from 1 raises.
+
+    Pins the rotation tolerance from above.  Scaling by ``1 + 1e-8`` moves
+    the determinant by about ``3e-8``, an order of magnitude outside the
+    documented ``1e-9``, so widening the tolerance fails this test.
+    """
+    with pytest.raises(ValueError, match='is not a proper rotation'):
+        _validate_rotation(_some_attitude() * (1.0 + 1e-8), 'test matrix')
+
+
+def test_a_shear_just_inside_tolerance_is_accepted() -> None:
+    """A unit-determinant shear smaller than the tolerance is accepted.
+
+    A shear of ``s`` leaves the determinant exactly 1 and moves
+    ``max|C C^T - I|`` by about ``s``, so it exercises the orthonormality
+    bound alone.
+    """
+    sheared = np.array([[1.0, 1e-11, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+    assert _outcome_of(lambda: _validate_rotation(sheared, 'test matrix')) == 'accepted'
+
+
+def test_a_shear_just_outside_tolerance_is_refused() -> None:
+    """A unit-determinant shear larger than the tolerance raises."""
+    sheared = np.array([[1.0, 1e-8, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+    with pytest.raises(ValueError, match='is not orthonormal'):
+        _validate_rotation(sheared, 'test matrix')

--- a/tests/spindoctor/test_navigate_image_files.py
+++ b/tests/spindoctor/test_navigate_image_files.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+import pytest
 from filecache import FCPath
 from PIL import Image
 
@@ -42,7 +43,9 @@ from spindoctor.support.summary_png import (
 class _FakeSnapshot:
     """Minimal stand-in for ObsSnapshotInst used by the driver tests."""
 
-    def __init__(self, *, blank: bool = False, midtime: float = 100.0) -> None:
+    def __init__(
+        self, *, blank: bool = False, midtime: float = 100.0, shutter_mode: str | None = None
+    ) -> None:
         rng = np.random.default_rng(seed=99)
         if blank:
             self.data = np.zeros((32, 32), np.float64)
@@ -56,15 +59,34 @@ class _FakeSnapshot:
         self.midtime = midtime
         # Stands in for ObsInst.camera, written to observation.camera.
         self.camera = 'NAC'
+        # Stands in for ObsInst.shutter_mode, written to
+        # observation.shutter_mode when the host exposes one.
+        self.shutter_mode = shutter_mode
 
     def extfov_data_sensor_mask(self) -> np.ndarray:
         return self._sensor_mask
+
+
+@pytest.fixture(autouse=True)
+def _fakes_report_as_simulated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Report this module's fake observations as simulated.
+
+    ``obs_class_to_inst_name`` cannot identify a test fake and returns
+    ``'unknown'``, which the orchestrator treats as a build defect and
+    warns about.  These fakes stand in for an observation carrying no SPICE
+    camera frame, which is exactly what a simulated image is, so they report
+    that instead of shaping the production set around the test suite.
+    """
+    monkeypatch.setattr(
+        'spindoctor.nav_orchestrator.orchestrator.obs_class_to_inst_name', lambda cls: 'sim'
+    )
 
 
 def _make_fake_obs_class(
     *,
     blank: bool = False,
     raise_on_load: BaseException | None = None,
+    shutter_mode: str | None = None,
 ) -> type:
     """Build a fresh per-test ``obs_class`` shim with controllable behavior.
 
@@ -74,13 +96,14 @@ def _make_fake_obs_class(
     """
     captured_blank = blank
     captured_raise = raise_on_load
+    captured_shutter_mode = shutter_mode
 
     class _FakeObsClass:
         @classmethod
         def from_file(cls, path: Any, **kwargs: Any) -> _FakeSnapshot:
             if captured_raise is not None:
                 raise captured_raise
-            return _FakeSnapshot(blank=captured_blank)
+            return _FakeSnapshot(blank=captured_blank, shutter_mode=captured_shutter_mode)
 
     return _FakeObsClass
 
@@ -167,6 +190,32 @@ def test_navigate_image_files_records_camera(tmp_path: Path) -> None:
         write_output_files=False,
     )
     assert metadata['observation']['camera'] == 'NAC'
+
+
+def test_navigate_image_files_records_shutter_mode(tmp_path: Path) -> None:
+    """A host that exposes a shutter mode writes observation.shutter_mode."""
+    obs_class = _make_fake_obs_class(shutter_mode='BOTSIM')
+    image_files = _make_image_files(tmp_path)
+    _success, metadata = navigate_image_files(
+        obs_class,
+        image_files,
+        FCPath(str(tmp_path / 'results')),
+        write_output_files=False,
+    )
+    assert metadata['observation']['shutter_mode'] == 'BOTSIM'
+
+
+def test_navigate_image_files_omits_absent_shutter_mode(tmp_path: Path) -> None:
+    """A host that exposes no shutter mode leaves the field out entirely."""
+    obs_class = _make_fake_obs_class()
+    image_files = _make_image_files(tmp_path)
+    _success, metadata = navigate_image_files(
+        obs_class,
+        image_files,
+        FCPath(str(tmp_path / 'results')),
+        write_output_files=False,
+    )
+    assert 'shutter_mode' not in metadata['observation']
 
 
 def test_navigate_image_files_load_error_records_index_epoch_and_camera(tmp_path: Path) -> None:

--- a/tests/spindoctor/test_navigate_run_log.py
+++ b/tests/spindoctor/test_navigate_run_log.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 
 import numpy as np
 import pdslogger
+import pytest
 from filecache import FCPath
 
 from spindoctor.config import (
@@ -55,6 +56,21 @@ class _StubResult:
         self.confidence = confidence
         self.confidence_rank = confidence_rank
         self.status_reason = status_reason
+
+
+@pytest.fixture(autouse=True)
+def _fakes_report_as_simulated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Report this module's fake observations as simulated.
+
+    ``obs_class_to_inst_name`` cannot identify a test fake and returns
+    ``'unknown'``, which the orchestrator treats as a build defect and
+    warns about.  These fakes stand in for an observation carrying no SPICE
+    camera frame, which is exactly what a simulated image is, so they report
+    that instead of shaping the production set around the test suite.
+    """
+    monkeypatch.setattr(
+        'spindoctor.nav_orchestrator.orchestrator.obs_class_to_inst_name', lambda cls: 'sim'
+    )
 
 
 def _main_log_of(tmp_path: Path, report: Any) -> str:
@@ -166,6 +182,7 @@ class _FakeSnapshot:
         self.extdata = self.data
         self.midtime = 100.0
         self.camera = 'NAC'
+        self.shutter_mode: str | None = None
 
     def extfov_data_sensor_mask(self) -> np.ndarray:
         """Return the sensor mask.


### PR DESCRIPTION
## Purpose

Phase A of `plans/CK_KERNEL_PLAN.md`. Navigation measures where a camera was actually pointing, but that measurement has only ever left the pipeline as a pixel offset in a JSON file, which only SpinDoctor knows how to apply. This records the same measurement as a C-matrix as well, so that the later phases can write it into a SPICE C-kernel that loads into oops, ISIS or a plain `spiceypy` script with one `furnsh`. The pixel offset is untouched and every existing consumer of it keeps working.

Part of #188. Targets the integration branch `rf_ck_kernels`, not `main`.

## Changes

- `spindoctor/support/cmatrix.py` is the single entry point that converts a navigated offset into the corrected J2000-to-camera rotation. It records `cmatrix` and `cmatrix_original`, the SPICE frame identities, and the exposure and clock block. Nothing else computes an attitude, so when oops gains its own corrected-attitude API this module's body is replaced and its interface stays.
- The oops observation frame is not the SPICE camera frame. The constant flip `R` relating them is measured at runtime, checked against the constant expected for the instrument, and checked epoch-independent, so the correction is conjugated into the SPICE convention rather than composed in the wrong frame. Measured: `diag(-1,-1,+1)` for Cassini NAC and WAC, `diag(+1,-1,-1)` for LORRI, identity for Galileo SSI, all to within 2e-16 and identical at start, midtime and stop.
- Voyager takes its own path. oops freezes its observation frame from a tolerance-snapped pointing lookup, so `pxform` at the midtime does not resolve at all; the frozen attitude is the baseline and the flip is the identity by construction.
- `NavResult` gains an optional `pointing` field, stamped by `NavOrchestrator.navigate` and by the manual-navigation driver, and serialized by the curator under `navigation_result.pointing` and `navigation_result.times`. `observation.shutter_mode` is recorded so a consumer can tell that two Cassini frames were exposed simultaneously and therefore share one spacecraft attitude.
- A result carrying a fitted camera rotation records the uncorrected matrix but no corrected one. The fitted rotation turns about a per-technique pivot that nothing records, so the correction it implies is not expressible from the recorded data. Twist support is tracked by #434.

## Type of Change

- [x] New feature (non-breaking)
- [x] Documentation

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] New or updated tests for changed code
- [x] Tested manually (describe below if applicable)

Unit suite `5082 passed, 7 xfailed`. Phase A integration `32 passed`. `spindoctor/support/cmatrix.py` is at 100% statement and branch coverage across both tiers. `ruff check`, `ruff format --check`, `mypy src tests` and `sphinx-build -W` are all clean.

Every guarantee is pinned by mutation rather than by assertion alone: the source was deliberately broken thirteen ways and each break confirmed to fail a named test. Flipping the `xy_offset` sign, transposing the correction (the `rotate`-versus-`axisar` confusion), and reversing the composition order each fail ten integration tests; dropping the `R` conjugation fails six, which is the mathematically correct count because Galileo and Voyager have an identity flip that makes the conjugation a genuine no-op there. Measuring the flip in the wrong direction fails fourteen. Widening the degenerate-axis guard from 1e-12 to 1e-5, which would silently swallow every correction below about 1.7 NAC pixels, fails six. The determinant, orthonormality, finiteness, flip-constant and epoch-independence guards are each pinned two-sidedly, accepted just inside their tolerance and refused just outside it.

Manual verification: navigated a real Cassini NAC frame end to end and confirmed the written `_metadata.json` carries both matrices, `CASSINI_ISS_NAC` / `-82360` / CK object `-82000`, the full times block, and `observation.shutter_mode`, parsing under a strict JSON reader with no non-finite tokens.

## Potential Impacts

Additive only. The `offset` field and its consumers are unchanged, so backplanes, reprojection and mosaicing behave exactly as before. `NavResult` gains an optional field defaulting to `None`. `NavOrchestrator.with_pointing` is newly public because the manual-navigation driver builds its own `NavResult` and needs to stamp it. `NavOrchestrator.navigate` no longer absorbs every exception unconditionally: a defect in the attitude computation, meaning an `AttributeError` or `TypeError`, now propagates by design rather than silently disabling pointing across a whole batch, while the SPICE and value errors the computation can legitimately raise are absorbed, reported to both logs, and leave the field unset. No wrong C-matrix can be recorded.

## Checklist

- [x] Code follows project style (`ruff check`, `ruff format`)
- [x] Type annotations present and `mypy` passes
- [x] Docstrings and Sphinx docs updated (if applicable)
- [x] No temporary or debug code left in
- [x] Breaking changes flagged in Type of Change above

## Notes

Six deviations from the plan were found and are reconciled into `plans/CK_KERNEL_PLAN.md` in the same commit, as the plan's own execution protocol requires. All six are corrections of fact; no scope statement, acceptance bound or metadata field moved, and Sections 1, 2.3, 3.1, 3.2, 3.4, 3.5, 3.6 and all of Section 5 are byte-identical to `main`.

The two that matter downstream. First, the plan specified the correction angle as `arccos(d . b)`, which loses all relative precision as the angle goes to zero: at a 0.001 px offset on a Cassini NAC it returns exactly 0.0, because the cosine of 6e-9 radians rounds to 1.0 in float64, so every sub-pixel correction would have been silently dropped. The implementation uses `arctan2(|d x b|, d . b)`, which is the same angle wherever `arccos` has any precision left and exact where it does not. Second, the plan's error budget for the rotation-versus-shift difference was wrong in both its values and its scaling law. Measured over a 17x17 grid across each full frame at 50 px of total displacement: Cassini NAC 6.01e-9 rad, Cassini WAC 5.91e-6 rad, LORRI 1.62e-8 rad, Galileo SSI 1.82e-8 rad, Voyager 1.29e-8 rad. The residual is near-linear in the offset, with a measured ratio of about 2.04 per doubling, not quadratic as the plan stated; it is second order in field angle, which is a different variable that the plan conflated with the offset. Both are recorded with the convention they were measured under, because the plan's earlier figures were unusable without it.

That matters for Phase D, whose 0.1 px per-axis decision rule is deliberately untouched here. The WAC geometric term alone is 9.89e-2 px of total displacement at a 50 px offset, so it very nearly consumes the whole budget, and because the term is linear rather than quadratic, halving the cohort frame's offset only halves it. Reaching a comfortable fifth of budget needs an offset near 10 px total. Phase D chooses its cohort accordingly and reports its measured residuals rather than moving the bound.

Voyager's tick conversion is `sce2t`, not the `sce2c` the plan named; the plan now carries the measured evidence and Section 3.3 is updated to match. Two further cautions were found and recorded for the later phases rather than left in this description: a Voyager image navigated through the oops fallback frame reproduces only at an 80000-tick tolerance rather than `800 + exposure_s/48`, so the reproduction step must try both; and `cspyce.ckmeta` computes rather than validates, returning `-999` for a nonexistent object `-999999` without raising, so a wrong CK object id would silently yield a wrong spacecraft clock and therefore silently wrong time tags.

One item is on disk but outside version control. The "Adding a new instrument / dataset" checklist in `/seti/newnav/CLAUDE.md` gained a step naming the frame mapping in `support/cmatrix.py`, without which a fifth instrument would silently record no attitude for any of its images. `/seti/newnav` is not a git repository, so that edit is not in this commit and will not travel with the branch. It needs a tracked home if it should.

Follow-ups from Section 7 of the plan are filed as #433, #434, #435, #436 and #437. The consumer-side switch from the offset to the C-matrix is the remaining half of #50 and is gated on the Phase D round-trip evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation metadata now includes corrected pointing matrices, reference frames, exposure timing, and spacecraft-clock values when available.
  * Manual and automated navigation preserve corrected pointing results.
  * Observation metadata now records optional shutter modes, including Cassini ISS `BOTSIM`.
  * Voyager metadata now exposes and validates the spacecraft identifier.

* **Documentation**
  * Added guidance for pointing, timing, shutter-mode metadata, and camera-matrix support.
  * Expanded API documentation for camera-matrix utilities.

* **Tests**
  * Added broad coverage for pointing calculations, metadata serialization, frame handling, shutter modes, and spacecraft identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->