### PR TITLE
Validate the CK object's spacecraft clock

### DIFF
--- a/plans/CK_KERNEL_PLAN.md
+++ b/plans/CK_KERNEL_PLAN.md
@@ -342,14 +342,16 @@ unset -- no wrong C-matrix is ever recorded, which is the property the
 raises in section 2.2 exist to guarantee. Two constraints on how it
 absorbs:
 
-- The caught set is only what the computation can legitimately raise: its
-  own `ValueError` guards, plus the `LookupError` / `OSError` /
-  `RuntimeError` / `ValueError` family cspyce raises for a missing frame,
-  an unreadable kernel, or a SPICE error. A `TypeError` or `AttributeError`
-  from a defect in the computation itself is deliberately **not** caught,
-  so a broken build fails on the first image instead of quietly dropping
-  pointing from a 50,000-image batch while every image still reports
-  `status=success`.
+- The caught set is exactly `NavPointingError`, the typed exception in
+  `support/exceptions.py` that the computation raises for every failure it
+  expects: its own guards, and the frame, kernel and clock lookups SPICE
+  cannot answer, each converted at the call site with `raise ... from` so
+  the original traceback survives. Everything else propagates. Catching the
+  untyped `LookupError` / `OSError` / `RuntimeError` / `ValueError` family
+  instead would make a `ValueError` or `RuntimeError` from a defect inside
+  the computation indistinguishable from an expected SPICE failure, and
+  quietly drop pointing from a 50,000-image batch while every image still
+  reports `status=success`.
 - Anything that degrades or omits a solution goes to **both** logs: detail
   to the image log, one line to the run log. An operator watching a batch
   must not have to open every per-image log to learn that pointing stopped

--- a/plans/CK_KERNEL_PLAN.md
+++ b/plans/CK_KERNEL_PLAN.md
@@ -335,12 +335,14 @@ so it calls `with_pointing` itself. Operator-ratified offsets are the
 highest-quality pointing in the corpus; leaving them unstamped would make
 them the one subset excluded from every generated kernel.
 
-`with_pointing` never raises. `navigate` is documented never to raise
-through to its caller, and a pointing solution is recorded metadata rather
-than the navigation itself, so a failure is reported and the field is left
+`with_pointing` absorbs only `NavPointingError`; everything else
+propagates. A pointing solution is recorded metadata rather than the
+navigation itself, so an expected failure is reported and the field is left
 unset -- no wrong C-matrix is ever recorded, which is the property the
-raises in section 2.2 exist to guarantee. Two constraints on how it
-absorbs:
+raises in section 2.2 exist to guarantee. That absorption is the one
+qualification on `navigate`'s otherwise unconditional guarantee not to
+raise through to its caller: a defect beneath the attitude computation
+does reach the caller, deliberately. Two constraints on how it absorbs:
 
 - The caught set is exactly `NavPointingError`, the typed exception in
   `support/exceptions.py` that the computation raises for every failure it

--- a/src/spindoctor/nav_orchestrator/orchestrator.py
+++ b/src/spindoctor/nav_orchestrator/orchestrator.py
@@ -886,8 +886,8 @@ class NavOrchestrator(NavBase):
 
         A misbehaving NavTechnique is logged with a full traceback and
         treated as if it produced no result.  Catching every exception is
-        intentional for the same reason as ``_extract_features``: the
-        orchestrator never raises through to its caller, failures land on
+        intentional for the same reason as ``_extract_features``: no
+        image-data problem raises through to the caller, failures land on
         the returned ``NavResult``.  ``NavContractError`` is exempt (see
         ``_extract_features``): it is logged at error level and re-raised
         for :meth:`navigate` to convert into a failed ``NavResult``.

--- a/src/spindoctor/nav_orchestrator/orchestrator.py
+++ b/src/spindoctor/nav_orchestrator/orchestrator.py
@@ -441,6 +441,11 @@ class NavOrchestrator(NavBase):
         Returns:
             ``result`` with its ``pointing`` field populated, or ``result``
             unchanged when no attitude could be computed.
