### PR TITLE
fix: classify a C-kernel from its basename, not its directory

### DIFF
--- a/plans/CK_KERNEL_PLAN.md
+++ b/plans/CK_KERNEL_PLAN.md
@@ -646,16 +646,27 @@ accumulates kernels from earlier images -- a superset. So:
    tolerance).
 3. **Tie-break** when several reproduce (expected: the holdings carry
    reconstructed, gapfill and predicted sets with overlapping coverage, and
-   oops loads gapfill by default): prefer by kernel class from the
-   directory name -- reconstructed over gapfill over predicted -- then the
-   lexicographically greatest basename. The reproducing candidates agree on
-   the attitude by construction, so the choice affects only which output
-   file carries the segment; it must merely be deterministic. A directory
-   naming no class ranks last, which puts the 95 Cassini kernels in
-   `CK-cruise` and `CK-jup` below predicted although they hold
-   reconstructed pointing. That is inert -- their epochs (1999-2001) do not
-   overlap the directories that do name a class (2003 onward) -- and it
-   decides filing rather than attitude either way.
+   oops loads gapfill by default): prefer by kernel class **read from the
+   kernel's own basename** -- reconstructed over gapfill over predicted --
+   then the lexicographically greatest basename. The reproducing candidates
+   agree on the attitude by construction, so the choice affects only which
+   output file carries the segment; it must merely be deterministic. The
+   class comes from the basename rather than from the directory holding it
+   for three reasons. The directory is a redundant restatement of what the
+   name already says, so it can only ever agree or be wrong. Two of the six
+   real Cassini CK directories name no class while every basename in them
+   does -- `CK-cruise` and `CK-jup`, 95 reconstructed kernels that a
+   directory reading ranks below predicted. And the basename is the form
+   the eventual kernel manager works from, so classifying by name is the
+   same fact expressed once instead of twice. Measured over the holdings,
+   all 1316 Cassini kernels classify (1093 reconstructed, 15 gapfill, 208
+   predicted). The encoding is mission-specific and is declared one mission
+   at a time: New Horizons marks only the two kernels released in both
+   forms, with a trailing `_recon` or `_pred`; Voyager and Galileo encode
+   nothing, so every kernel of theirs is `UNCLASSIFIED`, the class rank
+   ties for every candidate and the tie-break falls through to the basename
+   exactly as before. A kernel whose name declares no class ranks last, so
+   a name that does say is always preferred over one that does not.
 4. An eligible image **no** candidate reproduces gets no segment, reason
    `no_reproducing_baseline`. This is also the baseline-drift detector: if
    the kernel set changed since navigation, reproduction fails and the

