### PR TITLE
Close the loop from navigation through kernel and back

### DIFF
--- a/plans/CK_KERNEL_PLAN.md
+++ b/plans/CK_KERNEL_PLAN.md
@@ -598,6 +598,21 @@ accumulates kernels from earlier images -- a superset. So:
    by construction, and a tol-zero filter would drop the only candidate
    that reproduces it. The filter is only a filter -- reproduction decides
    -- so it is widened rather than tightened.
+
+   **An object whose spacecraft clock no kernel defines is recorded as
+   unreadable rather than stopping the scan.** `ckcov` reports coverage in
+   TDB, which needs that clock, and a real kernel can name an object that
+   has none: `nh_scispi_2015_recon.bc` in the New Horizons holdings
+   describes object **-1** beside -98000, `ckmeta` computes its clock as 0,
+   and no SCLK kernel supplies one, so `ckcov` raises
+   `SPICE(KERNELVARNOTFOUND)`. Refusing the scan there makes the whole
+   mission unindexable for the sake of an object no image will ever ask
+   about -- the defect Phase D hit on the first LORRI frame it ran. Such an
+   object contributes no coverage and is therefore never offered as a
+   candidate; an image that *does* correct one is refused before any
+   candidate is tried, naming the missing clock, exactly as a missing frame
+   kernel is (item 4 below), rather than being reported as a baseline that
+   drifted.
 2. **Per image** (grouped by candidate set so the kernel pool is switched
    per group, not per image): furnish the supporting kernels (LSK, SCLK,
    FK) plus one candidate CK at a time, evaluate the original attitude at
@@ -956,6 +971,61 @@ Cassini WAC frame, and one frame from each other instrument that has a
 navigated library frame. This is where acceptance criterion 2's
 per-instrument claim is earned. Local-only (needs local binary kernels);
 marked `integration`.
+
+**Galileo SSI cannot be in that cohort, and the reason is the plan's own
+rule rather than an omission.** `config_410_inst_gossi.yaml` sets
+`fit_camera_rotation: true`, and both Galileo library frames that navigate
+successfully fit a real rotation -- `C0059894800R` reports -0.432 deg and
+`C0059899900R` -0.431 deg -- so by section 1 they record `cmatrix_original`
+and no `cmatrix`, and the generator omits them as `rotation_unsupported`.
+The library's other six Galileo frames are `negative_cases` that do not
+navigate at all. There is therefore no Galileo image anywhere in the corpus
+that a corrected kernel can be written for, and the round-trip cohort is
+Cassini NAC, Cassini WAC, Voyager and LORRI. Phase D pins that as a
+measurement rather than leaving it implied: it navigates a Galileo frame and
+asserts the fitted rotation, the absent `cmatrix`, the present
+`cmatrix_original` and the `rotation_unsupported` omission, so the day twist
+support (section 7) lands, the test says so. Acceptance criterion 3 is
+consequently claimed for four instruments, not five; criterion 2's Galileo
+claim stands on Phase A's planted-offset recovery on a real Galileo frame,
+which does not need a `cmatrix` in a result to be measured.
+
+**What the round-trip residual is made of, measured.** The end-to-end
+residual has two independent parts, and only the first belongs to this plan:
+
+| Part | Measured over eleven real frames |
+|---|---|
+| The pointing chain: offset to `cmatrix` to segment to kernel to readback | 0 to 5.6e-17 rad against what the segment says; 1.5e-15 rad against the recorded `cmatrix`; the pool's pointing moves by the measured offset to within 0.0004 px |
+| The navigation re-measuring a nearly-zero offset | 0.0001 to 0.4853 px per axis, depending on which techniques carry the ensemble |
+
+The first is floating-point noise: a corrected kernel gives back the
+recorded attitude bit for bit, on every frame tried. The second is what the
+0.1 px target actually spends, and it is a property of the navigation
+techniques rather than of any instrument or of the size of the offset. A
+frame whose ensemble is carried by star centroids lands within 0.017 px of
+zero (measured: 0.0001 to 0.0170 px per axis over seven such frames, on all
+four instruments, at offsets from 1.86 to 49.2 px). A frame whose ensemble
+is carried by the correlation and distance-transform body techniques does
+not: `W1637520502_1_CALIB` (Cassini WAC, 1.86 px offset) leaves **0.1022 px**
+on `dv`, and `C3446143_GEOMED` (Voyager 1 WA, 28.8 px offset) leaves
+**0.4853 px** on `du`. Both are above the target and neither is a pointing
+defect -- on those two frames the pool's attitude reads back exact to
+8.8e-16 and 1.7e-16 rad and moves by 1.8636 px against a measured 1.8638 px
+and by 28.8355 px against a measured 28.8355 px. What is left is
+`BodyDiscCorrelateNav`, which the ensemble weights at 0.73 to 0.84 on those
+frames and which reports `du` on a coarse grid: it answers exactly -0.5 px
+in both runs of `W1637520502_1_CALIB` whether the truth is 0.14 px or zero.
+The techniques are not exactly shift-equivariant, and re-measuring after a
+shift does not return exactly the negative of that shift.
+
+The decision rule stands as written. What these measurements add is how to
+tell its two outcomes apart: a section 2 convention error leaves about
+*twice* the original offset (3.7 to 98 px on these frames) **and** a
+readback that disagrees, where technique non-equivariance leaves a fraction
+of a pixel and a readback that is exact to floating point. The round trip
+therefore asserts the chain on a body-navigated frame as well as on the
+star-navigated cohort, and pins the end-to-end offset only where the
+measurement is a pointing measurement.
 
 ### Phase E — Comment area, meta-kernel, report, driver
 

--- a/plans/CK_KERNEL_PLAN.md
+++ b/plans/CK_KERNEL_PLAN.md
@@ -984,8 +984,8 @@ that a corrected kernel can be written for, and the round-trip cohort is
 Cassini NAC, Cassini WAC, Voyager and LORRI. Phase D pins that as a
 measurement rather than leaving it implied: it navigates a Galileo frame and
 asserts the fitted rotation, the absent `cmatrix`, the present
-`cmatrix_original` and the `rotation_unsupported` omission, so the day twist
-support (section 7) lands, the test says so. Acceptance criterion 3 is
+`cmatrix_original` and the `rotation_unsupported` omission, so that on the
+day twist support (section 7) lands, the test says so. Acceptance criterion 3 is
 consequently claimed for four instruments, not five; criterion 2's Galileo
 claim stands on Phase A's planted-offset recovery on a real Galileo frame,
 which does not need a `cmatrix` in a result to be measured.
@@ -995,28 +995,32 @@ residual has two independent parts, and only the first belongs to this plan:
 
 | Part | Measured over eleven real frames |
 |---|---|
-| The pointing chain: offset to `cmatrix` to segment to kernel to readback | 0 to 5.6e-17 rad against what the segment says; 1.5e-15 rad against the recorded `cmatrix`; the pool's pointing moves by the measured offset to within 0.0004 px |
+| The pointing chain: offset to `cmatrix` to segment to kernel to readback | 0 to 5.6e-17 rad against what the segment says; at most 1.5e-15 rad against the recorded `cmatrix`; the pool's pointing moves by the measured offset to within 1.2e-3 px |
 | The navigation re-measuring a nearly-zero offset | 0.0001 to 0.4853 px per axis, depending on which techniques carry the ensemble |
 
 The first is floating-point noise: a corrected kernel gives back the
 recorded attitude bit for bit, on every frame tried. The second is what the
 0.1 px target actually spends, and it is a property of the navigation
 techniques rather than of any instrument or of the size of the offset. A
-frame whose ensemble is carried by star centroids lands within 0.017 px of
-zero (measured: 0.0001 to 0.0170 px per axis over seven such frames, on all
-four instruments, at offsets from 1.86 to 49.2 px). A frame whose ensemble
-is carried by the correlation and distance-transform body techniques does
-not: `W1637520502_1_CALIB` (Cassini WAC, 1.86 px offset) leaves **0.1022 px**
-on `dv`, and `C3446143_GEOMED` (Voyager 1 WA, 28.8 px offset) leaves
+frame navigated by the star techniques alone lands within 0.017 px of zero
+(measured: 0.0001 to 0.0170 px per axis over seven such frames, on all four
+instruments, at offsets from 1.86 to 49.2 px). A frame whose ensemble is
+carried by the correlation and distance-transform body techniques does not:
+`W1637520502_1_CALIB` (Cassini WAC, 1.86 px offset) leaves **0.1022 px** on
+`dv`, and `C3446143_GEOMED` (Voyager 1 WA, 28.8 px offset) leaves
 **0.4853 px** on `du`. Both are above the target and neither is a pointing
-defect -- on those two frames the pool's attitude reads back exact to
-8.8e-16 and 1.7e-16 rad and moves by 1.8636 px against a measured 1.8638 px
-and by 28.8355 px against a measured 28.8355 px. What is left is
-`BodyDiscCorrelateNav`, which the ensemble weights at 0.73 to 0.84 on those
-frames and which reports `du` on a coarse grid: it answers exactly -0.5 px
-in both runs of `W1637520502_1_CALIB` whether the truth is 0.14 px or zero.
-The techniques are not exactly shift-equivariant, and re-measuring after a
-shift does not return exactly the negative of that shift.
+defect -- on those two frames the record epochs read back to 2.6e-17 and
+0 rad, the midtime reads back the recorded `cmatrix` to 8.8e-16 and
+1.7e-16 rad, and the pool's pointing moves by the measured offset to within
+5.7e-5 and 5.1e-5 px. What is left is that those techniques do not return
+the shift they were given. Measured as the difference between a technique's
+two answers against the correction actually applied: `BodyLimbNav` falls
+0.139 px short on `W1637520502_1_CALIB`, and `BodyDiscCorrelateNav` falls
+0.504 px short on `C3446143_GEOMED`, where it answers `du` on a 0.25 px grid
+(-5.75 px in the first run and -0.5 px in the second) and the ensemble
+weights it at 0.73. The techniques are not exactly shift-equivariant, and
+re-measuring after a shift does not return exactly the negative of that
+shift.
 
 The decision rule stands as written. What these measurements add is how to
 tell its two outcomes apart: a section 2 convention error leaves about