+
+        Raises:
+            Exception: Anything other than ``NavPointingError`` raised by the
+                attitude computation propagates unchanged, so that a defect
+                there surfaces instead of being absorbed.
         """
         instrument = obs_class_to_inst_name(type(obs))
         try:
@@ -885,12 +890,23 @@ class NavOrchestrator(NavBase):
         technique X run on image Y" from the log alone.
 
         A misbehaving NavTechnique is logged with a full traceback and
-        treated as if it produced no result.  Catching every exception is
-        intentional for the same reason as ``_extract_features``: no
-        image-data problem raises through to the caller, failures land on
-        the returned ``NavResult``.  ``NavContractError`` is exempt (see
-        ``_extract_features``): it is logged at error level and re-raised
-        for :meth:`navigate` to convert into a failed ``NavResult``.
+        omitted from the returned list, exactly as if it had produced no
+        result; the other techniques still contribute, so the navigation
+        can still succeed on their evidence.  Catching every exception is
+        intentional for the same reason as ``_extract_features``: one
+        technique's defect must not fail the image.  ``NavContractError``
+        is exempt (see ``_extract_features``): it is logged at error level
+        and re-raised for :meth:`navigate` to convert into a failed
+        ``NavResult``.
+
+        Returns:
+            One entry per technique that ran and produced a result, in
+            registry order.  A skipped, infeasible, or failed technique
+            contributes no entry, so the list may be empty.
+
+        Raises:
+            NavContractError: Propagated from a technique that violated an
+                internal invariant, for :meth:`navigate` to convert.
         """
         results: list[NavTechniqueResult] = []
         names = [

--- a/src/spindoctor/nav_orchestrator/orchestrator.py
+++ b/src/spindoctor/nav_orchestrator/orchestrator.py
@@ -64,7 +64,7 @@ from spindoctor.nav_technique.nav_technique import (
 from spindoctor.nav_technique.technique_result import NavTechniqueResult
 from spindoctor.obs import obs_class_to_inst_name
 from spindoctor.support.cmatrix import compute_pointing
-from spindoctor.support.exceptions import NavContractError
+from spindoctor.support.exceptions import NavContractError, NavPointingError
 from spindoctor.support.filters import NavFilterKind, NavFilterSpec, apply_filter
 from spindoctor.support.image_quality import cosmic_ray_mask, saturation_mask
 from spindoctor.support.nav_base import NavBase
@@ -426,13 +426,13 @@ class NavOrchestrator(NavBase):
         A pointing solution is recorded metadata rather than the navigation
         itself, so an attitude the environment cannot supply is reported to
         both logs and simply not recorded, and no wrong C-matrix ever
-        reaches a kernel.  The absorbed set is ``LookupError``, ``OSError``,
-        ``RuntimeError`` and ``ValueError`` -- the computation's own guards
-        plus what cspyce raises for a missing frame, an unreadable kernel or
-        a SPICE error.  Anything else, an ``AttributeError`` or
-        ``TypeError`` from a defect in the computation itself, propagates by
-        design, so a broken build fails on the first image rather than
-        silently dropping pointing from a whole batch.
+        reaches a kernel.  The absorbed set is exactly
+        ``NavPointingError``, which the computation raises for every failure
+        it expects: its own guards, and the kernel and frame lookups SPICE
+        cannot answer.  Every other exception propagates by design, so a
+        defect in the computation fails on the first image rather than
+        silently dropping pointing from a whole batch while every image
+        still reports success.
 
         Parameters:
             result: The result to stamp.
@@ -449,16 +449,17 @@ class NavOrchestrator(NavBase):
                 offset_px=result.offset_px,
                 rotation_fitted=result.rotation_rad is not None,
             )
-        except (LookupError, OSError, RuntimeError, ValueError) as exc:
-            # The exception set is exactly what the computation can legitimately
-            # raise: its own ValueError guards, and the LookupError / OSError /
-            # RuntimeError / ValueError family cspyce raises for a missing
-            # frame, an unreadable kernel or a SPICE error.  A TypeError or
-            # AttributeError from a defect in the computation itself is
-            # deliberately not caught, so a broken build fails loudly on the
-            # first image instead of quietly dropping pointing from a whole
-            # batch.
+        except NavPointingError as exc:
+            # NavPointingError names the failures the computation expects, so
+            # catching it and nothing else keeps a defect inside that
+            # computation distinguishable: it raises a plain ValueError or
+            # AttributeError, which propagates and fails the run on its first
+            # image instead of quietly dropping pointing from a whole batch
+            # while every image still reports success.
             self._logger.exception('Could not compute the corrected pointing: %s', exc)
+            # The traceback goes to the per-image log and one line to the run
+            # log, so an operator watching a batch sees one line per affected
+            # image rather than a traceback per image.
             MAIN_LOGGER.error(
                 'Corrected pointing not recorded for this %s image: %s', instrument, exc
             )

--- a/src/spindoctor/support/__init__.py
+++ b/src/spindoctor/support/__init__.py
@@ -31,6 +31,8 @@ Modules:
         Common mathematical constants (e.g. ``PI``, ``HALFPI``).
     ``exceptions``
         ``NavContractError`` — typed exception for internal contract violations.
+        ``NavPointingError`` names the failures the corrected-attitude computation
+        expects, so a caller can absorb exactly those.
     ``nav_base``
         ``NavBase``, a small base class wiring ``Config`` and ``PdsLogger`` for nav
         objects.

--- a/src/spindoctor/support/cmatrix.py
+++ b/src/spindoctor/support/cmatrix.py
@@ -62,6 +62,7 @@ from spindoctor.obs import (
     ObsSnapshotInst,
     ObsVoyagerISS,
 )
+from spindoctor.support.exceptions import NavPointingError
 from spindoctor.support.types import NDArrayFloatType
 
 # The offset-to-attitude conversion is deliberately behind one public
@@ -82,6 +83,22 @@ __all__ = [
 _CASSINI_CK_FRAME_ID = -82000
 _GALILEO_CK_FRAME_ID = -77001
 _LORRI_CK_FRAME_ID = -98000
+
+# The spacecraft clock each mission's time tags are encoded against.  It is
+# not derivable from the CK object id by arithmetic -- Python's -31100 // 1000
+# is -32, a different spacecraft, silently -- so each mission states its own
+# and the resolved value is checked against it.  Voyager's is derived per
+# spacecraft alongside its CK object.
+_CASSINI_SCLK_ID = -82
+_GALILEO_SCLK_ID = -77
+_LORRI_SCLK_ID = -98
+
+# What cspyce raises when the furnished kernels cannot answer: a missing frame
+# or an unresolvable clock arrives as a LookupError, an unreadable kernel as
+# an OSError, and a SPICE error as a RuntimeError or a ValueError.  Each is an
+# environment failure rather than a defect, so it is converted to a
+# NavPointingError at the call site that made it.
+_SPICE_FAILURES = (LookupError, OSError, RuntimeError, ValueError)
 
 _IDENTITY: NDArrayFloatType = np.eye(3)
 _IDENTITY.setflags(write=False)
@@ -117,6 +134,8 @@ class _FrameIdentity:
         camera_frame: SPICE name of the frame the observation's boresight is
             expressed in.
         ck_frame_id: SPICE id of the object a corrected C-kernel targets.
+        sclk_id: SPICE id of the spacecraft clock that object's time tags are
+            encoded against.
         oops_from_spice: The constant rotation ``R`` relating the oops
             observation frame to the SPICE camera frame.
         frozen_oops_attitude: True when oops freezes the observation frame
@@ -126,6 +145,7 @@ class _FrameIdentity:
 
     camera_frame: str
     ck_frame_id: int
+    sclk_id: int
     oops_from_spice: NDArrayFloatType
     frozen_oops_attitude: bool
 
@@ -201,11 +221,11 @@ def _as_readonly_3x3(matrix: NDArrayFloatType) -> NDArrayFloatType:
         A read-only float64 copy.
 
     Raises:
-        ValueError: if the input is not 3x3.
+        NavPointingError: if the input is not 3x3.
     """
     out = np.array(matrix, dtype=np.float64)
     if out.shape != (3, 3):
-        raise ValueError(f'expected a 3x3 matrix; got shape {out.shape}')
+        raise NavPointingError(f'expected a 3x3 matrix; got shape {out.shape}')
     out.setflags(write=False)
     return out
 
@@ -218,7 +238,7 @@ def _validate_rotation(matrix: NDArrayFloatType, label: str) -> None:
         label: Name used in the exception message.
 
     Raises:
-        ValueError: if the matrix holds a non-finite value, or if its
+        NavPointingError: if the matrix holds a non-finite value, or if its
             determinant differs from 1, or it is not orthonormal, by more than
             the tolerance.
     """
@@ -227,16 +247,16 @@ def _validate_rotation(matrix: NDArrayFloatType, label: str) -> None:
     # is written as a bare NaN / Infinity token that strict JSON parsers
     # reject.  Reject it here, where the defect is still attributable.
     if not bool(np.all(np.isfinite(matrix))):
-        raise ValueError(f'{label} holds a non-finite value: {np.asarray(matrix).tolist()!r}')
+        raise NavPointingError(f'{label} holds a non-finite value: {np.asarray(matrix).tolist()!r}')
     det = float(np.linalg.det(matrix))
     if abs(det - 1.0) > _ROTATION_TOL:
-        raise ValueError(
+        raise NavPointingError(
             f'{label} is not a proper rotation: determinant {det!r} differs from 1 by more '
             f'than {_ROTATION_TOL}'
         )
     residual = float(np.max(np.abs(matrix @ matrix.T - np.eye(3))))
     if residual > _ROTATION_TOL:
-        raise ValueError(
+        raise NavPointingError(
             f'{label} is not orthonormal: max|C C^T - I| = {residual!r} exceeds {_ROTATION_TOL}'
         )
 
@@ -315,8 +335,8 @@ def _spice_cmatrix(
         the identity, since no correction must mean no change.
 
     Raises:
-        ValueError: if ``cmatrix_original`` or the corrected result is not a
-            proper orthonormal rotation.
+        NavPointingError: if ``cmatrix_original`` or the corrected result is
+            not a proper orthonormal rotation.
     """
     original = np.asarray(cmatrix_original, dtype=np.float64)
     _validate_rotation(original, 'cmatrix_original')
@@ -357,8 +377,8 @@ def _build_pointing_solution(
         supplied with no fitted rotation.
 
     Raises:
-        ValueError: if the baseline or the corrected matrix is not a proper
-            orthonormal rotation.
+        NavPointingError: if the baseline or the corrected matrix is not a
+            proper orthonormal rotation.
     """
     if offset_px is None or rotation_fitted:
         _validate_rotation(np.asarray(baseline.cmatrix_original, np.float64), 'cmatrix_original')
@@ -383,6 +403,11 @@ def compute_pointing(
     both attitudes in the SPICE convention along with the frame identities and
     the exposure times a C-kernel writer needs.
 
+    Every expected failure is reported as a ``NavPointingError``, so a caller
+    that must survive an attitude the environment cannot supply absorbs that
+    one exception and nothing else: any other exception escaping this function
+    is a defect in it.
+
     Parameters:
         obs: The navigated observation.
         offset_px: The navigated ``(dv, du)`` offset, or ``None``.
@@ -394,10 +419,13 @@ def compute_pointing(
         whose SPICE frames this module knows (a simulated image, for example).
 
     Raises:
-        ValueError: if the measured flip between the oops and SPICE frames
-            differs from the constant expected for the instrument, varies
-            across the exposure, or if either C-matrix is not a proper
-            orthonormal rotation.
+        NavPointingError: if the furnished kernels cannot supply the attitude,
+            the camera frame or the spacecraft clock; if the resolved
+            spacecraft clock is not the one expected for the mission; if the
+            measured flip between the oops and SPICE frames differs from the
+            constant expected for the instrument or varies across the
+            exposure; or if either C-matrix is not a proper orthonormal
+            rotation.
     """
     identity = _frame_identity(obs)
     if identity is None:
@@ -422,6 +450,7 @@ def _frame_identity(obs: ObsSnapshotInst) -> _FrameIdentity | None:
         return _FrameIdentity(
             camera_frame=f'CASSINI_ISS_{obs.camera}',
             ck_frame_id=_CASSINI_CK_FRAME_ID,
+            sclk_id=_CASSINI_SCLK_ID,
             oops_from_spice=_CASSINI_OOPS_FROM_SPICE,
             frozen_oops_attitude=False,
         )
@@ -429,6 +458,7 @@ def _frame_identity(obs: ObsSnapshotInst) -> _FrameIdentity | None:
         return _FrameIdentity(
             camera_frame='GLL_SCAN_PLATFORM',
             ck_frame_id=_GALILEO_CK_FRAME_ID,
+            sclk_id=_GALILEO_SCLK_ID,
             oops_from_spice=_IDENTITY,
             frozen_oops_attitude=False,
         )
@@ -436,17 +466,21 @@ def _frame_identity(obs: ObsSnapshotInst) -> _FrameIdentity | None:
         return _FrameIdentity(
             camera_frame='NH_LORRI',
             ck_frame_id=_LORRI_CK_FRAME_ID,
+            sclk_id=_LORRI_SCLK_ID,
             oops_from_spice=_LORRI_OOPS_FROM_SPICE,
             frozen_oops_attitude=False,
         )
     if isinstance(obs, ObsVoyagerISS):
         digit = obs.spacecraft_digit
+        # One instrument key serves two spacecraft, so the CK object and the
+        # spacecraft clock are both derived from which spacecraft this is.
         spacecraft_id = -(30 + int(digit))
         # The Voyager FK spells the cameras ISSNA and ISSWA, so the oops
         # detector names NAC and WAC contribute only their first letter.
         return _FrameIdentity(
             camera_frame=f'VG{digit}_ISS{obs.camera[0]}A',
             ck_frame_id=spacecraft_id * 1000 - 100,
+            sclk_id=spacecraft_id,
             oops_from_spice=_IDENTITY,
             frozen_oops_attitude=True,
         )
@@ -462,8 +496,17 @@ def _observation_attitude(obs: ObsSnapshotInst, et: float) -> NDArrayFloatType:
 
     Returns:
         The 3x3 rotation in the oops observation frame convention.
+
+    Raises:
+        NavPointingError: if the furnished kernels cannot place the frame at
+            this epoch.
     """
-    transform = obs.frame.wrt(oops.frame.Frame.J2000).transform_at_time(et)
+    try:
+        transform = obs.frame.wrt(oops.frame.Frame.J2000).transform_at_time(et)
+    except _SPICE_FAILURES as exc:
+        raise NavPointingError(
+            f'the observation frame has no attitude at et {et!r}: {exc}'
+        ) from exc
     return np.asarray(transform.matrix.vals, dtype=np.float64).reshape(3, 3)
 
 
@@ -478,9 +521,12 @@ def _attitude_baseline(obs: ObsSnapshotInst, identity: _FrameIdentity) -> Attitu
         The observation's AttitudeBaseline.
 
     Raises:
-        ValueError: if the measured flip between the oops observation frame
-            and the SPICE camera frame differs from the instrument's expected
-            constant or varies across the exposure.
+        NavPointingError: if the furnished kernels cannot supply the attitude,
+            the camera frame id or the clock strings; if the resolved
+            spacecraft clock is not the instrument's; or if the measured flip
+            between the oops observation frame and the SPICE camera frame
+            differs from the instrument's expected constant or varies across
+            the exposure.
     """
     start_et = float(obs.time[0])
     stop_et = float(obs.time[1])
@@ -498,27 +544,103 @@ def _attitude_baseline(obs: ObsSnapshotInst, identity: _FrameIdentity) -> Attitu
         for et in (start_et, stop_et):
             at_epoch = _observation_attitude(obs, et) @ _pxform(identity.camera_frame, et).T
             if not np.allclose(at_epoch, oops_from_spice, rtol=0.0, atol=_FLIP_TOL):
-                raise ValueError(
+                raise NavPointingError(
                     f'the rotation between the oops and SPICE {identity.camera_frame} frames '
                     f'is not constant across the exposure: it differs by up to '
                     f'{float(np.max(np.abs(at_epoch - oops_from_spice)))!r} between et {et!r} '
                     f'and the midtime {midtime_et!r}'
                 )
-    sclk_id = int(cspyce.ckmeta(identity.ck_frame_id, 'SCLK'))
+    sclk_id = _sclk_id(identity)
     return AttitudeBaseline(
         cmatrix_original=cmatrix_original,
         oops_from_spice=oops_from_spice,
         camera_frame=identity.camera_frame,
-        camera_frame_id=int(cspyce.namfrm(identity.camera_frame)),
+        camera_frame_id=_camera_frame_id(identity.camera_frame),
         ck_frame_id=identity.ck_frame_id,
         start_et=start_et,
         stop_et=stop_et,
         midtime_et=midtime_et,
         exposure_s=float(obs.texp),
-        sclk_start=str(cspyce.sce2s(sclk_id, start_et)),
-        sclk_midtime=str(cspyce.sce2s(sclk_id, midtime_et)),
-        sclk_stop=str(cspyce.sce2s(sclk_id, stop_et)),
+        sclk_start=_sclk_string(sclk_id, start_et),
+        sclk_midtime=_sclk_string(sclk_id, midtime_et),
+        sclk_stop=_sclk_string(sclk_id, stop_et),
     )
+
+
+def _sclk_id(identity: _FrameIdentity) -> int:
+    """Resolve the spacecraft clock for a CK object and check it is the right one.
+
+    ``cspyce.ckmeta`` computes a clock id from a CK object id rather than
+    validating it: it answers ``-999`` for the nonexistent object ``-999999``
+    and ``-12`` for ``-12345``, raising for neither.  A CK object that is
+    wrong for any reason therefore yields a plausible clock id, and every
+    clock string built from it encodes the wrong spacecraft's time while
+    ``sce2s`` reports success.  The resolved id is checked against the one the
+    mission actually uses before any clock string is built.
+
+    Parameters:
+        identity: The instrument's frame facts, carrying both the CK object
+            and the spacecraft clock expected for it.
+
+    Returns:
+        The resolved spacecraft clock id, equal to ``identity.sclk_id``.
+
+    Raises:
+        NavPointingError: if no clock resolves for the CK object, or if the
+            one that resolves is not the instrument's.
+    """
+    try:
+        resolved = int(cspyce.ckmeta(identity.ck_frame_id, 'SCLK'))
+    except _SPICE_FAILURES as exc:
+        raise NavPointingError(
+            f'no spacecraft clock resolves for CK object {identity.ck_frame_id}: {exc}'
+        ) from exc
+    if resolved != identity.sclk_id:
+        raise NavPointingError(
+            f'CK object {identity.ck_frame_id} resolves to spacecraft clock {resolved}, not the '
+            f'{identity.sclk_id} the {identity.camera_frame} camera is tagged against; every '
+            f'clock string built from it would encode the wrong spacecraft'
+        )
+    return resolved
+
+
+def _sclk_string(sclk_id: int, et: float) -> str:
+    """Encode one epoch as a spacecraft clock string.
+
+    Parameters:
+        sclk_id: SPICE id of the spacecraft clock.
+        et: TDB seconds past J2000.
+
+    Returns:
+        The clock string ``sce2s`` produces for that epoch.
+
+    Raises:
+        NavPointingError: if the furnished kernels cannot encode the epoch.
+    """
+    try:
+        return str(cspyce.sce2s(sclk_id, et))
+    except _SPICE_FAILURES as exc:
+        raise NavPointingError(
+            f'spacecraft clock {sclk_id} cannot encode et {et!r}: {exc}'
+        ) from exc
+
+
+def _camera_frame_id(camera_frame: str) -> int:
+    """Look up the SPICE id of a named frame.
+
+    Parameters:
+        camera_frame: SPICE name of the camera frame.
+
+    Returns:
+        The frame's SPICE id.
+
+    Raises:
+        NavPointingError: if the name resolves to no id in the kernel pool.
+    """
+    try:
+        return int(cspyce.namfrm(camera_frame))
+    except _SPICE_FAILURES as exc:
+        raise NavPointingError(f'the frame {camera_frame} has no SPICE id: {exc}') from exc
 
 
 def _pxform(camera_frame: str, et: float) -> NDArrayFloatType:
@@ -530,8 +652,19 @@ def _pxform(camera_frame: str, et: float) -> NDArrayFloatType:
 
     Returns:
         The 3x3 rotation ``pxform('J2000', camera_frame, et)`` as float64.
+
+    Raises:
+        NavPointingError: if the furnished kernels cannot supply the rotation
+            at this epoch.
     """
-    return np.asarray(cspyce.pxform('J2000', camera_frame, et), dtype=np.float64)
+    try:
+        matrix = cspyce.pxform('J2000', camera_frame, et)
+    except _SPICE_FAILURES as exc:
+        raise NavPointingError(
+            f'the furnished kernels cannot supply the J2000 to {camera_frame} rotation at '
+            f'et {et!r}: {exc}'
+        ) from exc
+    return np.asarray(matrix, dtype=np.float64)
 
 
 def _check_flip(measured: NDArrayFloatType, identity: _FrameIdentity) -> None:
@@ -542,11 +675,11 @@ def _check_flip(measured: NDArrayFloatType, identity: _FrameIdentity) -> None:
         identity: The instrument's frame facts, carrying the expected ``R``.
 
     Raises:
-        ValueError: if the two differ by more than ``_FLIP_TOL``.
+        NavPointingError: if the two differ by more than ``_FLIP_TOL``.
     """
     expected = np.asarray(identity.oops_from_spice, dtype=np.float64)
     if not np.allclose(measured, expected, rtol=0.0, atol=_FLIP_TOL):
-        raise ValueError(
+        raise NavPointingError(
             f'the rotation between the oops observation frame and the SPICE '
             f'{identity.camera_frame} frame is {measured.tolist()!r}, which differs from the '
             f'expected {expected.tolist()!r} by up to '

--- a/src/spindoctor/support/exceptions.py
+++ b/src/spindoctor/support/exceptions.py
@@ -7,9 +7,14 @@ ordinary technique failure.  Raising :class:`NavContractError` instead
 keeps the check active in optimized runs and lets the orchestrator treat
 the violation distinctly (error-level log plus a failed ``NavResult``
 with ``NavStatusReason.CONTRACT_VIOLATION``).
+
+:class:`NavPointingError` serves the mirror-image purpose: it names the
+failures the corrected-attitude computation can legitimately hit, so the
+one caller that must survive them absorbs exactly those and everything
+else -- a programming defect -- keeps propagating.
 """
 
-__all__ = ['NavContractError']
+__all__ = ['NavContractError', 'NavPointingError']
 
 
 class NavContractError(Exception):
@@ -23,4 +28,18 @@ class NavContractError(Exception):
     log it at error level and re-raise, and ``NavOrchestrator.navigate``
     converts it into a failed ``NavResult`` with
     ``NavStatusReason.CONTRACT_VIOLATION``.
+    """
+
+
+class NavPointingError(Exception):
+    """A navigated image's corrected attitude could not be computed.
+
+    Raised for the failures that computation expects: an attitude the
+    furnished kernels cannot supply, a frame or spacecraft clock that does
+    not resolve, a spacecraft clock that is not the mission's, and the
+    computation's own guards refusing a matrix that is not a proper
+    rotation.  It is the only exception ``NavOrchestrator.with_pointing``
+    absorbs, so a pointing solution the environment cannot supply is
+    reported and left unrecorded while a programming defect inside the
+    computation propagates and fails the run on its first image.
     """

--- a/tests/cmatrix_helpers.py
+++ b/tests/cmatrix_helpers.py
@@ -1,0 +1,56 @@
+"""Independent inverse helpers shared by the C-matrix tests.
+
+The hermetic and the real-frame C-matrix tests both check the recorded
+attitude by recovering the planted offset back out of it.  The recovery is
+written from the offset model itself, using only oops FOV primitives, and
+imports nothing from the forward path under test: that independence is what
+lets it catch a sign, conjugation or composition error.  A helper that
+called the implementation would agree with it whatever it did.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import oops
+
+from spindoctor.obs import ObsSnapshotInst
+
+
+def offset_from_correction(fov: oops.fov.FOV, correction: np.ndarray) -> tuple[float, float]:
+    """Recover the ``(dv, du)`` offset an oops-frame correction rotation encodes.
+
+    Maps the corrected boresight direction back through the rotation, reads
+    off the tangent-plane point that direction came from, and converts the
+    implied ``xy_offset`` back into pixels.
+
+    Parameters:
+        fov: The observation's unmodified oops FOV.
+        correction: The 3x3 correction rotation in oops observation frame
+            coordinates.
+
+    Returns:
+        The ``(dv, du)`` offset in pixels that produces this correction.
+    """
+    xy_los = fov.xy_from_uv(fov.uv_los)
+    corrected = np.asarray(fov.los_from_xy(xy_los).unit().vals, np.float64)
+    uncorrected = np.asarray(correction, np.float64).T @ corrected
+    xy_uncorrected = oops.Pair((uncorrected[0] / uncorrected[2], uncorrected[1] / uncorrected[2]))
+    uv = fov.uv_from_xy(xy_los - xy_uncorrected)
+    return (
+        float(uv.vals[1] - fov.uv_los.vals[1]),
+        float(uv.vals[0] - fov.uv_los.vals[0]),
+    )
+
+
+def observation_attitude(obs: ObsSnapshotInst, et: float) -> np.ndarray:
+    """Read the oops observation frame's J2000-to-frame rotation at one epoch.
+
+    Parameters:
+        obs: The observation whose frame is evaluated.
+        et: TDB seconds past J2000.
+
+    Returns:
+        The 3x3 rotation in the oops observation frame convention.
+    """
+    transform = obs.frame.wrt(oops.frame.Frame.J2000).transform_at_time(et)
+    return np.asarray(transform.matrix.vals, np.float64).reshape(3, 3)

--- a/tests/integration/test_cmatrix_frames.py
+++ b/tests/integration/test_cmatrix_frames.py
@@ -32,7 +32,6 @@ if 'PDS3_HOLDINGS_DIR' not in os.environ:
     )
 
 import cspyce  # noqa: E402  (guarded import)
-import oops  # noqa: E402  (guarded import)
 
 from spindoctor.obs import (  # noqa: E402
     ObsCassiniISS,
@@ -45,6 +44,10 @@ from spindoctor.support.cmatrix import (  # noqa: E402
     _attitude_baseline,
     _FrameIdentity,
     compute_pointing,
+)
+from tests.cmatrix_helpers import (  # noqa: E402  (guarded import)
+    observation_attitude,
+    offset_from_correction,
 )
 
 _CASSINI_NAC = 'calibrated/COISS_2xxx/COISS_2038/data/1572094226_1572114418/N1572105349_1_CALIB.IMG'
@@ -87,38 +90,11 @@ def _load(obs_class: type[ObsSnapshotInst], relative: str) -> ObsSnapshotInst:
     return cast(ObsSnapshotInst, obs_class.from_file(_url(relative)))
 
 
-def _observation_attitude(obs: ObsSnapshotInst, et: float) -> np.ndarray:
-    """Read the oops observation frame's J2000-to-frame rotation at one epoch."""
-    transform = obs.frame.wrt(oops.frame.Frame.J2000).transform_at_time(et)
-    return np.asarray(transform.matrix.vals, np.float64).reshape(3, 3)
-
-
 def _measured_flip(obs: ObsSnapshotInst, camera_frame: str, et: float) -> np.ndarray:
     """Measure ``R = C_oops . C_spice^T`` directly from SPICE at one epoch."""
     spice = np.asarray(cspyce.pxform('J2000', camera_frame, et), np.float64)
-    flip: np.ndarray = _observation_attitude(obs, et) @ spice.T
+    flip: np.ndarray = observation_attitude(obs, et) @ spice.T
     return flip
-
-
-def _offset_from_correction(fov: oops.fov.FOV, correction: np.ndarray) -> tuple[float, float]:
-    """Recover the ``(dv, du)`` offset an oops-frame correction rotation encodes.
-
-    The independent inverse of the production forward model: it maps the
-    corrected boresight direction back through the rotation, reads off the
-    tangent-plane point that direction came from, and converts the implied
-    ``xy_offset`` back into pixels.  Derived from the offset model rather than
-    from the forward code, so it does not reproduce a sign error the forward
-    code might contain.
-    """
-    xy_los = fov.xy_from_uv(fov.uv_los)
-    corrected = np.asarray(fov.los_from_xy(xy_los).unit().vals, np.float64)
-    uncorrected = np.asarray(correction, np.float64).T @ corrected
-    xy_uncorrected = oops.Pair((uncorrected[0] / uncorrected[2], uncorrected[1] / uncorrected[2]))
-    uv = fov.uv_from_xy(xy_los - xy_uncorrected)
-    return (
-        float(uv.vals[1] - fov.uv_los.vals[1]),
-        float(uv.vals[0] - fov.uv_los.vals[0]),
-    )
 
 
 def _rotation_about_z(angle_rad: float) -> np.ndarray:
@@ -236,7 +212,7 @@ def test_voyager_records_the_frozen_oops_attitude() -> None:
     obs = _load(ObsVoyagerISS, _VOYAGER_NAC)
     solution = compute_pointing(obs, offset_px=_OFFSET, rotation_fitted=False)
     assert solution is not None
-    frozen = _observation_attitude(obs, float(obs.midtime))
+    frozen = observation_attitude(obs, float(obs.midtime))
     recorded = np.asarray(solution.baseline.cmatrix_original, np.float64)
     assert float(np.max(np.abs(recorded - frozen))) == 0.0
 
@@ -347,7 +323,7 @@ def test_recorded_cmatrix_recovers_the_planted_offset(
     flip = np.asarray(solution.baseline.oops_from_spice, np.float64)
     corrected_oops = flip @ np.asarray(solution.cmatrix, np.float64)
     original_oops = flip @ np.asarray(solution.baseline.cmatrix_original, np.float64)
-    recovered = _offset_from_correction(obs.fov, corrected_oops @ original_oops.T)
+    recovered = offset_from_correction(obs.fov, corrected_oops @ original_oops.T)
     assert recovered[0] == pytest.approx(_OFFSET[0], abs=_RECOVERY_TOL_PX)
     assert recovered[1] == pytest.approx(_OFFSET[1], abs=_RECOVERY_TOL_PX)
 
@@ -379,7 +355,7 @@ def test_recorded_cmatrix_recovers_a_sub_pixel_offset(
     flip = np.asarray(solution.baseline.oops_from_spice, np.float64)
     corrected_oops = flip @ np.asarray(solution.cmatrix, np.float64)
     original_oops = flip @ np.asarray(solution.baseline.cmatrix_original, np.float64)
-    recovered = _offset_from_correction(obs.fov, corrected_oops @ original_oops.T)
+    recovered = offset_from_correction(obs.fov, corrected_oops @ original_oops.T)
     assert recovered[0] == pytest.approx(_SMALL_OFFSET[0], abs=_RECOVERY_TOL_PX)
     assert recovered[1] == pytest.approx(_SMALL_OFFSET[1], abs=_RECOVERY_TOL_PX)
 

--- a/tests/integration/test_cmatrix_frames.py
+++ b/tests/integration/test_cmatrix_frames.py
@@ -42,9 +42,12 @@ from spindoctor.obs import (  # noqa: E402
 )
 from spindoctor.support.cmatrix import (  # noqa: E402
     _attitude_baseline,
+    _frame_identity,
     _FrameIdentity,
+    _sclk_id,
     compute_pointing,
 )
+from spindoctor.support.exceptions import NavPointingError  # noqa: E402  (guarded import)
 from tests.cmatrix_helpers import (  # noqa: E402  (guarded import)
     observation_attitude,
     offset_from_correction,
@@ -108,6 +111,7 @@ def _cassini_nac_identity() -> _FrameIdentity:
     return _FrameIdentity(
         camera_frame='CASSINI_ISS_NAC',
         ck_frame_id=-82000,
+        sclk_id=-82,
         oops_from_spice=_CASSINI_FLIP_ARRAY,
         frozen_oops_attitude=False,
     )
@@ -295,6 +299,33 @@ def test_recorded_clock_strings_are_distinct_and_ordered(
 
 
 @pytest.mark.parametrize(
+    ('obs_class', 'relative', 'sclk_id'),
+    [
+        (ObsCassiniISS, _CASSINI_NAC, -82),
+        (ObsNewHorizonsLORRI, _LORRI, -98),
+        (ObsGalileoSSI, _GALILEO_SSI, -77),
+        (ObsVoyagerISS, _VOYAGER_NAC, -32),
+    ],
+    ids=['cassini_nac', 'lorri', 'galileo_ssi', 'voyager_nac'],
+)
+def test_the_recorded_ck_object_resolves_to_the_missions_clock(
+    obs_class: type[ObsSnapshotInst], relative: str, sclk_id: int
+) -> None:
+    """Each mission's CK object resolves to the spacecraft clock it expects.
+
+    ``ckmeta`` computes a clock id from a CK object id instead of validating
+    it, so a wrong CK object would yield a plausible clock and clock strings
+    encoding another spacecraft's time.  This pins the pair per mission
+    against what SPICE actually resolves.
+    """
+    obs = _load(obs_class, relative)
+    identity = _frame_identity(obs)
+    assert identity is not None
+    assert identity.sclk_id == sclk_id
+    assert _sclk_id(identity) == sclk_id
+
+
+@pytest.mark.parametrize(
     ('obs_class', 'relative'),
     [
         (ObsCassiniISS, _CASSINI_NAC),
@@ -379,7 +410,7 @@ def test_epoch_varying_flip_is_refused() -> None:
         return product
 
     stub = cast(ObsSnapshotInst, _StubObs(attitude, obs))
-    with pytest.raises(ValueError, match='is not constant across the exposure'):
+    with pytest.raises(NavPointingError, match='is not constant across the exposure'):
         _attitude_baseline(stub, _cassini_nac_identity())
 
 
@@ -397,5 +428,5 @@ def test_a_wrong_flip_measured_from_the_frame_is_refused() -> None:
         return spice
 
     stub = cast(ObsSnapshotInst, _StubObs(attitude, obs))
-    with pytest.raises(ValueError, match='differs from the expected'):
+    with pytest.raises(NavPointingError, match='differs from the expected'):
         _attitude_baseline(stub, _cassini_nac_identity())

--- a/tests/spindoctor/nav_orchestrator/test_orchestrator.py
+++ b/tests/spindoctor/nav_orchestrator/test_orchestrator.py
@@ -33,7 +33,7 @@ from spindoctor.nav_technique.feasibility import NavFeasibilityReport
 from spindoctor.nav_technique.nav_technique import NavTechnique
 from spindoctor.nav_technique.technique_result import NavTechniqueResult
 from spindoctor.support.cmatrix import AttitudeBaseline, PointingSolution
-from spindoctor.support.exceptions import NavContractError
+from spindoctor.support.exceptions import NavContractError, NavPointingError
 from spindoctor.support.filters import NavFilterKind, NavFilterSpec
 from spindoctor.support.status_reason import NavStatusReason
 
@@ -1360,7 +1360,7 @@ def test_orchestrator_reports_but_survives_a_failed_pointing_computation(
     """A pointing computation that raises is logged and leaves the result usable."""
 
     def _boom(obs: Any, *, offset_px: Any, rotation_fitted: bool) -> None:
-        raise ValueError('cmatrix is not a proper rotation')
+        raise NavPointingError('cmatrix is not a proper rotation')
 
     monkeypatch.setattr('spindoctor.nav_orchestrator.orchestrator.compute_pointing', _boom)
     obs = fake_obs
@@ -1382,7 +1382,7 @@ def test_orchestrator_reports_a_failed_pointing_to_the_run_log(
     """
 
     def _boom(obs: Any, *, offset_px: Any, rotation_fitted: bool) -> None:
-        raise RuntimeError('SPICE(NOFRAMECONNECT)')
+        raise NavPointingError('the furnished kernels cannot supply the rotation')
 
     monkeypatch.setattr('spindoctor.nav_orchestrator.orchestrator.compute_pointing', _boom)
     obs = fake_obs
@@ -1409,6 +1409,35 @@ def test_orchestrator_does_not_swallow_a_defect_in_the_pointing_computation(
     model = _FakeStarModel(obs, feature_count=3)
     orch = NavOrchestrator([model], only_techniques=['_FakeStarTechnique'])
     with pytest.raises(AttributeError, match='has no attribute'):
+        orch.navigate(obs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    'defect',
+    [ValueError, RuntimeError, LookupError, OSError],
+    ids=['value_error', 'runtime_error', 'lookup_error', 'os_error'],
+)
+def test_orchestrator_does_not_swallow_an_ordinary_exception_from_the_pointing_computation(
+    fake_obs: _FakeObs, monkeypatch: pytest.MonkeyPatch, defect: type[Exception]
+) -> None:
+    """Only the computation's own typed failure is absorbed.
+
+    A defect inside the computation raises an ordinary exception type, and
+    the types SPICE failures arrive as are the same ones ordinary defects
+    raise.  Absorbing that family would make the two indistinguishable and
+    drop pointing from a whole batch while every image reported success, so
+    the computation reports what it expects as a ``NavPointingError`` and
+    everything else propagates.
+    """
+
+    def _defective(obs: Any, *, offset_px: Any, rotation_fitted: bool) -> None:
+        raise defect('index 3 is out of bounds for axis 0 with size 3')
+
+    monkeypatch.setattr('spindoctor.nav_orchestrator.orchestrator.compute_pointing', _defective)
+    obs = fake_obs
+    model = _FakeStarModel(obs, feature_count=3)
+    orch = NavOrchestrator([model], only_techniques=['_FakeStarTechnique'])
+    with pytest.raises(defect, match='out of bounds'):
         orch.navigate(obs)  # type: ignore[arg-type]
 
 

--- a/tests/spindoctor/support/test_cmatrix.py
+++ b/tests/spindoctor/support/test_cmatrix.py
@@ -17,6 +17,7 @@ from typing import cast
 import numpy as np
 import oops
 import pytest
+from tests.cmatrix_helpers import offset_from_correction
 
 from spindoctor.obs import ObsSnapshotInst
 from spindoctor.support.cmatrix import (
@@ -101,27 +102,6 @@ def _baseline(
     )
 
 
-def _offset_from_correction(fov: oops.fov.FOV, correction: np.ndarray) -> tuple[float, float]:
-    """Recover the ``(dv, du)`` offset a correction rotation encodes.
-
-    The independent inverse of :func:`_oops_correction_matrix`: it maps the
-    corrected boresight direction back through the rotation, reads off the
-    tangent-plane point that direction came from, and converts the implied
-    ``xy_offset`` back into pixels.  Written from the offset model rather
-    than from the forward implementation, so it does not reproduce a sign
-    error the forward code might contain.
-    """
-    xy_los = fov.xy_from_uv(fov.uv_los)
-    corrected = np.asarray(fov.los_from_xy(xy_los).unit().vals, np.float64)
-    uncorrected = np.asarray(correction, np.float64).T @ corrected
-    xy_uncorrected = oops.Pair((uncorrected[0] / uncorrected[2], uncorrected[1] / uncorrected[2]))
-    uv = fov.uv_from_xy(xy_los - xy_uncorrected)
-    return (
-        float(uv.vals[1] - fov.uv_los.vals[1]),
-        float(uv.vals[0] - fov.uv_los.vals[0]),
-    )
-
-
 def test_correction_maps_the_uncorrected_boresight_onto_the_corrected_one() -> None:
     """``M . d`` is the direction the unmodified FOV assigns to the boresight."""
     fov = _fov()
@@ -156,7 +136,7 @@ def test_planted_offset_is_recovered_from_the_recorded_cmatrix() -> None:
     )
     assert solution.cmatrix is not None
     correction = np.asarray(solution.cmatrix, np.float64) @ original.T
-    recovered = _offset_from_correction(fov, correction)
+    recovered = offset_from_correction(fov, correction)
     assert recovered[0] == pytest.approx(_PLANTED_OFFSET[0], abs=1e-9)
     assert recovered[1] == pytest.approx(_PLANTED_OFFSET[1], abs=1e-9)
 
@@ -193,7 +173,7 @@ def test_cassini_style_flip_reproduces_the_offset_in_the_spice_convention() -> N
     assert solution.cmatrix is not None
     corrected_oops = _CASSINI_FLIP @ np.asarray(solution.cmatrix, np.float64)
     original_oops = _CASSINI_FLIP @ original
-    recovered = _offset_from_correction(fov, corrected_oops @ original_oops.T)
+    recovered = offset_from_correction(fov, corrected_oops @ original_oops.T)
     assert recovered[0] == pytest.approx(_PLANTED_OFFSET[0], abs=1e-9)
     assert recovered[1] == pytest.approx(_PLANTED_OFFSET[1], abs=1e-9)
 
@@ -294,7 +274,7 @@ def test_a_sub_pixel_offset_still_produces_a_real_correction() -> None:
     small = (0.05, -0.02)
     correction = _oops_correction_matrix(fov, small)
     assert not np.array_equal(correction, _IDENTITY)
-    recovered = _offset_from_correction(fov, correction)
+    recovered = offset_from_correction(fov, correction)
     assert recovered[0] == pytest.approx(small[0], abs=1e-9)
     assert recovered[1] == pytest.approx(small[1], abs=1e-9)
 
@@ -318,7 +298,7 @@ def test_conjugation_direction_is_pinned_by_a_non_involutory_flip() -> None:
         _baseline(original, flip), fov, offset_px=_PLANTED_OFFSET, rotation_fitted=False
     )
     assert solution.cmatrix is not None
-    recovered = _offset_from_correction(
+    recovered = offset_from_correction(
         fov, (flip @ np.asarray(solution.cmatrix, np.float64)) @ (flip @ original).T
     )
     assert recovered[0] == pytest.approx(_PLANTED_OFFSET[0], abs=1e-9)

--- a/tests/spindoctor/support/test_cmatrix.py
+++ b/tests/spindoctor/support/test_cmatrix.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import cast
 
+import cspyce
 import numpy as np
 import oops
 import pytest
@@ -21,15 +22,26 @@ from tests.cmatrix_helpers import offset_from_correction
 
 from spindoctor.obs import ObsSnapshotInst
 from spindoctor.support.cmatrix import (
+    _CASSINI_CK_FRAME_ID,
+    _CASSINI_SCLK_ID,
+    _GALILEO_CK_FRAME_ID,
+    _GALILEO_SCLK_ID,
+    _LORRI_CK_FRAME_ID,
+    _LORRI_SCLK_ID,
     AttitudeBaseline,
     _build_pointing_solution,
+    _camera_frame_id,
     _check_flip,
     _FrameIdentity,
     _oops_correction_matrix,
+    _pxform,
+    _sclk_id,
+    _sclk_string,
     _spice_cmatrix,
     _validate_rotation,
     compute_pointing,
 )
+from spindoctor.support.exceptions import NavPointingError
 
 # A Cassini-NAC-like square camera: 1024 pixels at 6 microradians each.  A
 # FlatFOV maps its boresight pixel to xy exactly (0, 0), which is what makes
@@ -43,6 +55,17 @@ _PLANTED_OFFSET = (8.68, -17.37)
 
 # The 180-degree flip oops applies on top of the SPICE Cassini ISS frames.
 _CASSINI_FLIP = np.diag([-1.0, -1.0, 1.0])
+
+# Voyager 1's scan-platform CK object, which is the wrong one for a Voyager 2
+# image: ``ckmeta`` answers -31 for it, the other spacecraft's clock.
+_VOYAGER1_CK_FRAME_ID = -31100
+_VOYAGER2_SCLK_ID = -32
+
+# A CK object no mission owns, used to pin what ``ckmeta`` does with one.
+_NONEXISTENT_CK_FRAME_ID = -999999
+
+# A spacecraft clock no furnished kernel can ever describe.
+_NONEXISTENT_SCLK_ID = -999
 
 _IDENTITY = np.eye(3)
 
@@ -77,7 +100,7 @@ def _outcome_of(check: Callable[[], None]) -> str:
     """
     try:
         check()
-    except ValueError:
+    except NavPointingError:
         return 'refused'
     return 'accepted'
 
@@ -216,7 +239,7 @@ def test_baseline_with_a_bad_determinant_raises() -> None:
     """A baseline attitude that is not a proper rotation is refused."""
     reflected = _some_attitude()
     reflected[0] = -reflected[0]
-    with pytest.raises(ValueError, match='cmatrix_original is not a proper rotation'):
+    with pytest.raises(NavPointingError, match='cmatrix_original is not a proper rotation'):
         _build_pointing_solution(
             _baseline(reflected), _fov(), offset_px=_PLANTED_OFFSET, rotation_fitted=False
         )
@@ -225,7 +248,7 @@ def test_baseline_with_a_bad_determinant_raises() -> None:
 def test_baseline_that_is_not_orthonormal_raises() -> None:
     """A unit-determinant baseline that is not orthonormal is refused."""
     sheared = np.array([[1.0, 1.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
-    with pytest.raises(ValueError, match='cmatrix_original is not orthonormal'):
+    with pytest.raises(NavPointingError, match='cmatrix_original is not orthonormal'):
         _build_pointing_solution(
             _baseline(sheared), _fov(), offset_px=_PLANTED_OFFSET, rotation_fitted=False
         )
@@ -235,7 +258,7 @@ def test_baseline_with_a_bad_determinant_raises_without_an_offset() -> None:
     """The baseline is checked even when no corrected attitude is produced."""
     reflected = _some_attitude()
     reflected[0] = -reflected[0]
-    with pytest.raises(ValueError, match='cmatrix_original is not a proper rotation'):
+    with pytest.raises(NavPointingError, match='cmatrix_original is not a proper rotation'):
         _build_pointing_solution(
             _baseline(reflected), _fov(), offset_px=None, rotation_fitted=False
         )
@@ -243,13 +266,13 @@ def test_baseline_with_a_bad_determinant_raises_without_an_offset() -> None:
 
 def test_corrected_cmatrix_that_is_not_a_rotation_raises() -> None:
     """A correction that is not a rotation is refused by the result check."""
-    with pytest.raises(ValueError, match='cmatrix is not a proper rotation'):
+    with pytest.raises(NavPointingError, match='cmatrix is not a proper rotation'):
         _spice_cmatrix(_some_attitude(), np.diag([1.0, 1.0, 2.0]), _IDENTITY)
 
 
 def test_attitude_baseline_rejects_a_matrix_of_the_wrong_shape() -> None:
     """A baseline built from a non-3x3 matrix is refused at construction."""
-    with pytest.raises(ValueError, match='expected a 3x3 matrix'):
+    with pytest.raises(NavPointingError, match='expected a 3x3 matrix'):
         _baseline(np.eye(4))
 
 
@@ -318,7 +341,7 @@ def test_a_nan_baseline_is_rejected() -> None:
     """A NaN attitude is refused rather than serialized as an invalid JSON token."""
     corrupted = _some_attitude()
     corrupted[1, 1] = np.nan
-    with pytest.raises(ValueError, match='cmatrix_original holds a non-finite value'):
+    with pytest.raises(NavPointingError, match='cmatrix_original holds a non-finite value'):
         _build_pointing_solution(
             _baseline(corrupted), _fov(), offset_px=_PLANTED_OFFSET, rotation_fitted=False
         )
@@ -328,7 +351,7 @@ def test_an_infinite_baseline_is_rejected() -> None:
     """An infinite attitude entry is refused for the same reason."""
     corrupted = _some_attitude()
     corrupted[0, 2] = np.inf
-    with pytest.raises(ValueError, match='cmatrix_original holds a non-finite value'):
+    with pytest.raises(NavPointingError, match='cmatrix_original holds a non-finite value'):
         _build_pointing_solution(
             _baseline(corrupted), _fov(), offset_px=None, rotation_fitted=False
         )
@@ -337,15 +360,16 @@ def test_an_infinite_baseline_is_rejected() -> None:
 def test_a_nan_correction_is_rejected_by_the_result_check() -> None:
     """A NaN reaching the corrected matrix is refused too."""
     corrupted = np.eye(3) * np.nan
-    with pytest.raises(ValueError, match='cmatrix holds a non-finite value'):
+    with pytest.raises(NavPointingError, match='cmatrix holds a non-finite value'):
         _spice_cmatrix(_some_attitude(), corrupted, _IDENTITY)
 
 
 def _cassini_identity() -> _FrameIdentity:
-    """The Cassini NAC frame identity, for the flip-check tests."""
+    """The Cassini NAC frame identity, for the flip-check and clock tests."""
     return _FrameIdentity(
         camera_frame='CASSINI_ISS_NAC',
-        ck_frame_id=-82000,
+        ck_frame_id=_CASSINI_CK_FRAME_ID,
+        sclk_id=_CASSINI_SCLK_ID,
         oops_from_spice=_CASSINI_FLIP,
         frozen_oops_attitude=False,
     )
@@ -353,13 +377,13 @@ def _cassini_identity() -> _FrameIdentity:
 
 def test_a_mismatched_flip_is_refused() -> None:
     """A measured flip that is not the instrument's constant raises."""
-    with pytest.raises(ValueError, match='differs from the expected'):
+    with pytest.raises(NavPointingError, match='differs from the expected'):
         _check_flip(_IDENTITY, _cassini_identity())
 
 
 def test_the_mismatched_flip_message_names_the_camera_frame() -> None:
     """The refusal says which frame disagreed, so it is attributable."""
-    with pytest.raises(ValueError, match='CASSINI_ISS_NAC'):
+    with pytest.raises(NavPointingError, match='CASSINI_ISS_NAC'):
         _check_flip(_IDENTITY, _cassini_identity())
 
 
@@ -373,8 +397,101 @@ def test_a_flip_just_outside_tolerance_is_refused() -> None:
     """A flip differing by more than the tolerance raises."""
     perturbed = _CASSINI_FLIP.copy()
     perturbed[0, 1] = 1e-8
-    with pytest.raises(ValueError, match='differs from the expected'):
+    with pytest.raises(NavPointingError, match='differs from the expected'):
         _check_flip(perturbed, _cassini_identity())
+
+
+def test_the_missions_own_clock_resolves_and_is_accepted() -> None:
+    """The clock SPICE resolves for a mission's CK object is the expected one.
+
+    Pins the expected constant against what ``ckmeta`` actually computes: a
+    typo in either the CK object or the clock id fails here rather than
+    producing time strings from a plausible-looking wrong clock.
+    """
+    assert _sclk_id(_cassini_identity()) == _CASSINI_SCLK_ID
+
+
+def _voyager2_identity_with_the_voyager1_ck_object() -> _FrameIdentity:
+    """A Voyager 2 identity carrying Voyager 1's CK object.
+
+    One Voyager instrument key serves two spacecraft, so naming the wrong
+    spacecraft's CK object is the realistic way this mismatch arises.
+    """
+    return _FrameIdentity(
+        camera_frame='VG2_ISSNA',
+        ck_frame_id=_VOYAGER1_CK_FRAME_ID,
+        sclk_id=_VOYAGER2_SCLK_ID,
+        oops_from_spice=_IDENTITY,
+        frozen_oops_attitude=True,
+    )
+
+
+def test_a_clock_that_is_not_the_missions_is_refused() -> None:
+    """A CK object resolving to another spacecraft's clock raises."""
+    with pytest.raises(NavPointingError, match='resolves to spacecraft clock -31'):
+        _sclk_id(_voyager2_identity_with_the_voyager1_ck_object())
+
+
+def test_the_refused_clock_message_names_the_expected_clock() -> None:
+    """The refusal says which clock was expected, so it is attributable."""
+    with pytest.raises(NavPointingError, match='not the -32'):
+        _sclk_id(_voyager2_identity_with_the_voyager1_ck_object())
+
+
+def test_ckmeta_computes_a_clock_for_a_ck_object_that_does_not_exist() -> None:
+    """``ckmeta`` computes rather than validates, which is why the check exists.
+
+    A nonexistent CK object still yields a plausible clock id and no error,
+    so trusting the round trip would write time strings from the wrong clock
+    while every call reported success.
+    """
+    assert int(cspyce.ckmeta(_NONEXISTENT_CK_FRAME_ID, 'SCLK')) == -999
+
+
+@pytest.mark.parametrize(
+    ('ck_frame_id', 'sclk_id'),
+    [
+        (_CASSINI_CK_FRAME_ID, _CASSINI_SCLK_ID),
+        (_GALILEO_CK_FRAME_ID, _GALILEO_SCLK_ID),
+        (_LORRI_CK_FRAME_ID, _LORRI_SCLK_ID),
+    ],
+    ids=['cassini', 'galileo', 'lorri'],
+)
+def test_each_recorded_ck_object_and_clock_pair_agrees_with_spice(
+    ck_frame_id: int, sclk_id: int
+) -> None:
+    """Every mission's CK object resolves to the clock recorded beside it.
+
+    ``ckmeta`` needs no kernels, so the pairing is checkable here as well as
+    on real frames.  A typo in either half of a pair would otherwise only
+    surface as time strings encoding another spacecraft's clock.
+    """
+    assert int(cspyce.ckmeta(ck_frame_id, 'SCLK')) == sclk_id
+
+
+def test_a_frame_the_kernel_pool_does_not_know_is_a_pointing_failure() -> None:
+    """A rotation SPICE cannot supply is reported as the computation's own failure."""
+    with pytest.raises(NavPointingError, match='cannot supply the J2000 to NO_SUCH_FRAME'):
+        _pxform('NO_SUCH_FRAME', 0.0)
+
+
+def test_the_spice_error_behind_a_pointing_failure_is_kept_as_the_cause() -> None:
+    """The original SPICE exception survives the conversion, so it stays debuggable."""
+    with pytest.raises(NavPointingError) as exc_info:
+        _pxform('NO_SUCH_FRAME', 0.0)
+    assert isinstance(exc_info.value.__cause__, LookupError)
+
+
+def test_a_frame_name_with_no_spice_id_is_a_pointing_failure() -> None:
+    """A frame name that resolves to no id is reported, not left to surface later."""
+    with pytest.raises(NavPointingError, match='NO_SUCH_FRAME has no SPICE id'):
+        _camera_frame_id('NO_SUCH_FRAME')
+
+
+def test_a_clock_that_cannot_encode_an_epoch_is_a_pointing_failure() -> None:
+    """A clock with no furnished SCLK kernel is reported rather than raising raw."""
+    with pytest.raises(NavPointingError, match='cannot encode et'):
+        _sclk_string(_NONEXISTENT_SCLK_ID, 0.0)
 
 
 def test_a_host_with_no_spice_camera_frame_records_nothing() -> None:
@@ -406,7 +523,7 @@ def test_a_determinant_just_outside_tolerance_is_refused() -> None:
     the determinant by about ``3e-8``, an order of magnitude outside the
     documented ``1e-9``, so widening the tolerance fails this test.
     """
-    with pytest.raises(ValueError, match='is not a proper rotation'):
+    with pytest.raises(NavPointingError, match='is not a proper rotation'):
         _validate_rotation(_some_attitude() * (1.0 + 1e-8), 'test matrix')
 
 
@@ -424,5 +541,5 @@ def test_a_shear_just_inside_tolerance_is_accepted() -> None:
 def test_a_shear_just_outside_tolerance_is_refused() -> None:
     """A unit-determinant shear larger than the tolerance raises."""
     sheared = np.array([[1.0, 1e-8, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
-    with pytest.raises(ValueError, match='is not orthonormal'):
+    with pytest.raises(NavPointingError, match='is not orthonormal'):
         _validate_rotation(sheared, 'test matrix')

--- a/tests/spindoctor/test_navigate_image_files.py
+++ b/tests/spindoctor/test_navigate_image_files.py
@@ -46,6 +46,16 @@ class _FakeSnapshot:
     def __init__(
         self, *, blank: bool = False, midtime: float = 100.0, shutter_mode: str | None = None
     ) -> None:
+        """Build a fake snapshot carrying one deterministic 32x32 image.
+
+        Parameters:
+            blank: True for an all-zero image, which the orchestrator's image
+                classifier rejects as carrying no data; False for a fixed-seed
+                noise field around a mean of 100, which it accepts.
+            midtime: The observation midtime in TDB seconds past J2000.
+            shutter_mode: The shutter mode the image was taken in, or ``None``
+                for a host whose labels carry no such field.
+        """
         rng = np.random.default_rng(seed=99)
         if blank:
             self.data = np.zeros((32, 32), np.float64)
@@ -64,6 +74,12 @@ class _FakeSnapshot:
         self.shutter_mode = shutter_mode
 
     def extfov_data_sensor_mask(self) -> np.ndarray:
+        """Report every pixel of the extended FOV as live sensor.
+
+        Returns:
+            A boolean array of ``extdata``'s shape, all True: this fake uses
+            zero extfov margin, so no pixel falls outside the detector.
+        """
         return self._sensor_mask
 
 
@@ -90,17 +106,46 @@ def _make_fake_obs_class(
 ) -> type:
     """Build a fresh per-test ``obs_class`` shim with controllable behavior.
 
-    Each call returns a brand-new class with the requested behavior baked in
-    as class-level constants (read-only).  The previous design used a single
-    shared `_FakeObsClass` whose mutable state raced under pytest-xdist.
+    Each call returns a brand-new class that closes over the requested
+    behavior, so nothing is shared between tests and the shims are safe under
+    parallel execution.
+
+    Parameters:
+        blank: True for a class whose images are all zero, so the driver takes
+            its no-data path.
+        raise_on_load: An exception ``from_file`` raises instead of returning a
+            snapshot, so the driver takes its image-load-failure path; ``None``
+            to load successfully.
+        shutter_mode: The shutter mode every loaded snapshot reports, or
+            ``None`` for a host whose labels carry no such field.
+
+    Returns:
+        A class exposing the one classmethod the driver calls, ``from_file``,
+        which takes a path and returns a ``_FakeSnapshot``.
     """
     captured_blank = blank
     captured_raise = raise_on_load
     captured_shutter_mode = shutter_mode
 
     class _FakeObsClass:
+        """The observation class the driver loads each image through."""
+
         @classmethod
         def from_file(cls, path: Any, **kwargs: Any) -> _FakeSnapshot:
+            """Return the configured fake snapshot, ignoring the path.
+
+            Parameters:
+                path: The image path the driver resolved; unread, since the
+                    snapshot's contents are fixed at class-construction time.
+                kwargs: Any further loader options the driver passes; unread.
+
+            Returns:
+                A ``_FakeSnapshot`` built with this class's captured settings.
+
+            Raises:
+                BaseException: whatever ``raise_on_load`` supplied, when the
+                    class was built to fail on load.
+            """
             if captured_raise is not None:
                 raise captured_raise
             return _FakeSnapshot(blank=captured_blank, shutter_mode=captured_shutter_mode)


### PR DESCRIPTION
## Purpose

Addresses the CodeRabbit review on #439, which landed after that PR was merged. One of the five findings is a real defect rather than style, and the rest are hygiene.

Part of #188. Targets the integration branch `rf_ck_kernels`, not `main`.

## Changes

- **The resolved spacecraft clock is now validated instead of trusted.** `cspyce.ckmeta` computes rather than validates: `ckmeta(-999999, 'SCLK')` returns `-999` and `ckmeta(-12345, 'SCLK')` returns `-12`, neither raising. So a wrong CK object id silently yielded a wrong clock, and `sce2s` then reported success while writing the `sclk_start` / `sclk_midtime` / `sclk_stop` strings from the wrong spacecraft. The mission's expected clock is now carried alongside its CK object and a mismatch is refused before any `sce2s` call can succeed. Voyager derives its clock per spacecraft rather than from the CK object, which is where the trap bites hardest: `-32100 // 1000` is `-33` in Python, a spacecraft that does not exist.
- **A dedicated exception replaces the broad catch.** The orchestrator caught `(LookupError, OSError, RuntimeError, ValueError)` around the attitude computation, which is wide enough that a genuine defect inside that computation was indistinguishable from an expected SPICE failure and was silently absorbed, leaving pointing unrecorded across a whole batch while every image still reported success. `NavPointingError` is raised at each expected failure point, wrapped `from` the original so the traceback survives, and the orchestrator now catches only that. A programming defect propagates.
- Test-helper de-duplication and docstrings, per the review.

## Type of Change

- [x] Bug fix (non-breaking)
- [x] Tests only (no production code change)

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] New or updated tests for changed code

Unit suite `5097 passed, 7 xfailed`; cmatrix integration `36 passed`; `ruff check`, `ruff format --check`, `mypy src tests` and `sphinx-build -W` all clean. Eleven new test functions covering thirty-six cases.

Both behavioral changes are pinned by mutation. Removing the clock mismatch check fails two named tests; setting the Cassini clock constant to `-81` fails one hermetic and nine integration tests; deriving Voyager's clock by integer division from the CK object fails eight integration tests. Making the computation raise a bare `ValueError` from a simulated internal defect confirms it propagates out of the orchestrator rather than being absorbed, while the same injection raising `NavPointingError` is absorbed and reported, which shows the split is by exception type and not by call site. Reverting the catch to the old tuple fails six tests.

Worth recording: the first clock-constant mutation initially escaped the hermetic tier, because the unit tests stated their own constants rather than checking the production ones. A test was added that validates the production CK-object-to-clock pairs against SPICE without kernels, so the mutation now fails in both tiers.

## Potential Impacts

`NavOrchestrator.navigate` no longer absorbs an arbitrary exception raised beneath the attitude computation; only `NavPointingError` is absorbed. That is the intended behavior change and is what makes a defect visible rather than silent. No metadata schema change: the expected clock lives on a private dataclass and nothing new reaches the JSON.

## Checklist

- [x] Code follows project style (`ruff check`, `ruff format`)
- [x] Type annotations present and `mypy` passes
- [x] Docstrings and Sphinx docs updated (if applicable)
- [x] No temporary or debug code left in
- [x] Breaking changes flagged in Type of Change above

## Notes

One review item was declined deliberately: the request to use `MAIN_LOGGER.exception` in place of `MAIN_LOGGER.error`. The per-image logger already emits the full traceback, and the design puts one line in the run log and the detail in the per-image log so that an operator watching a batch sees a single line per affected image rather than a traceback per image. The rationale is recorded as a comment at the call site so a later reader does not revert it.

Section 2.4 of `plans/CK_KERNEL_PLAN.md` is reconciled, since the caught set it described has changed. Nothing else in the plan was touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pointing-error handling so expected navigation failures are safely skipped while unrelated application defects continue to surface.
  * Added validation for spacecraft clock identifiers, frame data, and attitude calculations across supported missions.
  * Preserved underlying error details to make pointing failures easier to diagnose.

* **Documentation**
  * Clarified which pointing failures are recoverable and how they are reported.

* **Tests**
  * Expanded coverage for clock validation, frame lookup failures, error propagation, and mission-specific configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->