--- a/src/spindoctor/cli/ck/__init__.py
+++ b/src/spindoctor/cli/ck/__init__.py
@@ -70,7 +70,7 @@ from spindoctor.cli.ck.index import (
     CoverageInterval,
     KernelClass,
     build_ck_index,
-    kernel_class_for_directory,
+    kernel_class_for_basename,
 )
 from spindoctor.cli.ck.inputs import (
     Document,
@@ -138,7 +138,7 @@ __all__ = [
     'furnish_supporting_kernels',
     'furnished',
     'group_for_output',
-    'kernel_class_for_directory',
+    'kernel_class_for_basename',
     'kernel_paths',
     'object_frame_is_defined',
     'output_basename',

--- a/src/spindoctor/cli/ck/index.py
+++ b/src/spindoctor/cli/ck/index.py
@@ -32,6 +32,7 @@ The filter is only a filter: reproduction, not coverage, decides.
 """
 
 import math
+import re
 from collections.abc import Collection, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
@@ -84,10 +85,10 @@ _COVERAGE_TOL_TICKS = 0.0
 class KernelClass(Enum):
     """How the producer of a C-kernel described its pointing.
 
-    The holdings keep reconstructed, gapfill and predicted kernels in separate
-    directories with overlapping coverage, so an image can navigate against a
-    baseline that several files reproduce.  This is the first key of the
-    tie-break that then picks one of them.
+    The holdings carry reconstructed, gapfill and predicted kernels with
+    overlapping coverage, so an image can navigate against a baseline that
+    several files reproduce.  This is the first key of the tie-break that then
+    picks one of them.
     """
 
     RECONSTRUCTED = 'reconstructed'
@@ -101,20 +102,20 @@ class KernelClass(Enum):
 
         Returns:
             The class's position in the preference order: reconstructed
-            pointing before gapfill before predicted, and a directory naming no
-            class last of all.
+            pointing before gapfill before predicted, and a kernel whose name
+            declares no class last of all.
         """
         return _CLASS_PREFERENCE.index(self)
 
 
 # Reconstructed pointing is measured, gapfill fills what reconstruction did not
-# cover, and predicted pointing is a plan.  A directory whose name says nothing
-# about which of those it holds is preferred last, so a kernel that does say is
-# always chosen over one that does not.  That ranks the Cassini cruise
-# directories below predicted even though they hold reconstructed pointing,
-# which is inert only because their epochs do not overlap the directories that
-# do name a class; the ranking decides which output file carries a segment and
-# never which attitude it carries, so it is a filing question either way.
+# cover, and predicted pointing is a plan.  A kernel whose name declares none
+# of those is preferred last, so one that does declare a class is always chosen
+# over one that does not.  The ranking decides which output file carries a
+# segment and never which attitude it carries: every candidate it orders has
+# already reproduced the same recorded attitude.  A mission whose names declare
+# nothing therefore ties on this key for every candidate and falls through to
+# the basename, which is exactly what it did before any class existed.
 _CLASS_PREFERENCE: tuple[KernelClass, ...] = (
     KernelClass.RECONSTRUCTED,
     KernelClass.GAPFILL,
@@ -122,11 +123,66 @@ _CLASS_PREFERENCE: tuple[KernelClass, ...] = (
     KernelClass.UNCLASSIFIED,
 )
 
-# The token each class is recognized by in a directory name, lowercased.
-_CLASS_TOKENS: tuple[tuple[str, KernelClass], ...] = (
-    ('reconstructed', KernelClass.RECONSTRUCTED),
-    ('gapfill', KernelClass.GAPFILL),
-    ('predicted', KernelClass.PREDICTED),
+
+@dataclass(frozen=True)
+class _MissionNameRules:
+    """How one mission's C-kernel basenames declare a kernel class.
+
+    Parameters:
+        mission: The mission whose holdings the names come from.  It names the
+            source of each match in the message a two-class name is refused
+            with.
+        rules: One pattern per class the mission's names can declare, each
+            matched in full against the lowercased basename.  A mission whose
+            basenames declare no class carries no rules, which records that its
+            holdings were read and encode nothing rather than that nobody
+            looked.
+    """
+
+    mission: str
+    rules: tuple[tuple[re.Pattern[str], KernelClass], ...]
+
+
+# Cassini names the class in a release code that follows the two dates a
+# kernel's coverage spans: ``p`` for planned pointing, ``r`` for reconstructed,
+# plus a letter distinguishing successive releases of the same span.  Two
+# patterns carry the reconstructed class because two date conventions are in
+# use and the digit counts are what tell them apart: the Saturn tour and the
+# cruise stamp YYDOY_YYDOY, the Jupiter flyby stamps YYMMDD_YYMMDD, and the
+# earliest flyby release omits the code altogether.  The gapfill kernels are
+# ``pa`` names, so the predicted pattern excludes them itself instead of
+# relying on being tested second -- the patterns are mutually exclusive by
+# construction, not by order.  This is the convention rms-spyceman's Cassini
+# rules encode.
+_CASSINI_NAME_RULES: tuple[tuple[re.Pattern[str], KernelClass], ...] = (
+    (re.compile(r'\d{5}_\d{5}p[a-z]_gapfill_v\d+\.bc'), KernelClass.GAPFILL),
+    (re.compile(r'\d{5}_\d{5}p[a-z](?!_gapfill).*\.bc'), KernelClass.PREDICTED),
+    (re.compile(r'\d{5}_\d{5}r[a-z]\.bc'), KernelClass.RECONSTRUCTED),
+    (re.compile(r'\d{6}_\d{6}(?:r[a-z])?\.bc'), KernelClass.RECONSTRUCTED),
+)
+
+# New Horizons marks only the pair of kernels that exist in both forms, with a
+# trailing ``_recon`` or ``_pred`` on the mission's ``nh_`` prefix.  Every other
+# name in the holdings -- the merged pointing files and the hazard-search
+# kernels -- declares nothing, and is left declaring nothing rather than
+# guessed at from a prefix that says which product it is and not how its
+# pointing was made.
+_NEW_HORIZONS_NAME_RULES: tuple[tuple[re.Pattern[str], KernelClass], ...] = (
+    (re.compile(r'nh_.+_recon\.bc'), KernelClass.RECONSTRUCTED),
+    (re.compile(r'nh_.+_pred\.bc'), KernelClass.PREDICTED),
+)
+
+# The encoding is a property of each mission's naming convention, so it is
+# declared one mission at a time rather than as a single pattern set that would
+# be mission-specific only by the accident of matching one mission's names.
+# Voyager and Galileo are listed with no rules: each holds one kind of C-kernel
+# and neither names it anywhere in a basename, so ``UNCLASSIFIED`` is the
+# honest answer and the tie-break falls through to the basename for them.
+_MISSION_NAME_RULES: tuple[_MissionNameRules, ...] = (
+    _MissionNameRules(mission='Cassini', rules=_CASSINI_NAME_RULES),
+    _MissionNameRules(mission='New Horizons', rules=_NEW_HORIZONS_NAME_RULES),
+    _MissionNameRules(mission='Voyager', rules=()),
+    _MissionNameRules(mission='Galileo', rules=()),
 )
 
 
@@ -189,8 +245,8 @@ class CkFile:
 
     Parameters:
         path: Path to the file, local or remote.
-        kernel_class: How its producer described its pointing, taken from the
-            name of the directory it was found in.
+        kernel_class: How its producer described its pointing, declared by its
+            own basename.
         coverage: One interval per object per segment window, in the order
             SPICE reported them.
         unreadable_objects: The objects the file describes whose coverage
@@ -330,39 +386,66 @@ def preference_key(ck_file: CkFile) -> tuple[int, str, str]:
     )
 
 
-def kernel_class_for_directory(directory: str | Path | FCPath) -> KernelClass:
-    """Classify a kernel directory from its name.
+def kernel_class_for_basename(basename: str) -> KernelClass:
+    """Classify a C-kernel from its own basename.
+
+    The name is matched against the naming convention of every mission whose
+    C-kernels the scan reads.  Those conventions are disjoint, each anchored on
+    a shape only one mission's names have, so at most one class is ever
+    declared; a mission whose names encode no class contributes no pattern and
+    leaves its kernels ``UNCLASSIFIED``.
+
+    Pattern matching ignores case, since the holdings spell some kernel names
+    in upper case and a name's case says nothing about its class.  The
+    corrected-kernel marker below is tested on the name as spelled, which is
+    how the scan itself decides a file is a corrected kernel, so the two agree
+    on exactly which names those are.
 
     Parameters:
-        directory: The directory holding the kernels.
+        basename: The file's own name, extension included, spelled as the
+            holdings spell it and as image metadata records it.
 
     Returns:
-        The class its name declares, or ``UNCLASSIFIED`` when the name names
-        none.
+        The class the name declares, or ``UNCLASSIFIED`` when it declares none.
+        A name carrying no extension, or one under an extension its mission
+        does not use, declares none: the conventions include the extension.
 
     Raises:
-        ValueError: if the path has no final component to read, or if its name
-            declares more than one class, which no preference order can resolve
-            and which would otherwise be settled silently by the order the
-            names happen to be tested in.
+        ValueError: if the name is empty, is ``.`` or ``..``, or holds a path
+            separator, none of which is a file's own name and each of which
+            would otherwise be reported as declaring no class; if the name's
+            stem ends in the corrected-kernel marker, since a corrected kernel
+            is written by this program and is never a baseline candidate; or if
+            the name declares more than one class, which no preference order
+            can resolve and which would otherwise be settled silently by the
+            order the patterns happen to be tested in.
     """
-    root = FCPath(directory)
-    name = root.name
-    if len(name) == 0 or name in ('.', '..'):
+    if len(basename) == 0 or basename in ('.', '..') or '/' in basename:
         raise ValueError(
-            f'kernel directory {root.as_posix()!r} has no name to classify; name the directory '
-            f'itself rather than a path ending in a separator or a dot'
+            f'{basename!r} is not a C-kernel basename; classify the name of the file itself '
+            f'rather than a path or a fragment of one'
         )
-    lowered = name.lower()
-    matched = [kernel_class for token, kernel_class in _CLASS_TOKENS if token in lowered]
-    if len(matched) > 1:
+    if Path(basename).stem.endswith(OUTPUT_NAME_MARKER):
         raise ValueError(
-            f'kernel directory {name!r} names more than one kernel class: '
-            f'{[kernel_class.value for kernel_class in matched]}'
+            f'C-kernel basename {basename!r} names a corrected kernel, which this program '
+            f'writes and never classifies as a baseline candidate'
         )
-    if len(matched) == 0:
+    lowered = basename.lower()
+    matched = [
+        (mission_rules.mission, kernel_class)
+        for mission_rules in _MISSION_NAME_RULES
+        for pattern, kernel_class in mission_rules.rules
+        if pattern.fullmatch(lowered) is not None
+    ]
+    declared = {kernel_class for _, kernel_class in matched}
+    if len(declared) > 1:
+        raise ValueError(
+            f'C-kernel basename {basename!r} declares more than one kernel class: '
+            f'{sorted(f"{mission} {kernel_class.value}" for mission, kernel_class in matched)}'
+        )
+    if len(declared) == 0:
         return KernelClass.UNCLASSIFIED
-    return matched[0]
+    return matched[0][1]
 
 
 def build_ck_index(roots: Sequence[str | Path | FCPath]) -> CkIndex:
@@ -380,9 +463,9 @@ def build_ck_index(roots: Sequence[str | Path | FCPath]) -> CkIndex:
     indexing one would offer a correction as the baseline for the next run.
 
     Parameters:
-        roots: The directories to scan.  Each is classified by its own name, so
-            the reconstructed, gapfill and predicted directories of a mission
-            are listed separately.
+        roots: The directories to scan.  A directory is only where kernels are
+            found; each kernel is classified by its own basename, so how the
+            directories are named and split makes no difference to the index.
 
     Returns:
         The index.
@@ -390,18 +473,16 @@ def build_ck_index(roots: Sequence[str | Path | FCPath]) -> CkIndex:
     Raises:
         ValueError: if no directory is given, if one names the same directory
             as another once symbolic links and ``..`` are resolved, if one does
-            not exist or is not a directory, if a directory name declares more
-            than one kernel class, or if no C-kernel is found under any of them
-            -- an empty index would report every image as having no reproducing
-            baseline, which is indistinguishable from a genuine baseline drift.
+            not exist or is not a directory, if a kernel's basename declares
+            more than one kernel class, or if no C-kernel is found under any of
+            them -- an empty index would report every image as having no
+            reproducing baseline, which is indistinguishable from a genuine
+            baseline drift.
         OSError: if a file with a C-kernel extension cannot be read as one.
     """
     if len(roots) == 0:
         raise ValueError('no kernel directory to scan; the index would hold nothing')
     directories = [FCPath(root) for root in roots]
-    # Resolved for the duplicate test only.  The class comes from the name as
-    # given, since resolving a symbolic link can replace the very component
-    # that names the class.
     resolved = [root.resolve().as_posix() for root in directories]
     if len(set(resolved)) != len(resolved):
         raise ValueError(
@@ -410,8 +491,7 @@ def build_ck_index(roots: Sequence[str | Path | FCPath]) -> CkIndex:
         )
     files: list[CkFile] = []
     for root in directories:
-        kernel_class = kernel_class_for_directory(root)
-        files.extend(_index_one_file(path, kernel_class) for path in _kernel_files(root))
+        files.extend(_index_one_file(path) for path in _kernel_files(root))
     if len(files) == 0:
         raise ValueError(
             f'no C-kernel found under {[root.as_posix() for root in directories]}; every image '
@@ -451,20 +531,21 @@ def _kernel_files(root: FCPath) -> list[FCPath]:
     ]
 
 
-def _index_one_file(path: FCPath, kernel_class: KernelClass) -> CkFile:
-    """Read one C-kernel's objects and their coverage.
+def _index_one_file(path: FCPath) -> CkFile:
+    """Read one C-kernel's class, objects and coverage.
 
     Parameters:
         path: The file to read.
-        kernel_class: The class its directory declares.
 
     Returns:
         The indexed file, carrying the coverage of every object whose clock is
         furnished and the ids of the objects whose clock is not.
 
     Raises:
+        ValueError: if the file's basename declares more than one kernel class.
         OSError: if the file cannot be read as a C-kernel.
     """
+    kernel_class = kernel_class_for_basename(path.name)
     # SPICE reads a C-kernel by name from the local filesystem, so a remote one
     # is fetched first.  This is a no-op for a kernel that is already local.
     local = str(cast(Path, path.retrieve()))

--- a/tests/integration/test_ck_index_holdings.py
+++ b/tests/integration/test_ck_index_holdings.py
@@ -9,10 +9,19 @@ read from, so the object filter excludes them without any epoch reasoning.  The
 third is that a real kernel can name an object whose spacecraft clock no kernel
 defines, which the New Horizons holdings do and which the scan has to survive.
 
+The third is the classification itself.  A kernel's class comes from its own
+basename, and whether the patterns cover every name the holdings actually hold
+is a question only the holdings can answer -- a hand-written sample proves
+nothing about the 1200 names nobody typed out.  So every C-kernel of every
+mission is classified here and the totals are asserted per directory, which is
+also the one place the directory names appear: they are the grouping the counts
+are stated against, not an input to the answer.
+
 Everything else about the index is exercised hermetically.
 """
 
 import os
+from collections import Counter
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -34,7 +43,13 @@ if len(_RESOURCES) == 0 or not _VOYAGER_CK_DIR.is_dir():
 
 import cspyce  # noqa: E402  (guarded import)
 
-from spindoctor.cli.ck.index import CkIndex, build_ck_index  # noqa: E402  (guarded import)
+from spindoctor.cli.ck.index import (  # noqa: E402  (guarded import)
+    CK_SUFFIXES,
+    CkIndex,
+    KernelClass,
+    build_ck_index,
+    kernel_class_for_basename,
+)
 
 # The Voyager 1 scan platform, which ISS pointing is read from, and the bus,
 # which the long-baseline kernels describe.
@@ -49,6 +64,43 @@ _BUS_KERNEL = 'vgr1_super.bc'
 _SPACECRAFT_ID = -98000
 _CLOCKLESS_OBJECT_ID = -1
 _CLOCKLESS_KERNEL = 'nh_scispi_2015_recon.bc'
+# Every C-kernel directory of every mission the pipeline navigates, with the
+# class every kernel in it must be found to declare.  The Cassini cruise and
+# Jupiter directories name no class and their kernels do, which is the whole
+# reason the class is read from the basename; New Horizons marks only the pair
+# of kernels that exist in both forms; Voyager and Galileo mark nothing at all.
+_CLASSIFIED_DIRS: tuple[tuple[str, dict[KernelClass, int]], ...] = (
+    ('Cassini/CK-reconstructed', {KernelClass.RECONSTRUCTED: 998}),
+    ('Cassini/CK-cruise', {KernelClass.RECONSTRUCTED: 31}),
+    ('Cassini/CK-jup', {KernelClass.RECONSTRUCTED: 64}),
+    ('Cassini/CK-gapfill', {KernelClass.GAPFILL: 15}),
+    ('Cassini/CK-predicted', {KernelClass.PREDICTED: 104}),
+    ('Cassini/CK-predicted-v02', {KernelClass.PREDICTED: 104}),
+    (
+        'New-Horizons/CK-reconstructed',
+        {KernelClass.RECONSTRUCTED: 1, KernelClass.UNCLASSIFIED: 29},
+    ),
+    ('New-Horizons/CK-predicted', {KernelClass.PREDICTED: 1, KernelClass.UNCLASSIFIED: 1}),
+    ('Voyager/CK', {KernelClass.UNCLASSIFIED: 10}),
+    ('Galileo/CK', {KernelClass.UNCLASSIFIED: 52}),
+)
+
+
+def _holdings_basenames(directory: str) -> list[str]:
+    """List the C-kernel basenames one holdings directory holds.
+
+    Parameters:
+        directory: The directory's path below the SPICE root.
+
+    Returns:
+        The basenames, sorted, of every file with a C-kernel extension.
+    """
+    root = _SPICE_ROOT / directory
+    return sorted(
+        entry.name
+        for entry in root.iterdir()
+        if entry.is_file() and entry.suffix.lower() in CK_SUFFIXES
+    )
 
 
 @pytest.fixture
@@ -176,3 +228,71 @@ def test_that_file_still_covers_the_spacecraft(new_horizons_index: CkIndex) -> N
 def test_the_spacecraft_is_not_reported_unreadable(new_horizons_index: CkIndex) -> None:
     """Nothing an image needs is among the objects the index could not read."""
     assert _SPACECRAFT_ID not in new_horizons_index.unreadable_objects
+
+
+@pytest.mark.parametrize(
+    ('directory', 'expected'),
+    _CLASSIFIED_DIRS,
+    ids=[directory for directory, _ in _CLASSIFIED_DIRS],
+)
+def test_every_kernel_in_a_holdings_directory_classifies(
+    directory: str, expected: dict[KernelClass, int]
+) -> None:
+    """Every C-kernel a real directory holds declares the class it should.
+
+    Parameters:
+        directory: The directory's path below the SPICE root.
+        expected: How many of its kernels each class must account for.
+    """
+    counts = Counter(kernel_class_for_basename(name) for name in _holdings_basenames(directory))
+    assert dict(counts) == expected
+
+
+def test_the_cassini_holdings_classify_every_kernel_but_none_as_unclassified() -> None:
+    """Cassini names a class on all 1316 of its kernels, in six directories.
+
+    Two of those directories name no class at all, so this is the measurement
+    the change was made for: reading the directory leaves 95 reconstructed
+    kernels ranked below predicted, and reading the basename leaves none.
+    """
+    cassini = [
+        name
+        for directory, _ in _CLASSIFIED_DIRS
+        if directory.startswith('Cassini/')
+        for name in _holdings_basenames(directory)
+    ]
+    counts = Counter(kernel_class_for_basename(name) for name in cassini)
+    assert dict(counts) == {
+        KernelClass.RECONSTRUCTED: 1093,
+        KernelClass.GAPFILL: 15,
+        KernelClass.PREDICTED: 208,
+    }
+
+
+@pytest.mark.parametrize('directory', ['Voyager/CK', 'Galileo/CK'], ids=['voyager', 'galileo'])
+def test_a_mission_encoding_no_class_gets_none_invented_for_it(directory: str) -> None:
+    """Voyager and Galileo hold one kind of C-kernel and name it nowhere.
+
+    Every one of their kernels must be unclassified, so the class rank ties for
+    every candidate and the tie-break falls through to the basename.
+
+    Parameters:
+        directory: The mission's C-kernel directory below the SPICE root.
+    """
+    classes = {kernel_class_for_basename(name) for name in _holdings_basenames(directory)}
+    assert classes == {KernelClass.UNCLASSIFIED}
+
+
+def test_no_holdings_basename_declares_two_classes() -> None:
+    """The shipped patterns are mutually exclusive over every name in the holdings.
+
+    A name matching two patterns of different classes is refused, so a rule set
+    that overlapped anywhere in the holdings would abort the scan.  Classifying
+    every name without a refusal is the assertion.
+    """
+    classified = [
+        kernel_class_for_basename(name)
+        for directory, _ in _CLASSIFIED_DIRS
+        for name in _holdings_basenames(directory)
+    ]
+    assert len(classified) == 1410

--- a/tests/spindoctor/cli/ck/test_index.py
+++ b/tests/spindoctor/cli/ck/test_index.py
@@ -6,6 +6,7 @@ candidate filter are exercised against real SPICE files without touching the
 holdings.
 """
 
+import re
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -26,6 +27,7 @@ from tests.spindoctor.cli.ck.conftest import (
     write_type1_ck,
 )
 
+from spindoctor.cli.ck import index as index_module
 from spindoctor.cli.ck.index import (
     SNAPPED_LOOKUP_TOL_TICKS,
     CkFile,
@@ -33,7 +35,7 @@ from spindoctor.cli.ck.index import (
     CoverageInterval,
     KernelClass,
     build_ck_index,
-    kernel_class_for_directory,
+    kernel_class_for_basename,
 )
 from spindoctor.cli.ck.pointing import NDArrayFloatType
 from spindoctor.cli.ck.segment import CkSegment
@@ -57,6 +59,9 @@ _PREDICTED_NAME = '04009_04051px.bc'
 # A real merged New Horizons pointing file names this object beside the
 # spacecraft, so its coverage cannot be expressed in TDB.
 _CLOCKLESS_OBJECT_ID = -1
+
+# A name the Galileo holdings really hold, which declares no class.
+_UNCLASSIFIED_NAME = 'ckjabv3_plt.bc'
 
 
 def _write_ck(
@@ -108,18 +113,30 @@ def test_build_ck_index_records_the_object_and_its_coverage(
     assert index.files[0].coverage[0].stop_et == pytest.approx(ET0 + _COVERAGE_S, abs=1e-6)
 
 
-def test_build_ck_index_takes_the_class_from_the_directory(
-    pool: KernelPool, tmp_path: Path
-) -> None:
-    """Each root is classified by its own name, not by the files in it."""
-    reconstructed = tmp_path / 'CK-reconstructed'
-    gapfill = tmp_path / 'CK-gapfill'
-    _write_ck(reconstructed, _RECONSTRUCTED_NAME)
-    _write_ck(gapfill, _GAPFILL_NAME)
-    index = build_ck_index([reconstructed, gapfill])
+def test_build_ck_index_takes_the_class_from_the_basename(pool: KernelPool, tmp_path: Path) -> None:
+    """Each file is classified by its own name, whatever directory it sits in.
+
+    All three kernels share one directory whose name declares nothing, so only
+    the basenames can be supplying the three different classes.
+    """
+    root = tmp_path / 'CK'
+    for name in (_RECONSTRUCTED_NAME, _GAPFILL_NAME, _PREDICTED_NAME):
+        _write_ck(root, name)
+    index = build_ck_index([root])
     classes = {ck_file.basename: ck_file.kernel_class for ck_file in index.files}
     assert classes[_RECONSTRUCTED_NAME] is KernelClass.RECONSTRUCTED
     assert classes[_GAPFILL_NAME] is KernelClass.GAPFILL
+    assert classes[_PREDICTED_NAME] is KernelClass.PREDICTED
+
+
+def test_build_ck_index_ignores_a_directory_naming_another_class(
+    pool: KernelPool, tmp_path: Path
+) -> None:
+    """A directory whose name contradicts the file in it does not decide the class."""
+    root = tmp_path / 'CK-predicted'
+    _write_ck(root, _RECONSTRUCTED_NAME)
+    index = build_ck_index([root])
+    assert index.files[0].kernel_class is KernelClass.RECONSTRUCTED
 
 
 def test_build_ck_index_indexes_the_other_kernel_extension(
@@ -210,17 +227,15 @@ def test_candidates_offer_each_directory_holding_the_same_basename(
 
 
 def test_candidates_are_ordered_by_kernel_class(pool: KernelPool, tmp_path: Path) -> None:
-    """Reconstructed pointing is offered before gapfill before predicted."""
-    reconstructed = tmp_path / 'CK-reconstructed'
-    gapfill = tmp_path / 'CK-gapfill'
-    predicted = tmp_path / 'CK-predicted'
-    for directory, name in (
-        (predicted, _PREDICTED_NAME),
-        (gapfill, _GAPFILL_NAME),
-        (reconstructed, _RECONSTRUCTED_NAME),
-    ):
-        _write_ck(directory, name)
-    index = build_ck_index([predicted, gapfill, reconstructed])
+    """Reconstructed pointing is offered before gapfill before predicted.
+
+    One directory holds all three, so the order can only come from the names.
+    Sorted by name alone the gapfill kernel would come last, not second.
+    """
+    root = tmp_path / 'CK'
+    for name in (_PREDICTED_NAME, _GAPFILL_NAME, _RECONSTRUCTED_NAME):
+        _write_ck(root, name)
+    index = build_ck_index([root])
     candidates = index.candidates(
         basenames=[_PREDICTED_NAME, _GAPFILL_NAME, _RECONSTRUCTED_NAME],
         ck_frame_id=CASSINI_CK_FRAME_ID,
@@ -332,51 +347,225 @@ def test_coverage_refuses_a_window_that_ends_before_it_starts() -> None:
 
 
 @pytest.mark.parametrize(
-    ('name', 'expected'),
+    ('basename', 'expected'),
     [
-        ('CK-reconstructed', KernelClass.RECONSTRUCTED),
-        ('CK-gapfill', KernelClass.GAPFILL),
-        ('CK-predicted', KernelClass.PREDICTED),
-        ('CK-predicted-v02', KernelClass.PREDICTED),
-        ('CK-RECONSTRUCTED', KernelClass.RECONSTRUCTED),
-        ('CK', KernelClass.UNCLASSIFIED),
-        ('CK-cruise', KernelClass.UNCLASSIFIED),
+        ('03236_04002ra.bc', KernelClass.RECONSTRUCTED),
+        ('04059_04066rb.bc', KernelClass.RECONSTRUCTED),
+        ('00001_00092rc.bc', KernelClass.RECONSTRUCTED),
+        ('001001_001004ra.bc', KernelClass.RECONSTRUCTED),
+        ('010109_010114rb.bc', KernelClass.RECONSTRUCTED),
+        ('001105_001108.bc', KernelClass.RECONSTRUCTED),
+        ('03001_04001pa_gapfill_v01.bc', KernelClass.GAPFILL),
+        ('07001_08001pa_gapfill_v14.bc', KernelClass.GAPFILL),
+        ('04009_04051px.bc', KernelClass.PREDICTED),
+        ('04051_04092ph_psiv2.bc', KernelClass.PREDICTED),
+        ('04135_04171pd_fsiv.bc', KernelClass.PREDICTED),
+        ('04009_04051py_as_flown.bc', KernelClass.PREDICTED),
+        ('05099_05134pg_fsiv_lmb.bc', KernelClass.PREDICTED),
+        ('nh_scispi_2015_recon.bc', KernelClass.RECONSTRUCTED),
+        ('nh_scispi_2015_pred.bc', KernelClass.PREDICTED),
+        ('merged_nhpc_2007_01_v006.bc', KernelClass.UNCLASSIFIED),
+        ('nhpc_haz_2015.bc', KernelClass.UNCLASSIFIED),
+        ('vg2_nep_version1_type1_iss_sedr.bc', KernelClass.UNCLASSIFIED),
+        ('vgr1_super.bc', KernelClass.UNCLASSIFIED),
+        ('V1SAT_VERSION2_TYPE3_UVS_SEDR.ck', KernelClass.UNCLASSIFIED),
+        ('ckjabv3_plt.bc', KernelClass.UNCLASSIFIED),
+        ('gll_plt_pre_1990_v00.bc', KernelClass.UNCLASSIFIED),
     ],
     ids=[
-        'reconstructed',
-        'gapfill',
-        'predicted',
-        'predicted-v02',
-        'upper-case',
-        'bare',
-        'cruise',
+        'cassini-tour-ra',
+        'cassini-tour-rb',
+        'cassini-cruise-rc',
+        'cassini-jupiter-ra',
+        'cassini-jupiter-rb',
+        'cassini-jupiter-no-release-code',
+        'cassini-gapfill-v01',
+        'cassini-gapfill-v14',
+        'cassini-predicted-bare',
+        'cassini-predicted-psiv',
+        'cassini-predicted-fsiv',
+        'cassini-as-flown',
+        'cassini-predicted-two-suffixes',
+        'new-horizons-recon',
+        'new-horizons-pred',
+        'new-horizons-merged',
+        'new-horizons-hazard',
+        'voyager-sedr',
+        'voyager-bus',
+        'voyager-upper-case',
+        'galileo-platform',
+        'galileo-predicted-platform',
     ],
 )
-def test_kernel_class_for_directory(name: str, expected: KernelClass) -> None:
-    """Real holdings directory names classify as their names say.
+def test_kernel_class_for_basename(basename: str, expected: KernelClass) -> None:
+    """Real holdings basenames classify as their own names declare.
 
     Parameters:
-        name: The directory name.
-        expected: The class it declares.
+        basename: The kernel basename, taken from the real holdings.
+        expected: The class that name declares.
     """
-    assert kernel_class_for_directory(Path('/holdings/Cassini') / name) is expected
+    assert kernel_class_for_basename(basename) is expected
 
 
-def test_kernel_class_refuses_a_name_declaring_two_classes() -> None:
-    """A name matching two classes is ambiguous, not resolved by test order."""
-    with pytest.raises(ValueError, match='names more than one kernel class'):
-        kernel_class_for_directory(Path('/holdings/CK-gapfill-reconstructed'))
+def test_kernel_class_reads_a_cassini_name_whatever_its_case() -> None:
+    """Case carries no meaning, and the holdings do not spell every name alike."""
+    assert kernel_class_for_basename('03236_04002RA.BC') is KernelClass.RECONSTRUCTED
 
 
-@pytest.mark.parametrize('root', ['.', '/'], ids=['dot', 'separator'])
-def test_kernel_class_refuses_a_path_with_no_name(root: str) -> None:
-    """A path with no final component names no class.
+def _put_rules_in_force(
+    monkeypatch: pytest.MonkeyPatch, rules: tuple[tuple[re.Pattern[str], KernelClass], ...]
+) -> None:
+    """Make one replacement mission table the only one in force.
 
     Parameters:
-        root: A path whose final component is empty.
+        monkeypatch: The fixture that restores the shipped table afterwards.
+        rules: The patterns the single mission in force declares.
     """
-    with pytest.raises(ValueError, match='has no name to classify'):
-        kernel_class_for_directory(Path(root))
+    monkeypatch.setattr(
+        index_module,
+        '_MISSION_NAME_RULES',
+        (index_module._MissionNameRules(mission='Cassini', rules=rules),),
+    )
+
+
+def test_kernel_class_puts_gapfill_ahead_of_predicted_without_relying_on_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A gapfill name is a ``pa`` name, and the predicted pattern excludes it itself.
+
+    Reversing the order the patterns are tested in must not be able to turn
+    this kernel into a predicted one.
+
+    Parameters:
+        monkeypatch: The fixture that puts the reversed table in force.
+    """
+    _put_rules_in_force(monkeypatch, tuple(reversed(index_module._CASSINI_NAME_RULES)))
+    assert kernel_class_for_basename(_GAPFILL_NAME) is KernelClass.GAPFILL
+
+
+def test_kernel_class_refuses_a_name_declaring_two_classes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A name matching two classes is ambiguous, not resolved by test order.
+
+    The shipped patterns are mutually exclusive, so the guard is reached here
+    by putting a deliberately overlapping table in force: it exists to catch a
+    later edit that makes two patterns overlap, which would otherwise be
+    settled silently by whichever was tested first.
+
+    Parameters:
+        monkeypatch: The fixture that puts the overlapping table in force.
+    """
+    _put_rules_in_force(
+        monkeypatch,
+        (
+            (re.compile(r'\d{5}_\d{5}r[a-z]\.bc'), KernelClass.RECONSTRUCTED),
+            (re.compile(r'\d{5}_\d{5}.*\.bc'), KernelClass.PREDICTED),
+        ),
+    )
+    with pytest.raises(ValueError, match='declares more than one kernel class'):
+        kernel_class_for_basename(_RECONSTRUCTED_NAME)
+
+
+def test_kernel_class_accepts_two_patterns_of_one_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two patterns agreeing on the class is not ambiguity.
+
+    Cassini's two date conventions both mean reconstructed, so matching more
+    than one pattern is only a refusal when the classes differ.
+
+    Parameters:
+        monkeypatch: The fixture that puts the agreeing table in force.
+    """
+    _put_rules_in_force(
+        monkeypatch,
+        (
+            (re.compile(r'\d{5}_\d{5}r[a-z]\.bc'), KernelClass.RECONSTRUCTED),
+            (re.compile(r'\d{5}_\d{5}.*\.bc'), KernelClass.RECONSTRUCTED),
+        ),
+    )
+    assert kernel_class_for_basename(_RECONSTRUCTED_NAME) is KernelClass.RECONSTRUCTED
+
+
+def test_no_shipped_pattern_pair_overlaps_on_a_real_basename() -> None:
+    """The shipped patterns are mutually exclusive on every name they classify.
+
+    Mutual exclusivity is what lets the refusal above stay unreached, so it is
+    asserted here rather than assumed: every real name that any rule matches is
+    matched by rules of exactly one class.
+    """
+    names = [
+        '03236_04002ra.bc',
+        '00001_00092rc.bc',
+        '001105_001108.bc',
+        '03001_04001pa_gapfill_v01.bc',
+        '04009_04051px.bc',
+        '04009_04051py_as_flown.bc',
+        'nh_scispi_2015_recon.bc',
+        'nh_scispi_2015_pred.bc',
+    ]
+    for name in names:
+        matched = {
+            kernel_class
+            for mission_rules in index_module._MISSION_NAME_RULES
+            for pattern, kernel_class in mission_rules.rules
+            if pattern.fullmatch(name.lower()) is not None
+        }
+        assert len(matched) == 1
+
+
+@pytest.mark.parametrize(
+    'basename',
+    ['', '.', '..', '/', 'CK-reconstructed/03236_04002ra.bc', '/holdings/03236_04002ra.bc'],
+    ids=['empty', 'dot', 'dot-dot', 'separator', 'relative-path', 'absolute-path'],
+)
+def test_kernel_class_refuses_something_that_is_not_a_basename(basename: str) -> None:
+    """A path is not a file's own name, and would classify as declaring nothing.
+
+    Parameters:
+        basename: A value that names no single file.
+    """
+    with pytest.raises(ValueError, match='is not a C-kernel basename'):
+        kernel_class_for_basename(basename)
+
+
+@pytest.mark.parametrize(
+    'basename',
+    ['03236_04002ra_nav.bc', '04009_04051px_nav.bc'],
+    ids=['reconstructed-corrected', 'predicted-corrected'],
+)
+def test_kernel_class_refuses_a_corrected_kernel(basename: str) -> None:
+    """A corrected kernel is this program's output and never a baseline candidate.
+
+    Left to the patterns the two names below would answer differently -- the
+    predicted pattern ends in a wildcard and would accept the marker, the
+    reconstructed one would not -- so classifying either is refused outright.
+
+    Parameters:
+        basename: A corrected kernel's name.
+    """
+    with pytest.raises(ValueError, match='names a corrected kernel'):
+        kernel_class_for_basename(basename)
+
+
+@pytest.mark.parametrize(
+    'basename',
+    ['03236_04002ra', '03236_04002ra.ck', '03236_04002ra.bc.lbl', ' 03236_04002ra.bc'],
+    ids=['no-extension', 'other-extension', 'label', 'leading-space'],
+)
+def test_kernel_class_declines_to_guess_at_a_name_off_the_convention(basename: str) -> None:
+    """A name that is not the convention declares nothing rather than nearly matching.
+
+    The conventions include the extension, so a stem, a label and a name under
+    another mission's extension all fall through -- as does a name that differs
+    from a real one only by a character the filesystem keeps, since that is a
+    different file.
+
+    Parameters:
+        basename: A name close to a real one but not the convention.
+    """
+    assert kernel_class_for_basename(basename) is KernelClass.UNCLASSIFIED
 
 
 def test_build_ck_index_refuses_no_directories() -> None:
@@ -461,39 +650,40 @@ def test_build_ck_index_refuses_a_symlinked_duplicate(pool: KernelPool, tmp_path
         build_ck_index([root, link])
 
 
-def test_build_ck_index_classifies_a_symlink_by_the_name_given(
+def test_build_ck_index_classifies_a_symlinked_directory_by_the_basenames(
     pool: KernelPool, tmp_path: Path
 ) -> None:
-    """Resolving a link must not replace the component that names the class.
+    """A link named for one class holds whatever its files say they are.
 
-    The duplicate test resolves paths; the classification does not, because a
-    link named for its class can point at a directory that is not.
+    The duplicate test resolves the roots it is given; the classification never
+    looks at them at all, so neither spelling of the directory can change what
+    a kernel is.
     """
     actual = tmp_path / 'ck_files'
-    _write_ck(actual, _RECONSTRUCTED_NAME)
+    _write_ck(actual, _GAPFILL_NAME)
     link = tmp_path / 'CK-reconstructed'
     link.symlink_to(actual, target_is_directory=True)
     index = build_ck_index([link])
-    assert index.files[0].kernel_class is KernelClass.RECONSTRUCTED
+    assert index.files[0].kernel_class is KernelClass.GAPFILL
 
 
-def test_a_directory_naming_no_class_is_offered_last(pool: KernelPool, tmp_path: Path) -> None:
+def test_a_kernel_naming_no_class_is_offered_last(pool: KernelPool, tmp_path: Path) -> None:
     """A kernel that says nothing about its own pointing is the last resort.
 
-    The Cassini cruise directories hold reconstructed pointing under a name
-    that does not say so, and they must not outrank a directory that does.
+    The Galileo holdings name no class anywhere, and such a kernel must not
+    outrank one that does -- not even a predicted one, whose name sorts before
+    it and which would therefore win on the basename key alone.
     """
-    predicted = tmp_path / 'CK-predicted'
-    unclassified = tmp_path / 'CK'
-    _write_ck(predicted, _PREDICTED_NAME)
-    _write_ck(unclassified, 'zz00001_00092rc.bc')
-    index = build_ck_index([unclassified, predicted])
+    root = tmp_path / 'CK'
+    _write_ck(root, _PREDICTED_NAME)
+    _write_ck(root, _UNCLASSIFIED_NAME)
+    index = build_ck_index([root])
     candidates = index.candidates(
-        basenames=[_PREDICTED_NAME, 'zz00001_00092rc.bc'],
+        basenames=[_PREDICTED_NAME, _UNCLASSIFIED_NAME],
         ck_frame_id=CASSINI_CK_FRAME_ID,
         et=ET0 + 2.0,
     )
-    assert [ck_file.basename for ck_file in candidates] == [_PREDICTED_NAME, 'zz00001_00092rc.bc']
+    assert [ck_file.basename for ck_file in candidates] == [_PREDICTED_NAME, _UNCLASSIFIED_NAME]
 
 
 def test_one_basename_in_two_directories_of_a_class_is_ordered_by_path(


### PR DESCRIPTION
## Purpose

The tie-break that picks among candidate C-kernels reproducing an image's recorded attitude ranked them by a class read from the name of the directory each file sat in. Two of the six real Cassini CK directories name no class -- `CK-cruise` and `CK-jup` -- so their 95 kernels ranked below predicted although every one of their basenames declares reconstructed pointing.

Closes #449

## Changes

- `kernel_class_for_directory` becomes `kernel_class_for_basename` (`src/spindoctor/cli/ck/index.py:362`). `KernelClass` and `preference_rank` are unchanged; only the source of the class moved.
- The encoding is declared one mission at a time in `_MISSION_NAME_RULES` (`src/spindoctor/cli/ck/index.py:150`), each entry a named mission with its own patterns, rather than as one global pattern set that would be mission-specific only by the accident of matching one mission's names. Cassini names the class in the release code following the two dates a kernel spans, in either of two date conventions (YYDOY for the tour and cruise, YYMMDD for the Jupiter flyby, whose earliest release omits the code); New Horizons marks only the pair of kernels released in both forms, with a trailing `_recon` or `_pred`; Voyager and Galileo are listed with no rules at all, because their holdings hold one kind of C-kernel each and name it nowhere, so `UNCLASSIFIED` is the honest answer and the tie-break falls through to the basename exactly as it does today.
- The patterns are mutually exclusive by construction, not by test order: a gapfill name is a `pa` name, so the predicted pattern carries the `(?!_gapfill)` exclusion itself. Reversing the order the rules are tested in is therefore a semantic no-op, which is asserted directly rather than assumed.
- The refusal of a name declaring two classes survives, as the guard that a later edit cannot quietly reintroduce an order dependence. Two refusals are added: a value that is not a file's own name (empty, `.`, `..`, or holding a separator), which would otherwise be reported as declaring nothing; and a corrected `_nav` kernel, which the predicted pattern's trailing wildcard would have accepted while the reconstructed pattern rejected it.
- `build_ck_index` and `_index_one_file` no longer pass a per-directory class; `CkFile.kernel_class` keeps its meaning. Nothing downstream changes.
- `plans/CK_KERNEL_PLAN.md` section 3.3 step 3 now describes basename classification and why. Scope, acceptance bounds, the metadata schema, the omission-reason set and Phase D's 0.1 px rule are untouched.

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that alters existing behavior or public API)
- [ ] Refactor (no functional or API changes)
- [ ] Documentation
- [ ] Tests only (no production code change)
- [ ] CI / Build / Dependencies

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] End-to-end tests pass (if applicable)
- [x] New or updated tests for changed code
- [x] Tested manually (describe below if applicable)

Measured against the real holdings under `$OOPS_RESOURCES/SPICE`, every kernel of every mission, asserted in `tests/integration/test_ck_index_holdings.py`:

| directory | files | reconstructed | gapfill | predicted | unclassified |
|---|---|---|---|---|---|
| Cassini/CK-reconstructed | 998 | 998 | 0 | 0 | 0 |
| Cassini/CK-cruise | 31 | 31 | 0 | 0 | 0 |
| Cassini/CK-jup | 64 | 64 | 0 | 0 | 0 |
| Cassini/CK-gapfill | 15 | 0 | 15 | 0 | 0 |
| Cassini/CK-predicted | 104 | 0 | 0 | 104 | 0 |
| Cassini/CK-predicted-v02 | 104 | 0 | 0 | 104 | 0 |
| **Cassini total** | **1316** | **1093** | **15** | **208** | **0** |
| New-Horizons/CK | 0 | 0 | 0 | 0 | 0 |
| New-Horizons/CK-reconstructed | 30 | 1 | 0 | 0 | 29 |
| New-Horizons/CK-predicted | 2 | 0 | 0 | 1 | 1 |
| Voyager/CK | 10 | 0 | 0 | 0 | 10 |
| Galileo/CK | 52 | 0 | 0 | 0 | 52 |

`Cassini/CK-jup` holds one kernel with no release code at all, `001105_001108.bc`, which the Jupiter pattern accepts by making the code optional -- the same shape rms-spyceman's Jupiter rule encodes with an empty alternative, and the same file it lists in its Jupiter family.

## Potential Impacts

New Horizons is the one place this loses information rather than gaining it. Only 2 of its 32 kernels declare a class in a basename, so 29 that the directory made reconstructed and 1 that it made predicted are now unclassified. It is measured, bounded and filed as #452: `nhpc_haz_2015.bc` overlaps three `merged_nhpc_2015_*` kernels on object -98000 in the July 2015 hazard-search window, so a tie that the class used to break is now broken by name -- but only among candidates that have already reproduced the same attitude to 1e-9 radians, which a predicted and a reconstructed kernel do not. #452 also records that the two New Horizons kernels which do declare a class cannot be indexed at all today, for a reason that predates this change: they describe object -1 alongside -98000, and `ckcov` has no clock for it.

No public library API is affected: `spindoctor.cli.ck` is the kernel writer's own surface and nothing outside `spindoctor.cli` imports it.

## Checklist

- [x] Code follows project style (`ruff check`, `ruff format`)
- [x] Type annotations present and `mypy` passes
- [x] Docstrings and Sphinx docs updated (if applicable)
- [ ] CHANGES.md updated (if user-facing change)
- [x] No temporary or debug code left in
- [x] Breaking changes flagged in Type of Change above

## Notes

**Mutation verification.** Twelve mutations were applied to the committed classifier and both test tiers re-run. Eleven were killed. The one survivor is swapping the order the gapfill and predicted patterns are tested in, which is an equivalent mutant: the exclusion makes them disjoint, so order cannot matter. The stronger mutation that removes the exclusion *and* swaps the order is killed, and killed loudly -- the scan over the real Cassini holdings aborts on `03001_04001pa_gapfill_v01.bc` with the two-class refusal, taking 6 assignment fixtures with it. That is the refusal earning its place on real data, which is why it survives the port.

**Why the class comes from the basename and not from both.** The directory could have been kept as a fallback for a name that declares nothing. It was not: a fallback would put the New Horizons demotion back by reintroducing exactly the inference that #449 is about, and it would make the answer depend on which root a caller happened to name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - C-kernel classification now recognizes supported mission naming conventions directly from kernel filenames.
  - Candidate selection more reliably prioritizes reconstructed, gap-filled, and predicted kernels, with unclassified kernels ranked lowest.
  - Cassini and New Horizons kernels receive improved handling; Voyager and Galileo kernels remain supported as unclassified.
  - Invalid, ambiguous, path-like, and corrected kernel names are rejected with clearer validation behavior.
- **Tests**
  - Expanded coverage across real mission holdings and mixed-kernel directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->