### PR TITLE
Write navigated pointing into CK segments

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -21,3 +21,4 @@ This section provides detailed API documentation for the SpinDoctor system.
    api_reference/api_sim
    api_reference/api_ui
    api_reference/api_navigate_image_files
+   api_reference/api_spice_ids

--- a/docs/api_reference/api_spice_ids.rst
+++ b/docs/api_reference/api_spice_ids.rst
@@ -1,0 +1,7 @@
+spindoctor.spice_ids
+====================
+
+.. automodule:: spindoctor.spice_ids
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/plans/CK_KERNEL_PLAN.md
+++ b/plans/CK_KERNEL_PLAN.md
@@ -489,21 +489,26 @@ stays, because the file should say what it means, but the test guarding it
 must assert on the written records; no read-back assertion can see the
 difference.
 
-**Clocks.** Encoded SCLK comes from `cspyce.sce2c(sclk_id, et)` where
-`sclk_id = cspyce.ckmeta(ck_frame_id, 'SCLK')` -- the spacecraft clock ID
-(-82, -31, -77, -98), which is **not** derivable from the CK object id by
-integer division (`-31100 // 1000` is -32 in Python: wrong spacecraft,
-silently). The SCLK kernel furnished must be the one navigation used,
-resolved from `provenance.spice_kernels`; a different SCLK is a silent
+**Clocks.** Encoded SCLK comes from `cspyce.sce2c(sclk_id, et)`. The
+spacecraft clock ID (-82, -31, -77, -98) is **not** derivable from the CK
+object id by integer division (`-31100 // 1000` is -32 in Python: wrong
+spacecraft, silently). The SCLK kernel furnished must be the one navigation
+used, resolved from `provenance.spice_kernels`; a different SCLK is a silent
 time-tag error.
 
-**`ckmeta` will not catch a wrong CK id either.** It computes rather than
-validates: `ckmeta(-999999, 'SCLK')` returns `-999` and `ckmeta(-12345,
-'SCLK')` returns `-12`, neither raising. A `ck_frame_id` that is wrong for
-any reason therefore yields a plausible-looking clock id, a successful
-`sce2c`, and silently wrong time tags on every record. Validate the
-resolved `sclk_id` against the expected set for the mission rather than
-trusting the round trip.
+**The shared table is the resolver; `ckmeta` is only the cross-check.**
+`sclk_id` comes from the CK-object-to-clock mapping in
+`spindoctor/spice_ids.py` (section 3.6), and `cspyce.ckmeta(ck_frame_id,
+'SCLK')` is then required to agree with it. It is deliberately not the
+other way round, because `ckmeta` computes rather than validates:
+`ckmeta(-999999, 'SCLK')` returns `-999` and `ckmeta(-12345, 'SCLK')`
+returns `-12`, neither raising. A `ck_frame_id` that is wrong for any
+reason would otherwise yield a plausible-looking clock id, a successful
+`sce2c`, and silently wrong time tags on every record. Both call sites --
+the writer's `resolve_sclk_id` and the attitude computation's own resolver
+-- return the **recorded** id rather than the one `ckmeta` computed, even
+though the check has just proved them equal, so that weakening the check
+later cannot quietly promote `ckmeta` back to being the source.
 
 **Both attitudes are evaluated at the exposure midtime**, and Phase A's
 integration tier pins that against a moving attitude on LORRI alone -- the

--- a/plans/CK_KERNEL_PLAN.md
+++ b/plans/CK_KERNEL_PLAN.md
@@ -400,10 +400,12 @@ C_ck_corrected(t) = delta . C_ck_original(t)      for t in [start, stop]
 That is the physical model -- the spacecraft is pointed slightly wrong and
 the error turns with it -- so the *correction* is right at every epoch in
 the window. What the segment reproduces between its records is a separate
-question: it carries records only at start, midtime and stop, and
-interpolates between them, so smear geometry is right only to the fidelity
-of that interpolation, which is measured and bounded in Phase D's interior
-note and deferred to #444. **Exception: Voyager.** The
+question: it carries records at start, midtime and stop, plus a 1 s cadence
+above 10 s of exposure (section 3.3), and interpolates between them, so
+smear geometry is right only to the fidelity of that interpolation. That
+fidelity is measured in Phase D's interior note and is weaker than this
+paragraph once claimed; bounding it needs a denser, adaptive cadence
+(#444). **Exception: Voyager.** The
 navigated model assumed a constant, tolerance-snapped attitude (section
 2.2), so a Voyager segment carries that single corrected attitude,
 constant across its window; writing time-varying pointing there would
@@ -801,11 +803,16 @@ kernel pool, and a mid-process `furnsh` is not guaranteed to take effect:
    both sets and fails as *inconclusive-mismatch* (not as a pass) when
    they differ.
 5. Assert the corrected attitude at **start, midtime and stop only**.
-   Those are the epochs a segment carries records at, and they are the
-   epochs this plan claims. Interior epochs are deliberately **not**
-   asserted, because the record scheme does not currently bound them (see
-   the limitation below); testing them would pin a number this plan does
-   not undertake to hold.
+   Those three are the records every segment carries, and they are the
+   epochs this plan claims. A segment for an exposure longer than 10 s
+   additionally carries records at a 1 s cadence (section 3.3); those are
+   reproduced exactly too, but they are deliberately **not** asserted,
+   because they exist only on long exposures and asserting them would make
+   the validation's coverage depend on the cohort's exposure lengths.
+   Interior epochs -- anything between records -- are not asserted either,
+   because the record scheme does not bound them (see the limitation
+   below); testing them would pin a number this plan does not undertake to
+   hold.
 
 Tolerances: the target is at or below **0.1 px per axis**, and the
 C-matrix target is that offset's angular equivalent at the instrument's

--- a/plans/CK_KERNEL_PLAN.md
+++ b/plans/CK_KERNEL_PLAN.md
@@ -496,11 +496,27 @@ spacecraft, silently). The SCLK kernel furnished must be the one navigation
 used, resolved from `provenance.spice_kernels`; a different SCLK is a silent
 time-tag error.
 
+**How that resolution works, since `spice_kernels` does not answer it
+directly.** The list is sorted basenames with no load order, and in a batch
+run it accumulates every kernel earlier images furnished, so it can hold
+several clock kernels -- more than one for the same spacecraft, and others
+for spacecraft this image has nothing to do with. The driver that furnishes
+the pool (section 3.5) therefore filters the list to the clock kernels of
+the image's own resolved `sclk_id` and requires **exactly one** to survive.
+Zero means the recorded provenance cannot name the clock the time tags were
+encoded against, and several means it names more than one and cannot say
+which; both refuse the image rather than picking one, because either guess
+writes time tags that are wrong by whatever the two clock kernels disagree
+by, and a wrong time tag is not visible in the written kernel. This is the
+same discipline the clock id itself gets just below: the recorded value
+decides, and anything ambiguous is refused rather than resolved by
+preference.
+
 **The shared table is the resolver; `ckmeta` is only the cross-check.**
 `sclk_id` comes from the CK-object-to-clock mapping in
 `spindoctor/spice_ids.py` (section 3.6), and `cspyce.ckmeta(ck_frame_id,
 'SCLK')` is then required to agree with it. It is deliberately not the
-other way round, because `ckmeta` computes rather than validates:
+other way around, because `ckmeta` computes rather than validates:
 `ckmeta(-999999, 'SCLK')` returns `-999` and `ckmeta(-12345, 'SCLK')`
 returns `-12`, neither raising. A `ck_frame_id` that is wrong for any
 reason would otherwise yield a plausible-looking clock id, a successful

--- a/plans/CK_KERNEL_PLAN.md
+++ b/plans/CK_KERNEL_PLAN.md
@@ -452,9 +452,13 @@ Phase B measured two things about that paragraph. First, `sce2c` returns
 *continuous* encoded SCLK -- a tick with a fractional part -- so the
 single-record collapse happens only when the three epochs are
 indistinguishable as doubles (a nanosecond exposure near ET 5e8), not
-merely when the exposure is shorter than one tick; and when it does happen
-the midtime record is bit-identical to the start record, so "at midtime" is
-a statement of intent rather than an observable. Second, SPICE's own type-3
+merely when the exposure is shorter than one tick: measured against a
+1/256 s clock, a 1 ms exposure is 0.256 ticks and still produces three
+records. **The single-record path is therefore unreachable for any real
+exposure** -- the shortest Cassini ISS exposure is 5 ms -- and it exists as
+a guard, not as a case the corpus contains. When it does fire the midtime
+record is bit-identical to the start record, so "at midtime" is a statement
+of intent rather than an observable. Second, SPICE's own type-3
 reader restores quaternion sign on the way out: a segment written with a
 sign-discontinuous sequence reads back attitudes identical to a repaired
 one (0.0 rad difference at an interior epoch, measured). The enforcement
@@ -502,12 +506,15 @@ the wrong-frame error, and Phase B's test must fail if it is introduced.
 Two refinements from Phase B. The want-of-AV failure is `OSError`
 `SPICE(CKINSUFFDATA)` -- the same class and short message as pointing that
 is not covered at all -- so the two are not distinguishable from the
-exception. The writer therefore probes `ckgpav` once at the first record
-and, if it raises, reads the whole segment with `ckgp`; a genuine coverage
-gap still surfaces rather than being demoted to a missing-AV segment,
-because those `ckgp` lookups raise on it. And a **frozen (Voyager) segment
-writes `avflag = 0` whatever its baseline carries**: the segment's attitude
-is constant, so its angular velocity is zero, and the rigid-attachment
+exception. The rule the writer applies is therefore **all records or
+none**: it probes `ckgpav` at the first record as a fast path, but the
+sampling pass over every record is what decides, so an exposure straddling
+one original segment that carries AV and one that does not writes
+`avflag = 0` rather than failing. A genuine coverage gap still surfaces
+rather than being demoted to a missing-AV segment, because the `ckgp`
+lookups that then read the attitude raise on it. And a **frozen (Voyager)
+segment writes `avflag = 0` whatever its baseline carries**: the segment's
+attitude is constant, so its angular velocity is zero, and the rigid-attachment
 argument that licenses copying the baseline's vectors does not hold for a
 segment that deliberately drops the baseline's time variation. Voyager
 baselines carry no AV in any case, so the rule changes nothing on real
@@ -723,12 +730,25 @@ with `ckgpav` at `tol = 0`:
   truth within 1e-9 radians.
 - AV is bit-identical to the original's; the test **fails if AV is rotated
   through `delta`**.
-- An AV-less original yields `avflag = 0` and a working `ckgp` fallback.
+- An AV-less original yields `avflag = 0` and a working `ckgp` fallback,
+  and so does an exposure straddling one original segment that carries AV
+  and one that does not: a segment has one flag for all its records, so it
+  claims none rather than inventing vectors for the records that lack them.
 - A sign-discontinuous quaternion sequence is repaired, asserted on the
   written records rather than on a read-back attitude (section 3.3: SPICE
   restores the sign when it interpolates, so the read-back cannot see it);
   interpolated attitude mid-record stays continuous.
-- A sub-tick exposure produces a valid single-record segment.
+- Exposure epochs that collapse to a single encoded tick produce a valid
+  single-record segment. Per section 3.3 that needs three epochs equal as
+  doubles, which no real exposure produces, so a second test pins the
+  reachable neighbour: a sub-tick (1 ms) exposure still produces three
+  records.
+- The written file's `ckcov` window is exactly `[start_et, stop_et]` in
+  encoded SCLK. Asserting on the record array instead cannot see a segment
+  descriptor that advertises coverage the records do not have.
+- Baseline pointing is read at the record epoch with tolerance zero: an
+  exposure the original does not cover is refused rather than corrected
+  against the nearest attitude within some tolerance.
 - Sub-spacecraft-clock ids come from `ckmeta`, asserted for all four CK
   objects.
 

--- a/plans/CK_KERNEL_PLAN.md
+++ b/plans/CK_KERNEL_PLAN.md
@@ -442,10 +442,27 @@ One **type 3** segment per eligible image, interpolation interval exactly
 `[start_et, stop_et]`.
 
 **Records.** At exposure start, midtime, and stop. When `exposure_s`