--- a/src/spindoctor/cli/ck/assignment.py
+++ b/src/spindoctor/cli/ck/assignment.py
@@ -426,9 +426,11 @@ def assign_images(entries: Sequence[ImageEntry], index: CkIndex) -> tuple[Assign
         ValueError: if two entries name the same image, whose assignments
             could not then be told apart; if a C-kernel is already furnished,
             which would answer the reproduction lookups alongside the candidate
-            under test; or if a frame an image needs is not defined in the
+            under test; if a frame an image needs is not defined in the
             furnished kernels, which is a missing frame kernel and not a
-            baseline that has drifted.
+            baseline that has drifted; or if the index could not read the
+            coverage of an object an image needs, which is a missing clock
+            kernel and likewise not drift.
         OSError: if a candidate kernel cannot be furnished.
     """
     names = [entry.image_name for entry in entries]
@@ -436,6 +438,7 @@ def assign_images(entries: Sequence[ImageEntry], index: CkIndex) -> tuple[Assign
         raise ValueError('two images have the same name; their assignments cannot be told apart')
     _require_no_furnished_ck()
     _require_frames_defined(entries)
+    _require_coverage_readable(entries, index)
     losers = botsim_losers(entries)
     testable = [
         entry for entry in entries if entry.pointing is not None and entry.image_name not in losers
@@ -557,6 +560,44 @@ def _require_frames_defined(entries: Sequence[ImageEntry]) -> None:
                 f'kernel that names it has to be furnished before an image can be matched to the '
                 f'baseline it navigated against'
             ) from exc
+
+
+def _require_coverage_readable(entries: Sequence[ImageEntry], index: CkIndex) -> None:
+    """Refuse to run when the index could not read an object the images need.
+
+    The index expresses each file's coverage in TDB, which needs the clock the
+    object's time tags are encoded against; an object whose clock is not
+    furnished is recorded as unreadable and offers no coverage at all.  Its
+    candidates are then invisible to the coverage filter, so every image
+    correcting that object would be reported as having no reproducing
+    baseline -- the report that is meant to mean the holdings have changed
+    since navigation ran.  The missing clock is named here instead, before any
+    candidate is tried, exactly as a missing frame kernel is.
+
+    Parameters:
+        entries: The images the run considered.  Those carrying no pointing
+            correct no object and are skipped.
+        index: The pre-indexed C-kernels.
+
+    Raises:
+        ValueError: if any image corrects an object the index could not read.
+    """
+    unreadable = index.unreadable_objects
+    if len(unreadable) == 0:
+        return
+    blocked = sorted(
+        {
+            entry.pointing.ck_frame_id
+            for entry in entries
+            if entry.pointing is not None and entry.pointing.ck_frame_id in unreadable
+        }
+    )
+    if len(blocked) > 0:
+        raise ValueError(
+            f'the index could not read the coverage of CK object(s) {blocked}; the spacecraft '
+            f'clock kernel that encodes their time tags has to be furnished before an image can '
+            f'be matched to the baseline it navigated against'
+        )
 
 
 def _require_no_furnished_ck() -> None:

--- a/src/spindoctor/cli/ck/index.py
+++ b/src/spindoctor/cli/ck/index.py
@@ -15,8 +15,13 @@ The scan uses ``ckobj`` and ``ckcov`` at segment level in TDB.  Both read a
 file by name, so no C-kernel has to be furnished to be indexed, but the
 leapseconds kernel and the spacecraft clock kernel of every object encountered
 must be, since that is what converts a coverage window from clock ticks into
-TDB.  Both also need a real local file, so a kernel tree that lives remotely is
-fetched as it is scanned; for a tree that is already local nothing is copied.
+TDB.  An object whose clock is not furnished contributes no coverage and is
+recorded as unreadable instead, because a real kernel can name an object no
+clock kernel describes and no run should be stopped by an object none of its
+images asks about; an image that does ask about one is refused by the
+assignment step.  Both calls also need a real local file, so a kernel tree that
+lives remotely is fetched as it is scanned; for a tree that is already local
+nothing is copied.
 
 Coverage is read with a tolerance for the objects whose attitude was navigated
 through a tolerance-snapped pointing lookup.  Such a lookup answers with a
@@ -188,11 +193,18 @@ class CkFile:
             name of the directory it was found in.
         coverage: One interval per object per segment window, in the order
             SPICE reported them.
+        unreadable_objects: The objects the file describes whose coverage
+            could not be expressed in TDB, because no furnished kernel defines
+            the spacecraft clock their time tags are encoded against.  The file
+            offers no coverage for them, so it is never a candidate for one,
+            and an image that needs one is refused by the assignment step
+            rather than being told its baseline has drifted.
     """
 
     path: FCPath
     kernel_class: KernelClass
     coverage: tuple[CoverageInterval, ...]
+    unreadable_objects: tuple[int, ...] = ()
 
     @property
     def basename(self) -> str:
@@ -240,6 +252,21 @@ class CkIndex:
             grouped.setdefault(ck_file.basename, []).append(ck_file)
         object.__setattr__(
             self, '_by_basename', {name: tuple(found) for name, found in grouped.items()}
+        )
+
+    @property
+    def unreadable_objects(self) -> frozenset[int]:
+        """The objects whose coverage no indexed file could express in TDB.
+
+        An object appears here when the spacecraft clock its time tags are
+        encoded against is not furnished, so its coverage window cannot be
+        converted.  Nothing in the index offers coverage for such an object,
+        which makes it invisible to :meth:`candidates`; the assignment step
+        reads this so an image that needs one is refused for the reason it
+        actually has.
+        """
+        return frozenset(
+            ck_frame_id for ck_file in self.files for ck_frame_id in ck_file.unreadable_objects
         )
 
     def candidates(
@@ -432,36 +459,54 @@ def _index_one_file(path: FCPath, kernel_class: KernelClass) -> CkFile:
         kernel_class: The class its directory declares.
 
     Returns:
-        The indexed file.
+        The indexed file, carrying the coverage of every object whose clock is
+        furnished and the ids of the objects whose clock is not.
 
     Raises:
         OSError: if the file cannot be read as a C-kernel.
-        KeyError: if the spacecraft clock of an object the file describes is
-            not furnished, so its coverage cannot be expressed in TDB.
     """
     # SPICE reads a C-kernel by name from the local filesystem, so a remote one
     # is fetched first.  This is a no-op for a kernel that is already local.
     local = str(cast(Path, path.retrieve()))
     coverage: list[CoverageInterval] = []
+    unreadable: list[int] = []
     for ck_frame_id in sorted(int(value) for value in cspyce.ckobj(local)):
         tolerance = (
             SNAPPED_LOOKUP_TOL_TICKS
             if ck_frame_id in FROZEN_ATTITUDE_CK_IDS
             else _COVERAGE_TOL_TICKS
         )
-        window = [
-            float(value)
-            for value in cspyce.ckcov(
-                local,
-                ck_frame_id,
-                _COVERAGE_NEEDS_ANGULAR_VELOCITY,
-                _COVERAGE_LEVEL,
-                tolerance,
-                _COVERAGE_TIME_SYSTEM,
-            )
-        ]
+        try:
+            window = [
+                float(value)
+                for value in cspyce.ckcov(
+                    local,
+                    ck_frame_id,
+                    _COVERAGE_NEEDS_ANGULAR_VELOCITY,
+                    _COVERAGE_LEVEL,
+                    tolerance,
+                    _COVERAGE_TIME_SYSTEM,
+                )
+            ]
+        except LookupError:
+            # A real kernel can describe an object whose spacecraft clock no
+            # kernel defines: a merged New Horizons pointing file names object
+            # -1 beside the spacecraft, and the clock id SPICE computes for it
+            # is 0, which no SCLK kernel supplies.  Converting that object's
+            # coverage to TDB is impossible, and refusing the whole scan over
+            # it would make every New Horizons directory unindexable for the
+            # sake of an object no image will ever ask about.  The object is
+            # recorded instead, and an image that does ask about one is refused
+            # before any candidate is tried.
+            unreadable.append(ck_frame_id)
+            continue
         coverage.extend(
             CoverageInterval(ck_frame_id=ck_frame_id, start_et=window[at], stop_et=window[at + 1])
             for at in range(0, len(window), 2)
         )
-    return CkFile(path=path, kernel_class=kernel_class, coverage=tuple(coverage))
+    return CkFile(
+        path=path,
+        kernel_class=kernel_class,
+        coverage=tuple(coverage),
+        unreadable_objects=tuple(unreadable),
+    )

--- a/tests/integration/ck_round_trip.py
+++ b/tests/integration/ck_round_trip.py
@@ -1,0 +1,594 @@
+"""The three processes of the corrected-pointing round trip.
+
+Navigation measures a pointing correction; the C-kernel writer turns it into a
+kernel; a consumer furnishes that kernel and gets corrected geometry.  This
+module runs that loop end to end on one real image, as three steps meant to be
+run in three separate processes:
+
+``navigate``
+    Navigate the image the way the pipeline does, writing the per-image
+    metadata the kernel writer reads, plus the list of kernels oops furnished
+    while doing it.
+``generate``
+    Pair the image with the baseline kernel it navigated against and write the
+    corrected kernel, recording the corrected camera attitude the written
+    segment claims at the exposure start, midtime and stop.
+``renavigate``
+    Load the image again in a fresh process, furnish the corrected kernel, read
+    back the camera attitude at those three epochs, and navigate again.
+
+Three processes rather than one, because oops caches frames and manages its own
+kernel pool: a ``furnsh`` in the middle of a process that has already navigated
+is not guaranteed to take effect, and a round trip that quietly measured the
+uncorrected pointing twice would pass.  Each step writes its findings to a JSON
+file in a shared working directory, and the test that drives the three reads
+those files and does the deciding.  Nothing here asserts: a step that cannot do
+its job raises, and everything else is a measurement for the caller to judge.
+
+Two facts about the re-navigation step are worth stating, because they are what
+make it a real test rather than a formality:
+
+- The corrected kernel is furnished **after** the host's ``from_file`` returns,
+  since that is when oops has finished furnishing the originals, and SPICE
+  gives precedence to the C-kernel furnished last.  Furnishing it earlier would
+  put it underneath the originals, where it would be silently ignored.
+- A host that freezes its observation frame while ``from_file`` runs -- which is
+  what Voyager ISS does, building a fixed attitude out of one tolerance-snapped
+  pointing lookup -- cannot see a kernel furnished after that call returns at
+  all.  For those hosts the image is loaded a second time, with the correction
+  already furnished, and the second observation is the one navigated.  The
+  attitude readback then reports what the whole pool answers, so a correction
+  that failed to take effect is visible either way.
+"""
+
+import argparse
+import json
+import math
+import os
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any, cast
+
+import cspyce
+import numpy as np
+import oops
+from filecache import FCPath
+
+from spindoctor.cli.ck.assignment import assign_images, output_basename
+from spindoctor.cli.ck.images import ImageEntry
+from spindoctor.cli.ck.index import build_ck_index
+from spindoctor.cli.ck.pointing import ImagePointing, NDArrayFloatType
+from spindoctor.cli.ck.segment import (
+    FROZEN_ATTITUDE_CK_IDS,
+    CkSegment,
+    build_segment,
+    resolve_sclk_id,
+    write_segment,
+)
+from spindoctor.dataset.dataset import ImageFile, ImageFiles
+from spindoctor.nav_model import build_models_for_obs
+from spindoctor.nav_orchestrator import NavOrchestrator, build_metadata_dict
+from spindoctor.navigate_image_files import navigate_image_files
+from spindoctor.obs import (
+    ObsCassiniISS,
+    ObsGalileoSSI,
+    ObsNewHorizonsLORRI,
+    ObsSnapshotInst,
+    ObsVoyagerISS,
+)
+from tests.integration.sidecar import LibraryRoot, Sidecar, load_sidecar
+
+# The three steps, named as the driver names them on the command line.
+NAVIGATE = 'navigate'
+GENERATE = 'generate'
+RENAVIGATE = 'renavigate'
+
+# The epochs a segment always carries a record at, and the only ones this round
+# trip makes any claim about.  An exposure longer than 10 s carries more, at a
+# 1 s cadence, which are reproduced just as exactly but are deliberately not
+# asserted: they exist only on long exposures, so asserting them would make the
+# validation's coverage depend on the cohort's exposure lengths.
+RECORD_LABELS = ('start', 'midtime', 'stop')
+
+# The tolerance oops makes its snapped Voyager pointing lookup at, in spacecraft
+# clock ticks: a fixed part plus a term in the exposure.  Restated here rather
+# than imported because this module reproduces the *host's* lookup, and the
+# writer's copy of the same numbers exists to reproduce a *recorded* attitude;
+# tying the two together would let a change to one silently redefine the other.
+_SNAPPED_TOL_TICKS = 800.0
+_SNAPPED_TOL_EXPOSURE_DIVISOR = 48.0
+
+# The mission strings the image library uses, and the host class each names.
+_MISSION_TO_OBS_CLASS: dict[str, type[ObsSnapshotInst]] = {
+    'COISS': ObsCassiniISS,
+    'VGISS': ObsVoyagerISS,
+    'GOSSI': ObsGalileoSSI,
+    'NHLORRI': ObsNewHorizonsLORRI,
+}
+
+# A corrected kernel is written with no comment area; the comment area is
+# Phase E's business, and a segment reads back the same with or without one.
+_COMMENT_CHARS = 0
+
+# The pixel step a scale is measured over, one pixel along each axis from the
+# boresight.
+_SCALE_STEP_PX = 1.0
+
+
+def sidecar_for(image_id: str) -> Sidecar:
+    """Return the image library's sidecar for one image.
+
+    Parameters:
+        image_id: The library's id for the image, which is also its sidecar's
+            filename stem.
+
+    Returns:
+        The sidecar.
+
+    Raises:
+        ValueError: if no sidecar in the library carries that id, naming what
+            the library does hold so a typo is obvious.
+    """
+    for path in LibraryRoot().discover_sidecar_paths():
+        if path.stem == image_id:
+            return load_sidecar(path)
+    raise ValueError(f'no image library sidecar is named {image_id!r}')
+
+
+def holdings_url(sidecar: Sidecar) -> FCPath:
+    """Resolve one sidecar's image URL against the holdings root.
+
+    Parameters:
+        sidecar: The image's sidecar.
+
+    Returns:
+        The image's URL, with a ``pds3://`` scheme resolved against
+        ``PDS3_HOLDINGS_DIR`` and anything else passed through.
+
+    Raises:
+        KeyError: if the URL needs the holdings root and it is not set.
+    """
+    url = sidecar.image_url
+    if not url.startswith('pds3://'):
+        return FCPath(url)
+    root = os.environ['PDS3_HOLDINGS_DIR'].rstrip('/')
+    return FCPath(f'{root}/{url[len("pds3://") :]}')
+
+
+def step_path(work: Path, image_id: str, step: str) -> Path:
+    """Return the file one step writes its findings to.
+
+    Parameters:
+        work: The working directory the three steps share.
+        image_id: The library's id for the image.
+        step: Name of the step.
+
+    Returns:
+        The path.
+    """
+    return work / f'{image_id}_{step}.json'
+
+
+def metadata_path(work: Path, image_id: str) -> Path:
+    """Return the per-image navigation metadata the navigate step writes.
+
+    Parameters:
+        work: The working directory the three steps share.
+        image_id: The library's id for the image.
+
+    Returns:
+        The path, which is where ``navigate_image_files`` puts it.
+    """
+    return work / f'{image_id}_metadata.json'
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    """Read one JSON document written by an earlier step.
+
+    Parameters:
+        path: The file to read.
+
+    Returns:
+        The document.
+
+    Raises:
+        ValueError: if the file does not exist, which means the step that
+            writes it did not run or did not get that far, or if it does not
+            hold a JSON object.
+    """
+    if not path.is_file():
+        raise ValueError(f'{path} does not exist; the step that writes it did not complete')
+    document = json.loads(path.read_text())
+    if not isinstance(document, dict):
+        raise ValueError(f'{path} holds a {type(document).__name__}, not a JSON object')
+    return cast(dict[str, Any], document)
+
+
+def _write_json(path: Path, document: dict[str, Any]) -> None:
+    """Write one step's findings.
+
+    Parameters:
+        path: The file to write.
+        document: What to write.
+    """
+    path.write_text(json.dumps(document, indent=2, sort_keys=True))
+
+
+def furnished_kernels() -> list[dict[str, str]]:
+    """Report every kernel currently in the SPICE pool, in load order.
+
+    A navigation run's provenance records sorted basenames only, which is not
+    enough to furnish the same pool again: it holds no directories and no
+    order.  This is read straight from SPICE after a real load, so the
+    generate step can furnish exactly the supporting kernels the navigation
+    used and index exactly the directories its C-kernels came from.
+
+    Returns:
+        One entry per kernel, each holding its ``path`` and the ``kind``
+        SPICE reports (``CK``, ``SPK``, ``TEXT`` and so on), in the order they
+        were furnished.
+    """
+    kernels: list[dict[str, str]] = []
+    for at in range(int(cspyce.ktotal('ALL'))):
+        data = cspyce.kdata(at, 'ALL')
+        kernels.append({'path': str(data[0]), 'kind': str(data[1])})
+    return kernels
+
+
+def pixel_scales(fov: Any) -> tuple[float, float]:
+    """Measure one FOV's angular scale at the boresight, per axis.
+
+    The scale converts an attitude residual into the pixel error it causes,
+    which is the unit the round trip's tolerance is stated in.  It is measured
+    on the FOV itself rather than read from a table, since a binned or
+    subarrayed frame has a different scale from its instrument's nominal one.
+
+    Parameters:
+        fov: The observation's unmodified oops FOV.
+
+    Returns:
+        The angle subtended by one pixel at the boresight, in radians, along
+        ``u`` and along ``v``.
+
+    Raises:
+        ValueError: if either measured scale is not finite and positive, which
+            would make every angle-to-pixel conversion meaningless.
+    """
+    uv_los = fov.uv_los
+    boresight = np.asarray(fov.los_from_xy(fov.xy_from_uv(uv_los)).unit().vals, dtype=np.float64)
+    scales: list[float] = []
+    for step in ((_SCALE_STEP_PX, 0.0), (0.0, _SCALE_STEP_PX)):
+        stepped_uv = oops.Pair((uv_los.vals[0] + step[0], uv_los.vals[1] + step[1]))
+        direction = fov.los_from_xy(fov.xy_from_uv(stepped_uv)).unit()
+        stepped = np.asarray(direction.vals, dtype=np.float64)
+        cross = float(np.linalg.norm(np.cross(boresight, stepped)))
+        scales.append(float(np.arctan2(cross, float(np.dot(boresight, stepped)))))
+    for axis, scale in zip(('u', 'v'), scales, strict=True):
+        if not math.isfinite(scale) or scale <= 0.0:
+            raise ValueError(f'the FOV scale along {axis} is {scale!r}, not a positive angle')
+    return scales[0], scales[1]
+
+
+def angle_to_pixels(angle_rad: float, scale_rad_px: float) -> float:
+    """Convert an angular residual into the pixel error it causes.
+
+    Parameters:
+        angle_rad: The angle, in radians.
+        scale_rad_px: The angle one pixel subtends, in radians.
+
+    Returns:
+        The angle expressed in pixels.
+
+    Raises:
+        ValueError: if the angle is not finite, or if the scale is not finite
+            and positive.  A NaN divided by a scale is a NaN, which compares
+            False against every tolerance and so reads as a pass.
+    """
+    if not math.isfinite(angle_rad):
+        raise ValueError(f'the angle is {angle_rad!r}, not a finite number of radians')
+    if not math.isfinite(scale_rad_px) or scale_rad_px <= 0.0:
+        raise ValueError(f'the pixel scale is {scale_rad_px!r}, not a positive angle')
+    return angle_rad / scale_rad_px
+
+
+def record_index_for_tick(ticks: Sequence[float], tick: float) -> int:
+    """Return which of a segment's records sits at one encoded clock time.
+
+    The round trip claims the record epochs and nothing between them, so a
+    readback has to be compared against the record that is actually there.
+    The match is exact: a segment carries a record at the epoch or it does
+    not, and comparing a readback against the nearest record instead would
+    silently turn an assertion about a record into an assertion about an
+    interpolation.
+
+    Parameters:
+        ticks: The segment's encoded SCLK time tags, in record order.
+        tick: The encoded SCLK time to find.
+
+    Returns:
+        The index of the record at that time.
+
+    Raises:
+        ValueError: if no record sits exactly there, or if either the time or
+            the tags hold a non-finite value, which no comparison would
+            report.
+    """
+    if not math.isfinite(tick):
+        raise ValueError(f'the encoded clock time is {tick!r}, not a finite tick')
+    if len(ticks) == 0:
+        raise ValueError('the segment holds no records')
+    for at, value in enumerate(ticks):
+        if not math.isfinite(value):
+            raise ValueError(f'record {at} has a non-finite time tag: {value!r}')
+        if value == tick:
+            return at
+    raise ValueError(f'no record sits at encoded clock time {tick!r}; the tags are {list(ticks)!r}')
+
+
+def _as_matrix(values: Sequence[float]) -> NDArrayFloatType:
+    """Return nine row-major floats as a 3x3 array.
+
+    Parameters:
+        values: The nine elements.
+
+    Returns:
+        The 3x3 array.
+
+    Raises:
+        ValueError: if there are not exactly nine of them.
+    """
+    array = np.asarray(values, dtype=np.float64)
+    if array.shape != (9,):
+        raise ValueError(f'expected nine row-major floats; got shape {array.shape}')
+    return array.reshape(3, 3)
+
+
+def _flatten(matrix: NDArrayFloatType) -> list[float]:
+    """Return a 3x3 rotation as nine row-major floats.
+
+    Parameters:
+        matrix: The rotation.
+
+    Returns:
+        Its elements, unrounded, since they must reproduce to a nanoradian.
+    """
+    return [float(value) for value in np.asarray(matrix, dtype=np.float64).reshape(9)]
+
+
+def _snapped_tolerance(exposure_s: float) -> float:
+    """Return the tolerance a frozen-attitude host makes its lookup at.
+
+    Parameters:
+        exposure_s: The exposure duration in seconds.
+
+    Returns:
+        The tolerance in spacecraft clock ticks.
+    """
+    return _SNAPPED_TOL_TICKS + exposure_s / _SNAPPED_TOL_EXPOSURE_DIVISOR
+
+
+def camera_attitude_from_pool(pointing: ImagePointing, et: float) -> NDArrayFloatType:
+    """Read the camera attitude the furnished kernels now give at one epoch.
+
+    The lookup is the one the image's own host makes, so that what is measured
+    is what a consumer of these kernels would see.  Most hosts evaluate the
+    frame chain, which ``pxform`` reproduces.  A frozen-attitude host makes a
+    tolerance-snapped pointing lookup on the CK object and composes the fixed
+    rotation to the camera, and its camera frame cannot be evaluated by chain
+    at all, so the same lookup is made here.
+
+    Parameters:
+        pointing: The image's recorded pointing, naming the frames and the
+            exposure.
+        et: TDB seconds past J2000.
+
+    Returns:
+        The 3x3 J2000-to-camera rotation.
+
+    Raises:
+        OSError: if the pool holds no pointing there.
+        RuntimeError: if the frame chain cannot be evaluated there.
+    """
+    if pointing.ck_frame_id not in FROZEN_ATTITUDE_CK_IDS:
+        return np.asarray(cspyce.pxform('J2000', pointing.camera_frame, et), dtype=np.float64)
+    sclk_id = resolve_sclk_id(pointing.ck_frame_id)
+    j2000_to_object, _clkout = cspyce.ckgp(
+        pointing.ck_frame_id,
+        float(cspyce.sce2t(sclk_id, et)),
+        _snapped_tolerance(pointing.exposure_s),
+        'J2000',
+    )
+    object_to_camera = _object_to_camera(pointing, et)
+    attitude: NDArrayFloatType = object_to_camera @ np.asarray(j2000_to_object, dtype=np.float64)
+    return attitude
+
+
+def _object_to_camera(pointing: ImagePointing, et: float) -> NDArrayFloatType:
+    """Return the fixed rotation from the CK object's frame to the camera frame.
+
+    Parameters:
+        pointing: The image's recorded pointing.
+        et: TDB seconds past J2000.
+
+    Returns:
+        The 3x3 rotation.
+
+    Raises:
+        KeyError: if the CK object has no frame name in the furnished kernels.
+    """
+    ck_frame = str(cspyce.frmnam(pointing.ck_frame_id))
+    return np.asarray(cspyce.pxform(ck_frame, pointing.camera_frame, et), dtype=np.float64)
+
+
+def _claimed_camera_attitudes(
+    pointing: ImagePointing, segment: CkSegment
+) -> dict[str, dict[str, Any]]:
+    """Return the camera attitude the written segment claims at each record.
+
+    Taken from the segment's own quaternions rather than recomputed from the
+    baseline and the correction, so that what the re-navigation is compared
+    against is what was written rather than what was meant.
+
+    Parameters:
+        pointing: The image's recorded pointing.
+        segment: The segment written for it.
+
+    Returns:
+        One entry per record epoch, each holding the epoch, the encoded clock
+        time, the record index, and the claimed 3x3 camera attitude as nine
+        row-major floats.
+
+    Raises:
+        ValueError: if the segment carries no record at one of the epochs.
+    """
+    sclk_id = resolve_sclk_id(pointing.ck_frame_id)
+    epochs = (pointing.start_et, pointing.midtime_et, pointing.stop_et)
+    claimed: dict[str, dict[str, Any]] = {}
+    for label, et in zip(RECORD_LABELS, epochs, strict=True):
+        tick = float(cspyce.sce2c(sclk_id, et))
+        at = record_index_for_tick([float(value) for value in segment.sclkdp], tick)
+        object_attitude = np.asarray(cspyce.q2m(segment.quats[at]), dtype=np.float64)
+        claimed[label] = {
+            'et': et,
+            'tick': tick,
+            'record_index': at,
+            'cmatrix': _flatten(_object_to_camera(pointing, et) @ object_attitude),
+        }
+    return claimed
+
+
+def step_navigate(image_id: str, work: Path) -> None:
+    """Navigate one library image and record what the kernel writer will need.
+
+    Parameters:
+        image_id: The library's id for the image.
+        work: The working directory the three steps share.
+    """
+    sidecar = sidecar_for(image_id)
+    obs_class = _MISSION_TO_OBS_CLASS[sidecar.mission]
+    url = holdings_url(sidecar)
+    image_files = ImageFiles(
+        image_files=[ImageFile(image_file_url=url, label_file_url=url, results_path_stub=image_id)]
+    )
+    navigate_image_files(obs_class, image_files, FCPath(str(work)), write_output_files=True)
+    _write_json(step_path(work, image_id, NAVIGATE), {'kernels': furnished_kernels()})
+
+
+def step_generate(image_id: str, work: Path) -> None:
+    """Write the corrected kernel for one navigated image.
+
+    The pool is rebuilt from what the navigation run furnished: every kernel
+    but the C-kernels, since the assignment step needs a pool holding none, and
+    the directories those C-kernels came from as the candidate index.
+
+    Parameters:
+        image_id: The library's id for the image.
+        work: The working directory the three steps share.
+
+    Raises:
+        ValueError: if the image is not eligible for a segment, or if no
+            candidate kernel reproduces the baseline it navigated against.
+    """
+    metadata = read_json(metadata_path(work, image_id))
+    kernels = read_json(step_path(work, image_id, NAVIGATE))['kernels']
+    for kernel in kernels:
+        if kernel['kind'] != 'CK':
+            cspyce.furnsh(kernel['path'])
+    roots = sorted(
+        {str(Path(kernel['path']).parent) for kernel in kernels if kernel['kind'] == 'CK'}
+    )
+    entry = ImageEntry.from_metadata(metadata)
+    if entry.pointing is None:
+        raise ValueError(
+            f'{image_id} carries no corrected attitude to write: '
+            f'{entry.ineligibility_reason.value if entry.ineligibility_reason else "unknown"}'
+        )
+    assignment = assign_images([entry], build_ck_index(roots))[0]
+    if assignment.baseline is None:
+        raise ValueError(f'{image_id} has no reproducing baseline among {roots}')
+    local = str(cast(Path, assignment.baseline.path.retrieve()))
+    cspyce.furnsh(local)
+    try:
+        segment = build_segment(entry.pointing)
+    finally:
+        cspyce.unload(local)
+    output = work / output_basename(assignment.baseline.basename)
+    handle = int(cspyce.ckopn(str(output), output.stem, _COMMENT_CHARS))
+    write_segment(handle, segment)
+    cspyce.ckcls(handle)
+    _write_json(
+        step_path(work, image_id, GENERATE),
+        {
+            'baseline_path': str(assignment.baseline.path),
+            'ck_frame_id': entry.pointing.ck_frame_id,
+            'claimed': _claimed_camera_attitudes(entry.pointing, segment),
+            'has_angular_velocity': segment.has_angular_velocity,
+            'output_path': str(output),
+            'record_count': segment.record_count,
+            'segid': segment.segid,
+        },
+    )
+
+
+def step_renavigate(image_id: str, work: Path) -> None:
+    """Furnish the corrected kernel and navigate the same image again.
+
+    Parameters:
+        image_id: The library's id for the image.
+        work: The working directory the three steps share.
+    """
+    metadata = read_json(metadata_path(work, image_id))
+    generated = read_json(step_path(work, image_id, GENERATE))
+    pointing = ImagePointing.from_metadata(metadata)
+    sidecar = sidecar_for(image_id)
+    obs_class = _MISSION_TO_OBS_CLASS[sidecar.mission]
+    url = holdings_url(sidecar)
+    obs = cast(ObsSnapshotInst, obs_class.from_file(url))
+    cspyce.furnsh(generated['output_path'])
+    if pointing.ck_frame_id in FROZEN_ATTITUDE_CK_IDS:
+        # This host built its observation frame out of a pointing lookup while
+        # from_file ran, so the frame it returned cannot see a kernel furnished
+        # afterwards.  Loading again with the correction in the pool is what
+        # "furnish before any geometry is computed" means for such a host.
+        obs = cast(ObsSnapshotInst, obs_class.from_file(url))
+    measured = {
+        label: _flatten(camera_attitude_from_pool(pointing, float(claim['et'])))
+        for label, claim in generated['claimed'].items()
+    }
+    scale_u, scale_v = pixel_scales(obs.fov)
+    orchestrator = NavOrchestrator(build_models_for_obs(obs))
+    result = orchestrator.navigate(obs)
+    _write_json(
+        step_path(work, image_id, RENAVIGATE),
+        {
+            'measured': measured,
+            'navigation_result': build_metadata_dict(result),
+            'scale_u_rad_px': scale_u,
+            'scale_v_rad_px': scale_v,
+        },
+    )
+
+
+_STEPS: dict[str, Callable[[str, Path], None]] = {
+    NAVIGATE: step_navigate,
+    GENERATE: step_generate,
+    RENAVIGATE: step_renavigate,
+}
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run one step of the round trip.
+
+    Parameters:
+        argv: The command line, or ``None`` to read ``sys.argv``.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('step', choices=sorted(_STEPS))
+    parser.add_argument('image_id', help='the image library id of the image to run on')
+    parser.add_argument('work_dir', help='the directory the three steps share')
+    args = parser.parse_args(argv)
+    _STEPS[args.step](args.image_id, Path(args.work_dir))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/test_ck_index_holdings.py
+++ b/tests/integration/test_ck_index_holdings.py
@@ -1,11 +1,13 @@
 """Real-holdings integration tests for ``spindoctor.cli.ck.index``.
 
-Two things about the pre-index cannot be settled by kernels the suite writes
+Three things about the pre-index cannot be settled by kernels the suite writes
 itself.  The first is that it survives a real kernel directory, which holds
 subdirectories, comment files and label files beside the binaries.  The second
 is the claim the assignment rules rest on: that Voyager's decades-spanning bus
 kernels describe a different object from the scan platform the ISS pointing is
-read from, so the object filter excludes them without any epoch reasoning.
+read from, so the object filter excludes them without any epoch reasoning.  The
+third is that a real kernel can name an object whose spacecraft clock no kernel
+defines, which the New Horizons holdings do and which the scan has to survive.
 
 Everything else about the index is exercised hermetically.
 """
@@ -21,6 +23,8 @@ pytestmark = pytest.mark.integration
 _RESOURCES = os.environ.get('OOPS_RESOURCES', '')
 _SPICE_ROOT = Path(_RESOURCES) / 'SPICE'
 _VOYAGER_CK_DIR = _SPICE_ROOT / 'Voyager' / 'CK'
+_NEW_HORIZONS_ROOT = _SPICE_ROOT / 'New-Horizons'
+_NEW_HORIZONS_CK_DIR = _NEW_HORIZONS_ROOT / 'CK-reconstructed'
 
 if len(_RESOURCES) == 0 or not _VOYAGER_CK_DIR.is_dir():
     pytest.skip(
@@ -39,6 +43,12 @@ _BUS_ID = -31000
 
 _PLATFORM_KERNEL = 'vg1_sat_version1_type1_iss_sedr.bc'
 _BUS_KERNEL = 'vgr1_super.bc'
+
+# The New Horizons spacecraft, and the object one merged pointing file names
+# beside it whose clock no kernel defines.
+_SPACECRAFT_ID = -98000
+_CLOCKLESS_OBJECT_ID = -1
+_CLOCKLESS_KERNEL = 'nh_scispi_2015_recon.bc'
 
 
 @pytest.fixture
@@ -108,3 +118,61 @@ def test_a_platform_epoch_selects_no_bus_kernel(voyager_index: CkIndex) -> None:
     )
     assert _BUS_KERNEL not in {ck_file.basename for ck_file in candidates}
     assert _PLATFORM_KERNEL in {ck_file.basename for ck_file in candidates}
+
+
+@pytest.fixture
+def new_horizons_clocks() -> Iterator[None]:
+    """Furnish the leapseconds and New Horizons clock kernels, then unload them.
+
+    Yields:
+        Nothing; the kernels are furnished for the body of the test.
+    """
+    kernels = [_SPICE_ROOT / 'leapseconds.ker']
+    kernels.extend(sorted((_NEW_HORIZONS_ROOT / 'SCLK').glob('*.tsc')))
+    for kernel in kernels:
+        cspyce.furnsh(str(kernel))
+    try:
+        yield
+    finally:
+        for kernel in reversed(kernels):
+            cspyce.unload(str(kernel))
+
+
+@pytest.fixture
+def new_horizons_index(new_horizons_clocks: None) -> CkIndex:
+    """Index the real New Horizons reconstructed C-kernel directory.
+
+    Parameters:
+        new_horizons_clocks: The furnished clock kernels the coverage read
+            needs.
+
+    Returns:
+        The index of every C-kernel in the directory.
+    """
+    return build_ck_index([_NEW_HORIZONS_CK_DIR])
+
+
+def test_a_real_directory_holding_an_object_with_no_clock_indexes(
+    new_horizons_index: CkIndex,
+) -> None:
+    """The New Horizons holdings scan through, object -1 and all.
+
+    One merged pointing file names object -1 beside the spacecraft, and the
+    clock id SPICE computes for it is 0, which no SCLK kernel defines.  Reading
+    that object's coverage in TDB is impossible, and refusing the scan over it
+    would leave the whole mission unindexable.
+    """
+    by_name = {ck_file.basename: ck_file for ck_file in new_horizons_index.files}
+    assert by_name[_CLOCKLESS_KERNEL].unreadable_objects == (_CLOCKLESS_OBJECT_ID,)
+
+
+def test_that_file_still_covers_the_spacecraft(new_horizons_index: CkIndex) -> None:
+    """The object the images actually correct keeps its coverage."""
+    by_name = {ck_file.basename: ck_file for ck_file in new_horizons_index.files}
+    covered = {interval.ck_frame_id for interval in by_name[_CLOCKLESS_KERNEL].coverage}
+    assert covered == {_SPACECRAFT_ID}
+
+
+def test_the_spacecraft_is_not_reported_unreadable(new_horizons_index: CkIndex) -> None:
+    """Nothing an image needs is among the objects the index could not read."""
+    assert _SPACECRAFT_ID not in new_horizons_index.unreadable_objects

--- a/tests/integration/test_ck_round_trip.py
+++ b/tests/integration/test_ck_round_trip.py
@@ -32,10 +32,11 @@ What is asserted, and why in these units:
   techniques re-measure rather than recompute.  A convention error anywhere in
   the chain would leave roughly twice the original offset here, which is
   several pixels on every frame in the cohort.
-- **Both runs committed the same techniques.**  The comparison above is only
-  meaningful when the same measurement was repeated; a run that committed a
-  different set has not been shown to agree or to disagree, so the test fails
-  as inconclusive rather than passing.
+- **Both runs committed the same techniques, and the same ones carried
+  weight.**  The comparison above is only meaningful when the same measurement
+  was repeated; a run that committed a different set, or in which a technique's
+  confidence collapsed, has not been shown to agree or to disagree, so the test
+  fails as inconclusive rather than passing.
 
 The cohort is one star-navigated Cassini NAC frame, one Cassini WAC frame, one
 Voyager frame and one New Horizons LORRI frame, and a fifth frame -- a Cassini
@@ -112,12 +113,13 @@ COHORT = (_CASSINI_NAC, _CASSINI_WAC, _VOYAGER_NAC, _LORRI)
 # centroids.  Its pointing chain is asserted exactly like the cohort's, and its
 # re-navigated offset deliberately is not: the techniques are not exactly
 # shift-equivariant, and re-measuring this frame after the correction leaves
-# 0.1022 px on dv, of which 0.5 px of du comes from BodyDiscCorrelateNav
-# answering on a coarse grid in both runs alike.  Pinning that number would
+# 0.1022 px on dv, most of it BodyLimbNav's answers differing by 1.720 px
+# where the correction moved the model by 1.858.  Pinning that number would
 # pin a property of the navigation techniques in a test about pointing; the
-# frame is here because the part this plan owns is exact on it -- the pool's
-# attitude reads back to 8.8e-16 rad and moves by 1.8636 px against a measured
-# 1.8638 px -- and a convention error would still leave several pixels.
+# frame is here because the part this plan owns is exact on it -- the record
+# epochs read back to 2.6e-17 rad, the midtime to 8.8e-16 rad, and the pool's
+# pointing moves by the measured offset to within 5.7e-5 px -- and a
+# convention error would still leave several pixels.
 _CASSINI_WAC_BODY = 'W1637520502_1_CALIB'
 
 # A Galileo SSI frame the library records as navigating successfully.  Galileo
@@ -136,11 +138,12 @@ _GALILEO_SSI = 'C0059894800R'
 OFFSET_TOL_PX = 0.02
 
 # How far a corrected attitude read back from the kernel pool may sit from the
-# attitude it should be, in radians.  The measured disagreements are 0 to
-# 3.8e-17 rad for a record read back against what the segment says and 1.5e-15
-# rad for the midtime read back against the recorded corrected C-matrix -- both
-# floating-point noise.  The pin is three orders above the largest of them and
-# still six orders inside a thousandth of a Cassini NAC pixel.
+# attitude it should be, in radians.  Measured over eleven real frames, the
+# disagreements are 0 to 5.6e-17 rad for a record read back against what the
+# segment says and at most 1.5e-15 rad for the midtime read back against the
+# recorded corrected C-matrix -- both floating-point noise.  The pin is nearly
+# three orders above the largest of them and still six orders inside a
+# thousandth of a Cassini NAC pixel.
 ATTITUDE_TOL_RAD = 1e-12
 
 # Each step gets its own generous ceiling so a hung navigation fails the test
@@ -285,6 +288,28 @@ def committed_techniques(block: dict[str, Any]) -> set[str]:
     return set(block['techniques_used']) - set(block['excluded_from_consensus'])
 
 
+def contributing_techniques(block: dict[str, Any]) -> set[str]:
+    """Return the techniques that carried any weight in a navigation.
+
+    A technique that ran and answered with no confidence is in the committed
+    set above but contributed nothing to the offset, so the two sets are not
+    the same statement: a run where a technique's confidence collapsed
+    measured something different even though it ran the same techniques.
+
+    Parameters:
+        block: One run's ``navigation_result`` metadata block.
+
+    Returns:
+        The committed techniques whose confidence is above zero.
+    """
+    committed = committed_techniques(block)
+    return {
+        entry['technique_name']
+        for entry in block['per_technique']
+        if entry['technique_name'] in committed and float(entry['confidence']) > 0.0
+    }
+
+
 @pytest.fixture(scope='module')
 def round_trips() -> dict[str, RoundTrip]:
     """Hold each frame's findings, so a frame two fixtures ask for runs once.
@@ -391,7 +416,10 @@ def test_both_runs_committed_the_same_techniques(round_trip: RoundTrip) -> None:
 
     Comparing offsets across runs that committed different techniques would
     compare two different measurements, so a mismatch is reported as
-    inconclusive rather than as agreement or disagreement.
+    inconclusive rather than as agreement or disagreement.  Both which
+    techniques ran and which of them carried any weight have to match: a
+    technique whose confidence collapsed between the runs contributed to one
+    offset and not to the other.
     """
     first = committed_techniques(round_trip.navigated)
     second = committed_techniques(round_trip.renavigated)
@@ -399,6 +427,13 @@ def test_both_runs_committed_the_same_techniques(round_trip: RoundTrip) -> None:
         f'inconclusive-mismatch for {round_trip.image_id}: the first run committed '
         f'{sorted(first)} and the re-navigation committed {sorted(second)}, so the two offsets '
         f'are not measurements of the same thing'
+    )
+    weighted_first = contributing_techniques(round_trip.navigated)
+    weighted_second = contributing_techniques(round_trip.renavigated)
+    assert weighted_second == weighted_first, (
+        f'inconclusive-mismatch for {round_trip.image_id}: {sorted(weighted_first)} carried '
+        f'weight in the first run and {sorted(weighted_second)} in the re-navigation, so the two '
+        f'offsets are not measurements of the same thing'
     )
 
 

--- a/tests/integration/test_ck_round_trip.py
+++ b/tests/integration/test_ck_round_trip.py
@@ -1,0 +1,623 @@
+"""The corrected-pointing round trip, on real images against real kernels.
+
+This is the acceptance test of the C-kernel work: navigate a real image, write
+the corrected kernel its measurement implies, furnish that kernel in a fresh
+process, and navigate the same image again.  If everything from the C-matrix
+convention through the segment writer to the baseline pairing is right, the
+second navigation finds nothing left to correct.
+
+The three steps run as three subprocesses, because oops caches frames and
+manages its own kernel pool; :mod:`tests.integration.ck_round_trip` is the
+program each subprocess runs, and this module reads what the three of them
+wrote and does the deciding.
+
+What is asserted, and why in these units:
+
+- **The pointing actually changed.**  Read straight from the kernel pool at the
+  exposure midtime, the camera attitude has moved from the one navigation
+  recorded by exactly the offset navigation measured.  Without this, a kernel
+  that was furnished underneath the originals and silently ignored would leave
+  the re-navigation measuring the same offset as the first run and, on a frame
+  whose offset happened to be small, look like a pass.
+- **The record epochs read back exactly.**  A segment carries records at the
+  exposure start, midtime and stop; those are the epochs this plan claims, and
+  the readback is compared against what the segment says rather than against
+  what it was meant to say.  Interior epochs are deliberately not asserted: the
+  record scheme does not bound them, and a longer exposure's 1 s cadence
+  records are reproduced just as exactly but exist only on long exposures.
+- **The re-navigated offset is zero.**  This is the end-to-end statement, and
+  the only one whose residual is not pure floating-point noise: the pointing
+  chain reproduces to 1e-15 radians, while a second navigation of a corrected
+  frame lands within a few thousandths of a pixel of zero because the
+  techniques re-measure rather than recompute.  A convention error anywhere in
+  the chain would leave roughly twice the original offset here, which is
+  several pixels on every frame in the cohort.
+- **Both runs committed the same techniques.**  The comparison above is only
+  meaningful when the same measurement was repeated; a run that committed a
+  different set has not been shown to agree or to disagree, so the test fails
+  as inconclusive rather than passing.
+
+The cohort is one star-navigated Cassini NAC frame, one Cassini WAC frame, one
+Voyager frame and one New Horizons LORRI frame, and a fifth frame -- a Cassini
+WAC view of a resolved body -- carries the pointing assertions but not the
+offset one, because on that frame the offset measures the navigation techniques
+rather than the pointing.  Galileo SSI cannot take part at all and is tested for
+exactly that: its navigation fits a camera rotation, whose pivot no result
+records, so it records no corrected attitude to write.
+"""
+
+import json
+import math
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.integration
+
+_RESOURCES = os.environ.get('OOPS_RESOURCES', '')
+_SPICE_ROOT = Path(_RESOURCES) / 'SPICE'
+
+if (
+    len(_RESOURCES) == 0
+    or not (_SPICE_ROOT / 'Cassini' / 'CK-reconstructed').is_dir()
+    or 'PDS3_HOLDINGS_DIR' not in os.environ
+):
+    pytest.skip(
+        'the round trip needs local binary kernels and the holdings; set OOPS_RESOURCES to a '
+        'local SPICE tree and PDS3_HOLDINGS_DIR to the holdings',
+        allow_module_level=True,
+    )
+
+import oops  # noqa: E402  (guarded import)
+
+from spindoctor.cli.ck.assignment import rotation_angle_rad  # noqa: E402  (guarded import)
+from spindoctor.cli.ck.images import (  # noqa: E402  (guarded import)
+    ImageEntry,
+    OmissionReason,
+)
+from tests.integration.ck_round_trip import (  # noqa: E402  (guarded import)
+    GENERATE,
+    NAVIGATE,
+    RECORD_LABELS,
+    RENAVIGATE,
+    angle_to_pixels,
+    metadata_path,
+    pixel_scales,
+    read_json,
+    record_index_for_tick,
+    sidecar_for,
+    step_path,
+)
+
+# The frames the round trip runs on.  The two Cassini frames are star
+# navigated, which is the best-constrained truth the library holds, and the WAC
+# one is small-offset on purpose: the rotation-versus-shift difference between
+# an exact rigid rotation and a uniform pixel shift is 9.89e-2 px at a 50 px
+# total offset on a WAC and is linear in the offset, so a 4.8 px frame spends
+# about a hundredth of the budget on it.
+_CASSINI_NAC = 'N1461997416_1_CALIB'
+_CASSINI_WAC = 'W1580760393_1_CALIB'
+_VOYAGER_NAC = 'C1205021_GEOMED'
+_LORRI = 'lor_0030713591_0x633_sci'
+
+COHORT = (_CASSINI_NAC, _CASSINI_WAC, _VOYAGER_NAC, _LORRI)
+
+# A Cassini WAC frame of a resolved body, whose ensemble is carried by the
+# correlation and distance-transform body techniques rather than by star
+# centroids.  Its pointing chain is asserted exactly like the cohort's, and its
+# re-navigated offset deliberately is not: the techniques are not exactly
+# shift-equivariant, and re-measuring this frame after the correction leaves
+# 0.1022 px on dv, of which 0.5 px of du comes from BodyDiscCorrelateNav
+# answering on a coarse grid in both runs alike.  Pinning that number would
+# pin a property of the navigation techniques in a test about pointing; the
+# frame is here because the part this plan owns is exact on it -- the pool's
+# attitude reads back to 8.8e-16 rad and moves by 1.8636 px against a measured
+# 1.8638 px -- and a convention error would still leave several pixels.
+_CASSINI_WAC_BODY = 'W1637520502_1_CALIB'
+
+# A Galileo SSI frame the library records as navigating successfully.  Galileo
+# is the one instrument configured to fit a camera rotation, so it stands in
+# for the whole mission here.
+_GALILEO_SSI = 'C0059894800R'
+
+# How far the re-navigated offset may sit from zero, per axis, in pixels.
+# Measured across the cohort the largest residual is 0.0029 px (LORRI); the
+# others are 0.0006 / 0.0014 (NAC), 0.0009 / 0.0024 (WAC) and 0.0002 / 0.0001
+# (Voyager).  The pin is seven times the largest of those and five times inside
+# the 0.1 px per-axis target, which leaves room for a technique's subpixel
+# refinement to change without loosening what this test is for: a convention
+# error in the C-matrix, the conjugation or the correction's direction leaves
+# about twice the original offset here, between 3.7 and 98 px on these frames.
+OFFSET_TOL_PX = 0.02
+
+# How far a corrected attitude read back from the kernel pool may sit from the
+# attitude it should be, in radians.  The measured disagreements are 0 to
+# 3.8e-17 rad for a record read back against what the segment says and 1.5e-15
+# rad for the midtime read back against the recorded corrected C-matrix -- both
+# floating-point noise.  The pin is three orders above the largest of them and
+# still six orders inside a thousandth of a Cassini NAC pixel.
+ATTITUDE_TOL_RAD = 1e-12
+
+# Each step gets its own generous ceiling so a hung navigation fails the test
+# rather than the suite.  A step takes seconds; this is not a performance bound.
+_STEP_TIMEOUT_S = 900.0
+
+# How much of a failed step's output to quote back.
+_OUTPUT_TAIL_CHARS = 4000
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _StubFov:
+    """A field of view whose every pixel looks in one direction.
+
+    Stands in for a degenerate FOV, which no real instrument has and which no
+    constructor will build: its pixel scale is zero, so every angle-to-pixel
+    conversion made through it would divide by zero.
+    """
+
+    def __init__(self) -> None:
+        """Report the boresight at the middle of a one-pixel detector."""
+        self.uv_los = oops.Pair((0.5, 0.5))
+
+    def xy_from_uv(self, uv: Any) -> Any:
+        """Return the tangent-plane origin whatever pixel is asked about.
+
+        Parameters:
+            uv: The pixel, ignored.
+
+        Returns:
+            The origin.
+        """
+        return oops.Pair((0.0, 0.0))
+
+    def los_from_xy(self, xy: Any) -> Any:
+        """Return the boresight whatever tangent-plane point is asked about.
+
+        Parameters:
+            xy: The tangent-plane point, ignored.
+
+        Returns:
+            The boresight direction.
+        """
+        return oops.Vector3((0.0, 0.0, 1.0))
+
+
+def _run_step(step: str, image_id: str, work: Path) -> None:
+    """Run one step of the round trip in its own process.
+
+    Parameters:
+        step: Name of the step.
+        image_id: The library's id for the image.
+        work: The working directory the three steps share.
+
+    Raises:
+        AssertionError: if the step fails, quoting the end of its output.
+    """
+    completed = subprocess.run(
+        [sys.executable, '-m', 'tests.integration.ck_round_trip', step, image_id, str(work)],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=_STEP_TIMEOUT_S,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            f'the {step} step failed for {image_id} with exit status {completed.returncode}\n'
+            f'stdout:\n{completed.stdout[-_OUTPUT_TAIL_CHARS:]}\n'
+            f'stderr:\n{completed.stderr[-_OUTPUT_TAIL_CHARS:]}'
+        )
+
+
+class RoundTrip:
+    """What the three steps found for one image.
+
+    Parameters:
+        image_id: The library's id for the image.
+        work: The working directory the three steps shared.
+    """
+
+    def __init__(self, image_id: str, work: Path) -> None:
+        """Read the three steps' findings."""
+        self.image_id = image_id
+        self.work = work
+        self.navigated = read_json(metadata_path(work, image_id))['navigation_result']
+        self.generated = read_json(step_path(work, image_id, GENERATE))
+        renavigated = read_json(step_path(work, image_id, RENAVIGATE))
+        self.renavigated = renavigated['navigation_result']
+        self.measured = renavigated['measured']
+        # The smaller of the two axis scales, so an attitude residual converts
+        # to the larger number of pixels; on these frames the two differ by
+        # about a hundredth of a percent.
+        self.scale_rad_px = min(
+            float(renavigated['scale_u_rad_px']), float(renavigated['scale_v_rad_px'])
+        )
+
+    @property
+    def cmatrix(self) -> Any:
+        """The corrected attitude the first navigation recorded."""
+        return self.navigated['pointing']['cmatrix']
+
+    @property
+    def cmatrix_original(self) -> Any:
+        """The uncorrected attitude the first navigation recorded."""
+        return self.navigated['pointing']['cmatrix_original']
+
+    def claimed(self, label: str) -> Any:
+        """Return the camera attitude the written segment claims at one record.
+
+        Parameters:
+            label: Which record: ``start``, ``midtime`` or ``stop``.
+
+        Returns:
+            The 3x3 attitude, as nine row-major floats.
+        """
+        return self.generated['claimed'][label]['cmatrix']
+
+    def pixels(self, angle_rad: float) -> float:
+        """Express an angle in pixels of this image's own FOV.
+
+        Parameters:
+            angle_rad: The angle in radians.
+
+        Returns:
+            The angle in pixels.
+        """
+        return angle_to_pixels(angle_rad, self.scale_rad_px)
+
+
+def committed_techniques(block: dict[str, Any]) -> set[str]:
+    """Return the techniques whose measurement a navigation committed to.
+
+    Parameters:
+        block: One run's ``navigation_result`` metadata block.
+
+    Returns:
+        The techniques that ran, less those the ensemble excluded, which is
+        the set that decided the offset.
+    """
+    return set(block['techniques_used']) - set(block['excluded_from_consensus'])
+
+
+@pytest.fixture(scope='module')
+def round_trips() -> dict[str, RoundTrip]:
+    """Hold each frame's findings, so a frame two fixtures ask for runs once.
+
+    Returns:
+        The cache, empty to begin with.
+    """
+    return {}
+
+
+def _round_trip(
+    image_id: str, cache: dict[str, RoundTrip], tmp_path_factory: pytest.TempPathFactory
+) -> RoundTrip:
+    """Run the three steps for one frame, or return what they already found.
+
+    Parameters:
+        image_id: The library's id for the image.
+        cache: The findings of the frames already run.
+        tmp_path_factory: Where the three steps share their working directory.
+
+    Returns:
+        The round trip's findings.
+    """
+    if image_id not in cache:
+        work = tmp_path_factory.mktemp(image_id)
+        for step in (NAVIGATE, GENERATE, RENAVIGATE):
+            _run_step(step, image_id, work)
+        cache[image_id] = RoundTrip(image_id, work)
+    return cache[image_id]
+
+
+@pytest.fixture(scope='module', params=COHORT)
+def round_trip(
+    request: pytest.FixtureRequest,
+    round_trips: dict[str, RoundTrip],
+    tmp_path_factory: pytest.TempPathFactory,
+) -> RoundTrip:
+    """Return the findings for one frame whose re-navigated offset is pinned.
+
+    Parameters:
+        request: The parametrization, naming the image.
+        round_trips: The cache of findings.
+        tmp_path_factory: Where the three steps share their working directory.
+
+    Returns:
+        The round trip's findings.
+    """
+    return _round_trip(str(request.param), round_trips, tmp_path_factory)
+
+
+@pytest.fixture(scope='module', params=(*COHORT, _CASSINI_WAC_BODY))
+def chain_round_trip(
+    request: pytest.FixtureRequest,
+    round_trips: dict[str, RoundTrip],
+    tmp_path_factory: pytest.TempPathFactory,
+) -> RoundTrip:
+    """Return the findings for one frame whose pointing chain is asserted.
+
+    This is the cohort plus the body-navigated frame, whose chain is exact
+    although its re-navigated offset is a measurement of the navigation
+    techniques rather than of the pointing.
+
+    Parameters:
+        request: The parametrization, naming the image.
+        round_trips: The cache of findings.
+        tmp_path_factory: Where the three steps share their working directory.
+
+    Returns:
+        The round trip's findings.
+    """
+    return _round_trip(str(request.param), round_trips, tmp_path_factory)
+
+
+@pytest.fixture(scope='module')
+def galileo_navigation(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Any]:
+    """Navigate one Galileo SSI frame and return its metadata.
+
+    Only the first step runs: the point is that this frame never reaches the
+    second one.
+
+    Parameters:
+        tmp_path_factory: Where the step writes its findings.
+
+    Returns:
+        The image's full navigation metadata.
+    """
+    work = tmp_path_factory.mktemp(_GALILEO_SSI)
+    _run_step(NAVIGATE, _GALILEO_SSI, work)
+    return read_json(metadata_path(work, _GALILEO_SSI))
+
+
+def test_the_first_navigation_succeeded(chain_round_trip: RoundTrip) -> None:
+    """The frame navigates, which is the premise of everything below."""
+    assert chain_round_trip.navigated['status'] == 'success'
+
+
+def test_the_re_navigation_succeeded(chain_round_trip: RoundTrip) -> None:
+    """Correcting the pointing does not stop the frame from navigating."""
+    assert chain_round_trip.renavigated['status'] == 'success'
+
+
+def test_both_runs_committed_the_same_techniques(round_trip: RoundTrip) -> None:
+    """The two runs repeated one measurement rather than making two.
+
+    Comparing offsets across runs that committed different techniques would
+    compare two different measurements, so a mismatch is reported as
+    inconclusive rather than as agreement or disagreement.
+    """
+    first = committed_techniques(round_trip.navigated)
+    second = committed_techniques(round_trip.renavigated)
+    assert second == first, (
+        f'inconclusive-mismatch for {round_trip.image_id}: the first run committed '
+        f'{sorted(first)} and the re-navigation committed {sorted(second)}, so the two offsets '
+        f'are not measurements of the same thing'
+    )
+
+
+def test_the_kernel_moved_the_pointing_by_the_measured_offset(chain_round_trip: RoundTrip) -> None:
+    """The furnished pool answers a pointing that has moved, and by how much.
+
+    Read at the exposure midtime, the camera attitude has left the one the
+    navigation recorded by the number of pixels the navigation measured.  A
+    corrected kernel that was furnished but had no effect -- buried under the
+    originals, or written for the wrong object -- leaves this at zero.
+    """
+    moved_rad = rotation_angle_rad(
+        np.asarray(chain_round_trip.measured['midtime']).reshape(3, 3),
+        np.asarray(chain_round_trip.cmatrix_original).reshape(3, 3),
+    )
+    offset = chain_round_trip.navigated['offset_px']
+    expected_px = math.hypot(float(offset[0]), float(offset[1]))
+    assert chain_round_trip.pixels(moved_rad) == pytest.approx(expected_px, abs=OFFSET_TOL_PX)
+
+
+def test_the_pool_answers_the_recorded_corrected_attitude(chain_round_trip: RoundTrip) -> None:
+    """At the midtime, the corrected kernel gives back the recorded C-matrix.
+
+    This is the whole claim of the metadata field, made against SPICE rather
+    than against the code that wrote it.
+    """
+    residual_rad = rotation_angle_rad(
+        np.asarray(chain_round_trip.measured['midtime']).reshape(3, 3),
+        np.asarray(chain_round_trip.cmatrix).reshape(3, 3),
+    )
+    assert residual_rad <= ATTITUDE_TOL_RAD
+
+
+@pytest.mark.parametrize('label', RECORD_LABELS)
+def test_a_record_epoch_reads_back_what_the_segment_claims(
+    chain_round_trip: RoundTrip, label: str
+) -> None:
+    """Each of the three record epochs answers exactly what was written.
+
+    The comparison is against the segment's own quaternions, so a segment that
+    wrote something other than the corrected attitude fails here rather than
+    being compared against the intention it was written with.
+
+    Parameters:
+        label: Which record: the exposure start, midtime or stop.
+    """
+    residual_rad = rotation_angle_rad(
+        np.asarray(chain_round_trip.measured[label]).reshape(3, 3),
+        np.asarray(chain_round_trip.claimed(label)).reshape(3, 3),
+    )
+    assert residual_rad <= ATTITUDE_TOL_RAD
+
+
+def test_the_re_navigated_offset_is_zero_along_v(round_trip: RoundTrip) -> None:
+    """Nothing is left to correct along ``v``."""
+    assert abs(float(round_trip.renavigated['offset_px'][0])) <= OFFSET_TOL_PX
+
+
+def test_the_re_navigated_offset_is_zero_along_u(round_trip: RoundTrip) -> None:
+    """Nothing is left to correct along ``u``."""
+    assert abs(float(round_trip.renavigated['offset_px'][1])) <= OFFSET_TOL_PX
+
+
+def test_the_re_navigated_cmatrix_matches_the_first(round_trip: RoundTrip) -> None:
+    """The second run's corrected attitude is the first run's.
+
+    The second run computes its own C-matrix from its own (near zero) offset on
+    top of the corrected baseline, so this is the same statement as the offset
+    above expressed as a rotation -- and it is the form acceptance asks for.
+    """
+    residual_rad = rotation_angle_rad(
+        np.asarray(round_trip.renavigated['pointing']['cmatrix']).reshape(3, 3),
+        np.asarray(round_trip.cmatrix).reshape(3, 3),
+    )
+    assert round_trip.pixels(residual_rad) <= OFFSET_TOL_PX
+
+
+def test_a_galileo_frame_fits_a_camera_rotation(galileo_navigation: dict[str, Any]) -> None:
+    """Galileo navigation really does fit the rotation its config asks for.
+
+    This is the fact that keeps Galileo out of the cohort, so it is measured
+    rather than assumed: the frame navigates successfully and reports a fitted
+    rotation of a few tenths of a degree.
+    """
+    result = galileo_navigation['navigation_result']
+    assert 'rotation_deg' in result
+    assert result['rotation_deg'] != 0.0
+
+
+def test_a_galileo_frame_records_no_corrected_attitude(
+    galileo_navigation: dict[str, Any],
+) -> None:
+    """A fitted rotation means no C-matrix, since its pivot is not recorded."""
+    assert 'cmatrix' not in galileo_navigation['navigation_result']['pointing']
+
+
+def test_a_galileo_frame_still_records_its_uncorrected_attitude(
+    galileo_navigation: dict[str, Any],
+) -> None:
+    """Everything but the correction is recorded, exactly as section 2.3 says."""
+    assert 'cmatrix_original' in galileo_navigation['navigation_result']['pointing']
+
+
+def test_a_galileo_frame_is_omitted_as_rotation_unsupported(
+    galileo_navigation: dict[str, Any],
+) -> None:
+    """The generator's own reading of that frame is the reason it gets no segment."""
+    entry = ImageEntry.from_metadata(galileo_navigation)
+    assert entry.ineligibility_reason is OmissionReason.ROTATION_UNSUPPORTED
+
+
+def test_pixel_scales_measures_a_flat_fov() -> None:
+    """A FOV's measured scale is the scale it was built with."""
+    fov = oops.fov.FlatFOV(uv_scale=(1.0e-5, 2.0e-5), uv_shape=(64, 64))
+    scale_u, scale_v = pixel_scales(fov)
+    assert scale_u == pytest.approx(1.0e-5, rel=1e-6)
+    assert scale_v == pytest.approx(2.0e-5, rel=1e-6)
+
+
+def test_pixel_scales_refuses_a_fov_with_no_scale() -> None:
+    """A FOV every pixel of which looks the same way has no scale to measure."""
+    with pytest.raises(ValueError, match='not a positive angle'):
+        pixel_scales(_StubFov())
+
+
+@pytest.mark.parametrize(
+    'angle_rad', [float('nan'), float('inf'), float('-inf')], ids=['nan', 'inf', '-inf']
+)
+def test_angle_to_pixels_refuses_a_non_finite_angle(angle_rad: float) -> None:
+    """A non-finite angle divides into a non-finite number of pixels.
+
+    Which then compares False against every tolerance there is, and so reads as
+    a pass.
+
+    Parameters:
+        angle_rad: The angle that must be refused.
+    """
+    with pytest.raises(ValueError, match='not a finite number of radians'):
+        angle_to_pixels(angle_rad, 6.0e-6)
+
+
+@pytest.mark.parametrize(
+    'scale_rad_px',
+    [0.0, -6.0e-6, float('nan'), float('inf')],
+    ids=['zero', 'negative', 'nan', 'inf'],
+)
+def test_angle_to_pixels_refuses_an_unusable_scale(scale_rad_px: float) -> None:
+    """A scale that is not a positive angle converts nothing.
+
+    Parameters:
+        scale_rad_px: The scale that must be refused.
+    """
+    with pytest.raises(ValueError, match='not a positive angle'):
+        angle_to_pixels(1.0e-6, scale_rad_px)
+
+
+def test_angle_to_pixels_converts_at_the_measured_scale() -> None:
+    """One pixel of angle is one pixel."""
+    assert angle_to_pixels(1.2e-5, 6.0e-6) == pytest.approx(2.0)
+
+
+def test_record_index_for_tick_finds_the_record() -> None:
+    """A time tag a segment holds names the record holding it."""
+    assert record_index_for_tick([10.0, 20.0, 30.0], 20.0) == 1
+
+
+def test_record_index_for_tick_refuses_an_epoch_with_no_record() -> None:
+    """An epoch between two records is an interpolation, not a record.
+
+    Comparing a readback against the nearest record would turn an assertion
+    about what was written into an assertion about what SPICE interpolated.
+    """
+    with pytest.raises(ValueError, match='no record sits at encoded clock time'):
+        record_index_for_tick([10.0, 20.0, 30.0], 25.0)
+
+
+def test_record_index_for_tick_refuses_an_empty_segment() -> None:
+    """A segment with no records holds no epoch at all."""
+    with pytest.raises(ValueError, match='holds no records'):
+        record_index_for_tick([], 20.0)
+
+
+@pytest.mark.parametrize('tick', [float('nan'), float('inf')], ids=['nan', 'inf'])
+def test_record_index_for_tick_refuses_a_non_finite_epoch(tick: float) -> None:
+    """A non-finite time tag matches nothing and reports nothing.
+
+    Parameters:
+        tick: The encoded clock time that must be refused.
+    """
+    with pytest.raises(ValueError, match='not a finite tick'):
+        record_index_for_tick([10.0, 20.0], tick)
+
+
+def test_record_index_for_tick_refuses_a_non_finite_tag() -> None:
+    """A segment whose tags are not finite cannot be searched by comparison."""
+    with pytest.raises(ValueError, match='non-finite time tag'):
+        record_index_for_tick([10.0, float('nan'), 30.0], 30.0)
+
+
+def test_sidecar_for_refuses_an_unknown_image() -> None:
+    """An image id the library does not hold is named rather than guessed at."""
+    with pytest.raises(ValueError, match='no image library sidecar is named'):
+        sidecar_for('N0000000000_0_CALIB')
+
+
+def test_sidecar_for_finds_a_cohort_frame() -> None:
+    """Each cohort frame is a real library entry, found by its own id."""
+    assert sidecar_for(_CASSINI_NAC).image_id == _CASSINI_NAC
+
+
+def test_read_json_refuses_a_missing_file(tmp_path: Path) -> None:
+    """A step's findings that are not there mean the step did not finish."""
+    with pytest.raises(ValueError, match='did not complete'):
+        read_json(tmp_path / 'absent.json')
+
+
+def test_read_json_refuses_a_document_that_is_not_an_object(tmp_path: Path) -> None:
+    """A JSON list where a step's findings belong is a malformed file."""
+    path = tmp_path / 'list.json'
+    path.write_text(json.dumps([1, 2, 3]))
+    with pytest.raises(ValueError, match='not a JSON object'):
+        read_json(path)

--- a/tests/spindoctor/cli/ck/test_assignment.py
+++ b/tests/spindoctor/cli/ck/test_assignment.py
@@ -79,6 +79,11 @@ _DECOY_NAME = 'zz04002_04009ra.bc'
 
 _IMAGE_NAME = 'N1484573295_1.IMG'
 
+# An object whose clock id SPICE computes as 0, which no SCLK kernel defines,
+# so a real kernel naming it beside the spacecraft leaves its coverage
+# unreadable.  No image corrects it.
+_CLOCKLESS_OBJECT_ID = -1
+
 
 def _turned(angle_rad: float) -> Callable[[float], NDArrayFloatType]:
     """Return an attitude history turned from the baseline by a fixed rotation.
@@ -427,6 +432,55 @@ def test_assign_refuses_a_pool_that_already_holds_a_kernel(
     pool.furnish(path)
     with pytest.raises(ValueError, match='already furnished'):
         assign_images([entry], index)
+
+
+def test_assign_refuses_an_object_whose_coverage_the_index_could_not_read(
+    pool: KernelPool, tmp_path: Path
+) -> None:
+    """A clock kernel the index needed and did not have is named, not blamed on drift.
+
+    An object whose coverage could not be expressed in TDB offers no candidate
+    at all, so every image correcting it would otherwise be reported as having
+    no reproducing baseline -- which is the report reserved for holdings that
+    changed since navigation ran.
+    """
+    root = tmp_path / 'CK-reconstructed'
+    path = _write_candidate(root, _TRUE_NAME)
+    index = CkIndex(
+        files=(
+            CkFile(
+                path=FCPath(path),
+                kernel_class=KernelClass.RECONSTRUCTED,
+                coverage=(),
+                unreadable_objects=(CASSINI_CK_FRAME_ID,),
+            ),
+        )
+    )
+    entry = _entry(cmatrix_original=_cassini_recorded(pool), kernels=(_TRUE_NAME,))
+    with pytest.raises(ValueError, match='could not read the coverage'):
+        assign_images([entry], index)
+
+
+def test_assign_ignores_an_unreadable_object_no_image_needs(
+    pool: KernelPool, tmp_path: Path
+) -> None:
+    """An object nothing corrects does not stop a run, however unreadable it is."""
+    root = tmp_path / 'CK-reconstructed'
+    path = _write_candidate(root, _TRUE_NAME)
+    covering = build_ck_index([root]).files[0].coverage
+    index = CkIndex(
+        files=(
+            CkFile(
+                path=FCPath(path),
+                kernel_class=KernelClass.RECONSTRUCTED,
+                coverage=covering,
+                unreadable_objects=(_CLOCKLESS_OBJECT_ID,),
+            ),
+        )
+    )
+    entry = _entry(cmatrix_original=_cassini_recorded(pool), kernels=(_TRUE_NAME,))
+    assignments = assign_images([entry], index)
+    assert assignments[0].baseline is not None
 
 
 def test_the_candidate_pool_is_left_as_it_was_found(pool: KernelPool, tmp_path: Path) -> None:

--- a/tests/spindoctor/cli/ck/test_assignment.py
+++ b/tests/spindoctor/cli/ck/test_assignment.py
@@ -483,6 +483,36 @@ def test_assign_ignores_an_unreadable_object_no_image_needs(
     assert assignments[0].baseline is not None
 
 
+def test_an_image_with_no_pointing_names_no_object_to_read(
+    pool: KernelPool, tmp_path: Path
+) -> None:
+    """An image that did not navigate corrects nothing, unreadable or otherwise.
+
+    It carries no pointing at all, so it names no CK object, and an index that
+    could not read some object's coverage does not turn it into a refusal.
+    """
+    root = tmp_path / 'CK-reconstructed'
+    path = _write_candidate(root, _TRUE_NAME)
+    index = CkIndex(
+        files=(
+            CkFile(
+                path=FCPath(path),
+                kernel_class=KernelClass.RECONSTRUCTED,
+                coverage=(),
+                unreadable_objects=(CASSINI_CK_FRAME_ID,),
+            ),
+        )
+    )
+    entry = _entry(
+        cmatrix_original=_cassini_recorded(pool),
+        kernels=(_TRUE_NAME,),
+        cmatrix=None,
+        status='failed',
+    )
+    assignments = assign_images([entry], index)
+    assert assignments[0].omission_reason is OmissionReason.NOT_ELIGIBLE
+
+
 def test_the_candidate_pool_is_left_as_it_was_found(pool: KernelPool, tmp_path: Path) -> None:
     """Every candidate furnished for a test is unloaded again."""
     root = tmp_path / 'CK-reconstructed'

--- a/tests/spindoctor/cli/ck/test_index.py
+++ b/tests/spindoctor/cli/ck/test_index.py
@@ -20,7 +20,9 @@ from tests.spindoctor.cli.ck.conftest import (
     VOYAGER_CK_FRAME_ID,
     KernelPool,
     baseline_attitude,
+    baseline_segment,
     write_baseline_ck,
+    write_ck,
     write_type1_ck,
 )
 
@@ -34,6 +36,7 @@ from spindoctor.cli.ck.index import (
     kernel_class_for_directory,
 )
 from spindoctor.cli.ck.pointing import NDArrayFloatType
+from spindoctor.cli.ck.segment import CkSegment
 
 # The clocks the two test objects are tagged against, matching the test SCLK.
 _CASSINI_SCLK_ID = -82
@@ -49,6 +52,11 @@ _RECORD_STEP_S = 0.5
 _RECONSTRUCTED_NAME = '03236_04002ra.bc'
 _GAPFILL_NAME = '03001_04001pa_gapfill_v01.bc'
 _PREDICTED_NAME = '04009_04051px.bc'
+
+# An object whose clock id SPICE computes as 0, which no SCLK kernel defines.
+# A real merged New Horizons pointing file names this object beside the
+# spacecraft, so its coverage cannot be expressed in TDB.
+_CLOCKLESS_OBJECT_ID = -1
 
 
 def _write_ck(
@@ -566,3 +574,102 @@ def test_the_coverage_filter_admits_every_epoch_the_snapped_lookup_reaches(
     index = build_ck_index([root])
     furthest_et = float(cspyce.sct2e(_VOYAGER_SCLK_ID, tick + SNAPPED_LOOKUP_TOL_TICKS))
     assert index.files[0].covers(VOYAGER_CK_FRAME_ID, furthest_et) is True
+
+
+def _write_ck_naming_a_clockless_object(directory: Path, name: str) -> Path:
+    """Write a kernel describing the test bus and an object with no clock.
+
+    This is the shape a real merged New Horizons pointing file has: the
+    spacecraft, whose clock every mission kernel set furnishes, and a second
+    object whose clock id SPICE computes as 0, which no SCLK kernel defines.
+
+    Parameters:
+        directory: Directory to write into.
+        name: Basename of the kernel.
+
+    Returns:
+        The path written.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    epochs = [ET0 + step * _RECORD_STEP_S for step in range(3)]
+    ticks = [float(cspyce.sce2c(_CASSINI_SCLK_ID, et)) for et in epochs]
+    quats = np.vstack(
+        [np.asarray(cspyce.m2q(baseline_attitude(et)), dtype=np.float64) for et in epochs]
+    )
+    write_ck(
+        path,
+        [
+            baseline_segment(
+                ck_frame_id=CASSINI_CK_FRAME_ID,
+                sclk_id=_CASSINI_SCLK_ID,
+                epochs=epochs,
+                attitude=baseline_attitude,
+                angular_velocity=None,
+            ),
+            CkSegment(
+                ck_frame_id=_CLOCKLESS_OBJECT_ID,
+                segid='clockless',
+                sclkdp=np.asarray(ticks, dtype=np.float64),
+                quats=quats,
+                avvs=None,
+            ),
+        ],
+    )
+    return path
+
+
+def test_an_object_with_no_clock_is_recorded_rather_than_stopping_the_scan(
+    pool: KernelPool, tmp_path: Path
+) -> None:
+    """A file naming an object no clock kernel describes still indexes.
+
+    The New Horizons holdings hold such a file, so refusing the scan over it
+    would make the whole mission unindexable for the sake of an object no
+    image ever asks about.
+    """
+    root = tmp_path / 'CK-reconstructed'
+    _write_ck_naming_a_clockless_object(root, _RECONSTRUCTED_NAME)
+    index = build_ck_index([root])
+    assert index.files[0].unreadable_objects == (_CLOCKLESS_OBJECT_ID,)
+
+
+def test_the_readable_object_of_that_file_is_still_covered(
+    pool: KernelPool, tmp_path: Path
+) -> None:
+    """The objects whose clock is furnished keep their coverage."""
+    root = tmp_path / 'CK-reconstructed'
+    _write_ck_naming_a_clockless_object(root, _RECONSTRUCTED_NAME)
+    index = build_ck_index([root])
+    covered = {interval.ck_frame_id for interval in index.files[0].coverage}
+    assert covered == {CASSINI_CK_FRAME_ID}
+
+
+def test_an_unreadable_object_is_offered_as_no_candidate(pool: KernelPool, tmp_path: Path) -> None:
+    """A file offers no coverage for an object whose window it could not read."""
+    root = tmp_path / 'CK-reconstructed'
+    _write_ck_naming_a_clockless_object(root, _RECONSTRUCTED_NAME)
+    index = build_ck_index([root])
+    candidates = index.candidates(
+        basenames=[_RECONSTRUCTED_NAME], ck_frame_id=_CLOCKLESS_OBJECT_ID, et=ET0
+    )
+    assert candidates == ()
+
+
+def test_the_index_gathers_every_unreadable_object_it_met(pool: KernelPool, tmp_path: Path) -> None:
+    """The index reports the unreadable objects of all its files together."""
+    root = tmp_path / 'CK-reconstructed'
+    _write_ck_naming_a_clockless_object(root, _RECONSTRUCTED_NAME)
+    _write_ck(root, _GAPFILL_NAME)
+    index = build_ck_index([root])
+    assert index.unreadable_objects == frozenset({_CLOCKLESS_OBJECT_ID})
+
+
+def test_an_index_of_readable_files_reports_no_unreadable_object(
+    pool: KernelPool, tmp_path: Path
+) -> None:
+    """Nothing is reported unreadable when every object's clock is furnished."""
+    root = tmp_path / 'CK-reconstructed'
+    _write_ck(root, _RECONSTRUCTED_NAME)
+    index = build_ck_index([root])
+    assert index.unreadable_objects == frozenset()


### PR DESCRIPTION
## Purpose

Phase D of `plans/CK_KERNEL_PLAN.md`: the acceptance test for the whole plan. Everything before it built machinery; this measures whether the machinery is right, end to end, against real kernels.

The test navigates a real image, generates a corrected kernel from what navigation recorded, furnishes that kernel in a fresh process, and navigates again. If every convention in the chain is right, the second navigation finds nothing left to correct.

Part of #188. **Stacked on Phase C**; targets `rf_ck_kernels`.

## Changes

- A three-step round trip run as three subprocesses, because oops caches frames and manages its own kernel pool and a mid-process furnish is not guaranteed to take effect. The correction is furnished after the host has finished loading the image and before any geometry is computed; a host that freezes its observation frame while loading is given the image a second time with the correction already in the pool.
- The test asserts the pointing **actually changed** before it asserts anything about the offset, because an offset near zero cannot distinguish a kernel that took effect from one that was silently buried under the originals.
- Both runs' winning technique sets are recorded, and a disagreement fails as inconclusive rather than passing, since the comparison is only meaningful when the two runs measured the same thing.

## Type of Change

- [x] Tests only (no production code change)
- [x] Bug fix (non-breaking)

## Testing

- [x] Integration tests pass (if applicable)
- [x] New or updated tests for changed code

75 tests. Full suite `5367 passed, 7 xfailed`; `ruff check`, `ruff format --check`, `mypy src tests` and `sphinx-build -W` clean.

**Measured residual across the cohort: at most 0.0029 px per axis**, against the plan's target of 0.1 px per axis. Per instrument: Cassini NAC 0.0014, Cassini WAC 0.0024, Voyager 0.0002, LORRI 0.0029. The written records read back what the segment says to at most 5.6e-17 radians, and the midtime attitude reproduces the recorded C-matrix to at most 1.5e-15 radians. The test pins at 0.02 px per axis, seven times the largest measurement and five times inside the target; the margin is that size because navigation is deterministic here, so the headroom is for technique internals changing rather than for noise.

The mutations confirm the test can fail. Writing the baseline unchanged instead of the correction, writing the uncorrected matrix on the frozen-attitude path, furnishing the correction where the originals bury it, and skipping the reload a frozen host needs are each caught. The most informative one: **dropping the frame conjugation produces offsets of exactly twice the original**, as the plan predicts a frame-convention error would — and the pointing-changed and record-readback assertions both *pass* under it. Only the offset assertion catches it, which is the case for asserting the offset itself rather than a magnitude.

## Potential Impacts

None on production code. The round trip adds about three and a half minutes to the integration suite.

## Notes

Two frames outside the cohort exceed the target and are reported rather than hidden: a Cassini WAC frame at 0.1022 px and a Voyager wide-angle frame at 0.4853 px. Neither is a pointing defect — on both, the record epochs read back to 1e-16 radians and the furnished pool's pointing moves by the measured offset to within 5e-5 px. The residual is that the body techniques do not return the shift they were given: one answers on a quarter-pixel grid while carrying most of the ensemble weight, and the other's two fits differ by less than the correction moved the model. Every star-navigated frame lands within 0.017 px. Filed as #447; the fix is navigation-side and outside this plan.

Galileo cannot take part, for a structural reason worth recording. It is the one instrument that fits a camera rotation, and a result carrying a fitted rotation records no corrected matrix at all, because the rotation turns about a per-technique pivot that nothing writes down. Its frames are omitted as unsupported, four tests pin that, and the plan is reconciled to claim the criterion for four instruments rather than five.

A defect found while building this: the New Horizons holdings could not be indexed at all. One kernel there describes an object for which no clock is defined, and reading its coverage raises rather than returning nothing, which aborted the scan for the whole mission. Such an object is now recorded as unreadable and offers no coverage, and an image that would correct one is refused by name before any candidate is tried.