-exceeds 10 s, additional records at a 1 s cadence. (SPICE offers no API to
-enumerate a type-3 segment's interior records, so the earlier idea of
-copying the original's record times is dropped; at typical exposure lengths
-the window contains no interior records anyway.) Time tags must be
+exceeds 10 s, additional records at a 1 s cadence.
+
+Those cadence records earn their place, and it is worth saying how, because
+nothing asserts them. The segment declares one interpolation interval
+spanning `[start_et, stop_et]`, so SPICE interpolates between bracketing
+records for **every** epoch in the window -- an epoch between records is
+interpolated, not fallen through to the original kernels, which happens
+only outside the window. Each added record therefore shortens every
+interpolation span it touches and improves accuracy continuously across the
+window rather than at instants. Measured on a real Cassini reconstructed
+kernel, a 60 s exposure carrying only the three mandatory records has a
+worst interior error of 25.98 px; at the 1 s cadence it is 1.07 px. The
+cadence reduces interior error by more than twenty-fold and **bounds
+nothing** -- 1.07 px is still well outside any tolerance this plan states,
+which is why a consumer is told (Phase D's interior note) that only the
+record epochs are claimed. Replacing this fixed cadence with an adaptive
+one that does bound the error is #444.
+
+(SPICE offers no API to enumerate a type-3 segment's interior records, so
+the earlier idea of copying the original's record times is dropped.) Time
+tags must be
 **strictly increasing in encoded SCLK**; an exposure so short that start,
 mid and stop collapse to one tick produces a single-record segment at
 midtime, which type 3 permits and Phase B tests. Records are quaternions

--- a/plans/CK_KERNEL_PLAN.md
+++ b/plans/CK_KERNEL_PLAN.md
@@ -631,6 +631,17 @@ would drag oops in transitively. The guarantee is asserted on `sys.modules`
 after importing the writer package in a fresh interpreter, not by scanning
 source text.
 
+The one fact the writer and the attitude computation must agree on -- which
+spacecraft clock each CK object's time tags are encoded against -- therefore
+lives in `spindoctor/spice_ids.py`, a top-level constants module importing
+only the standard library, which both sides read. It is deliberately not
+under `spindoctor/support/`, which the writer may not import at all. That
+mapping is the check against `ckmeta` computing a clock id rather than
+validating one, so a second copy of it would be a silent way for the check
+to rot on one side while it kept passing on the other; `cmatrix` derives
+each instrument's clock from it, and the writer's `resolve_sclk_id`
+validates against it. Both keep their own error type and message.
+
 The `cspyce` surface the writer needs, all present in the installed 2.3.6:
 `furnsh`, `unload`, `kclear`, `pxform`, `frmnam`, `namfrm`, `ckmeta`,
 `sce2c`, `sce2s`, `ckobj`, `ckcov`, `ckgp`, `ckgpav`, `m2q`, `ckopn`,

--- a/plans/CK_KERNEL_PLAN.md
+++ b/plans/CK_KERNEL_PLAN.md
@@ -796,6 +796,18 @@ kernel pool, and a mid-process `furnsh` is not guaranteed to take effect:
    when both runs commit the same winning technique set; the test records
    both sets and fails as *inconclusive-mismatch* (not as a pass) when
    they differ.
+5. Assert the corrected attitude at **interior** epochs of the exposure as
+   well as at start, midtime and stop. A corrected segment carries records
+   at exactly those three epochs, so they are reproduced exactly by
+   construction, and a validation that samples only them is structurally
+   unable to observe interior resampling loss. Measured on a real Cassini
+   reconstructed kernel, the interior loss reaches **0.290 px** maximum on
+   a 2 s exposure with 8.2% of samples over 0.1 px, and **0.445 px** on a
+   10 s exposure with 4.2% over; a 60 s exposure written at the 1 s cadence
+   still loses **0.643 px** at the median. The loss is attributable rather
+   than noise: a zero-correction run shows the same error, and the cause is
+   a rate discontinuity in the baseline inside the window that the segment
+   interpolates across.
 
 Tolerances: the target is at or below **0.1 px per axis**, and the
 C-matrix target is that offset's angular equivalent at the instrument's
@@ -809,6 +821,19 @@ frame, at a 50 px total offset, against a 0.1 px per-axis target -- convert
 before comparing. Choose the WAC cohort frame accordingly, remembering the
 bound is **linear** in the offset, not quadratic: about 10 px of total
 offset buys a fifth of budget.
+
+Interior tolerance: the interior bound is a **separate quantity** from the
+midtime bound and is stated separately. The 0.1 px per-axis midtime target
+and its decision rule above are unchanged by it. An interior residual above
+that target is **not** automatically a convention defect, because this loss
+is characterized and attributable: the validation records the measured
+interior residual, pins it at measured-plus-margin, and names issue #440 as
+the reason the bound sits where it does, so a later change to the record
+scheme can ratchet it down. A convention error has the opposite signature
+-- a near-uniform displacement across the whole frame of roughly twice the
+navigated offset, present at every epoch including the record epochs -- so
+the assertion must distinguish the two rather than collapsing them into one
+threshold.
 
 Cohort: one star-navigated Cassini NAC frame (best-constrained truth), one
 Cassini WAC frame, and one frame from each other instrument that has a

--- a/plans/CK_KERNEL_PLAN.md
+++ b/plans/CK_KERNEL_PLAN.md
@@ -444,9 +444,23 @@ the window contains no interior records anyway.) Time tags must be
 mid and stop collapse to one tick produces a single-record segment at
 midtime, which type 3 permits and Phase B tests. Records are quaternions
 from `cspyce.m2q` with **sign continuity enforced**: `m2q` fixes the scalar
-component non-negative, which can flip sign between adjacent records and
-corrupt the interpolation; each record is negated as needed to keep a
-non-negative dot product with its predecessor.
+component non-negative, which flips the sign between adjacent records
+whenever the attitude's rotation angle passes 180 degrees; each record is
+negated as needed to keep a non-negative dot product with its predecessor.
+
+Phase B measured two things about that paragraph. First, `sce2c` returns
+*continuous* encoded SCLK -- a tick with a fractional part -- so the
+single-record collapse happens only when the three epochs are
+indistinguishable as doubles (a nanosecond exposure near ET 5e8), not
+merely when the exposure is shorter than one tick; and when it does happen
+the midtime record is bit-identical to the start record, so "at midtime" is
+a statement of intent rather than an observable. Second, SPICE's own type-3
+reader restores quaternion sign on the way out: a segment written with a
+sign-discontinuous sequence reads back attitudes identical to a repaired
+one (0.0 rad difference at an interior epoch, measured). The enforcement
+stays, because the file should say what it means, but the test guarding it
+must assert on the written records; no read-back assertion can see the
+difference.
 
 **Clocks.** Encoded SCLK comes from `cspyce.sce2c(sclk_id, et)` where
 `sclk_id = cspyce.ckmeta(ck_frame_id, 'SCLK')` -- the spacecraft clock ID
@@ -484,6 +498,20 @@ same vectors bit-identically and `avflag = 1`; when the original has none
 corrected segment writes `avflag = 0` and queries fall back to `ckgp`.
 Rotating AV through `delta` -- superficially the "thorough" treatment -- is
 the wrong-frame error, and Phase B's test must fail if it is introduced.
+
+Two refinements from Phase B. The want-of-AV failure is `OSError`
+`SPICE(CKINSUFFDATA)` -- the same class and short message as pointing that
+is not covered at all -- so the two are not distinguishable from the
+exception. The writer therefore probes `ckgpav` once at the first record
+and, if it raises, reads the whole segment with `ckgp`; a genuine coverage
+gap still surfaces rather than being demoted to a missing-AV segment,
+because those `ckgp` lookups raise on it. And a **frozen (Voyager) segment
+writes `avflag = 0` whatever its baseline carries**: the segment's attitude
+is constant, so its angular velocity is zero, and the rigid-attachment
+argument that licenses copying the baseline's vectors does not hold for a
+segment that deliberately drops the baseline's time variation. Voyager
+baselines carry no AV in any case, so the rule changes nothing on real
+data.
 
 **Files mirror the originals.** Each output `.bc` corresponds to exactly
 one original CK file and carries the segments of the images whose corrected
@@ -683,8 +711,10 @@ The type-3 segment writer for a single image: `F` and `delta` per section
 3.1, records, SCLK, quaternion sign continuity, AV policy, the
 single-record degenerate path.
 
-Tests are hermetic: the suite writes its own minimal LSK and SCLK text
-kernels (small text files `furnsh` accepts), plus an original CK produced
+Tests are hermetic: the suite writes its own minimal LSK, SCLK and FK text
+kernels (small text files `furnsh` accepts) -- the FK because `F` is
+`pxform(frmnam(ck_frame_id), camera_frame, mid)` and both of those frames
+have to be defined for the call to resolve -- plus an original CK produced
 by the writer's own primitives, so no holdings are needed. Write a kernel
 from a constructed attitude history and correction, furnish, query back
 with `ckgpav` at `tol = 0`:
@@ -694,8 +724,10 @@ with `ckgpav` at `tol = 0`:
 - AV is bit-identical to the original's; the test **fails if AV is rotated
   through `delta`**.
 - An AV-less original yields `avflag = 0` and a working `ckgp` fallback.
-- A sign-discontinuous quaternion sequence is repaired; interpolated
-  attitude mid-record stays continuous.
+- A sign-discontinuous quaternion sequence is repaired, asserted on the
+  written records rather than on a read-back attitude (section 3.3: SPICE
+  restores the sign when it interpolates, so the read-back cannot see it);
+  interpolated attitude mid-record stays continuous.
 - A sub-tick exposure produces a valid single-record segment.
 - Sub-spacecraft-clock ids come from `ckmeta`, asserted for all four CK
   objects.

--- a/plans/CK_KERNEL_PLAN.md
+++ b/plans/CK_KERNEL_PLAN.md
@@ -398,8 +398,12 @@ C_ck_corrected(t) = delta . C_ck_original(t)      for t in [start, stop]
 ```
 
 That is the physical model -- the spacecraft is pointed slightly wrong and
-the error turns with it -- so attitude still varies correctly within the
-exposure and smear geometry stays right. **Exception: Voyager.** The
+the error turns with it -- so the *correction* is right at every epoch in
+the window. What the segment reproduces between its records is a separate
+question: it carries records only at start, midtime and stop, and
+interpolates between them, so smear geometry is right only to the fidelity
+of that interpolation, which is measured and bounded in Phase D's interior
+note and deferred to #444. **Exception: Voyager.** The
 navigated model assumed a constant, tolerance-snapped attitude (section
 2.2), so a Voyager segment carries that single corrected attitude,
 constant across its window; writing time-varying pointing there would
@@ -796,18 +800,12 @@ kernel pool, and a mid-process `furnsh` is not guaranteed to take effect:
    when both runs commit the same winning technique set; the test records
    both sets and fails as *inconclusive-mismatch* (not as a pass) when
    they differ.
-5. Assert the corrected attitude at **interior** epochs of the exposure as
-   well as at start, midtime and stop. A corrected segment carries records
-   at exactly those three epochs, so they are reproduced exactly by
-   construction, and a validation that samples only them is structurally
-   unable to observe interior resampling loss. Measured on a real Cassini
-   reconstructed kernel, the interior loss reaches **0.290 px** maximum on
-   a 2 s exposure with 8.2% of samples over 0.1 px, and **0.445 px** on a
-   10 s exposure with 4.2% over; a 60 s exposure written at the 1 s cadence
-   still loses **0.643 px** at the median. The loss is attributable rather
-   than noise: a zero-correction run shows the same error, and the cause is
-   a rate discontinuity in the baseline inside the window that the segment
-   interpolates across.
+5. Assert the corrected attitude at **start, midtime and stop only**.
+   Those are the epochs a segment carries records at, and they are the
+   epochs this plan claims. Interior epochs are deliberately **not**
+   asserted, because the record scheme does not currently bound them (see
+   the limitation below); testing them would pin a number this plan does
+   not undertake to hold.
 
 Tolerances: the target is at or below **0.1 px per axis**, and the
 C-matrix target is that offset's angular equivalent at the instrument's
@@ -822,18 +820,26 @@ before comparing. Choose the WAC cohort frame accordingly, remembering the
 bound is **linear** in the offset, not quadratic: about 10 px of total
 offset buys a fifth of budget.
 
-Interior tolerance: the interior bound is a **separate quantity** from the
-midtime bound and is stated separately. The 0.1 px per-axis midtime target
-and its decision rule above are unchanged by it. An interior residual above
-that target is **not** automatically a convention defect, because this loss
-is characterized and attributable: the validation records the measured
-interior residual, pins it at measured-plus-margin, and names issue #440 as
-the reason the bound sits where it does, so a later change to the record
-scheme can ratchet it down. A convention error has the opposite signature
--- a near-uniform displacement across the whole frame of roughly twice the
-navigated offset, present at every epoch including the record epochs -- so
-the assertion must distinguish the two rather than collapsing them into one
-threshold.
+**Interior epochs are outside what this plan claims, and that is a
+measured limitation rather than an oversight.** A segment reproduces its
+record epochs exactly and interpolates between them, so an epoch inside
+the exposure carries the reconstruction error of that interpolation.
+Measured on a real Cassini reconstructed kernel against its own attitude,
+in NAC pixels, sampled across the window: a 2 s exposure reaches 0.708 px
+worst case with 42.9% of samples over 0.1 px; a 10 s exposure at the 1 s
+cadence reaches 0.699 px with 24.6% over; a 60 s exposure reaches 1.071 px
+with 19.5% over, and 25.983 px if the cadence does not apply. The loss is
+attributable rather than noise -- a zero-correction run shows the same
+error -- and it comes from rate structure in the baseline that the segment
+interpolates across.
+
+Bounding it is deferred to a denser, adaptive record cadence (#444). Until
+that lands, the round trip asserts the three record epochs and nothing
+between them, and the user guide states the limitation plainly rather than
+implying interior fidelity the kernels do not provide. A consumer that
+evaluates geometry at the midtime -- which is what the backplane and
+reprojection stages do -- is unaffected and exact; the cost falls only on a
+consumer integrating smear across the exposure.
 
 Cohort: one star-navigated Cassini NAC frame (best-constrained truth), one
 Cassini WAC frame, and one frame from each other instrument that has a

--- a/src/spindoctor/cli/ck/__init__.py
+++ b/src/spindoctor/cli/ck/__init__.py
@@ -21,6 +21,13 @@ library.  That table is the check against ``ckmeta`` computing a clock id
 rather than validating one, so a second copy of it here would be a silent way
 for the check to rot on one side while it kept passing on the other.
 
+This package is part of the ``spindoctor.cli`` tree, which holds the command
+line programs and the helpers only they use; the importable library API is the
+rest of ``spindoctor``.  Its names are therefore reachable and documented in
+place, but they are not published API and have no page in the API reference,
+which covers the library packages -- the same footing as every other
+``spindoctor.cli`` subpackage.
+
 One global to respect: ``cspyce.use_errors()`` / ``cspyce.use_flags()`` is
 process-wide and shared with oops.  This package assumes the exceptions regime
 (``use_errors``, the package default) and never flips it.

--- a/src/spindoctor/cli/ck/__init__.py
+++ b/src/spindoctor/cli/ck/__init__.py
@@ -1,0 +1,36 @@
+"""C-kernel generation from the corrected pointing navigation recorded.
+
+Navigation measures where a camera was actually pointing and records that
+measurement as a C-matrix in the image's metadata.  This package turns those
+recorded matrices into SPICE C-kernels, so the same measurement loads into any
+SPICE-aware tool with a ``furnsh`` instead of having to be applied as a pixel
+offset by hand.
+
+The package consumes the recorded C-matrix and performs no offset-to-rotation
+conversion of its own.  It imports ``cspyce`` and **nothing** from oops, and
+nothing from ``spindoctor.support`` either, since the module that computes the
+C-matrix lives there and imports oops: one convenience import would pull the
+whole geometry stack into a program that only writes kernels.  That guarantee
+is checked on ``sys.modules`` in a fresh interpreter rather than by reading the
+source.
+
+One global to respect: ``cspyce.use_errors()`` / ``cspyce.use_flags()`` is
+process-wide and shared with oops.  This package assumes the exceptions regime
+(``use_errors``, the package default) and never flips it.
+"""
+
+from spindoctor.cli.ck.pointing import ImagePointing
+from spindoctor.cli.ck.segment import (
+    CkSegment,
+    build_segment,
+    resolve_sclk_id,
+    write_segment,
+)
+
+__all__ = [
+    'CkSegment',
+    'ImagePointing',
+    'build_segment',
+    'resolve_sclk_id',
+    'write_segment',
+]

--- a/src/spindoctor/cli/ck/__init__.py
+++ b/src/spindoctor/cli/ck/__init__.py
@@ -14,6 +14,13 @@ whole geometry stack into a program that only writes kernels.  That guarantee
 is checked on ``sys.modules`` in a fresh interpreter rather than by reading the
 source.
 
+The one table it shares with the attitude computation -- which spacecraft clock
+each CK object's time tags are encoded against -- lives in
+``spindoctor.spice_ids``, a constants module importing only the standard
+library.  That table is the check against ``ckmeta`` computing a clock id
+rather than validating one, so a second copy of it here would be a silent way
+for the check to rot on one side while it kept passing on the other.
+
 One global to respect: ``cspyce.use_errors()`` / ``cspyce.use_flags()`` is
 process-wide and shared with oops.  This package assumes the exceptions regime
 (``use_errors``, the package default) and never flips it.

--- a/src/spindoctor/cli/ck/pointing.py
+++ b/src/spindoctor/cli/ck/pointing.py
@@ -114,27 +114,56 @@ class ImagePointing:
                 corrected ``cmatrix`` is absent for every image that navigated
                 without an offset or with a fitted camera rotation, and such an
                 image cannot be given a segment.
-            TypeError: if a field is present but holds a value no number can
-                be read from, such as a JSON ``null``.  That is a malformed
-                document rather than an image without a solution, so it fails
-                loudly instead of being reported as an omission.
+            TypeError: if a field is present but holds a value of the wrong
+                kind -- a JSON ``null`` where a number belongs, or anything
+                but text where ``image_name`` or ``camera_frame`` belongs.
+                That is a malformed document rather than an image without a
+                solution, so it fails loudly instead of being reported as an
+                omission.  Text is never coerced: ``str(None)`` is ``'None'``,
+                which would name a written segment.
         """
         observation = _section(metadata, 'observation', 'metadata')
         navigation_result = _section(metadata, 'navigation_result', 'metadata')
         pointing = _section(navigation_result, 'pointing', 'navigation_result')
         times = _section(navigation_result, 'times', 'navigation_result')
         return cls(
-            image_name=str(_field(observation, 'image_name', 'observation')),
+            image_name=_text(observation, 'image_name', 'observation'),
             cmatrix=np.asarray(_field(pointing, 'cmatrix', 'pointing'), dtype=np.float64).reshape(
                 3, 3
             ),
-            camera_frame=str(_field(pointing, 'camera_frame', 'pointing')),
+            camera_frame=_text(pointing, 'camera_frame', 'pointing'),
             ck_frame_id=int(_field(pointing, 'ck_frame_id', 'pointing')),
             start_et=float(_field(times, 'start_et', 'times')),
             stop_et=float(_field(times, 'stop_et', 'times')),
             midtime_et=float(_field(times, 'midtime_et', 'times')),
             exposure_s=float(_field(times, 'exposure_s', 'times')),
         )
+
+
+def _text(section: dict[str, Any], key: str, where: str) -> str:
+    """Return one required metadata value that must already be a string.
+
+    ``str()`` is deliberately not used to coerce.  A JSON ``null`` coerces to
+    the text ``'None'``, which is neither empty nor obviously wrong, so an
+    image whose name is null would otherwise be given a segment identified as
+    ``None`` and pass every check downstream of it.
+
+    Parameters:
+        section: The dict to read.
+        key: The key that must be present.
+        where: Name of the section, used in the exception message.
+
+    Returns:
+        The value stored under ``key``.
+
+    Raises:
+        ValueError: if ``key`` is absent.
+        TypeError: if the value present is not a string.
+    """
+    value = _field(section, key, where)
+    if not isinstance(value, str):
+        raise TypeError(f'{where} field {key!r} is {type(value).__name__}, not a string: {value!r}')
+    return value
 
 
 def _field(section: dict[str, Any], key: str, where: str) -> Any:

--- a/src/spindoctor/cli/ck/pointing.py
+++ b/src/spindoctor/cli/ck/pointing.py
@@ -128,9 +128,7 @@ class ImagePointing:
         times = _section(navigation_result, 'times', 'navigation_result')
         return cls(
             image_name=_text(observation, 'image_name', 'observation'),
-            cmatrix=np.asarray(_field(pointing, 'cmatrix', 'pointing'), dtype=np.float64).reshape(
-                3, 3
-            ),
+            cmatrix=_rotation_from_metadata(_field(pointing, 'cmatrix', 'pointing')),
             camera_frame=_text(pointing, 'camera_frame', 'pointing'),
             ck_frame_id=int(_field(pointing, 'ck_frame_id', 'pointing')),
             start_et=float(_field(times, 'start_et', 'times')),
@@ -138,6 +136,34 @@ class ImagePointing:
             midtime_et=float(_field(times, 'midtime_et', 'times')),
             exposure_s=float(_field(times, 'exposure_s', 'times')),
         )
+
+
+def _rotation_from_metadata(value: Any) -> NDArrayFloatType:
+    """Read a recorded C-matrix, accepting only the shapes the schema writes.
+
+    The metadata records a C-matrix as nine row-major floats, so a flat
+    nine-element sequence is the canonical form and a 3x3 nesting is accepted
+    as the obvious equivalent.  Reshaping whatever arrives is deliberately not
+    done: ``(1, 9)`` and ``(3, 3, 1)`` also hold nine values and would reshape
+    silently, so a document malformed in a way worth knowing about would be
+    read as if it were well formed.
+
+    Parameters:
+        value: The recorded ``cmatrix`` value, as read from the metadata.
+
+    Returns:
+        The 3x3 rotation.
+
+    Raises:
+        ValueError: if the value does not hold nine numbers as a flat
+            sequence or a 3x3 nesting.
+    """
+    array = np.asarray(value, dtype=np.float64)
+    if array.shape not in ((9,), (3, 3)):
+        raise ValueError(
+            f'cmatrix must be nine row-major floats or a 3x3 nesting; got shape {array.shape}'
+        )
+    return array.reshape(3, 3)
 
 
 def _text(section: dict[str, Any], key: str, where: str) -> str:

--- a/src/spindoctor/cli/ck/pointing.py
+++ b/src/spindoctor/cli/ck/pointing.py
@@ -1,0 +1,194 @@
+"""One navigated image's recorded pointing, as a C-kernel writer reads it.
+
+The navigation pipeline records, for every image it navigates, the corrected
+camera attitude as a C-matrix in the SPICE camera frame convention at the
+exposure midtime, beside the frame identities and the exposure epochs a
+C-kernel segment needs.  This module turns that recorded metadata block into
+the single input type the segment writer accepts.
+
+The writer reads the metadata rather than sharing the pipeline's in-memory
+dataclass on purpose: the pipeline's version is produced by code that imports
+oops, and a kernel writer that imports oops defeats the point of writing
+kernels.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+# Spelled here rather than imported from ``spindoctor.support.types`` because
+# the writer must not import ``spindoctor.support``: its modules pull in oops.
+NDArrayFloatType = npt.NDArray[np.floating[Any]]
+
+# A recorded C-matrix must be a proper rotation to this tolerance.  Anything
+# looser is a defect in what was recorded, not something to orthonormalize
+# away, and it would be written into a kernel other tools trust.
+_ROTATION_TOL = 1e-9
+
+
+@dataclass(frozen=True)
+class ImagePointing:
+    """The corrected pointing of one navigated image.
+
+    Parameters:
+        image_name: Basename of the navigated image.  It names the segment
+            written for the image.
+        cmatrix: Corrected J2000-to-camera rotation at the exposure midtime,
+            in the SPICE camera frame convention (``v_camera = C . v_J2000``).
+        camera_frame: SPICE name of the camera frame ``cmatrix`` is expressed
+            in, for example ``'CASSINI_ISS_NAC'``.
+        ck_frame_id: SPICE id of the object a corrected C-kernel targets --
+            the bus or scan platform the existing kernels describe, not the
+            camera.
+        start_et: Exposure start, TDB seconds past J2000.
+        stop_et: Exposure stop, TDB seconds past J2000.
+        midtime_et: Exposure midtime, TDB seconds past J2000.
+        exposure_s: Exposure duration in seconds.
+
+    Raises:
+        ValueError: if ``image_name`` is empty, if ``cmatrix`` is not a 3x3
+            proper orthonormal rotation, if the three epochs are not ordered
+            ``start <= midtime <= stop``, or if ``exposure_s`` is negative.
+    """
+
+    image_name: str
+    cmatrix: NDArrayFloatType
+    camera_frame: str
+    ck_frame_id: int
+    start_et: float
+    stop_et: float
+    midtime_et: float
+    exposure_s: float
+
+    def __post_init__(self) -> None:
+        """Store the C-matrix read-only and refuse anything unusable."""
+        object.__setattr__(self, 'cmatrix', _as_rotation(self.cmatrix, 'cmatrix'))
+        if len(self.image_name) == 0:
+            raise ValueError('image_name is empty; a segment must name the image it corrects')
+        if not self.start_et <= self.midtime_et <= self.stop_et:
+            raise ValueError(
+                f'exposure epochs are out of order for {self.image_name}: start {self.start_et!r}, '
+                f'midtime {self.midtime_et!r}, stop {self.stop_et!r}'
+            )
+        if self.exposure_s < 0.0:
+            raise ValueError(f'exposure_s is negative for {self.image_name}: {self.exposure_s!r}')
+
+    @classmethod
+    def from_metadata(cls, metadata: dict[str, Any]) -> 'ImagePointing':
+        """Read one image's pointing out of its navigation metadata.
+
+        The metadata is the per-image ``_metadata.json`` dict the navigation
+        pipeline writes.  The fields read are ``observation.image_name``, the
+        ``navigation_result.pointing`` block (``cmatrix``, ``camera_frame``,
+        ``ck_frame_id``) and the ``navigation_result.times`` block
+        (``start_et``, ``stop_et``, ``midtime_et``, ``exposure_s``).  Nothing
+        else is consulted, and no eligibility rule is applied here: an image
+        whose pointing this constructor accepts is one the writer can express,
+        not necessarily one that should be written.
+
+        Parameters:
+            metadata: The image's full navigation metadata dict.
+
+        Returns:
+            The image's ImagePointing.
+
+        Raises:
+            ValueError: if any of those fields is absent, or if the values
+                present do not satisfy the ImagePointing invariants.  A
+                corrected ``cmatrix`` is absent for every image that navigated
+                without an offset or with a fitted camera rotation, and such an
+                image cannot be given a segment.
+        """
+        observation = _section(metadata, 'observation', 'metadata')
+        navigation_result = _section(metadata, 'navigation_result', 'metadata')
+        pointing = _section(navigation_result, 'pointing', 'navigation_result')
+        times = _section(navigation_result, 'times', 'navigation_result')
+        return cls(
+            image_name=str(_field(observation, 'image_name', 'observation')),
+            cmatrix=np.asarray(_field(pointing, 'cmatrix', 'pointing'), dtype=np.float64).reshape(
+                3, 3
+            ),
+            camera_frame=str(_field(pointing, 'camera_frame', 'pointing')),
+            ck_frame_id=int(_field(pointing, 'ck_frame_id', 'pointing')),
+            start_et=float(_field(times, 'start_et', 'times')),
+            stop_et=float(_field(times, 'stop_et', 'times')),
+            midtime_et=float(_field(times, 'midtime_et', 'times')),
+            exposure_s=float(_field(times, 'exposure_s', 'times')),
+        )
+
+
+def _field(section: dict[str, Any], key: str, where: str) -> Any:
+    """Return one required metadata value.
+
+    Parameters:
+        section: The dict to read.
+        key: The key that must be present.
+        where: Name of the section, used in the exception message.
+
+    Returns:
+        The value stored under ``key``.
+
+    Raises:
+        ValueError: if ``key`` is absent.
+    """
+    if key not in section:
+        raise ValueError(f'{where} has no {key!r} field; the metadata records no such value')
+    return section[key]
+
+
+def _section(metadata: dict[str, Any], key: str, where: str) -> dict[str, Any]:
+    """Return one required metadata sub-dict.
+
+    Parameters:
+        metadata: The dict to read.
+        key: The key that must be present and hold a dict.
+        where: Name of the enclosing section, used in the exception message.
+
+    Returns:
+        The sub-dict stored under ``key``.
+
+    Raises:
+        ValueError: if ``key`` is absent or does not hold a dict.
+    """
+    value = _field(metadata, key, where)
+    if not isinstance(value, dict):
+        raise ValueError(f'{where}.{key} is {type(value).__name__}, not a section')
+    return value
+
+
+def _as_rotation(matrix: NDArrayFloatType, label: str) -> NDArrayFloatType:
+    """Copy a matrix into a read-only 3x3 rotation, refusing anything else.
+
+    Parameters:
+        matrix: Any 3x3 array-like of numbers.
+        label: Name used in the exception messages.
+
+    Returns:
+        A read-only float64 copy.
+
+    Raises:
+        ValueError: if the input is not 3x3, holds a non-finite value, or is
+            not a proper orthonormal rotation to within ``_ROTATION_TOL``.
+    """
+    out = np.array(matrix, dtype=np.float64)
+    if out.shape != (3, 3):
+        raise ValueError(f'{label} is not a 3x3 matrix; got shape {out.shape}')
+    # NaN fails every inequality below, so both tolerance guards would pass a
+    # non-finite matrix silently.
+    if not bool(np.all(np.isfinite(out))):
+        raise ValueError(f'{label} holds a non-finite value: {out.tolist()!r}')
+    det = float(np.linalg.det(out))
+    if abs(det - 1.0) > _ROTATION_TOL:
+        raise ValueError(
+            f'{label} is not a proper rotation: determinant {det!r} differs from 1 by more '
+            f'than {_ROTATION_TOL}'
+        )
+    residual = float(np.max(np.abs(out @ out.T - np.eye(3))))
+    if residual > _ROTATION_TOL:
+        raise ValueError(
+            f'{label} is not orthonormal: max|C C^T - I| = {residual!r} exceeds {_ROTATION_TOL}'
+        )
+    out.setflags(write=False)
+    return out

--- a/src/spindoctor/cli/ck/pointing.py
+++ b/src/spindoctor/cli/ck/pointing.py
@@ -12,6 +12,7 @@ oops, and a kernel writer that imports oops defeats the point of writing
 kernels.
 """
 
+import math
 from dataclasses import dataclass
 from typing import Any
 
@@ -49,7 +50,8 @@ class ImagePointing:
 
     Raises:
         ValueError: if ``image_name`` is empty, if ``cmatrix`` is not a 3x3
-            proper orthonormal rotation, if the three epochs are not ordered
+            proper orthonormal rotation, if any epoch or ``exposure_s`` is not
+            finite, if the three epochs are not ordered
             ``start <= midtime <= stop``, or if ``exposure_s`` is negative.
     """
 
@@ -67,6 +69,18 @@ class ImagePointing:
         object.__setattr__(self, 'cmatrix', _as_rotation(self.cmatrix, 'cmatrix'))
         if len(self.image_name) == 0:
             raise ValueError('image_name is empty; a segment must name the image it corrects')
+        # Checked before the comparisons below, which a NaN would answer with
+        # False rather than refuse, and which an infinite epoch would satisfy
+        # outright.  Every one of these values reaches a clock encoding or a
+        # record cadence, where a non-finite value stops being attributable.
+        for field, value in (
+            ('start_et', self.start_et),
+            ('stop_et', self.stop_et),
+            ('midtime_et', self.midtime_et),
+            ('exposure_s', self.exposure_s),
+        ):
+            if not math.isfinite(value):
+                raise ValueError(f'{field} is not finite for {self.image_name}: {value!r}')
         if not self.start_et <= self.midtime_et <= self.stop_et:
             raise ValueError(
                 f'exposure epochs are out of order for {self.image_name}: start {self.start_et!r}, '

--- a/src/spindoctor/cli/ck/pointing.py
+++ b/src/spindoctor/cli/ck/pointing.py
@@ -114,6 +114,10 @@ class ImagePointing:
                 corrected ``cmatrix`` is absent for every image that navigated
                 without an offset or with a fitted camera rotation, and such an
                 image cannot be given a segment.
+            TypeError: if a field is present but holds a value no number can
+                be read from, such as a JSON ``null``.  That is a malformed
+                document rather than an image without a solution, so it fails
+                loudly instead of being reported as an omission.
         """
         observation = _section(metadata, 'observation', 'metadata')
         navigation_result = _section(metadata, 'navigation_result', 'metadata')

--- a/src/spindoctor/cli/ck/segment.py
+++ b/src/spindoctor/cli/ck/segment.py
@@ -92,8 +92,8 @@ class CkSegment:
 
     Raises:
         ValueError: if the arrays disagree on the record count, have the wrong
-            width, hold no records, or if the time tags are not strictly
-            increasing.
+            width, hold no records, hold a non-finite value, or if the time
+            tags are not strictly increasing.
     """
 
     ck_frame_id: int
@@ -125,6 +125,15 @@ class CkSegment:
                 f'segment id {self.segid!r} is longer than the {_SEGID_MAX_CHARS} characters '
                 f'SPICE stores'
             )
+        # Before the ordering check below, which a non-finite value defeats
+        # rather than fails: every comparison against a NaN is False, so a NaN
+        # time tag would read as strictly increasing, and an infinite one
+        # satisfies the ordering outright.  Both would then reach ckw03 as
+        # record data.
+        _reject_non_finite(sclkdp, 'sclkdp')
+        _reject_non_finite(quats, 'quats')
+        if avvs is not None:
+            _reject_non_finite(avvs, 'avvs')
         gaps = np.diff(sclkdp)
         if count > 1 and float(np.min(gaps)) <= 0.0:
             raise ValueError(
@@ -166,6 +175,29 @@ class CkSegment:
         coverage after it.
         """
         return float(self.sclkdp[-1])
+
+
+def _reject_non_finite(values: NDArrayFloatType, label: str) -> None:
+    """Raise unless every value in a record array is finite.
+
+    A non-finite record is not something SPICE reports back: ``ckw03`` stores
+    what it is handed, and a NaN quaternion or time tag becomes a kernel that
+    answers nonsense to every consumer that furnishes it.  It also cannot be
+    caught by the comparisons that validate ordering, since a NaN answers False
+    to all of them.
+
+    Parameters:
+        values: The record array to check.
+        label: Name of the array, used in the exception message.
+
+    Raises:
+        ValueError: if any value is not finite, naming the first such index.
+    """
+    offenders = np.argwhere(~np.isfinite(values))
+    if offenders.shape[0] == 0:
+        return
+    index = tuple(int(position) for position in offenders[0])
+    raise ValueError(f'{label} holds a non-finite value at index {index}: {float(values[index])!r}')
 
 
 def resolve_sclk_id(ck_frame_id: int) -> int:

--- a/src/spindoctor/cli/ck/segment.py
+++ b/src/spindoctor/cli/ck/segment.py
@@ -232,7 +232,12 @@ def resolve_sclk_id(ck_frame_id: int) -> int:
             f'CK object {ck_frame_id} resolves to spacecraft clock {sclk_id}, not the expected '
             f'{expected}'
         )
-    return sclk_id
+    # The recorded id is returned, not the one ``ckmeta`` computed, even though
+    # the check above has just proved them equal.  ``ckmeta`` answers for
+    # objects that do not exist, so it is a cross-check here and never the
+    # source: if this check is ever weakened, the time tags still come from the
+    # recorded table rather than from whatever ``ckmeta`` returned.
+    return expected
 
 
 def build_segment(pointing: ImagePointing) -> CkSegment:

--- a/src/spindoctor/cli/ck/segment.py
+++ b/src/spindoctor/cli/ck/segment.py
@@ -112,9 +112,9 @@ class CkSegment:
         """
         sclkdp = np.array(self.sclkdp, dtype=np.float64)
         quats = np.array(self.quats, dtype=np.float64)
-        count = sclkdp.shape[0]
-        if sclkdp.ndim != 1 or count == 0:
+        if sclkdp.ndim != 1 or sclkdp.size == 0:
             raise ValueError(f'sclkdp must hold at least one time tag; got shape {sclkdp.shape}')
+        count = sclkdp.shape[0]
         if quats.shape != (count, 4):
             raise ValueError(f'quats must have shape {(count, 4)}; got {quats.shape}')
         avvs = None if self.avvs is None else np.array(self.avvs, dtype=np.float64)
@@ -282,8 +282,10 @@ def write_segment(handle: int, segment: CkSegment) -> None:
         segment: The segment to add.
 
     Raises:
-        ValueError: if SPICE refuses the record set, for example because the
-            time tags are not strictly increasing.
+        OSError: if SPICE refuses the write, for example because the handle is
+            not open for writing or the file cannot be extended.  The record
+            set itself is already valid: ``CkSegment`` enforces the count,
+            width and strictly-increasing invariants when it is constructed.
     """
     avvs = segment.avvs
     if avvs is None:

--- a/src/spindoctor/cli/ck/segment.py
+++ b/src/spindoctor/cli/ck/segment.py
@@ -29,8 +29,11 @@ Angular velocity is copied unchanged and never rotated.  CK angular velocity is
 expressed in the segment's base reference frame (J2000), and two frames rigidly
 attached to each other have identical angular velocity in that frame, so
 rotating it through ``delta`` -- superficially the thorough treatment -- writes
-a vector in no frame at all.  A baseline that carries no angular velocity
-yields a segment that carries none, and consumers fall back to ``ckgp``.
+a vector in no frame at all.  A segment carries one angular velocity flag for
+all of its records, so a baseline that lacks angular velocity at any record --
+including an exposure straddling one baseline segment that has it and one that
+does not -- yields a segment that carries none, and consumers fall back to
+``ckgp``.
 
 The caller owns the kernel pool: the supporting kernels (LSK, SCLK, FK) and the
 one baseline C-kernel whose attitude the image was navigated against must be
@@ -115,18 +118,23 @@ class CkSegment:
     avvs: NDArrayFloatType | None
 
     def __post_init__(self) -> None:
-        """Refuse a record set SPICE would reject or a consumer would misread."""
-        sclkdp = np.asarray(self.sclkdp, dtype=np.float64)
-        quats = np.asarray(self.quats, dtype=np.float64)
+        """Refuse a record set SPICE would reject, and store it read-only.
+
+        The arrays are stored as read-only float64 copies, so the invariants
+        checked here still hold when the segment is written: a caller that
+        keeps a reference to the array it passed in cannot edit the records
+        out from under them.
+        """
+        sclkdp = np.array(self.sclkdp, dtype=np.float64)
+        quats = np.array(self.quats, dtype=np.float64)
         count = sclkdp.shape[0]
         if sclkdp.ndim != 1 or count == 0:
             raise ValueError(f'sclkdp must hold at least one time tag; got shape {sclkdp.shape}')
         if quats.shape != (count, 4):
             raise ValueError(f'quats must have shape {(count, 4)}; got {quats.shape}')
-        if self.avvs is not None and np.asarray(self.avvs).shape != (count, 3):
-            raise ValueError(
-                f'avvs must have shape {(count, 3)}; got {np.asarray(self.avvs).shape}'
-            )
+        avvs = None if self.avvs is None else np.array(self.avvs, dtype=np.float64)
+        if avvs is not None and avvs.shape != (count, 3):
+            raise ValueError(f'avvs must have shape {(count, 3)}; got {avvs.shape}')
         if len(self.segid) > _SEGID_MAX_CHARS:
             raise ValueError(
                 f'segment id {self.segid!r} is longer than the {_SEGID_MAX_CHARS} characters '
@@ -138,11 +146,18 @@ class CkSegment:
                 f'encoded SCLK time tags are not strictly increasing: smallest step is '
                 f'{float(np.min(gaps))!r}'
             )
+        sclkdp.setflags(write=False)
+        quats.setflags(write=False)
+        object.__setattr__(self, 'sclkdp', sclkdp)
+        object.__setattr__(self, 'quats', quats)
+        if avvs is not None:
+            avvs.setflags(write=False)
+            object.__setattr__(self, 'avvs', avvs)
 
     @property
     def record_count(self) -> int:
         """Number of records in the segment."""
-        return int(np.asarray(self.sclkdp).shape[0])
+        return int(self.sclkdp.shape[0])
 
     @property
     def has_angular_velocity(self) -> bool:
@@ -151,13 +166,21 @@ class CkSegment:
 
     @property
     def begtim(self) -> float:
-        """Encoded SCLK at which the segment's coverage begins."""
-        return float(np.asarray(self.sclkdp)[0])
+        """Encoded SCLK at which the segment's coverage begins.
+
+        This is the first record's time tag, and the segment advertises no
+        coverage before it.
+        """
+        return float(self.sclkdp[0])
 
     @property
     def endtim(self) -> float:
-        """Encoded SCLK at which the segment's coverage ends."""
-        return float(np.asarray(self.sclkdp)[-1])
+        """Encoded SCLK at which the segment's coverage ends.
+
+        This is the last record's time tag, and the segment advertises no
+        coverage after it.
+        """
+        return float(self.sclkdp[-1])
 
 
 def resolve_sclk_id(ck_frame_id: int) -> int:
@@ -196,22 +219,28 @@ def resolve_sclk_id(ck_frame_id: int) -> int:
 def build_segment(pointing: ImagePointing) -> CkSegment:
     """Build the corrected type-3 segment for one navigated image.
 
-    The caller must already have furnished the supporting kernels and the one
-    baseline C-kernel the image navigated against; the baseline attitude is
-    read from the pool at the exposure midtime and at every record epoch.
+    The caller must already have furnished the supporting kernels: the
+    spacecraft clock navigation used, and the frame kernel defining the CK
+    object's frame and the camera frame.  Every object but a frozen-attitude
+    one also needs the baseline C-kernel the image navigated against, read at
+    the exposure midtime and at every record epoch; a frozen-attitude object's
+    segment carries one constant attitude and never reads the baseline.
 
     Records go at the exposure start, midtime and stop, plus a 1 s cadence when
     the exposure is longer than 10 s, each encoded with ``cspyce.sce2c``.  Time
-    tags that do not strictly increase are dropped, and an exposure short enough
-    that all three epochs encode to one tick yields a single record at the
-    midtime.
+    tags that do not strictly increase are dropped, and epochs that all encode
+    to one tick yield a single record at the midtime.  Since ``sce2c`` encodes
+    a fractional tick, that happens only for an exposure whose start, midtime
+    and stop are one floating-point value, not merely for an exposure shorter
+    than a tick.
 
     Parameters:
         pointing: The image's recorded corrected pointing.
 
     Returns:
         The segment to write, carrying the baseline's angular velocity
-        unchanged when the baseline has any and none when it does not.
+        unchanged when the baseline has it at every record, and none when the
+        baseline lacks it anywhere.
 
     Raises:
         ValueError: if the CK object is not one this writer knows, if the
@@ -254,9 +283,12 @@ def build_segment(pointing: ImagePointing) -> CkSegment:
 def write_segment(handle: int, segment: CkSegment) -> None:
     """Add one type-3 segment to an open C-kernel.
 
-    The segment's interpolation interval spans its records exactly, so a
-    consumer is never handed interpolated pointing outside the exposure the
-    correction was measured over.
+    The segment is descriptor-bounded and interpolation-bounded by its own
+    records: its begin and end times are the first and last time tag, and its
+    one interpolation interval starts at the first.  A consumer asking
+    ``ckcov`` what the file covers is therefore told exactly the exposure, and
+    is never handed interpolated pointing outside the window the correction was
+    measured over.
 
     Parameters:
         handle: Handle of a C-kernel opened for writing, from ``cspyce.ckopn``.
@@ -389,7 +421,11 @@ def _baseline_attitude(ck_frame_id: int, tick: float) -> NDArrayFloatType:
 
 
 def _baseline_has_angular_velocity(ck_frame_id: int, tick: float) -> bool:
-    """Report whether the furnished baseline carries angular velocity.
+    """Probe whether the furnished baseline carries angular velocity.
+
+    This is the fast path only.  It answers for one time tag, and a segment's
+    flag has to hold for every record, so ``_baseline_history`` samples all of
+    them and its result, not this probe, decides what the segment claims.
 
     Parameters:
         ck_frame_id: SPICE id of the object.
@@ -411,6 +447,61 @@ def _baseline_has_angular_velocity(ck_frame_id: int, tick: float) -> bool:
     return True
 
 
+def _sample_with_angular_velocity(
+    ck_frame_id: int, ticks: list[float]
+) -> tuple[list[NDArrayFloatType], NDArrayFloatType] | None:
+    """Sample the baseline attitude and angular velocity at every record.
+
+    Parameters:
+        ck_frame_id: SPICE id of the object.
+        ticks: The encoded SCLK time tags to sample.
+
+    Returns:
+        The attitudes and angular velocity vectors, or ``None`` when any
+        record has no angular velocity available.  ``None`` also comes back
+        when a record has no pointing at all, which the attitude-only pass
+        then raises on.
+    """
+    attitudes: list[NDArrayFloatType] = []
+    velocities: list[NDArrayFloatType] = []
+    for tick in ticks:
+        try:
+            cmat, av, _clkout = cspyce.ckgpav(ck_frame_id, tick, _LOOKUP_TOL_TICKS, _BASE_FRAME)
+        except OSError:
+            return None
+        attitudes.append(np.asarray(cmat, dtype=np.float64))
+        velocities.append(np.asarray(av, dtype=np.float64))
+    return attitudes, np.vstack(velocities)
+
+
+def _baseline_history(
+    ck_frame_id: int, ticks: list[float]
+) -> tuple[list[NDArrayFloatType], NDArrayFloatType | None]:
+    """Sample the baseline attitude at each record, with angular velocity if all have it.
+
+    A segment carries one angular velocity flag for all of its records, so an
+    exposure straddling a baseline segment that has angular velocity and one
+    that does not cannot claim it: the corrected segment then carries none at
+    all rather than inventing vectors for the records that lack them.
+
+    Parameters:
+        ck_frame_id: SPICE id of the object.
+        ticks: The encoded SCLK time tags to sample.
+
+    Returns:
+        The baseline attitudes and its angular velocity vectors, or ``None``
+        for the angular velocity when any record has none.
+
+    Raises:
+        OSError: if the furnished kernels provide no pointing at a record.
+    """
+    if _baseline_has_angular_velocity(ck_frame_id, ticks[0]):
+        sampled = _sample_with_angular_velocity(ck_frame_id, ticks)
+        if sampled is not None:
+            return sampled
+    return [_baseline_attitude(ck_frame_id, tick) for tick in ticks], None
+
+
 def _corrected_history(
     ck_frame_id: int, ticks: list[float], delta: NDArrayFloatType
 ) -> tuple[list[NDArrayFloatType], NDArrayFloatType | None]:
@@ -423,27 +514,17 @@ def _corrected_history(
 
     Returns:
         The corrected attitudes and the baseline's angular velocity vectors,
-        or ``None`` for the angular velocity when the baseline carries none.
+        or ``None`` for the angular velocity when the baseline does not carry
+        it at every record.
 
     Raises:
         OSError: if the furnished kernels provide no pointing at a record.
     """
-    with_av = _baseline_has_angular_velocity(ck_frame_id, ticks[0])
-    attitudes: list[NDArrayFloatType] = []
-    sampled_av: list[NDArrayFloatType] = []
-    for tick in ticks:
-        if with_av:
-            cmat, av, _clkout = cspyce.ckgpav(ck_frame_id, tick, _LOOKUP_TOL_TICKS, _BASE_FRAME)
-            # Copied, never rotated through delta: angular velocity is
-            # expressed in the segment's base frame, which the correction does
-            # not touch, and two frames rigidly attached to each other share it.
-            sampled_av.append(np.asarray(av, dtype=np.float64))
-        else:
-            cmat = _baseline_attitude(ck_frame_id, tick)
-        attitudes.append(delta @ np.asarray(cmat, dtype=np.float64))
-    if not with_av:
-        return attitudes, None
-    return attitudes, np.vstack(sampled_av)
+    attitudes, velocities = _baseline_history(ck_frame_id, ticks)
+    # The angular velocity is passed through untouched: it is expressed in the
+    # segment's base frame, which the correction does not rotate, and two
+    # frames rigidly attached to each other share it.
+    return [delta @ attitude for attitude in attitudes], velocities
 
 
 def _quaternion_sequence(attitudes: list[NDArrayFloatType]) -> NDArrayFloatType:

--- a/src/spindoctor/cli/ck/segment.py
+++ b/src/spindoctor/cli/ck/segment.py
@@ -203,12 +203,16 @@ def _reject_non_finite(values: NDArrayFloatType, label: str) -> None:
 def resolve_sclk_id(ck_frame_id: int) -> int:
     """Return the spacecraft clock a CK object's time tags are encoded against.
 
-    The id comes from ``cspyce.ckmeta`` and is then checked against the clock
-    recorded for the object, because ``ckmeta`` computes rather than validates:
-    it answers for objects that do not exist, so an unnoticed wrong CK id would
-    produce a wrong clock, a successful encoding, and silently wrong time tags.
-    The recorded clocks are the ones the attitude computation checks against
-    too, so the two cannot drift apart.
+    The id comes from the recorded CK-object-to-clock mapping, and
+    ``cspyce.ckmeta`` is then required to agree with it.  It is deliberately
+    that way round rather than the reverse, because ``ckmeta`` computes rather
+    than validates: it answers for objects that do not exist, so taking its
+    word would turn an unnoticed wrong CK id into a wrong clock, a successful
+    encoding, and silently wrong time tags.  The returned value is the
+    recorded one even though the check has just proved the two equal, so that
+    weakening the check later cannot quietly make ``ckmeta`` the source.  The
+    recorded clocks are the ones the attitude computation checks against too,
+    so the two cannot drift apart.
 
     Parameters:
         ck_frame_id: SPICE id of the object a corrected C-kernel targets.

--- a/src/spindoctor/cli/ck/segment.py
+++ b/src/spindoctor/cli/ck/segment.py
@@ -48,22 +48,7 @@ import cspyce
 import numpy as np
 
 from spindoctor.cli.ck.pointing import ImagePointing, NDArrayFloatType
-
-# The CK objects whose corrected pointing this writer can express, each mapped
-# to the spacecraft clock its time tags must be encoded against.  ``ckmeta``
-# computes this mapping rather than validating it -- it answers -999 for the
-# nonexistent object -999999 without raising -- so a wrong CK id would yield a
-# plausible clock, a successful encoding, and silently wrong time tags on every
-# record.  The resolved id is therefore checked against this table.  Note that
-# the clock is not derivable from the CK object by integer division either:
-# ``-31100 // 1000`` is -32 in Python, which is the other spacecraft.
-_EXPECTED_SCLK_ID: dict[int, int] = {
-    -82000: -82,  # Cassini bus
-    -77001: -77,  # Galileo scan platform
-    -98000: -98,  # New Horizons spacecraft
-    -31100: -31,  # Voyager 1 scan platform
-    -32100: -32,  # Voyager 2 scan platform
-}
+from spindoctor.spice_ids import CK_OBJECT_SCLK_ID
 
 # The CK objects whose navigated attitude was a frozen, tolerance-snapped
 # lookup rather than an evaluated frame chain.  Their segments carry one
@@ -186,10 +171,12 @@ class CkSegment:
 def resolve_sclk_id(ck_frame_id: int) -> int:
     """Return the spacecraft clock a CK object's time tags are encoded against.
 
-    The id comes from ``cspyce.ckmeta`` and is then checked against the value
-    expected for the object, because ``ckmeta`` computes rather than validates:
+    The id comes from ``cspyce.ckmeta`` and is then checked against the clock
+    recorded for the object, because ``ckmeta`` computes rather than validates:
     it answers for objects that do not exist, so an unnoticed wrong CK id would
     produce a wrong clock, a successful encoding, and silently wrong time tags.
+    The recorded clocks are the ones the attitude computation checks against
+    too, so the two cannot drift apart.
 
     Parameters:
         ck_frame_id: SPICE id of the object a corrected C-kernel targets.
@@ -201,12 +188,12 @@ def resolve_sclk_id(ck_frame_id: int) -> int:
         ValueError: if the object is not one this writer knows, or if the id
             ``ckmeta`` resolves is not the one expected for it.
     """
-    if ck_frame_id not in _EXPECTED_SCLK_ID:
+    if ck_frame_id not in CK_OBJECT_SCLK_ID:
         raise ValueError(
             f'CK object {ck_frame_id} is not one this writer knows; expected one of '
-            f'{sorted(_EXPECTED_SCLK_ID)}'
+            f'{sorted(CK_OBJECT_SCLK_ID)}'
         )
-    expected = _EXPECTED_SCLK_ID[ck_frame_id]
+    expected = CK_OBJECT_SCLK_ID[ck_frame_id]
     sclk_id = int(cspyce.ckmeta(ck_frame_id, 'SCLK'))
     if sclk_id != expected:
         raise ValueError(

--- a/src/spindoctor/cli/ck/segment.py
+++ b/src/spindoctor/cli/ck/segment.py
@@ -1,0 +1,470 @@
+"""Type-3 C-kernel segments carrying one navigated image's corrected pointing.
+
+Navigation measures the correction at the camera, but the C-kernels that exist
+describe a bus or a scan platform, and that is where the correction has to be
+written.  With ``F = pxform(ck_frame, camera_frame, midtime)`` -- always
+computed, never assumed, because Cassini's ``F`` is a permutation-like matrix
+nowhere near the identity -- the corrected attitude of the CK object and the
+correction expressed in that object's own coordinates are::
+
+    C_ck_corrected(mid) = F^-1 . cmatrix
+    delta               = C_ck_corrected(mid) . C_ck_original(mid)^T
+
+with ``C_ck_original`` read from the baseline kernels the caller has furnished.
+Across the exposure the correction is held body-fixed::
+
+    C_ck_corrected(t) = delta . C_ck_original(t)
+
+which is the physical model -- the spacecraft is pointed slightly wrong and the
+error turns with it -- so attitude still varies correctly inside the exposure
+and smear geometry stays right.
+
+Voyager is the exception.  Its navigated attitude came from a frozen,
+tolerance-snapped pointing lookup rather than a time-varying frame chain, so a
+Voyager segment carries the single corrected attitude, constant across its
+window; writing time-varying pointing there would disagree with what was
+navigated.
+
+Angular velocity is copied unchanged and never rotated.  CK angular velocity is
+expressed in the segment's base reference frame (J2000), and two frames rigidly
+attached to each other have identical angular velocity in that frame, so
+rotating it through ``delta`` -- superficially the thorough treatment -- writes
+a vector in no frame at all.  A baseline that carries no angular velocity
+yields a segment that carries none, and consumers fall back to ``ckgp``.
+
+The caller owns the kernel pool: the supporting kernels (LSK, SCLK, FK) and the
+one baseline C-kernel whose attitude the image was navigated against must be
+furnished before ``build_segment`` is called, and the SCLK must be the one
+navigation used, since a different one is a silent time-tag error.
+"""
+
+import math
+from dataclasses import dataclass
+
+import cspyce
+import numpy as np
+
+from spindoctor.cli.ck.pointing import ImagePointing, NDArrayFloatType
+
+# The CK objects whose corrected pointing this writer can express, each mapped
+# to the spacecraft clock its time tags must be encoded against.  ``ckmeta``
+# computes this mapping rather than validating it -- it answers -999 for the
+# nonexistent object -999999 without raising -- so a wrong CK id would yield a
+# plausible clock, a successful encoding, and silently wrong time tags on every
+# record.  The resolved id is therefore checked against this table.  Note that
+# the clock is not derivable from the CK object by integer division either:
+# ``-31100 // 1000`` is -32 in Python, which is the other spacecraft.
+_EXPECTED_SCLK_ID: dict[int, int] = {
+    -82000: -82,  # Cassini bus
+    -77001: -77,  # Galileo scan platform
+    -98000: -98,  # New Horizons spacecraft
+    -31100: -31,  # Voyager 1 scan platform
+    -32100: -32,  # Voyager 2 scan platform
+}
+
+# The CK objects whose navigated attitude was a frozen, tolerance-snapped
+# lookup rather than an evaluated frame chain.  Their segments carry one
+# constant attitude across the exposure.
+_FROZEN_ATTITUDE_CK_IDS = frozenset({-31100, -32100})
+
+# Every segment is written relative to J2000, which is what the recorded
+# C-matrices are referenced to.
+_BASE_FRAME = 'J2000'
+
+# Records go at the exposure start, midtime and stop.  An exposure longer than
+# this gets additional records at the cadence below, so that a long exposure's
+# attitude history is not reduced to three points.
+_LONG_EXPOSURE_S = 10.0
+_RECORD_CADENCE_S = 1.0
+
+# Baseline pointing is read at the record epoch itself, not at whatever nearby
+# epoch a tolerance would admit.
+_LOOKUP_TOL_TICKS = 0.0
+
+# One interpolation interval per segment, spanning the exposure exactly.
+_INTERVAL_COUNT = 1
+
+# SPICE segment identifiers hold at most this many characters.
+_SEGID_MAX_CHARS = 40
+
+
+@dataclass(frozen=True)
+class CkSegment:
+    """One type-3 C-kernel segment, ready to be written.
+
+    Parameters:
+        ck_frame_id: SPICE id of the object the segment describes.
+        segid: Segment identifier, at most 40 characters.
+        sclkdp: Encoded SCLK time tags, shape ``(n,)``, strictly increasing.
+        quats: SPICE quaternions of the attitude at each time tag, shape
+            ``(n, 4)``, sign-continuous from one record to the next.
+        avvs: Angular velocity at each time tag in the segment's base frame
+            (J2000), shape ``(n, 3)``, or ``None`` when the segment carries no
+            angular velocity.
+
+    Raises:
+        ValueError: if the arrays disagree on the record count, have the wrong
+            width, hold no records, or if the time tags are not strictly
+            increasing.
+    """
+
+    ck_frame_id: int
+    segid: str
+    sclkdp: NDArrayFloatType
+    quats: NDArrayFloatType
+    avvs: NDArrayFloatType | None
+
+    def __post_init__(self) -> None:
+        """Refuse a record set SPICE would reject or a consumer would misread."""
+        sclkdp = np.asarray(self.sclkdp, dtype=np.float64)
+        quats = np.asarray(self.quats, dtype=np.float64)
+        count = sclkdp.shape[0]
+        if sclkdp.ndim != 1 or count == 0:
+            raise ValueError(f'sclkdp must hold at least one time tag; got shape {sclkdp.shape}')
+        if quats.shape != (count, 4):
+            raise ValueError(f'quats must have shape {(count, 4)}; got {quats.shape}')
+        if self.avvs is not None and np.asarray(self.avvs).shape != (count, 3):
+            raise ValueError(
+                f'avvs must have shape {(count, 3)}; got {np.asarray(self.avvs).shape}'
+            )
+        if len(self.segid) > _SEGID_MAX_CHARS:
+            raise ValueError(
+                f'segment id {self.segid!r} is longer than the {_SEGID_MAX_CHARS} characters '
+                f'SPICE stores'
+            )
+        gaps = np.diff(sclkdp)
+        if count > 1 and float(np.min(gaps)) <= 0.0:
+            raise ValueError(
+                f'encoded SCLK time tags are not strictly increasing: smallest step is '
+                f'{float(np.min(gaps))!r}'
+            )
+
+    @property
+    def record_count(self) -> int:
+        """Number of records in the segment."""
+        return int(np.asarray(self.sclkdp).shape[0])
+
+    @property
+    def has_angular_velocity(self) -> bool:
+        """True when the segment carries angular velocity."""
+        return self.avvs is not None
+
+    @property
+    def begtim(self) -> float:
+        """Encoded SCLK at which the segment's coverage begins."""
+        return float(np.asarray(self.sclkdp)[0])
+
+    @property
+    def endtim(self) -> float:
+        """Encoded SCLK at which the segment's coverage ends."""
+        return float(np.asarray(self.sclkdp)[-1])
+
+
+def resolve_sclk_id(ck_frame_id: int) -> int:
+    """Return the spacecraft clock a CK object's time tags are encoded against.
+
+    The id comes from ``cspyce.ckmeta`` and is then checked against the value
+    expected for the object, because ``ckmeta`` computes rather than validates:
+    it answers for objects that do not exist, so an unnoticed wrong CK id would
+    produce a wrong clock, a successful encoding, and silently wrong time tags.
+
+    Parameters:
+        ck_frame_id: SPICE id of the object a corrected C-kernel targets.
+
+    Returns:
+        The spacecraft clock id, for example -82 for the Cassini bus (-82000).
+
+    Raises:
+        ValueError: if the object is not one this writer knows, or if the id
+            ``ckmeta`` resolves is not the one expected for it.
+    """
+    if ck_frame_id not in _EXPECTED_SCLK_ID:
+        raise ValueError(
+            f'CK object {ck_frame_id} is not one this writer knows; expected one of '
+            f'{sorted(_EXPECTED_SCLK_ID)}'
+        )
+    expected = _EXPECTED_SCLK_ID[ck_frame_id]
+    sclk_id = int(cspyce.ckmeta(ck_frame_id, 'SCLK'))
+    if sclk_id != expected:
+        raise ValueError(
+            f'CK object {ck_frame_id} resolves to spacecraft clock {sclk_id}, not the expected '
+            f'{expected}'
+        )
+    return sclk_id
+
+
+def build_segment(pointing: ImagePointing) -> CkSegment:
+    """Build the corrected type-3 segment for one navigated image.
+
+    The caller must already have furnished the supporting kernels and the one
+    baseline C-kernel the image navigated against; the baseline attitude is
+    read from the pool at the exposure midtime and at every record epoch.
+
+    Records go at the exposure start, midtime and stop, plus a 1 s cadence when
+    the exposure is longer than 10 s, each encoded with ``cspyce.sce2c``.  Time
+    tags that do not strictly increase are dropped, and an exposure short enough
+    that all three epochs encode to one tick yields a single record at the
+    midtime.
+
+    Parameters:
+        pointing: The image's recorded corrected pointing.
+
+    Returns:
+        The segment to write, carrying the baseline's angular velocity
+        unchanged when the baseline has any and none when it does not.
+
+    Raises:
+        ValueError: if the CK object is not one this writer knows, if the
+            resolved spacecraft clock is not the expected one, or if the image
+            name does not fit a SPICE segment identifier.
+        OSError: if the furnished kernels provide no pointing for the CK object
+            at the exposure midtime or at a record epoch.
+        KeyError: if the CK object has no frame name in the furnished kernels.
+    """
+    segid = _segment_id(pointing.image_name)
+    sclk_id = resolve_sclk_id(pointing.ck_frame_id)
+    ticks = _record_ticks(pointing, sclk_id)
+    corrected_midtime = _corrected_attitude_at_midtime(pointing)
+    attitudes: list[NDArrayFloatType]
+    avvs: NDArrayFloatType | None
+    if pointing.ck_frame_id in _FROZEN_ATTITUDE_CK_IDS:
+        # The navigated model assumed one snapped attitude across the whole
+        # exposure, so the segment says exactly that.  It carries no angular
+        # velocity: a constant attitude has none, and the rigid-attachment
+        # argument that lets a body-fixed segment copy the baseline's angular
+        # velocity does not hold for a segment that deliberately drops the
+        # baseline's time variation.
+        attitudes = [corrected_midtime] * len(ticks)
+        avvs = None
+    else:
+        baseline_midtime = _baseline_attitude(
+            pointing.ck_frame_id, float(cspyce.sce2c(sclk_id, pointing.midtime_et))
+        )
+        delta = corrected_midtime @ baseline_midtime.T
+        attitudes, avvs = _corrected_history(pointing.ck_frame_id, ticks, delta)
+    return CkSegment(
+        ck_frame_id=pointing.ck_frame_id,
+        segid=segid,
+        sclkdp=np.asarray(ticks, dtype=np.float64),
+        quats=_quaternion_sequence(attitudes),
+        avvs=avvs,
+    )
+
+
+def write_segment(handle: int, segment: CkSegment) -> None:
+    """Add one type-3 segment to an open C-kernel.
+
+    The segment's interpolation interval spans its records exactly, so a
+    consumer is never handed interpolated pointing outside the exposure the
+    correction was measured over.
+
+    Parameters:
+        handle: Handle of a C-kernel opened for writing, from ``cspyce.ckopn``.
+        segment: The segment to add.
+
+    Raises:
+        ValueError: if SPICE refuses the record set, for example because the
+            time tags are not strictly increasing.
+    """
+    avvs = segment.avvs
+    if avvs is None:
+        # ckw03 wants an array either way; with avflag false it is ignored.
+        avvs = np.zeros((segment.record_count, 3), dtype=np.float64)
+    cspyce.ckw03(
+        handle,
+        segment.begtim,
+        segment.endtim,
+        segment.ck_frame_id,
+        _BASE_FRAME,
+        segment.has_angular_velocity,
+        segment.segid,
+        np.asarray(segment.sclkdp, dtype=np.float64),
+        np.asarray(segment.quats, dtype=np.float64),
+        np.asarray(avvs, dtype=np.float64),
+        _INTERVAL_COUNT,
+        [segment.begtim],
+    )
+
+
+def _segment_id(image_name: str) -> str:
+    """Return the segment identifier naming one image.
+
+    Parameters:
+        image_name: Basename of the navigated image.
+
+    Returns:
+        The identifier to store in the segment.
+
+    Raises:
+        ValueError: if the name is longer than a SPICE segment identifier,
+            since truncating it would silently lose the image's identity.
+    """
+    if len(image_name) > _SEGID_MAX_CHARS:
+        raise ValueError(
+            f'image name {image_name!r} is longer than the {_SEGID_MAX_CHARS} characters a '
+            f'SPICE segment identifier holds'
+        )
+    return image_name
+
+
+def _record_epochs(pointing: ImagePointing) -> list[float]:
+    """Return the epochs a segment carries records at, in increasing order.
+
+    Parameters:
+        pointing: The image's recorded corrected pointing.
+
+    Returns:
+        The exposure start, midtime and stop, plus interior epochs at
+        ``_RECORD_CADENCE_S`` when the exposure exceeds ``_LONG_EXPOSURE_S``.
+    """
+    epochs = [pointing.start_et, pointing.midtime_et, pointing.stop_et]
+    if pointing.exposure_s > _LONG_EXPOSURE_S:
+        steps = math.floor((pointing.stop_et - pointing.start_et) / _RECORD_CADENCE_S)
+        epochs.extend(pointing.start_et + step * _RECORD_CADENCE_S for step in range(1, steps + 1))
+    return sorted(epochs)
+
+
+def _record_ticks(pointing: ImagePointing, sclk_id: int) -> list[float]:
+    """Encode the record epochs, keeping only strictly increasing time tags.
+
+    Parameters:
+        pointing: The image's recorded corrected pointing.
+        sclk_id: The spacecraft clock the tags are encoded against.
+
+    Returns:
+        The encoded SCLK time tags, strictly increasing.  A single tag at the
+        exposure midtime when the epochs all encode to one tick, which type 3
+        permits.
+    """
+    ticks: list[float] = []
+    for epoch in _record_epochs(pointing):
+        tick = float(cspyce.sce2c(sclk_id, epoch))
+        if len(ticks) == 0 or tick > ticks[-1]:
+            ticks.append(tick)
+    if len(ticks) < 2:
+        return [float(cspyce.sce2c(sclk_id, pointing.midtime_et))]
+    return ticks
+
+
+def _corrected_attitude_at_midtime(pointing: ImagePointing) -> NDArrayFloatType:
+    """Return the corrected attitude of the CK object at the exposure midtime.
+
+    The recorded C-matrix is the corrected attitude of the *camera*; the
+    segment describes the object the baseline kernels describe.  The fixed
+    rotation between them is read from the furnished frame kernels rather than
+    assumed, since for Cassini it is nowhere near the identity.
+
+    Parameters:
+        pointing: The image's recorded corrected pointing.
+
+    Returns:
+        The 3x3 J2000-to-CK-object rotation at the midtime.
+
+    Raises:
+        KeyError: if the CK object has no frame name in the furnished kernels.
+    """
+    ck_frame = str(cspyce.frmnam(pointing.ck_frame_id))
+    camera_from_ck = np.asarray(
+        cspyce.pxform(ck_frame, pointing.camera_frame, pointing.midtime_et), dtype=np.float64
+    )
+    corrected: NDArrayFloatType = camera_from_ck.T @ np.asarray(pointing.cmatrix, dtype=np.float64)
+    return corrected
+
+
+def _baseline_attitude(ck_frame_id: int, tick: float) -> NDArrayFloatType:
+    """Read the baseline attitude of a CK object at one encoded SCLK time.
+
+    Parameters:
+        ck_frame_id: SPICE id of the object.
+        tick: Encoded SCLK time tag.
+
+    Returns:
+        The 3x3 J2000-to-CK-object rotation the furnished kernels give.
+
+    Raises:
+        OSError: if the furnished kernels provide no pointing there.
+    """
+    cmat, _clkout = cspyce.ckgp(ck_frame_id, tick, _LOOKUP_TOL_TICKS, _BASE_FRAME)
+    return np.asarray(cmat, dtype=np.float64)
+
+
+def _baseline_has_angular_velocity(ck_frame_id: int, tick: float) -> bool:
+    """Report whether the furnished baseline carries angular velocity.
+
+    Parameters:
+        ck_frame_id: SPICE id of the object.
+        tick: Encoded SCLK time tag to probe.
+
+    Returns:
+        True when angular velocity is available there.
+    """
+    try:
+        cspyce.ckgpav(ck_frame_id, tick, _LOOKUP_TOL_TICKS, _BASE_FRAME)
+    except OSError:
+        # SPICE reports "this segment carries no angular velocity" and "no
+        # pointing here at all" as the same insufficient-data error, so the two
+        # are not distinguishable from the exception.  Demoting the second to a
+        # segment without angular velocity hides nothing: the attitude lookups
+        # that follow use ckgp at the same time tags and raise for pointing
+        # that genuinely is not there.
+        return False
+    return True
+
+
+def _corrected_history(
+    ck_frame_id: int, ticks: list[float], delta: NDArrayFloatType
+) -> tuple[list[NDArrayFloatType], NDArrayFloatType | None]:
+    """Apply a body-fixed correction to the baseline attitude at each record.
+
+    Parameters:
+        ck_frame_id: SPICE id of the object.
+        ticks: The encoded SCLK time tags to sample.
+        delta: The correction in the CK object's own coordinates.
+
+    Returns:
+        The corrected attitudes and the baseline's angular velocity vectors,
+        or ``None`` for the angular velocity when the baseline carries none.
+
+    Raises:
+        OSError: if the furnished kernels provide no pointing at a record.
+    """
+    with_av = _baseline_has_angular_velocity(ck_frame_id, ticks[0])
+    attitudes: list[NDArrayFloatType] = []
+    sampled_av: list[NDArrayFloatType] = []
+    for tick in ticks:
+        if with_av:
+            cmat, av, _clkout = cspyce.ckgpav(ck_frame_id, tick, _LOOKUP_TOL_TICKS, _BASE_FRAME)
+            # Copied, never rotated through delta: angular velocity is
+            # expressed in the segment's base frame, which the correction does
+            # not touch, and two frames rigidly attached to each other share it.
+            sampled_av.append(np.asarray(av, dtype=np.float64))
+        else:
+            cmat = _baseline_attitude(ck_frame_id, tick)
+        attitudes.append(delta @ np.asarray(cmat, dtype=np.float64))
+    if not with_av:
+        return attitudes, None
+    return attitudes, np.vstack(sampled_av)
+
+
+def _quaternion_sequence(attitudes: list[NDArrayFloatType]) -> NDArrayFloatType:
+    """Convert attitudes to SPICE quaternions, keeping the sequence continuous.
+
+    ``cspyce.m2q`` fixes the scalar component non-negative, so a sequence whose
+    rotation angle crosses 180 degrees comes back with a sign flip between
+    adjacent records even though the attitude moved barely at all.  Each record
+    is negated as needed to keep a non-negative dot product with its
+    predecessor, which leaves the attitude it represents unchanged.
+
+    Parameters:
+        attitudes: The 3x3 rotations, one per record, in record order.
+
+    Returns:
+        The quaternions, shape ``(n, 4)``.
+    """
+    quats: list[NDArrayFloatType] = []
+    for attitude in attitudes:
+        quat = np.asarray(cspyce.m2q(attitude), dtype=np.float64)
+        if len(quats) > 0 and float(np.dot(quat, quats[-1])) < 0.0:
+            quat = -quat
+        quats.append(quat)
+    return np.vstack(quats)

--- a/src/spindoctor/spice_ids.py
+++ b/src/spindoctor/spice_ids.py
@@ -1,0 +1,41 @@
+"""SPICE ids shared by the attitude computation and the C-kernel writer.
+
+The one fact recorded here is which spacecraft clock a C-kernel object's time
+tags are encoded against.  ``cspyce.ckmeta`` computes that mapping rather than
+validating it -- it answers -999 for the nonexistent object -999999 without
+raising -- so a wrong CK object id yields a plausible clock id, a successful
+encoding, and silently wrong time tags on every record.  Every consumer
+therefore checks what ``ckmeta`` resolves against the mapping below instead of
+trusting it, and every consumer reads this one mapping: a second copy of these
+numbers is a way for one side's check to rot while the other side's keeps
+passing.
+
+The clock is not derivable from the CK object by arithmetic.  Python's
+``-31100 // 1000`` is -32, which is the other Voyager, so each object states
+its clock explicitly.
+
+This module holds constants and imports only the standard library, which is
+what lets the kernel writer read it: the writer must pull in neither oops nor
+anything from ``spindoctor.support``, and that guarantee is asserted on
+``sys.modules`` in a fresh interpreter.
+"""
+
+from collections.abc import Mapping
+from types import MappingProxyType
+
+__all__ = [
+    'CK_OBJECT_SCLK_ID',
+]
+
+# Read-only so that no consumer can edit the table the other consumer checks
+# against.
+CK_OBJECT_SCLK_ID: Mapping[int, int] = MappingProxyType(
+    {
+        -82000: -82,  # Cassini bus
+        -77001: -77,  # Galileo scan platform
+        -98000: -98,  # New Horizons spacecraft
+        -31100: -31,  # Voyager 1 scan platform
+        -32100: -32,  # Voyager 2 scan platform
+    }
+)
+"""The spacecraft clock each supported CK object's time tags are encoded against."""

--- a/src/spindoctor/support/cmatrix.py
+++ b/src/spindoctor/support/cmatrix.py
@@ -62,6 +62,7 @@ from spindoctor.obs import (
     ObsSnapshotInst,
     ObsVoyagerISS,
 )
+from spindoctor.spice_ids import CK_OBJECT_SCLK_ID
 from spindoctor.support.exceptions import NavPointingError
 from spindoctor.support.types import NDArrayFloatType
 
@@ -83,15 +84,6 @@ __all__ = [
 _CASSINI_CK_FRAME_ID = -82000
 _GALILEO_CK_FRAME_ID = -77001
 _LORRI_CK_FRAME_ID = -98000
-
-# The spacecraft clock each mission's time tags are encoded against.  It is
-# not derivable from the CK object id by arithmetic -- Python's -31100 // 1000
-# is -32, a different spacecraft, silently -- so each mission states its own
-# and the resolved value is checked against it.  Voyager's is derived per
-# spacecraft alongside its CK object.
-_CASSINI_SCLK_ID = -82
-_GALILEO_SCLK_ID = -77
-_LORRI_SCLK_ID = -98
 
 # What cspyce raises when the furnished kernels cannot answer: a missing frame
 # or an unresolvable clock arrives as a LookupError, an unreadable kernel as
@@ -436,6 +428,30 @@ def compute_pointing(
     )
 
 
+def _ck_object_sclk_id(ck_frame_id: int) -> int:
+    """Return the spacecraft clock a CK object's time tags are encoded against.
+
+    The value is read from the shared mapping the C-kernel writer reads too,
+    so that the clock a correction is timed with and the clock it is written
+    with cannot disagree.
+
+    Parameters:
+        ck_frame_id: SPICE id of the object a corrected C-kernel targets.
+
+    Returns:
+        The spacecraft clock id recorded for that object.
+
+    Raises:
+        NavPointingError: if no clock is recorded for the object.
+    """
+    if ck_frame_id not in CK_OBJECT_SCLK_ID:
+        raise NavPointingError(
+            f'CK object {ck_frame_id} has no recorded spacecraft clock; expected one of '
+            f'{sorted(CK_OBJECT_SCLK_ID)}'
+        )
+    return CK_OBJECT_SCLK_ID[ck_frame_id]
+
+
 def _frame_identity(obs: ObsSnapshotInst) -> _FrameIdentity | None:
     """Return the SPICE frame facts for an observation's instrument.
 
@@ -445,12 +461,16 @@ def _frame_identity(obs: ObsSnapshotInst) -> _FrameIdentity | None:
     Returns:
         The instrument's ``_FrameIdentity``, or ``None`` for a host with no
         SPICE camera frame this module knows.
+
+    Raises:
+        NavPointingError: if the instrument's CK object has no recorded
+            spacecraft clock.
     """
     if isinstance(obs, ObsCassiniISS):
         return _FrameIdentity(
             camera_frame=f'CASSINI_ISS_{obs.camera}',
             ck_frame_id=_CASSINI_CK_FRAME_ID,
-            sclk_id=_CASSINI_SCLK_ID,
+            sclk_id=_ck_object_sclk_id(_CASSINI_CK_FRAME_ID),
             oops_from_spice=_CASSINI_OOPS_FROM_SPICE,
             frozen_oops_attitude=False,
         )
@@ -458,7 +478,7 @@ def _frame_identity(obs: ObsSnapshotInst) -> _FrameIdentity | None:
         return _FrameIdentity(
             camera_frame='GLL_SCAN_PLATFORM',
             ck_frame_id=_GALILEO_CK_FRAME_ID,
-            sclk_id=_GALILEO_SCLK_ID,
+            sclk_id=_ck_object_sclk_id(_GALILEO_CK_FRAME_ID),
             oops_from_spice=_IDENTITY,
             frozen_oops_attitude=False,
         )
@@ -466,21 +486,23 @@ def _frame_identity(obs: ObsSnapshotInst) -> _FrameIdentity | None:
         return _FrameIdentity(
             camera_frame='NH_LORRI',
             ck_frame_id=_LORRI_CK_FRAME_ID,
-            sclk_id=_LORRI_SCLK_ID,
+            sclk_id=_ck_object_sclk_id(_LORRI_CK_FRAME_ID),
             oops_from_spice=_LORRI_OOPS_FROM_SPICE,
             frozen_oops_attitude=False,
         )
     if isinstance(obs, ObsVoyagerISS):
         digit = obs.spacecraft_digit
-        # One instrument key serves two spacecraft, so the CK object and the
-        # spacecraft clock are both derived from which spacecraft this is.
-        spacecraft_id = -(30 + int(digit))
+        # One instrument key serves two spacecraft, so the CK object is derived
+        # from which spacecraft this is; its clock then follows from the object
+        # rather than from the same digit, so a wrong derivation is refused
+        # instead of producing a self-consistent wrong pair.
+        ck_frame_id = -(30 + int(digit)) * 1000 - 100
         # The Voyager FK spells the cameras ISSNA and ISSWA, so the oops
         # detector names NAC and WAC contribute only their first letter.
         return _FrameIdentity(
             camera_frame=f'VG{digit}_ISS{obs.camera[0]}A',
-            ck_frame_id=spacecraft_id * 1000 - 100,
-            sclk_id=spacecraft_id,
+            ck_frame_id=ck_frame_id,
+            sclk_id=_ck_object_sclk_id(ck_frame_id),
             oops_from_spice=_IDENTITY,
             frozen_oops_attitude=True,
         )

--- a/src/spindoctor/support/cmatrix.py
+++ b/src/spindoctor/support/cmatrix.py
@@ -623,7 +623,12 @@ def _sclk_id(identity: _FrameIdentity) -> int:
             f'{identity.sclk_id} the {identity.camera_frame} camera is tagged against; every '
             f'clock string built from it would encode the wrong spacecraft'
         )
-    return resolved
+    # The recorded id is returned, not the one ``ckmeta`` computed, even though
+    # the check above has just proved them equal.  ``ckmeta`` answers for
+    # objects that do not exist, so it is a cross-check here and never the
+    # source: if this check is ever weakened, the clock strings still come from
+    # the recorded table rather than from whatever ``ckmeta`` returned.
+    return identity.sclk_id
 
 
 def _sclk_string(sclk_id: int, et: float) -> str:

--- a/tests/spindoctor/cli/ck/conftest.py
+++ b/tests/spindoctor/cli/ck/conftest.py
@@ -306,14 +306,21 @@ def baseline_segment(
 def write_ck(path: Path, segments: Sequence[CkSegment]) -> None:
     """Write segments to a new C-kernel.
 
+    The handle is closed even when a write raises.  SPICE caps the number of
+    DAF files open at once, so a handle leaked by a test that exercises a
+    failure path would go on to break an unrelated ``ckopn`` later in the same
+    worker, with an error naming neither the leak nor its cause.
+
     Parameters:
         path: File to create.
         segments: The segments to add, in order.
     """
     handle = cspyce.ckopn(str(path), 'baseline', 0)
-    for segment in segments:
-        write_segment(handle, segment)
-    cspyce.ckcls(handle)
+    try:
+        for segment in segments:
+            write_segment(handle, segment)
+    finally:
+        cspyce.ckcls(handle)
 
 
 def write_baseline_ck(

--- a/tests/spindoctor/cli/ck/conftest.py
+++ b/tests/spindoctor/cli/ck/conftest.py
@@ -1,0 +1,324 @@
+"""Hermetic SPICE fixtures and helpers for the C-kernel writer tests.
+
+Every kernel these tests use is written here: a minimal leapseconds kernel, a
+spacecraft clock kernel for the two clocks under test, a frame kernel defining
+one CK-class frame per mission with a camera frame fixed to it at a rotation
+nowhere near the identity, and the baseline C-kernels themselves, produced
+through the writer's own segment primitives.  Nothing reads the holdings and
+nothing needs a kernel from disk, so the whole suite runs with no environment
+set.
+
+The SPICE kernel pool is process-global, so the pool fixture unloads exactly
+what it furnished instead of calling ``kclear``, which would also discard
+whatever an unrelated test furnished earlier in the same worker.
+"""
+
+from collections.abc import Callable, Iterator, Sequence
+from pathlib import Path
+
+import cspyce
+import numpy as np
+import pytest
+
+from spindoctor.cli.ck.pointing import NDArrayFloatType
+from spindoctor.cli.ck.segment import CkSegment, write_segment
+
+# The two CK objects the tests exercise: a bus whose baseline attitude varies
+# across the exposure, and a scan platform standing in for the frozen-attitude
+# mission.  Both ids are real, because the writer refuses any other.
+CASSINI_CK_FRAME_ID = -82000
+CASSINI_CAMERA_FRAME = 'SD_TEST_NAC'
+VOYAGER_CK_FRAME_ID = -31100
+VOYAGER_CAMERA_FRAME = 'SD_TEST_VGCAM'
+
+# The epoch the test kernels are built around, and the clock tick size the test
+# SCLK declares.  ET0 is far enough from J2000 that a nanosecond exposure is
+# below the resolution of a double, which is what makes the degenerate
+# single-record path reachable without hand-feeding three identical epochs.
+ET0 = 5.0e8
+TICKS_PER_SECOND = 256.0
+
+# The baseline attitude turns at a constant rate about a fixed axis, which
+# makes SPICE's spherical interpolation exact at every epoch between records
+# and lets a test assert against the analytic attitude rather than against
+# another interpolation.
+_BASELINE_AXIS = np.array([0.30, -0.50, 0.81])
+_BASELINE_RATE_RAD_S = 3.0e-3
+_BASELINE_ORIENTATION_AXIS = np.array([0.6, 0.7, -0.39])
+_BASELINE_ORIENTATION_RAD = 1.13
+
+# Angular velocity that varies from record to record and points along none of
+# the axes above, so a copy that quietly rotated it would not come back equal.
+_AV_AT_ET0 = np.array([1.7e-3, -4.2e-4, 9.1e-4])
+_AV_RATE = np.array([2.3e-5, 6.1e-5, -1.9e-5])
+
+_LSK_TEXT = """KPL/LSK
+
+Minimal leapseconds kernel written by the SpinDoctor C-kernel writer tests.
+
+\\begindata
+DELTET/DELTA_T_A = 32.184
+DELTET/K         = 1.657D-3
+DELTET/EB        = 1.671D-2
+DELTET/M         = ( 6.239996D0 1.99096871D-7 )
+DELTET/DELTA_AT  = ( 10, @1972-JAN-1
+                     32, @1999-JAN-1
+                     37, @2017-JAN-1 )
+\\begintext
+"""
+
+_SCLK_TEXT = """KPL/SCLK
+
+Minimal spacecraft clock kernel written by the SpinDoctor C-kernel writer
+tests.  Both clocks tick at 1/256 second and run on TDB, so an encoded tick is
+exactly 256 times the TDB seconds past J2000.
+
+\\begindata
+SCLK_KERNEL_ID           = ( @2000-01-01/00:00:00 )
+
+SCLK_DATA_TYPE_82        = ( 1 )
+SCLK01_TIME_SYSTEM_82    = ( 1 )
+SCLK01_N_FIELDS_82       = ( 2 )
+SCLK01_MODULI_82         = ( 4294967296 256 )
+SCLK01_OFFSETS_82        = ( 0 0 )
+SCLK01_OUTPUT_DELIM_82   = ( 1 )
+SCLK_PARTITION_START_82  = ( 0.0000000000000E+00 )
+SCLK_PARTITION_END_82    = ( 1.0995116277750E+12 )
+SCLK01_COEFFICIENTS_82   = ( 0.0000000000000E+00 0.0000000000000E+00 1.0000000000000E+00 )
+
+SCLK_DATA_TYPE_31        = ( 1 )
+SCLK01_TIME_SYSTEM_31    = ( 1 )
+SCLK01_N_FIELDS_31       = ( 2 )
+SCLK01_MODULI_31         = ( 4294967296 256 )
+SCLK01_OFFSETS_31        = ( 0 0 )
+SCLK01_OUTPUT_DELIM_31   = ( 1 )
+SCLK_PARTITION_START_31  = ( 0.0000000000000E+00 )
+SCLK_PARTITION_END_31    = ( 1.0995116277750E+12 )
+SCLK01_COEFFICIENTS_31   = ( 0.0000000000000E+00 0.0000000000000E+00 1.0000000000000E+00 )
+\\begintext
+"""
+
+_FK_TEXT = """KPL/FK
+
+Minimal frame kernel written by the SpinDoctor C-kernel writer tests.  Each
+camera frame sits at a large fixed rotation from the CK object's frame, so a
+test cannot pass by confusing the two.
+
+\\begindata
+FRAME_SD_TEST_BUS         = -82000
+FRAME_-82000_NAME         = 'SD_TEST_BUS'
+FRAME_-82000_CLASS        = 3
+FRAME_-82000_CLASS_ID     = -82000
+FRAME_-82000_CENTER       = -82
+CK_-82000_SCLK            = -82
+CK_-82000_SPK             = -82
+
+FRAME_SD_TEST_NAC         = -82361
+FRAME_-82361_NAME         = 'SD_TEST_NAC'
+FRAME_-82361_CLASS        = 4
+FRAME_-82361_CLASS_ID     = -82361
+FRAME_-82361_CENTER       = -82
+TKFRAME_-82361_SPEC       = 'ANGLES'
+TKFRAME_-82361_RELATIVE   = 'SD_TEST_BUS'
+TKFRAME_-82361_ANGLES     = ( -90.0, 60.0, 30.0 )
+TKFRAME_-82361_AXES       = ( 3, 1, 3 )
+TKFRAME_-82361_UNITS      = 'DEGREES'
+
+FRAME_SD_TEST_PLATFORM    = -31100
+FRAME_-31100_NAME         = 'SD_TEST_PLATFORM'
+FRAME_-31100_CLASS        = 3
+FRAME_-31100_CLASS_ID     = -31100
+FRAME_-31100_CENTER       = -31
+CK_-31100_SCLK            = -31
+CK_-31100_SPK             = -31
+
+FRAME_SD_TEST_VGCAM       = -31101
+FRAME_-31101_NAME         = 'SD_TEST_VGCAM'
+FRAME_-31101_CLASS        = 4
+FRAME_-31101_CLASS_ID     = -31101
+FRAME_-31101_CENTER       = -31
+TKFRAME_-31101_SPEC       = 'ANGLES'
+TKFRAME_-31101_RELATIVE   = 'SD_TEST_PLATFORM'
+TKFRAME_-31101_ANGLES     = ( 20.0, -35.0, 110.0 )
+TKFRAME_-31101_AXES       = ( 1, 2, 3 )
+TKFRAME_-31101_UNITS      = 'DEGREES'
+\\begintext
+"""
+
+
+class KernelPool:
+    """The kernels one test furnished, so teardown can unload just those.
+
+    Parameters:
+        root: Directory the test may write its kernels into.
+    """
+
+    def __init__(self, root: Path) -> None:
+        """Start with an empty record of furnished kernels."""
+        self.root = root
+        self._furnished: list[Path] = []
+
+    def furnish(self, path: Path) -> None:
+        """Furnish one kernel and remember it.
+
+        Parameters:
+            path: The kernel to furnish.
+        """
+        cspyce.furnsh(str(path))
+        self._furnished.append(path)
+
+    def unload(self, path: Path) -> None:
+        """Unload one furnished kernel.
+
+        Parameters:
+            path: The kernel to unload.
+        """
+        cspyce.unload(str(path))
+        self._furnished.remove(path)
+
+    def unload_all(self) -> None:
+        """Unload every kernel this pool furnished, most recent first."""
+        for path in reversed(list(self._furnished)):
+            self.unload(path)
+
+
+@pytest.fixture
+def pool(tmp_path: Path) -> Iterator[KernelPool]:
+    """Furnish the hermetic LSK, SCLK and FK, and unload them afterwards."""
+    kernels = KernelPool(tmp_path)
+    for name, text in (('test.tls', _LSK_TEXT), ('test.tsc', _SCLK_TEXT), ('test.tf', _FK_TEXT)):
+        path = tmp_path / name
+        path.write_text(text)
+        kernels.furnish(path)
+    try:
+        yield kernels
+    finally:
+        kernels.unload_all()
+
+
+def axis_rotation(axis: NDArrayFloatType, angle_rad: float) -> NDArrayFloatType:
+    """Return the rotation of ``angle_rad`` about ``axis``.
+
+    Parameters:
+        axis: Rotation axis; need not be normalized.
+        angle_rad: Rotation angle in radians.
+
+    Returns:
+        The 3x3 rotation matrix, active on vectors.
+    """
+    unit = np.asarray(axis, dtype=np.float64) / float(np.linalg.norm(axis))
+    rotation: NDArrayFloatType = np.asarray(cspyce.axisar(unit, angle_rad), dtype=np.float64)
+    return rotation
+
+
+def baseline_attitude(et: float) -> NDArrayFloatType:
+    """Return the baseline J2000-to-CK-object attitude at one epoch.
+
+    The attitude turns at a constant rate about a fixed axis, so SPICE's
+    interpolation between any two records reproduces this function exactly and
+    a test can assert against it directly.
+
+    Parameters:
+        et: TDB seconds past J2000.
+
+    Returns:
+        The 3x3 rotation.
+    """
+    turned = axis_rotation(_BASELINE_AXIS, _BASELINE_RATE_RAD_S * (et - ET0))
+    start = axis_rotation(_BASELINE_ORIENTATION_AXIS, _BASELINE_ORIENTATION_RAD)
+    attitude: NDArrayFloatType = turned @ start
+    return attitude
+
+
+def sweeping_attitude(et: float) -> NDArrayFloatType:
+    """Return a baseline attitude whose rotation angle crosses 180 degrees.
+
+    The angle passes through 180 degrees two seconds after ET0, which is the
+    midtime of the exposure the tests use.  A quaternion sequence taken from
+    this attitude flips sign between adjacent records there, because ``m2q``
+    fixes the scalar component non-negative and the scalar component changes
+    sign as the rotation angle passes 180 degrees.
+
+    Parameters:
+        et: TDB seconds past J2000.
+
+    Returns:
+        The 3x3 rotation.
+    """
+    angle_rad = np.radians(160.0) + np.radians(10.0) * (et - ET0)
+    return axis_rotation(_BASELINE_AXIS, float(angle_rad))
+
+
+def baseline_angular_velocity(et: float) -> NDArrayFloatType:
+    """Return the baseline angular velocity at one epoch, in J2000.
+
+    Parameters:
+        et: TDB seconds past J2000.
+
+    Returns:
+        The 3-vector, varying from record to record.
+    """
+    velocity: NDArrayFloatType = _AV_AT_ET0 + _AV_RATE * (et - ET0)
+    return velocity
+
+
+def write_baseline_ck(
+    path: Path,
+    *,
+    ck_frame_id: int,
+    sclk_id: int,
+    epochs: Sequence[float],
+    attitude: Callable[[float], NDArrayFloatType],
+    angular_velocity: Callable[[float], NDArrayFloatType] | None,
+) -> None:
+    """Write the baseline C-kernel a corrected segment is measured against.
+
+    The quaternions come straight from ``cspyce.m2q`` rather than through the
+    writer's sign-continuity helper, so a baseline is exactly what a real
+    kernel is: whatever the producer stored.
+
+    Parameters:
+        path: File to create.
+        ck_frame_id: SPICE id of the object the segment describes.
+        sclk_id: Spacecraft clock the time tags are encoded against.
+        epochs: Record epochs, TDB seconds past J2000, strictly increasing.
+        attitude: The J2000-to-CK-object rotation at an epoch.
+        angular_velocity: The angular velocity at an epoch, or None to write a
+            segment carrying none.
+    """
+    ticks = [float(cspyce.sce2c(sclk_id, et)) for et in epochs]
+    quats = np.vstack([np.asarray(cspyce.m2q(attitude(et)), dtype=np.float64) for et in epochs])
+    avvs = None
+    if angular_velocity is not None:
+        avvs = np.vstack([angular_velocity(et) for et in epochs])
+    segment = CkSegment(
+        ck_frame_id=ck_frame_id,
+        segid='baseline',
+        sclkdp=np.asarray(ticks, dtype=np.float64),
+        quats=quats,
+        avvs=avvs,
+    )
+    handle = cspyce.ckopn(str(path), 'baseline', 0)
+    write_segment(handle, segment)
+    cspyce.ckcls(handle)
+
+
+def rotation_angle_between(first: NDArrayFloatType, second: NDArrayFloatType) -> float:
+    """Return the angle of the rotation carrying one attitude onto another.
+
+    The angle is taken through a quaternion rather than through the trace,
+    because the trace form loses half its digits as the angle goes to zero,
+    which is exactly the regime these comparisons live in.  It is zero if and
+    only if the two matrices are equal, so it detects a wrong direction as
+    readily as a wrong magnitude.
+
+    Parameters:
+        first: A 3x3 rotation.
+        second: A 3x3 rotation.
+
+    Returns:
+        The angle in radians, in [0, pi].
+    """
+    relative = np.asarray(first, dtype=np.float64) @ np.asarray(second, dtype=np.float64).T
+    quat = np.asarray(cspyce.m2q(relative), dtype=np.float64)
+    return float(2.0 * np.arctan2(float(np.linalg.norm(quat[1:])), abs(float(quat[0]))))

--- a/tests/spindoctor/cli/ck/conftest.py
+++ b/tests/spindoctor/cli/ck/conftest.py
@@ -262,6 +262,60 @@ def baseline_angular_velocity(et: float) -> NDArrayFloatType:
     return velocity
 
 
+def baseline_segment(
+    *,
+    ck_frame_id: int,
+    sclk_id: int,
+    epochs: Sequence[float],
+    attitude: Callable[[float], NDArrayFloatType],
+    angular_velocity: Callable[[float], NDArrayFloatType] | None,
+    segid: str = 'baseline',
+) -> CkSegment:
+    """Build one baseline segment from an attitude history.
+
+    The quaternions come straight from ``cspyce.m2q`` rather than through the
+    writer's sign-continuity helper, so a baseline is exactly what a real
+    kernel is: whatever the producer stored.
+
+    Parameters:
+        ck_frame_id: SPICE id of the object the segment describes.
+        sclk_id: Spacecraft clock the time tags are encoded against.
+        epochs: Record epochs, TDB seconds past J2000, strictly increasing.
+        attitude: The J2000-to-CK-object rotation at an epoch.
+        angular_velocity: The angular velocity at an epoch, or None for a
+            segment carrying none.
+        segid: Segment identifier.
+
+    Returns:
+        The segment.
+    """
+    ticks = [float(cspyce.sce2c(sclk_id, et)) for et in epochs]
+    quats = np.vstack([np.asarray(cspyce.m2q(attitude(et)), dtype=np.float64) for et in epochs])
+    avvs = None
+    if angular_velocity is not None:
+        avvs = np.vstack([angular_velocity(et) for et in epochs])
+    return CkSegment(
+        ck_frame_id=ck_frame_id,
+        segid=segid,
+        sclkdp=np.asarray(ticks, dtype=np.float64),
+        quats=quats,
+        avvs=avvs,
+    )
+
+
+def write_ck(path: Path, segments: Sequence[CkSegment]) -> None:
+    """Write segments to a new C-kernel.
+
+    Parameters:
+        path: File to create.
+        segments: The segments to add, in order.
+    """
+    handle = cspyce.ckopn(str(path), 'baseline', 0)
+    for segment in segments:
+        write_segment(handle, segment)
+    cspyce.ckcls(handle)
+
+
 def write_baseline_ck(
     path: Path,
     *,
@@ -273,10 +327,6 @@ def write_baseline_ck(
 ) -> None:
     """Write the baseline C-kernel a corrected segment is measured against.
 
-    The quaternions come straight from ``cspyce.m2q`` rather than through the
-    writer's sign-continuity helper, so a baseline is exactly what a real
-    kernel is: whatever the producer stored.
-
     Parameters:
         path: File to create.
         ck_frame_id: SPICE id of the object the segment describes.
@@ -286,21 +336,18 @@ def write_baseline_ck(
         angular_velocity: The angular velocity at an epoch, or None to write a
             segment carrying none.
     """
-    ticks = [float(cspyce.sce2c(sclk_id, et)) for et in epochs]
-    quats = np.vstack([np.asarray(cspyce.m2q(attitude(et)), dtype=np.float64) for et in epochs])
-    avvs = None
-    if angular_velocity is not None:
-        avvs = np.vstack([angular_velocity(et) for et in epochs])
-    segment = CkSegment(
-        ck_frame_id=ck_frame_id,
-        segid='baseline',
-        sclkdp=np.asarray(ticks, dtype=np.float64),
-        quats=quats,
-        avvs=avvs,
+    write_ck(
+        path,
+        [
+            baseline_segment(
+                ck_frame_id=ck_frame_id,
+                sclk_id=sclk_id,
+                epochs=epochs,
+                attitude=attitude,
+                angular_velocity=angular_velocity,
+            )
+        ],
     )
-    handle = cspyce.ckopn(str(path), 'baseline', 0)
-    write_segment(handle, segment)
-    cspyce.ckcls(handle)
 
 
 def rotation_angle_between(first: NDArrayFloatType, second: NDArrayFloatType) -> float:

--- a/tests/spindoctor/cli/ck/test_pointing.py
+++ b/tests/spindoctor/cli/ck/test_pointing.py
@@ -163,6 +163,34 @@ def test_from_metadata_refuses_a_non_finite_exposure(exposure_s: float) -> None:
 
 
 @pytest.mark.parametrize(
+    'cmatrix',
+    [
+        [[float(v) for v in _QUARTER_TURN]],
+        [[[float(v)] for v in _QUARTER_TURN[0:3]]] * 3,
+        [float(v) for v in _QUARTER_TURN][:8],
+    ],
+    ids=['nested-1x9', 'nested-3x3x1', 'eight-values'],
+)
+def test_from_metadata_refuses_a_misshapen_cmatrix(cmatrix: list[Any]) -> None:
+    """A nine-value array of the wrong shape is refused, not reshaped.
+
+    ``reshape(3, 3)`` accepts every nine-element array, so a document nested
+    one level too deep would otherwise be read as if it were well formed.
+
+    Parameters:
+        cmatrix: A recorded C-matrix whose shape the schema does not write.
+    """
+    with pytest.raises(ValueError, match='cmatrix must be nine row-major floats'):
+        ImagePointing.from_metadata(_metadata(cmatrix=cmatrix))
+
+
+def test_from_metadata_reads_a_flat_nine_value_cmatrix() -> None:
+    """The canonical flat form the curator writes is read as a 3x3."""
+    pointing = ImagePointing.from_metadata(_metadata())
+    assert pointing.cmatrix.shape == (3, 3)
+
+
+@pytest.mark.parametrize(
     'field', ['image_name', 'camera_frame'], ids=['image-name', 'camera-frame']
 )
 def test_from_metadata_refuses_a_null_text_field(field: str) -> None:

--- a/tests/spindoctor/cli/ck/test_pointing.py
+++ b/tests/spindoctor/cli/ck/test_pointing.py
@@ -143,6 +143,36 @@ def test_from_metadata_refuses_a_negative_exposure() -> None:
         ImagePointing.from_metadata(_metadata(exposure_s=-1.0))
 
 
+@pytest.mark.parametrize(
+    'exposure_s',
+    [float('nan'), float('inf'), float('-inf')],
+    ids=['nan', 'inf', 'negative-inf'],
+)
+def test_from_metadata_refuses_a_non_finite_exposure(exposure_s: float) -> None:
+    """A non-finite duration is refused rather than carried into the cadence.
+
+    A NaN in particular passes a negativity test, since every comparison
+    against it is False, and would reach the record-cadence arithmetic
+    unnoticed.
+    """
+    with pytest.raises(ValueError, match='exposure_s is not finite'):
+        ImagePointing.from_metadata(_metadata(exposure_s=exposure_s))
+
+
+@pytest.mark.parametrize(
+    'field', ['start_et', 'stop_et', 'midtime_et'], ids=['start', 'stop', 'midtime']
+)
+def test_from_metadata_refuses_a_non_finite_epoch(field: str) -> None:
+    """A non-finite epoch is refused before it reaches a clock encoding.
+
+    The ordering check catches a NaN epoch only as a side effect of every
+    comparison against NaN being False; an infinite one satisfies the ordering
+    outright.
+    """
+    with pytest.raises(ValueError, match=f'{field} is not finite'):
+        ImagePointing.from_metadata(_metadata(**{field: float('inf')}))
+
+
 def test_from_metadata_refuses_an_empty_image_name() -> None:
     """A segment must name the image it corrects."""
     with pytest.raises(ValueError, match='image_name is empty'):

--- a/tests/spindoctor/cli/ck/test_pointing.py
+++ b/tests/spindoctor/cli/ck/test_pointing.py
@@ -163,6 +163,23 @@ def test_from_metadata_refuses_a_non_finite_exposure(exposure_s: float) -> None:
 
 
 @pytest.mark.parametrize(
+    'field', ['image_name', 'camera_frame'], ids=['image-name', 'camera-frame']
+)
+def test_from_metadata_refuses_a_null_text_field(field: str) -> None:
+    """A null where text belongs is refused rather than coerced.
+
+    ``str(None)`` is the text ``'None'``, which is neither empty nor
+    obviously wrong, so a null image name would otherwise identify a written
+    segment and pass every downstream check.
+
+    Parameters:
+        field: Name of the text field set to a JSON null.
+    """
+    with pytest.raises(TypeError, match=f'{field!r} is NoneType, not a string'):
+        ImagePointing.from_metadata(_metadata(**{field: None}))
+
+
+@pytest.mark.parametrize(
     'field', ['start_et', 'stop_et', 'midtime_et'], ids=['start', 'stop', 'midtime']
 )
 def test_from_metadata_refuses_a_non_finite_epoch(field: str) -> None:

--- a/tests/spindoctor/cli/ck/test_pointing.py
+++ b/tests/spindoctor/cli/ck/test_pointing.py
@@ -154,6 +154,9 @@ def test_from_metadata_refuses_a_non_finite_exposure(exposure_s: float) -> None:
     A NaN in particular passes a negativity test, since every comparison
     against it is False, and would reach the record-cadence arithmetic
     unnoticed.
+
+    Parameters:
+        exposure_s: Non-finite duration recorded in the metadata.
     """
     with pytest.raises(ValueError, match='exposure_s is not finite'):
         ImagePointing.from_metadata(_metadata(exposure_s=exposure_s))
@@ -168,6 +171,9 @@ def test_from_metadata_refuses_a_non_finite_epoch(field: str) -> None:
     The ordering check catches a NaN epoch only as a side effect of every
     comparison against NaN being False; an infinite one satisfies the ordering
     outright.
+
+    Parameters:
+        field: Name of the exposure epoch set to infinity.
     """
     with pytest.raises(ValueError, match=f'{field} is not finite'):
         ImagePointing.from_metadata(_metadata(**{field: float('inf')}))

--- a/tests/spindoctor/cli/ck/test_pointing.py
+++ b/tests/spindoctor/cli/ck/test_pointing.py
@@ -1,0 +1,171 @@
+"""Hermetic tests for ``spindoctor.cli.ck.pointing``.
+
+The writer's input type is the boundary between the navigation metadata and
+SPICE, so these tests pin what it accepts out of a metadata dict and what it
+refuses.  Nothing here furnishes a kernel.
+"""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from spindoctor.cli.ck.pointing import ImagePointing
+
+# A recognizable, deliberately non-symmetric rotation: a quarter turn about Z.
+_QUARTER_TURN = [0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+
+_START_ET = 5.0e8
+_EXPOSURE_S = 2.0
+
+
+def _metadata(**overrides: Any) -> dict[str, Any]:
+    """Build a navigation metadata dict shaped like the pipeline's own.
+
+    Parameters:
+        overrides: Values replacing entries of the ``pointing`` or ``times``
+            blocks, or of the top-level ``observation`` block.
+
+    Returns:
+        The metadata dict.
+    """
+    pointing: dict[str, Any] = {
+        'cmatrix': list(_QUARTER_TURN),
+        'cmatrix_original': list(_QUARTER_TURN),
+        'camera_frame': 'CASSINI_ISS_NAC',
+        'camera_frame_id': -82360,
+        'ck_frame_id': -82000,
+    }
+    times: dict[str, Any] = {
+        'start_et': _START_ET,
+        'stop_et': _START_ET + _EXPOSURE_S,
+        'midtime_et': _START_ET + _EXPOSURE_S / 2.0,
+        'exposure_s': _EXPOSURE_S,
+        'sclk_start': '1/1484573293.055',
+        'sclk_midtime': '1/1484573295.118',
+        'sclk_stop': '1/1484573297.181',
+    }
+    observation: dict[str, Any] = {
+        'image_name': 'N1484573295_1.IMG',
+        'instrument': 'COISS',
+        'camera': 'NAC',
+        'shutter_mode': 'NACONLY',
+    }
+    for key, value in overrides.items():
+        if key in pointing:
+            pointing[key] = value
+        elif key in times:
+            times[key] = value
+        else:
+            observation[key] = value
+    return {
+        'status': 'success',
+        'observation': observation,
+        'navigation_result': {'pointing': pointing, 'times': times},
+    }
+
+
+def test_from_metadata_reads_the_recorded_block() -> None:
+    """Every field the writer needs comes out of the metadata unchanged."""
+    pointing = ImagePointing.from_metadata(_metadata())
+    assert pointing.image_name == 'N1484573295_1.IMG'
+    assert pointing.camera_frame == 'CASSINI_ISS_NAC'
+    assert pointing.ck_frame_id == -82000
+    assert pointing.start_et == _START_ET
+    assert pointing.stop_et == _START_ET + _EXPOSURE_S
+    assert pointing.midtime_et == _START_ET + _EXPOSURE_S / 2.0
+    assert pointing.exposure_s == _EXPOSURE_S
+    assert np.array_equal(pointing.cmatrix, np.asarray(_QUARTER_TURN).reshape(3, 3))
+
+
+def test_from_metadata_stores_the_matrix_read_only() -> None:
+    """The stored C-matrix cannot be mutated behind the writer's back."""
+    pointing = ImagePointing.from_metadata(_metadata())
+    assert pointing.cmatrix.flags.writeable is False
+
+
+def test_from_metadata_refuses_a_result_with_no_corrected_matrix() -> None:
+    """An image that navigated without a corrected attitude has no segment to write."""
+    metadata = _metadata()
+    del metadata['navigation_result']['pointing']['cmatrix']
+    with pytest.raises(ValueError, match="pointing has no 'cmatrix' field"):
+        ImagePointing.from_metadata(metadata)
+
+
+def test_from_metadata_refuses_a_result_with_no_pointing_block() -> None:
+    """Metadata predating the recorded pointing is refused, not guessed at."""
+    metadata = _metadata()
+    del metadata['navigation_result']['pointing']
+    with pytest.raises(ValueError, match="navigation_result has no 'pointing' field"):
+        ImagePointing.from_metadata(metadata)
+
+
+def test_from_metadata_refuses_a_times_block_of_the_wrong_shape() -> None:
+    """A section that is not a section is named as such."""
+    metadata = _metadata()
+    metadata['navigation_result']['times'] = [1.0, 2.0]
+    with pytest.raises(ValueError, match=r'navigation_result\.times is list, not a section'):
+        ImagePointing.from_metadata(metadata)
+
+
+def test_from_metadata_refuses_a_missing_epoch() -> None:
+    """An absent exposure epoch is refused rather than defaulted."""
+    metadata = _metadata()
+    del metadata['navigation_result']['times']['midtime_et']
+    with pytest.raises(ValueError, match="times has no 'midtime_et' field"):
+        ImagePointing.from_metadata(metadata)
+
+
+def test_from_metadata_refuses_a_matrix_that_is_not_a_rotation() -> None:
+    """A C-matrix that lost orthonormality is refused, not orthonormalized."""
+    scaled = [value * 1.5 for value in _QUARTER_TURN]
+    with pytest.raises(ValueError, match='cmatrix is not a proper rotation'):
+        ImagePointing.from_metadata(_metadata(cmatrix=scaled))
+
+
+def test_from_metadata_refuses_a_non_finite_matrix() -> None:
+    """A non-finite C-matrix is refused before any tolerance test can pass it."""
+    broken = list(_QUARTER_TURN)
+    broken[0] = float('nan')
+    with pytest.raises(ValueError, match='cmatrix holds a non-finite value'):
+        ImagePointing.from_metadata(_metadata(cmatrix=broken))
+
+
+def test_from_metadata_refuses_epochs_out_of_order() -> None:
+    """A midtime outside the exposure is refused."""
+    with pytest.raises(ValueError, match='exposure epochs are out of order'):
+        ImagePointing.from_metadata(_metadata(midtime_et=_START_ET - 1.0))
+
+
+def test_from_metadata_refuses_a_negative_exposure() -> None:
+    """A negative exposure duration is refused."""
+    with pytest.raises(ValueError, match='exposure_s is negative'):
+        ImagePointing.from_metadata(_metadata(exposure_s=-1.0))
+
+
+def test_from_metadata_refuses_an_empty_image_name() -> None:
+    """A segment must name the image it corrects."""
+    with pytest.raises(ValueError, match='image_name is empty'):
+        ImagePointing.from_metadata(_metadata(image_name=''))
+
+
+def test_refuses_a_matrix_that_is_not_orthonormal() -> None:
+    """A shear has determinant 1 and is still not an attitude."""
+    shear = [1.0, 0.1, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+    with pytest.raises(ValueError, match='cmatrix is not orthonormal'):
+        ImagePointing.from_metadata(_metadata(cmatrix=shear))
+
+
+def test_refuses_a_matrix_of_the_wrong_shape() -> None:
+    """Anything but a 3x3 is refused by name rather than by a numpy message."""
+    with pytest.raises(ValueError, match=r'cmatrix is not a 3x3 matrix; got shape \(2, 2\)'):
+        ImagePointing(
+            image_name='N1484573295_1.IMG',
+            cmatrix=np.eye(2),
+            camera_frame='CASSINI_ISS_NAC',
+            ck_frame_id=-82000,
+            start_et=_START_ET,
+            stop_et=_START_ET + _EXPOSURE_S,
+            midtime_et=_START_ET + _EXPOSURE_S / 2.0,
+            exposure_s=_EXPOSURE_S,
+        )

--- a/tests/spindoctor/cli/ck/test_segment.py
+++ b/tests/spindoctor/cli/ck/test_segment.py
@@ -202,7 +202,12 @@ def _attitude_from_pool(ck_frame_id: int, sclk_id: int, et: float) -> NDArrayFlo
     ids=['start', 'midtime', 'stop', 'interior'],
 )
 def test_corrected_attitude_matches_composed_truth(pool: KernelPool, query_et: float) -> None:
-    """The written attitude is the planted correction on the baseline history."""
+    """The written attitude is the planted correction on the baseline history.
+
+    Parameters:
+        query_et: Epoch the corrected kernel is queried at, TDB seconds past
+            J2000.
+    """
     case = _build_case(pool)
     _swap_to_corrected(pool, case)
     read = _attitude_from_pool(CASSINI_CK_FRAME_ID, -82, query_et)
@@ -453,7 +458,12 @@ def test_a_sub_tick_exposure_still_yields_three_records(pool: KernelPool) -> Non
 def test_record_count_follows_the_cadence(
     pool: KernelPool, exposure_s: float, expected_records: int
 ) -> None:
-    """Long exposures get a one-second cadence; short ones get three records."""
+    """Long exposures get a one-second cadence; short ones get three records.
+
+    Parameters:
+        exposure_s: Exposure duration under test, in seconds.
+        expected_records: Records the segment should hold for that duration.
+    """
     start_et = ET0 + 1.0
     stop_et = start_et + exposure_s
     case = _build_case(
@@ -471,7 +481,12 @@ def test_record_count_follows_the_cadence(
 def test_frozen_attitude_object_is_constant_across_the_exposure(
     pool: KernelPool, query_et: float
 ) -> None:
-    """A frozen-attitude object carries one attitude, not the baseline history."""
+    """A frozen-attitude object carries one attitude, not the baseline history.
+
+    Parameters:
+        query_et: Epoch the corrected kernel is queried at, TDB seconds past
+            J2000.
+    """
     case = _build_case(pool, ck_frame_id=VOYAGER_CK_FRAME_ID, camera_frame=VOYAGER_CAMERA_FRAME)
     _swap_to_corrected(pool, case)
     read = _attitude_from_pool(VOYAGER_CK_FRAME_ID, -31, query_et)
@@ -507,6 +522,10 @@ def test_resolve_sclk_id(ck_frame_id: int, sclk_id: int) -> None:
 
     Voyager 1 is the case integer division gets wrong: ``-31100 // 1000`` is
     -32 in Python, which is the other spacecraft.
+
+    Parameters:
+        ck_frame_id: SPICE id of the object a corrected kernel targets.
+        sclk_id: Spacecraft clock that object's time tags are encoded against.
     """
     assert resolve_sclk_id(ck_frame_id) == sclk_id
 
@@ -574,6 +593,9 @@ def test_segment_refuses_a_scalar_time_tag(sclkdp: object) -> None:
     A zero-dimensional array has no length to read, so the shape guard has to
     run before anything indexes it; otherwise the failure is an ``IndexError``
     from inside the guard's own arithmetic.
+
+    Parameters:
+        sclkdp: Scalar passed where the time tag array belongs.
     """
     with pytest.raises(ValueError, match=r'sclkdp must hold at least one time tag; got shape \(\)'):
         CkSegment(
@@ -582,6 +604,67 @@ def test_segment_refuses_a_scalar_time_tag(sclkdp: object) -> None:
             sclkdp=cast(NDArrayFloatType, sclkdp),
             quats=np.vstack([cspyce.m2q(np.eye(3))]),
             avvs=None,
+        )
+
+
+@pytest.mark.parametrize('bad', [float('nan'), float('inf')], ids=['nan', 'inf'])
+def test_segment_refuses_a_non_finite_time_tag(bad: float) -> None:
+    """A non-finite time tag is refused rather than handed to ckw03.
+
+    The ordering check is no defense: a NaN reads as strictly increasing
+    because every comparison against it is False, and an infinity satisfies
+    the ordering outright.
+
+    Parameters:
+        bad: Non-finite value planted in the second time tag.
+    """
+    quats = np.vstack([cspyce.m2q(np.eye(3))] * 2)
+    with pytest.raises(ValueError, match=r'sclkdp holds a non-finite value at index \(1,\)'):
+        CkSegment(
+            ck_frame_id=CASSINI_CK_FRAME_ID,
+            segid='non-finite',
+            sclkdp=np.array([1.0, bad]),
+            quats=quats,
+            avvs=None,
+        )
+
+
+@pytest.mark.parametrize('bad', [float('nan'), float('inf')], ids=['nan', 'inf'])
+def test_segment_refuses_a_non_finite_quaternion(bad: float) -> None:
+    """A non-finite quaternion component is refused, naming where it sits.
+
+    Parameters:
+        bad: Non-finite value planted in the second record's third component.
+    """
+    quats = np.vstack([cspyce.m2q(np.eye(3))] * 2)
+    quats[1, 2] = bad
+    with pytest.raises(ValueError, match=r'quats holds a non-finite value at index \(1, 2\)'):
+        CkSegment(
+            ck_frame_id=CASSINI_CK_FRAME_ID,
+            segid='non-finite',
+            sclkdp=np.array([1.0, 2.0]),
+            quats=quats,
+            avvs=None,
+        )
+
+
+@pytest.mark.parametrize('bad', [float('nan'), float('inf')], ids=['nan', 'inf'])
+def test_segment_refuses_a_non_finite_angular_velocity(bad: float) -> None:
+    """A non-finite angular velocity component is refused, naming where it sits.
+
+    Parameters:
+        bad: Non-finite value planted in the first record's second component.
+    """
+    quats = np.vstack([cspyce.m2q(np.eye(3))] * 2)
+    avvs = np.zeros((2, 3))
+    avvs[0, 1] = bad
+    with pytest.raises(ValueError, match=r'avvs holds a non-finite value at index \(0, 1\)'):
+        CkSegment(
+            ck_frame_id=CASSINI_CK_FRAME_ID,
+            segid='non-finite',
+            sclkdp=np.array([1.0, 2.0]),
+            quats=quats,
+            avvs=avvs,
         )
 
 

--- a/tests/spindoctor/cli/ck/test_segment.py
+++ b/tests/spindoctor/cli/ck/test_segment.py
@@ -19,15 +19,18 @@ from tests.spindoctor.cli.ck.conftest import (
     CASSINI_CAMERA_FRAME,
     CASSINI_CK_FRAME_ID,
     ET0,
+    TICKS_PER_SECOND,
     VOYAGER_CAMERA_FRAME,
     VOYAGER_CK_FRAME_ID,
     KernelPool,
     axis_rotation,
     baseline_angular_velocity,
     baseline_attitude,
+    baseline_segment,
     rotation_angle_between,
     sweeping_attitude,
     write_baseline_ck,
+    write_ck,
 )
 
 from spindoctor.cli.ck.pointing import ImagePointing, NDArrayFloatType
@@ -236,6 +239,31 @@ def test_angular_velocity_is_copied_unchanged(pool: KernelPool) -> None:
     assert np.array_equal(corrected_av[2], baseline_av[2])
 
 
+def test_written_coverage_is_exactly_the_exposure(pool: KernelPool) -> None:
+    """The file advertises the exposure and not one tick more.
+
+    ``ckcov`` reports what the segment descriptor claims, which is what a
+    consumer and the file-mirroring step both read; it is independent of the
+    records the segment actually holds, so a descriptor widened beyond them
+    would go unnoticed by any assertion made on the record array.
+    """
+    case = _build_case(pool)
+    cover = cspyce.ckcov(
+        str(case.corrected_path), CASSINI_CK_FRAME_ID, False, 'SEGMENT', 0.0, 'SCLK'
+    )
+    assert len(cover) == 2
+    assert float(cover[0]) == _tick(-82, _START_ET)
+    assert float(cover[1]) == _tick(-82, _STOP_ET)
+
+
+def test_pointing_outside_the_written_window_falls_through(pool: KernelPool) -> None:
+    """A consumer gets nothing from the corrected kernel outside the exposure."""
+    case = _build_case(pool)
+    _swap_to_corrected(pool, case)
+    with pytest.raises(OSError, match='CKINSUFFDATA'):
+        cspyce.ckgp(CASSINI_CK_FRAME_ID, _tick(-82, _STOP_ET + 0.25), 0.0, 'J2000')
+
+
 def test_angular_velocity_absent_from_baseline_stays_absent(pool: KernelPool) -> None:
     """A baseline without angular velocity yields a segment without it."""
     case = _build_case(pool, with_angular_velocity=False)
@@ -248,6 +276,104 @@ def test_angular_velocity_absent_from_baseline_stays_absent(pool: KernelPool) ->
     read = _attitude_from_pool(CASSINI_CK_FRAME_ID, -82, midtime)
     truth = case.correction @ baseline_attitude(midtime)
     assert rotation_angle_between(read, truth) < _ANGLE_TOL_RAD
+
+
+def test_angular_velocity_missing_from_part_of_the_exposure_is_not_claimed(
+    pool: KernelPool,
+) -> None:
+    """An exposure straddling a baseline that loses angular velocity claims none.
+
+    One flag covers the whole segment, so a segment cannot say that half its
+    records have angular velocity.  It must not fail either: the pointing is
+    all there.
+    """
+    sclk_id = resolve_sclk_id(CASSINI_CK_FRAME_ID)
+    baseline_path = pool.root / 'baseline.bc'
+    write_ck(
+        baseline_path,
+        [
+            baseline_segment(
+                ck_frame_id=CASSINI_CK_FRAME_ID,
+                sclk_id=sclk_id,
+                epochs=[ET0 + step * 0.5 for step in range(5)],
+                attitude=baseline_attitude,
+                angular_velocity=baseline_angular_velocity,
+                segid='with-av',
+            ),
+            baseline_segment(
+                ck_frame_id=CASSINI_CK_FRAME_ID,
+                sclk_id=sclk_id,
+                epochs=[ET0 + 2.5 + step * 0.5 for step in range(5)],
+                attitude=baseline_attitude,
+                angular_velocity=None,
+                segid='without-av',
+            ),
+        ],
+    )
+    pool.furnish(baseline_path)
+    correction = axis_rotation(_CORRECTION_AXIS, _CORRECTION_RAD)
+    midtime = (_START_ET + _STOP_ET) / 2.0
+    camera_from_ck = np.asarray(
+        cspyce.pxform(str(cspyce.frmnam(CASSINI_CK_FRAME_ID)), CASSINI_CAMERA_FRAME, midtime),
+        dtype=np.float64,
+    )
+    pointing = ImagePointing(
+        image_name=_IMAGE_NAME,
+        cmatrix=camera_from_ck @ correction @ baseline_attitude(midtime),
+        camera_frame=CASSINI_CAMERA_FRAME,
+        ck_frame_id=CASSINI_CK_FRAME_ID,
+        start_et=_START_ET,
+        stop_et=_STOP_ET,
+        midtime_et=midtime,
+        exposure_s=_STOP_ET - _START_ET,
+    )
+    segment = build_segment(pointing)
+    # The premise: angular velocity at the first record, none at the last.
+    cspyce.ckgpav(CASSINI_CK_FRAME_ID, _tick(sclk_id, _START_ET), 0.0, 'J2000')
+    with pytest.raises(OSError, match='CKINSUFFDATA'):
+        cspyce.ckgpav(CASSINI_CK_FRAME_ID, _tick(sclk_id, _STOP_ET), 0.0, 'J2000')
+    assert segment.avvs is None
+    assert segment.record_count == 3
+    truth = correction @ baseline_attitude(_STOP_ET)
+    written = np.asarray(cspyce.q2m(segment.quats[-1]), dtype=np.float64)
+    assert rotation_angle_between(written, truth) < _ANGLE_TOL_RAD
+
+
+def test_a_record_outside_the_baseline_coverage_is_refused(pool: KernelPool) -> None:
+    """Baseline pointing is read at the record epoch, never snapped to a distant one.
+
+    The lookup tolerance is zero, so an exposure the baseline does not cover
+    fails instead of being corrected against whatever attitude happens to be
+    nearest.
+    """
+    with pytest.raises(OSError, match='CKINSUFFDATA'):
+        _build_case(pool, start_et=ET0 + 10.0, stop_et=ET0 + 12.0)
+
+
+def test_a_ck_object_with_no_frame_name_is_refused(pool: KernelPool) -> None:
+    """Without the frame kernel there is no rotation to the camera, and no guess at one."""
+    pointing = ImagePointing(
+        image_name=_IMAGE_NAME,
+        cmatrix=np.eye(3),
+        camera_frame=CASSINI_CAMERA_FRAME,
+        ck_frame_id=CASSINI_CK_FRAME_ID,
+        start_et=_START_ET,
+        stop_et=_STOP_ET,
+        midtime_et=(_START_ET + _STOP_ET) / 2.0,
+        exposure_s=_STOP_ET - _START_ET,
+    )
+    pool.unload(pool.root / 'test.tf')
+    with pytest.raises(KeyError, match='FRAMEIDNOTFOUND'):
+        build_segment(pointing)
+
+
+def test_segment_stores_its_records_read_only(pool: KernelPool) -> None:
+    """A caller cannot edit a validated record set after the fact."""
+    case = _build_case(pool)
+    assert case.segment.sclkdp.flags.writeable is False
+    assert case.segment.quats.flags.writeable is False
+    assert case.segment.avvs is not None
+    assert case.segment.avvs.flags.writeable is False
 
 
 def test_quaternion_records_are_sign_continuous(pool: KernelPool) -> None:
@@ -269,24 +395,55 @@ def test_quaternion_records_are_sign_continuous(pool: KernelPool) -> None:
     assert rotation_angle_between(read, truth) < _ANGLE_TOL_RAD
 
 
-def test_sub_tick_exposure_yields_one_record(pool: KernelPool) -> None:
-    """An exposure below the resolution of an epoch collapses to one record."""
+def test_coincident_exposure_epochs_yield_one_record(pool: KernelPool) -> None:
+    """Three epochs that are one floating-point value yield one valid record.
+
+    This is the only way the single-record path is reached.  ``sce2c`` encodes
+    a fractional tick, so an exposure merely shorter than a tick still encodes
+    to three distinct time tags: with the test clock's 1/256 s tick, a 1 ms
+    exposure is 0.256 ticks and produces three records.  Only epochs that do
+    not differ as doubles collapse, which no real exposure produces -- the
+    shortest Cassini ISS exposure is 5 ms.
+    """
     start_et = ET0 + 2.0
     stop_et = start_et + 1.0e-9
+    midtime_et = start_et + 5.0e-10
     case = _build_case(
         pool,
         start_et=start_et,
         stop_et=stop_et,
-        midtime_et=start_et + 5.0e-10,
+        midtime_et=midtime_et,
         exposure_s=1.0e-9,
     )
     _swap_to_corrected(pool, case)
     read = _attitude_from_pool(CASSINI_CK_FRAME_ID, -82, start_et)
     truth = case.correction @ baseline_attitude(case.pointing.midtime_et)
     assert stop_et == start_et
+    assert midtime_et == start_et
     assert case.segment.record_count == 1
     assert case.segment.begtim == case.segment.endtim
     assert rotation_angle_between(read, truth) < _ANGLE_TOL_RAD
+
+
+def test_a_sub_tick_exposure_still_yields_three_records(pool: KernelPool) -> None:
+    """An exposure shorter than a clock tick is not degenerate.
+
+    The encoded time tags differ in their fractional part, so the ordinary
+    three-record path applies.
+    """
+    start_et = ET0 + 2.0
+    exposure_s = 1.0e-3
+    case = _build_case(
+        pool,
+        start_et=start_et,
+        stop_et=start_et + exposure_s,
+        midtime_et=start_et + exposure_s / 2.0,
+        exposure_s=exposure_s,
+    )
+    ticks = np.asarray(case.segment.sclkdp, dtype=np.float64)
+    assert exposure_s * TICKS_PER_SECOND < 1.0
+    assert case.segment.record_count == 3
+    assert float(np.min(np.diff(ticks))) > 0.0
 
 
 @pytest.mark.parametrize(
@@ -324,7 +481,9 @@ def test_frozen_attitude_object_is_constant_across_the_exposure(
 
 
 def test_frozen_attitude_object_carries_no_angular_velocity(pool: KernelPool) -> None:
-    """A constant-attitude segment claims no angular velocity, whatever the baseline had."""
+    """A constant-attitude segment claims no angular velocity, whatever the
+    baseline had.
+    """
     case = _build_case(pool, ck_frame_id=VOYAGER_CK_FRAME_ID, camera_frame=VOYAGER_CAMERA_FRAME)
     assert case.segment.avvs is None
     assert case.segment.has_angular_velocity is False

--- a/tests/spindoctor/cli/ck/test_segment.py
+++ b/tests/spindoctor/cli/ck/test_segment.py
@@ -1,0 +1,440 @@
+"""Hermetic tests for ``spindoctor.cli.ck.segment``.
+
+Each test builds its own baseline C-kernel from a known attitude history, plants
+a known correction, has the writer produce the corrected segment, and then reads
+the corrected kernel back through SPICE.  The assertions compare attitudes to
+the composed truth matrix itself rather than to the magnitude of the correction,
+because a magnitude survives a reversed composition, a dropped conjugation and a
+sign flip alike.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import cspyce
+import numpy as np
+import pytest
+from tests.spindoctor.cli.ck.conftest import (
+    CASSINI_CAMERA_FRAME,
+    CASSINI_CK_FRAME_ID,
+    ET0,
+    VOYAGER_CAMERA_FRAME,
+    VOYAGER_CK_FRAME_ID,
+    KernelPool,
+    axis_rotation,
+    baseline_angular_velocity,
+    baseline_attitude,
+    rotation_angle_between,
+    sweeping_attitude,
+    write_baseline_ck,
+)
+
+from spindoctor.cli.ck.pointing import ImagePointing, NDArrayFloatType
+from spindoctor.cli.ck.segment import CkSegment, build_segment, resolve_sclk_id, write_segment
+
+# The correction the tests plant, expressed in the CK object's own frame.  It is
+# far larger than a navigated correction ever is and turns about an axis shared
+# with neither the baseline attitude nor the baseline angular velocity, so a
+# composition applied in the wrong order or on the wrong side cannot come out
+# equal to the right one by symmetry.
+_CORRECTION_AXIS = np.array([-0.8, 0.1, 0.59])
+_CORRECTION_RAD = np.radians(5.0)
+
+# The baseline kernels carry records every half second from ET0, and the
+# exposure under test runs from ET0 + 1 to ET0 + 3, so its records land on
+# baseline records and its interior sample epochs do not.
+_BASELINE_STEP_S = 0.5
+_BASELINE_RECORDS = 9
+_START_ET = ET0 + 1.0
+_STOP_ET = ET0 + 3.0
+
+# Two attitudes agree when the rotation between them is smaller than this.  It
+# is the plan's reproduction bound; the quaternion round trip through SPICE
+# costs about 1e-16 radians, so the bound is not tight against numerical noise.
+_ANGLE_TOL_RAD = 1e-9
+
+_IMAGE_NAME = 'N1484573295_1.IMG'
+
+
+@dataclass(frozen=True)
+class _Case:
+    """One planted correction, its baseline kernel, and the corrected kernel.
+
+    Parameters:
+        pointing: The recorded pointing handed to the writer.
+        segment: The segment the writer built.
+        correction: The correction planted in the CK object's own frame.
+        baseline_path: The baseline kernel, furnished when the case is built.
+        corrected_path: The corrected kernel, written but not yet furnished.
+    """
+
+    pointing: ImagePointing
+    segment: CkSegment
+    correction: NDArrayFloatType
+    baseline_path: Path
+    corrected_path: Path
+
+
+def _build_case(
+    pool: KernelPool,
+    *,
+    ck_frame_id: int = CASSINI_CK_FRAME_ID,
+    camera_frame: str = CASSINI_CAMERA_FRAME,
+    attitude: Callable[[float], NDArrayFloatType] = baseline_attitude,
+    with_angular_velocity: bool = True,
+    baseline_records: int = _BASELINE_RECORDS,
+    start_et: float = _START_ET,
+    stop_et: float = _STOP_ET,
+    midtime_et: float | None = None,
+    exposure_s: float | None = None,
+    correction_rad: float = _CORRECTION_RAD,
+    image_name: str = _IMAGE_NAME,
+) -> _Case:
+    """Plant a correction, write the corrected kernel, and report both.
+
+    The baseline kernel is left furnished so a test can read baseline values
+    before swapping in the corrected one.
+
+    Parameters:
+        pool: The test's kernel pool.
+        ck_frame_id: SPICE id of the object under test.
+        camera_frame: SPICE name of the camera frame the C-matrix is in.
+        attitude: The baseline J2000-to-CK-object rotation at an epoch.
+        with_angular_velocity: Whether the baseline kernel carries angular
+            velocity.
+        baseline_records: Number of half-second records in the baseline.
+        start_et: Exposure start.
+        stop_et: Exposure stop.
+        midtime_et: Exposure midtime; the arithmetic midpoint when None.
+        exposure_s: Exposure duration; ``stop_et - start_et`` when None.
+        correction_rad: Size of the planted correction.
+        image_name: Basename recorded for the image.
+
+    Returns:
+        The case.
+    """
+    sclk_id = resolve_sclk_id(ck_frame_id)
+    epochs = [ET0 + step * _BASELINE_STEP_S for step in range(baseline_records)]
+    baseline_path = pool.root / 'baseline.bc'
+    write_baseline_ck(
+        baseline_path,
+        ck_frame_id=ck_frame_id,
+        sclk_id=sclk_id,
+        epochs=epochs,
+        attitude=attitude,
+        angular_velocity=baseline_angular_velocity if with_angular_velocity else None,
+    )
+    pool.furnish(baseline_path)
+    midtime = (start_et + stop_et) / 2.0 if midtime_et is None else midtime_et
+    correction = axis_rotation(_CORRECTION_AXIS, correction_rad)
+    camera_from_ck = np.asarray(
+        cspyce.pxform(str(cspyce.frmnam(ck_frame_id)), camera_frame, midtime), dtype=np.float64
+    )
+    pointing = ImagePointing(
+        image_name=image_name,
+        cmatrix=camera_from_ck @ correction @ attitude(midtime),
+        camera_frame=camera_frame,
+        ck_frame_id=ck_frame_id,
+        start_et=start_et,
+        stop_et=stop_et,
+        midtime_et=midtime,
+        exposure_s=stop_et - start_et if exposure_s is None else exposure_s,
+    )
+    segment = build_segment(pointing)
+    corrected_path = pool.root / 'corrected.bc'
+    handle = cspyce.ckopn(str(corrected_path), 'corrected', 0)
+    write_segment(handle, segment)
+    cspyce.ckcls(handle)
+    return _Case(
+        pointing=pointing,
+        segment=segment,
+        correction=correction,
+        baseline_path=baseline_path,
+        corrected_path=corrected_path,
+    )
+
+
+def _swap_to_corrected(pool: KernelPool, case: _Case) -> None:
+    """Unload the baseline kernel and furnish the corrected one.
+
+    Parameters:
+        pool: The test's kernel pool.
+        case: The case whose kernels are swapped.
+    """
+    pool.unload(case.baseline_path)
+    pool.furnish(case.corrected_path)
+
+
+def _tick(sclk_id: int, et: float) -> float:
+    """Return the encoded SCLK for an epoch.
+
+    Parameters:
+        sclk_id: The spacecraft clock.
+        et: TDB seconds past J2000.
+
+    Returns:
+        The encoded time tag.
+    """
+    return float(cspyce.sce2c(sclk_id, et))
+
+
+def _attitude_from_pool(ck_frame_id: int, sclk_id: int, et: float) -> NDArrayFloatType:
+    """Read the furnished pointing for a CK object at one epoch.
+
+    Parameters:
+        ck_frame_id: SPICE id of the object.
+        sclk_id: The spacecraft clock.
+        et: TDB seconds past J2000.
+
+    Returns:
+        The 3x3 J2000-to-CK-object rotation.
+    """
+    cmat, _clkout = cspyce.ckgp(ck_frame_id, _tick(sclk_id, et), 0.0, 'J2000')
+    return np.asarray(cmat, dtype=np.float64)
+
+
+@pytest.mark.parametrize(
+    'query_et',
+    [_START_ET, (_START_ET + _STOP_ET) / 2.0, _STOP_ET, _START_ET + 0.7],
+    ids=['start', 'midtime', 'stop', 'interior'],
+)
+def test_corrected_attitude_matches_composed_truth(pool: KernelPool, query_et: float) -> None:
+    """The written attitude is the planted correction on the baseline history."""
+    case = _build_case(pool)
+    _swap_to_corrected(pool, case)
+    read = _attitude_from_pool(CASSINI_CK_FRAME_ID, -82, query_et)
+    truth = case.correction @ baseline_attitude(query_et)
+    assert rotation_angle_between(read, truth) < _ANGLE_TOL_RAD
+
+
+def test_baseline_attitude_is_not_the_corrected_one(pool: KernelPool) -> None:
+    """The correction really moved the pointing, by the angle that was planted."""
+    case = _build_case(pool)
+    _swap_to_corrected(pool, case)
+    read = _attitude_from_pool(CASSINI_CK_FRAME_ID, -82, case.pointing.midtime_et)
+    moved = rotation_angle_between(read, baseline_attitude(case.pointing.midtime_et))
+    assert moved == pytest.approx(_CORRECTION_RAD, abs=_ANGLE_TOL_RAD)
+
+
+def test_angular_velocity_is_copied_unchanged(pool: KernelPool) -> None:
+    """Angular velocity is the baseline's own vectors, not rotated by delta."""
+    case = _build_case(pool)
+    record_ets = [_START_ET, (_START_ET + _STOP_ET) / 2.0, _STOP_ET]
+    baseline_av = [
+        np.asarray(cspyce.ckgpav(CASSINI_CK_FRAME_ID, _tick(-82, et), 0.0, 'J2000')[1])
+        for et in record_ets
+    ]
+    _swap_to_corrected(pool, case)
+    corrected_av = [
+        np.asarray(cspyce.ckgpav(CASSINI_CK_FRAME_ID, _tick(-82, et), 0.0, 'J2000')[1])
+        for et in record_ets
+    ]
+    assert case.segment.has_angular_velocity is True
+    assert np.array_equal(corrected_av[0], baseline_av[0])
+    assert np.array_equal(corrected_av[1], baseline_av[1])
+    assert np.array_equal(corrected_av[2], baseline_av[2])
+
+
+def test_angular_velocity_absent_from_baseline_stays_absent(pool: KernelPool) -> None:
+    """A baseline without angular velocity yields a segment without it."""
+    case = _build_case(pool, with_angular_velocity=False)
+    _swap_to_corrected(pool, case)
+    midtime = case.pointing.midtime_et
+    assert case.segment.has_angular_velocity is False
+    assert case.segment.avvs is None
+    with pytest.raises(OSError, match='CKINSUFFDATA'):
+        cspyce.ckgpav(CASSINI_CK_FRAME_ID, _tick(-82, midtime), 0.0, 'J2000')
+    read = _attitude_from_pool(CASSINI_CK_FRAME_ID, -82, midtime)
+    truth = case.correction @ baseline_attitude(midtime)
+    assert rotation_angle_between(read, truth) < _ANGLE_TOL_RAD
+
+
+def test_quaternion_records_are_sign_continuous(pool: KernelPool) -> None:
+    """A sequence whose raw quaternions flip sign is written continuous."""
+    case = _build_case(pool, attitude=sweeping_attitude)
+    record_ets = [_START_ET, (_START_ET + _STOP_ET) / 2.0, _STOP_ET]
+    raw = np.vstack([cspyce.m2q(case.correction @ sweeping_attitude(et)) for et in record_ets])
+    raw_dots = [float(np.dot(raw[index], raw[index + 1])) for index in range(len(raw) - 1)]
+    written = np.asarray(case.segment.quats, dtype=np.float64)
+    written_dots = [
+        float(np.dot(written[index], written[index + 1])) for index in range(len(written) - 1)
+    ]
+    _swap_to_corrected(pool, case)
+    interior_et = _START_ET + 0.3
+    read = _attitude_from_pool(CASSINI_CK_FRAME_ID, -82, interior_et)
+    truth = case.correction @ sweeping_attitude(interior_et)
+    assert min(raw_dots) < 0.0
+    assert min(written_dots) >= 0.0
+    assert rotation_angle_between(read, truth) < _ANGLE_TOL_RAD
+
+
+def test_sub_tick_exposure_yields_one_record(pool: KernelPool) -> None:
+    """An exposure below the resolution of an epoch collapses to one record."""
+    start_et = ET0 + 2.0
+    stop_et = start_et + 1.0e-9
+    case = _build_case(
+        pool,
+        start_et=start_et,
+        stop_et=stop_et,
+        midtime_et=start_et + 5.0e-10,
+        exposure_s=1.0e-9,
+    )
+    _swap_to_corrected(pool, case)
+    read = _attitude_from_pool(CASSINI_CK_FRAME_ID, -82, start_et)
+    truth = case.correction @ baseline_attitude(case.pointing.midtime_et)
+    assert stop_et == start_et
+    assert case.segment.record_count == 1
+    assert case.segment.begtim == case.segment.endtim
+    assert rotation_angle_between(read, truth) < _ANGLE_TOL_RAD
+
+
+@pytest.mark.parametrize(
+    ('exposure_s', 'expected_records'),
+    [(2.0, 3), (10.0, 3), (25.0, 27)],
+    ids=['short', 'at-threshold', 'long'],
+)
+def test_record_count_follows_the_cadence(
+    pool: KernelPool, exposure_s: float, expected_records: int
+) -> None:
+    """Long exposures get a one-second cadence; short ones get three records."""
+    start_et = ET0 + 1.0
+    stop_et = start_et + exposure_s
+    case = _build_case(
+        pool,
+        baseline_records=int(exposure_s / _BASELINE_STEP_S) + 6,
+        start_et=start_et,
+        stop_et=stop_et,
+    )
+    assert case.segment.record_count == expected_records
+    assert case.segment.begtim == _tick(-82, start_et)
+    assert case.segment.endtim == _tick(-82, stop_et)
+
+
+@pytest.mark.parametrize('query_et', [_START_ET, _STOP_ET], ids=['start', 'stop'])
+def test_frozen_attitude_object_is_constant_across_the_exposure(
+    pool: KernelPool, query_et: float
+) -> None:
+    """A frozen-attitude object carries one attitude, not the baseline history."""
+    case = _build_case(pool, ck_frame_id=VOYAGER_CK_FRAME_ID, camera_frame=VOYAGER_CAMERA_FRAME)
+    _swap_to_corrected(pool, case)
+    read = _attitude_from_pool(VOYAGER_CK_FRAME_ID, -31, query_et)
+    truth = case.correction @ baseline_attitude(case.pointing.midtime_et)
+    assert rotation_angle_between(read, truth) < _ANGLE_TOL_RAD
+
+
+def test_frozen_attitude_object_carries_no_angular_velocity(pool: KernelPool) -> None:
+    """A constant-attitude segment claims no angular velocity, whatever the baseline had."""
+    case = _build_case(pool, ck_frame_id=VOYAGER_CK_FRAME_ID, camera_frame=VOYAGER_CAMERA_FRAME)
+    assert case.segment.avvs is None
+    assert case.segment.has_angular_velocity is False
+
+
+def test_frozen_attitude_ignores_the_baseline_time_variation(pool: KernelPool) -> None:
+    """The frozen segment's start and stop attitudes are the same rotation."""
+    case = _build_case(pool, ck_frame_id=VOYAGER_CK_FRAME_ID, camera_frame=VOYAGER_CAMERA_FRAME)
+    _swap_to_corrected(pool, case)
+    at_start = _attitude_from_pool(VOYAGER_CK_FRAME_ID, -31, _START_ET)
+    at_stop = _attitude_from_pool(VOYAGER_CK_FRAME_ID, -31, _STOP_ET)
+    assert rotation_angle_between(at_start, at_stop) < _ANGLE_TOL_RAD
+
+
+@pytest.mark.parametrize(
+    ('ck_frame_id', 'sclk_id'),
+    [(-82000, -82), (-77001, -77), (-98000, -98), (-31100, -31), (-32100, -32)],
+    ids=['cassini', 'galileo', 'new-horizons', 'voyager-1', 'voyager-2'],
+)
+def test_resolve_sclk_id(ck_frame_id: int, sclk_id: int) -> None:
+    """Each CK object resolves to its own spacecraft clock.
+
+    Voyager 1 is the case integer division gets wrong: ``-31100 // 1000`` is
+    -32 in Python, which is the other spacecraft.
+    """
+    assert resolve_sclk_id(ck_frame_id) == sclk_id
+
+
+def test_resolve_sclk_id_refuses_an_unknown_object() -> None:
+    """An object outside the known set is refused rather than looked up."""
+    with pytest.raises(ValueError, match='CK object -999999 is not one this writer knows'):
+        resolve_sclk_id(-999999)
+
+
+def test_resolve_sclk_id_refuses_a_clock_that_is_not_the_expected_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The resolved clock is checked, not trusted; a wrong one is silent otherwise."""
+    monkeypatch.setattr(cspyce, 'ckmeta', lambda ckid, meta: -99)
+    with pytest.raises(
+        ValueError, match='CK object -82000 resolves to spacecraft clock -99, not the expected -82'
+    ):
+        resolve_sclk_id(CASSINI_CK_FRAME_ID)
+
+
+def test_segment_refuses_repeated_time_tags() -> None:
+    """Time tags that do not strictly increase are refused before SPICE sees them."""
+    quats = np.vstack([cspyce.m2q(np.eye(3))] * 2)
+    with pytest.raises(ValueError, match='not strictly increasing'):
+        CkSegment(
+            ck_frame_id=CASSINI_CK_FRAME_ID,
+            segid='repeat',
+            sclkdp=np.array([1.0, 1.0]),
+            quats=quats,
+            avvs=None,
+        )
+
+
+def test_segment_refuses_a_quaternion_count_mismatch() -> None:
+    """A record set whose arrays disagree on length is refused."""
+    quats = np.vstack([cspyce.m2q(np.eye(3))])
+    with pytest.raises(ValueError, match=r'quats must have shape \(2, 4\)'):
+        CkSegment(
+            ck_frame_id=CASSINI_CK_FRAME_ID,
+            segid='mismatch',
+            sclkdp=np.array([1.0, 2.0]),
+            quats=quats,
+            avvs=None,
+        )
+
+
+def test_segment_refuses_an_angular_velocity_count_mismatch() -> None:
+    """Angular velocity that does not cover every record is refused."""
+    quats = np.vstack([cspyce.m2q(np.eye(3))] * 2)
+    with pytest.raises(ValueError, match=r'avvs must have shape \(2, 3\)'):
+        CkSegment(
+            ck_frame_id=CASSINI_CK_FRAME_ID,
+            segid='mismatch',
+            sclkdp=np.array([1.0, 2.0]),
+            quats=quats,
+            avvs=np.zeros((1, 3)),
+        )
+
+
+def test_segment_refuses_an_empty_record_set() -> None:
+    """A segment with no records is refused."""
+    with pytest.raises(ValueError, match='sclkdp must hold at least one time tag'):
+        CkSegment(
+            ck_frame_id=CASSINI_CK_FRAME_ID,
+            segid='empty',
+            sclkdp=np.array([]),
+            quats=np.zeros((0, 4)),
+            avvs=None,
+        )
+
+
+def test_segment_refuses_an_overlong_identifier() -> None:
+    """A segment identifier longer than SPICE stores is refused."""
+    quats = np.vstack([cspyce.m2q(np.eye(3))])
+    with pytest.raises(ValueError, match='longer than the 40 characters SPICE stores'):
+        CkSegment(
+            ck_frame_id=CASSINI_CK_FRAME_ID,
+            segid='X' * 41,
+            sclkdp=np.array([1.0]),
+            quats=quats,
+            avvs=None,
+        )
+
+
+def test_build_segment_refuses_an_overlong_image_name(pool: KernelPool) -> None:
+    """An image name that would not fit the segment identifier is refused."""
+    with pytest.raises(ValueError, match='longer than the 40 characters'):
+        _build_case(pool, image_name='N' * 41)

--- a/tests/spindoctor/cli/ck/test_segment.py
+++ b/tests/spindoctor/cli/ck/test_segment.py
@@ -11,6 +11,7 @@ sign flip alike.
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 import cspyce
 import numpy as np
@@ -34,7 +35,7 @@ from tests.spindoctor.cli.ck.conftest import (
 )
 
 from spindoctor.cli.ck.pointing import ImagePointing, NDArrayFloatType
-from spindoctor.cli.ck.segment import CkSegment, build_segment, resolve_sclk_id, write_segment
+from spindoctor.cli.ck.segment import CkSegment, build_segment, resolve_sclk_id
 
 # The correction the tests plant, expressed in the CK object's own frame.  It is
 # far larger than a navigated correction ever is and turns about an axis shared
@@ -146,9 +147,7 @@ def _build_case(
     )
     segment = build_segment(pointing)
     corrected_path = pool.root / 'corrected.bc'
-    handle = cspyce.ckopn(str(corrected_path), 'corrected', 0)
-    write_segment(handle, segment)
-    cspyce.ckcls(handle)
+    write_ck(corrected_path, [segment])
     return _Case(
         pointing=pointing,
         segment=segment,
@@ -565,6 +564,24 @@ def test_segment_refuses_an_angular_velocity_count_mismatch() -> None:
             sclkdp=np.array([1.0, 2.0]),
             quats=quats,
             avvs=np.zeros((1, 3)),
+        )
+
+
+@pytest.mark.parametrize('sclkdp', [np.float64(1.0), 1.0], ids=['numpy-scalar', 'python-float'])
+def test_segment_refuses_a_scalar_time_tag(sclkdp: object) -> None:
+    """A scalar where the record array belongs is refused, and by the documented type.
+
+    A zero-dimensional array has no length to read, so the shape guard has to
+    run before anything indexes it; otherwise the failure is an ``IndexError``
+    from inside the guard's own arithmetic.
+    """
+    with pytest.raises(ValueError, match=r'sclkdp must hold at least one time tag; got shape \(\)'):
+        CkSegment(
+            ck_frame_id=CASSINI_CK_FRAME_ID,
+            segid='scalar',
+            sclkdp=cast(NDArrayFloatType, sclkdp),
+            quats=np.vstack([cspyce.m2q(np.eye(3))]),
+            avvs=None,
         )
 
 

--- a/tests/spindoctor/cli/ck/test_writer_imports.py
+++ b/tests/spindoctor/cli/ck/test_writer_imports.py
@@ -12,6 +12,12 @@ import json
 import subprocess
 import sys
 
+import pytest
+
+# An import that hangs -- a module blocking on a network resource, say -- would
+# otherwise stall the run with no failure to read.
+_PROBE_TIMEOUT_S = 120.0
+
 _PROBE = """
 import json
 import sys
@@ -27,8 +33,14 @@ print(json.dumps({'forbidden': forbidden, 'loaded': sorted(sys.modules)}))
 """
 
 
-def _probe_modules() -> dict[str, list[str]]:
+@pytest.fixture(scope='module')
+def probed_modules() -> dict[str, list[str]]:
     """Import the writer package in a fresh interpreter and report sys.modules.
+
+    The interpreter is a real subprocess, which is the whole point: the
+    guarantee is about what an import does from nothing, and this process has
+    already imported oops for other tests.  What is reused across the two tests
+    below is only the answer that one subprocess gave.
 
     Returns:
         A dict with the forbidden modules that loaded and every module that
@@ -39,18 +51,20 @@ def _probe_modules() -> dict[str, list[str]]:
         capture_output=True,
         text=True,
         check=True,
+        timeout=_PROBE_TIMEOUT_S,
     )
     result: dict[str, list[str]] = json.loads(completed.stdout)
     return result
 
 
-def test_writer_package_loads_no_oops_and_no_support() -> None:
+def test_writer_package_loads_no_oops_and_no_support(
+    probed_modules: dict[str, list[str]],
+) -> None:
     """Importing the writer pulls in neither oops nor spindoctor.support."""
-    assert _probe_modules()['forbidden'] == []
+    assert probed_modules['forbidden'] == []
 
 
-def test_writer_package_really_imported() -> None:
+def test_writer_package_really_imported(probed_modules: dict[str, list[str]]) -> None:
     """The probe proves its own point only if the writer actually loaded."""
-    loaded = _probe_modules()['loaded']
-    assert 'spindoctor.cli.ck.segment' in loaded
-    assert 'cspyce' in loaded
+    assert 'spindoctor.cli.ck.segment' in probed_modules['loaded']
+    assert 'cspyce' in probed_modules['loaded']

--- a/tests/spindoctor/cli/ck/test_writer_imports.py
+++ b/tests/spindoctor/cli/ck/test_writer_imports.py
@@ -1,0 +1,56 @@
+"""The C-kernel writer's import guarantee.
+
+The writer exists so that a navigated attitude can be turned into a kernel
+without the geometry stack, and one convenience import from
+``spindoctor.support`` -- where the module that computes the C-matrix lives --
+would drag oops in transitively.  Reading the source cannot prove that, since
+the offending import could be two modules deep, so the check runs a fresh
+interpreter and looks at what actually loaded.
+"""
+
+import json
+import subprocess
+import sys
+
+_PROBE = """
+import json
+import sys
+
+import spindoctor.cli.ck  # noqa: F401
+
+forbidden = sorted(
+    name
+    for name in sys.modules
+    if name == 'oops' or name.startswith('oops.') or name.startswith('spindoctor.support')
+)
+print(json.dumps({'forbidden': forbidden, 'loaded': sorted(sys.modules)}))
+"""
+
+
+def _probe_modules() -> dict[str, list[str]]:
+    """Import the writer package in a fresh interpreter and report sys.modules.
+
+    Returns:
+        A dict with the forbidden modules that loaded and every module that
+        loaded.
+    """
+    completed = subprocess.run(
+        [sys.executable, '-c', _PROBE],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    result: dict[str, list[str]] = json.loads(completed.stdout)
+    return result
+
+
+def test_writer_package_loads_no_oops_and_no_support() -> None:
+    """Importing the writer pulls in neither oops nor spindoctor.support."""
+    assert _probe_modules()['forbidden'] == []
+
+
+def test_writer_package_really_imported() -> None:
+    """The probe proves its own point only if the writer actually loaded."""
+    loaded = _probe_modules()['loaded']
+    assert 'spindoctor.cli.ck.segment' in loaded
+    assert 'cspyce' in loaded

--- a/tests/spindoctor/support/test_cmatrix.py
+++ b/tests/spindoctor/support/test_cmatrix.py
@@ -14,24 +14,20 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import cast
 
-import cspyce
 import numpy as np
 import oops
 import pytest
 from tests.cmatrix_helpers import offset_from_correction
 
 from spindoctor.obs import ObsSnapshotInst
+from spindoctor.spice_ids import CK_OBJECT_SCLK_ID
 from spindoctor.support.cmatrix import (
     _CASSINI_CK_FRAME_ID,
-    _CASSINI_SCLK_ID,
-    _GALILEO_CK_FRAME_ID,
-    _GALILEO_SCLK_ID,
-    _LORRI_CK_FRAME_ID,
-    _LORRI_SCLK_ID,
     AttitudeBaseline,
     _build_pointing_solution,
     _camera_frame_id,
     _check_flip,
+    _ck_object_sclk_id,
     _FrameIdentity,
     _oops_correction_matrix,
     _pxform,
@@ -369,7 +365,7 @@ def _cassini_identity() -> _FrameIdentity:
     return _FrameIdentity(
         camera_frame='CASSINI_ISS_NAC',
         ck_frame_id=_CASSINI_CK_FRAME_ID,
-        sclk_id=_CASSINI_SCLK_ID,
+        sclk_id=CK_OBJECT_SCLK_ID[_CASSINI_CK_FRAME_ID],
         oops_from_spice=_CASSINI_FLIP,
         frozen_oops_attitude=False,
     )
@@ -402,13 +398,19 @@ def test_a_flip_just_outside_tolerance_is_refused() -> None:
 
 
 def test_the_missions_own_clock_resolves_and_is_accepted() -> None:
-    """The clock SPICE resolves for a mission's CK object is the expected one.
+    """The clock SPICE resolves for a mission's CK object is the recorded one.
 
-    Pins the expected constant against what ``ckmeta`` actually computes: a
-    typo in either the CK object or the clock id fails here rather than
-    producing time strings from a plausible-looking wrong clock.
+    Pins the recorded clock against what ``ckmeta`` actually computes: a typo
+    in either the CK object or the clock id fails here rather than producing
+    time strings from a plausible-looking wrong clock.
     """
-    assert _sclk_id(_cassini_identity()) == _CASSINI_SCLK_ID
+    assert _sclk_id(_cassini_identity()) == CK_OBJECT_SCLK_ID[_CASSINI_CK_FRAME_ID]
+
+
+def test_a_ck_object_with_no_recorded_clock_is_a_pointing_failure() -> None:
+    """An object outside the recorded set is refused rather than looked up."""
+    with pytest.raises(NavPointingError, match='has no recorded spacecraft clock'):
+        _ck_object_sclk_id(_NONEXISTENT_CK_FRAME_ID)
 
 
 def _voyager2_identity_with_the_voyager1_ck_object() -> _FrameIdentity:
@@ -436,37 +438,6 @@ def test_the_refused_clock_message_names_the_expected_clock() -> None:
     """The refusal says which clock was expected, so it is attributable."""
     with pytest.raises(NavPointingError, match='not the -32'):
         _sclk_id(_voyager2_identity_with_the_voyager1_ck_object())
-
-
-def test_ckmeta_computes_a_clock_for_a_ck_object_that_does_not_exist() -> None:
-    """``ckmeta`` computes rather than validates, which is why the check exists.
-
-    A nonexistent CK object still yields a plausible clock id and no error,
-    so trusting the round trip would write time strings from the wrong clock
-    while every call reported success.
-    """
-    assert int(cspyce.ckmeta(_NONEXISTENT_CK_FRAME_ID, 'SCLK')) == -999
-
-
-@pytest.mark.parametrize(
-    ('ck_frame_id', 'sclk_id'),
-    [
-        (_CASSINI_CK_FRAME_ID, _CASSINI_SCLK_ID),
-        (_GALILEO_CK_FRAME_ID, _GALILEO_SCLK_ID),
-        (_LORRI_CK_FRAME_ID, _LORRI_SCLK_ID),
-    ],
-    ids=['cassini', 'galileo', 'lorri'],
-)
-def test_each_recorded_ck_object_and_clock_pair_agrees_with_spice(
-    ck_frame_id: int, sclk_id: int
-) -> None:
-    """Every mission's CK object resolves to the clock recorded beside it.
-
-    ``ckmeta`` needs no kernels, so the pairing is checkable here as well as
-    on real frames.  A typo in either half of a pair would otherwise only
-    surface as time strings encoding another spacecraft's clock.
-    """
-    assert int(cspyce.ckmeta(ck_frame_id, 'SCLK')) == sclk_id
 
 
 def test_a_frame_the_kernel_pool_does_not_know_is_a_pointing_failure() -> None:

--- a/tests/spindoctor/test_spice_ids.py
+++ b/tests/spindoctor/test_spice_ids.py
@@ -1,0 +1,66 @@
+"""Tests for the shared CK-object-to-spacecraft-clock mapping.
+
+The mapping exists because ``cspyce.ckmeta`` computes a clock id from a CK
+object id instead of validating one, so both the attitude computation and the
+C-kernel writer check what it resolves against a recorded table rather than
+trusting it.  These tests pin the table against SPICE and pin both consumers
+to the table, so the two checks cannot drift apart into one that bites and one
+that no longer does.
+
+``ckmeta`` needs no furnished kernels, so all of this is hermetic.
+"""
+
+from typing import cast
+
+import cspyce
+import pytest
+
+from spindoctor.cli.ck.segment import resolve_sclk_id
+from spindoctor.spice_ids import CK_OBJECT_SCLK_ID
+from spindoctor.support.cmatrix import _CASSINI_CK_FRAME_ID, _ck_object_sclk_id
+
+# The recorded pairs, in a stable order so a failure names the same case run
+# to run.  Voyager 1 is the pair integer division gets wrong: ``-31100 //
+# 1000`` is -32 in Python, which is the other spacecraft.
+_RECORDED_PAIRS = sorted(CK_OBJECT_SCLK_ID.items())
+
+# A CK object no mission owns, used to pin what ``ckmeta`` does with one.
+_NONEXISTENT_CK_FRAME_ID = -999999
+
+
+@pytest.mark.parametrize(('ck_frame_id', 'sclk_id'), _RECORDED_PAIRS)
+def test_every_recorded_pair_agrees_with_spice(ck_frame_id: int, sclk_id: int) -> None:
+    """Each recorded CK object resolves to the clock recorded beside it.
+
+    A typo in either half of a pair would otherwise only surface as time tags
+    encoding another spacecraft's clock, on every record of every kernel.
+    """
+    assert int(cspyce.ckmeta(ck_frame_id, 'SCLK')) == sclk_id
+
+
+@pytest.mark.parametrize(('ck_frame_id', 'sclk_id'), _RECORDED_PAIRS)
+def test_the_attitude_computation_reads_the_recorded_pair(ck_frame_id: int, sclk_id: int) -> None:
+    """The attitude computation's clock for an object is the recorded one."""
+    assert _ck_object_sclk_id(ck_frame_id) == sclk_id
+
+
+@pytest.mark.parametrize(('ck_frame_id', 'sclk_id'), _RECORDED_PAIRS)
+def test_the_kernel_writer_reads_the_recorded_pair(ck_frame_id: int, sclk_id: int) -> None:
+    """The writer's resolved clock for an object is the recorded one."""
+    assert resolve_sclk_id(ck_frame_id) == sclk_id
+
+
+def test_ckmeta_computes_a_clock_for_a_ck_object_that_does_not_exist() -> None:
+    """``ckmeta`` computes rather than validates, which is why the table exists.
+
+    A nonexistent CK object still yields a plausible clock id and no error, so
+    trusting the round trip would write time tags from the wrong clock while
+    every call reported success.
+    """
+    assert int(cspyce.ckmeta(_NONEXISTENT_CK_FRAME_ID, 'SCLK')) == -999
+
+
+def test_the_recorded_table_is_read_only() -> None:
+    """Neither consumer can edit the table the other one checks against."""
+    with pytest.raises(TypeError, match='does not support item assignment'):
+        cast(dict[int, int], CK_OBJECT_SCLK_ID)[_CASSINI_CK_FRAME_ID] = -1


### PR DESCRIPTION
## Purpose

Phase B of `plans/CK_KERNEL_PLAN.md`: the type-3 segment writer for a single image. It takes the corrected attitude Phase A recorded in an image's metadata and writes it into a SPICE C-kernel segment covering exactly that image's exposure, so a plain `furnsh` gives any SPICE-based tool the navigated pointing.

Part of #188. Targets the integration branch `rf_ck_kernels`, not `main`.

## Changes

- `src/spindoctor/cli/ck/` is the writer core. It reads the recorded C-matrix and performs no offset-to-rotation conversion of its own, and it imports `cspyce` and nothing from oops. That guarantee is asserted on `sys.modules` in a fresh interpreter rather than by scanning source text, because a single careless helper import would drag oops in transitively.
- The correction is expressed in the CK object's own frame by conjugating through the camera-to-object rotation read from the kernels at runtime, never assumed, since Cassini's is a permutation-like matrix nowhere near identity. Across the exposure it is held body-fixed, which is the physical model: the spacecraft is pointed slightly wrong and the error turns with it, so attitude still varies within the exposure. Voyager is the exception and carries one constant attitude, because that is what its navigation assumed.
- Angular velocity is copied from the baseline unchanged and never rotated through the correction. This is the counterintuitive rule and it is the correct one: CK angular velocity lives in the segment's base reference frame, and two frames rigidly attached to each other have identical angular velocity there. A segment whose baseline carries no angular velocity declares none rather than inventing it.
- Quaternion sign continuity is enforced on the written records. `m2q` fixes the scalar component non-negative, which flips the sign between adjacent records whenever the rotation angle passes 180 degrees.
- The spacecraft clock is resolved through the shared table in `spindoctor/spice_ids.py` and validated, never taken on trust from `ckmeta`.

## Type of Change

- [x] New feature (non-breaking)
- [x] Refactor (no functional or API changes)

## Testing

- [x] Unit tests pass
- [x] New or updated tests for changed code

Unit suite `5162 passed, 7 xfailed`; writer package `51 passed` at 100% statement and branch coverage; `ruff check`, `ruff format --check`, `mypy src tests` and `sphinx-build -W` clean.

The tests are hermetic. They write their own leapsecond, clock and frame kernels and build their baseline C-kernel through the writer's own primitives, so they need no holdings: verified passing with every holdings environment variable unset and with no network. They unload exactly what they furnish and never call `kclear`, which would blow away a pool oops owns in a shared process; the kernel pool is empty before and after the package, and the suite was checked for order independence and for collisions against a process that had already furnished the real Cassini kernels.

Sixteen mutations were applied and reverted. Fourteen die on named tests, including both reversals of the correction composition, applying it on the wrong side, dropping and transposing the camera-to-object conjugation, rotating angular velocity through the correction, holding the correction inertially rather than body-fixed, deriving the spacecraft clock by integer division, advertising coverage wider than the records, loosening the lookup tolerance, and storing caller arrays writable. The two survivors are equivalent mutants and are argued as such rather than left unexplained: the angular-velocity probe site cannot change an outcome defined as "every record or none", and the degenerate single-record epoch is provably the same float as its alternative because the epochs are sorted and the clock encoding is monotone.

The inertial-hold mutation is the one worth calling out. It is exact at the midtime and wrong only across the exposure, which is precisely the plausible-looking reversal that a midtime-only assertion would miss; it is caught because the attitude is asserted at start, stop and an interior epoch.

## Potential Impacts

Additive. A new package that nothing else imports yet, plus a new top-level module holding the CK-object-to-clock table. No existing behavior changes.

## Checklist

- [x] Code follows project style (`ruff check`, `ruff format`)
- [x] Type annotations present and `mypy` passes
- [x] Docstrings and Sphinx docs updated (if applicable)
- [x] No temporary or debug code left in
- [x] Breaking changes flagged in Type of Change above

## Notes

Five deviations were found and are reconciled into the plan in the same commits. The two that change what a later phase must do: the plan's claim that a sign flip corrupts the interpolation is false, because SPICE repairs the sign on read, so the guard must be asserted on the written records and a read-back assertion would have been vacuous; and the encoded clock is continuous rather than integral, so the single-record path needs epochs that are equal as doubles rather than merely a sub-tick exposure, which makes it unreachable for any real exposure and a guard rather than a case. The plan's acceptance bullet for that case was corrected and the test renamed to describe what it actually covers.

The CK-object-to-clock table was extracted to `spindoctor/spice_ids.py` so the writer and the attitude computation share one copy. Section 3.6 forbids the writer importing `spindoctor.support`, which had forced two independent copies of exactly the constants whose purpose is to catch a wrong id, so a drift between them would have disabled the check on one side while the other kept passing. The shared module imports nothing beyond the standard library, and the import guarantee still holds. It also closed a real hole: Voyager previously derived both its CK object and its clock from the same spacecraft digit, so a wrong digit produced a self-consistent wrong pair that no check could catch, whereas a bad digit now yields an object absent from the table and is refused.

The round-trip validation was widened to assert interior epochs as well as start, midtime and stop, per an operator decision recorded on #440. A corrected segment reproduces its record epochs exactly by construction, so a validation sampling only those is structurally unable to see interior resampling loss, which measures up to 0.290 px on a 2 second Cassini exposure with 8.2% of samples over 0.1 px. The 0.1 px per-axis midtime target and its decision rule are untouched, and the interior bound is stated as a separate quantity because this loss is characterized and attributable rather than a convention error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added C-kernel generation from corrected image pointing and exposure timing, including rotation-matrix validation.
  - Added spacecraft-clock resolution for supported missions with exact coverage handling.
  - Added angular-velocity support, frozen-attitude segments, and quaternion sign continuity.
- **Documentation**
  - Expanded the API reference for C-kernel generation and spacecraft-clock mappings.
- **Tests**
  - Added hermetic tests covering pointing validation, interpolation accuracy, coverage windows, clock mapping, angular velocity, and import isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->