### PR TITLE
Add the results index core layer, schema, and version gate

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -93,13 +93,16 @@ jobs:
           # in different processes.
           # The marker expression restates the default from addopts, because a
           # -m flag replaces addopts' own rather than adding to it.  It skips
-          # two tiers.  The integration tier is the operator-curated
-          # image-library regression tests; those rely on real PDS3 holdings +
-          # SPICE kernels and are slow / flaky in CI.  The postgres tier needs a
-          # PostgreSQL server named by SPINDOCTOR_TEST_POSTGRES_URL, and CI runs
-          # no service container for one.  Run both locally before merging: the
-          # integration tier against a populated $PDS3_HOLDINGS_DIR, the
-          # postgres tier against a local server.
+          # two tiers.  The integration tier reaches real archive holdings; the
+          # operator-curated image-library regression tests are one part of it,
+          # and it needs a populated $PDS3_HOLDINGS_DIR, the oops resources and
+          # SPICE kernels under $OOPS_RESOURCES, and the $UCAC4_PATH / $YBSC_PATH
+          # star catalogs -- slow, and unavailable to this job, whose buckets are
+          # closed for egress cost.  The postgres tier needs a PostgreSQL server
+          # named by SPINDOCTOR_TEST_POSTGRES_URL, and CI runs no service
+          # container for one.  Run both locally before merging: the integration
+          # tier against that environment, the postgres tier against a local
+          # server.
           python -m pytest --cov --cov-report=xml -n auto --dist=loadfile \
             -m "not integration and not postgres"
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -91,11 +91,17 @@ jobs:
           # loadfile keeps each test file on one xdist worker; PyQt6 + default load
           # scheduling has caused worker crashes when tests from the same file ran
           # in different processes.
-          # ``-m "not integration"`` skips the operator-curated image-library
-          # regression tests; those rely on real PDS3 holdings + SPICE kernels
-          # and are slow / flaky in CI.  Run the integration suite locally
-          # against a populated $PDS3_HOLDINGS_DIR before merging.
-          python -m pytest --cov --cov-report=xml -n auto --dist=loadfile -m "not integration"
+          # The marker expression restates the default from addopts, because a
+          # -m flag replaces addopts' own rather than adding to it.  It skips
+          # two tiers.  The integration tier is the operator-curated
+          # image-library regression tests; those rely on real PDS3 holdings +
+          # SPICE kernels and are slow / flaky in CI.  The postgres tier needs a
+          # PostgreSQL server named by SPINDOCTOR_TEST_POSTGRES_URL, and CI runs
+          # no service container for one.  Run both locally before merging: the
+          # integration tier against a populated $PDS3_HOLDINGS_DIR, the
+          # postgres tier against a local server.
+          python -m pytest --cov --cov-report=xml -n auto --dist=loadfile \
+            -m "not integration and not postgres"
 
       - name: Print coverage report
         run: |

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -13,6 +13,7 @@ This section provides detailed API documentation for the SpinDoctor system.
    api_reference/api_nav_model
    api_reference/api_nav_technique
    api_reference/api_reproj
+   api_reference/api_results_index
    api_reference/api_dataset
    api_reference/api_obs
    api_reference/api_annotation

--- a/docs/api_reference/api_results_index.rst
+++ b/docs/api_reference/api_results_index.rst
@@ -2,6 +2,9 @@ spindoctor.results_index
 ========================
 
 .. automodule:: spindoctor.results_index
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 .. automodule:: spindoctor.results_index.schema
    :members:

--- a/docs/api_reference/api_results_index.rst
+++ b/docs/api_reference/api_results_index.rst
@@ -1,0 +1,14 @@
+spindoctor.results_index
+========================
+
+.. automodule:: spindoctor.results_index
+
+.. automodule:: spindoctor.results_index.schema
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: spindoctor.results_index.engine
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/dev_guide/dev_guide_config_and_static_data.rst
+++ b/docs/dev_guide/dev_guide_config_and_static_data.rst
@@ -210,8 +210,10 @@ results index URL:
   produced by ``sd_backplanes``.
 - ``bundle_results_root`` — write root for PDS4 bundles produced by
   ``sd_create_bundle``.
-- ``results_db`` — connection URL of the results index, a database built from
-  the navigation results tree by ``sd_stats_ingest``. A ``sqlite:`` URL names a
+- ``results_db`` — connection URL of the results index, a database derived from
+  the navigation results tree by a separate ingest step. It is not
+  authoritative: the per-image ``_metadata.json`` documents are, and the index
+  can be deleted and rebuilt from them. A ``sqlite:`` URL names a
   local filesystem path and nothing else: it carries no query string, because
   the driver would then open a file named after the query rather than the file
   named in the URL. A ``postgresql+psycopg:`` URL names a server. Leaving it

--- a/docs/dev_guide/dev_guide_config_and_static_data.rst
+++ b/docs/dev_guide/dev_guide_config_and_static_data.rst
@@ -212,8 +212,10 @@ results index URL:
   ``sd_create_bundle``.
 - ``results_db`` — connection URL of the results index, a database built from
   the navigation results tree by ``sd_stats_ingest``. A ``sqlite:`` URL names a
-  local filesystem path; a ``postgresql+psycopg:`` URL names a server. Leaving
-  it unset means "no index", which is the default mode of every program, and the
+  local filesystem path and nothing else: it carries no query string, because
+  the driver would then open a file named after the query rather than the file
+  named in the URL. A ``postgresql+psycopg:`` URL names a server. Leaving it
+  unset means "no index", which is the default mode of every program, and the
   literal value ``none`` says so explicitly, overriding a URL set elsewhere.
 
 Each root may be a local path or a URL; ``filecache``-aware consumers handle

--- a/docs/dev_guide/dev_guide_config_and_static_data.rst
+++ b/docs/dev_guide/dev_guide_config_and_static_data.rst
@@ -76,8 +76,9 @@ shipping sections:
   :doc:`dev_guide_backplanes`.
 - ``pds4`` — per-dataset PDS4 template directories and bundle names; see
   :doc:`dev_guide_pds4`.
-- ``environment`` — runtime paths (``pds3_holdings_root``,
-  ``nav_results_root``, ``backplane_results_root``, ``bundle_results_root``).
+- ``environment`` — deployment locations (``pds3_holdings_root``,
+  ``nav_results_root``, ``backplane_results_root``, ``bundle_results_root``,
+  ``results_db``).
 - ``body_shape`` — static per-body shape catalogue (see
   :ref:`static-data-citations` below).
 - ``coiss`` / ``vgiss`` / ``gossi`` / ``nhlorri`` — per-camera blocks
@@ -197,7 +198,8 @@ dataclass).
 Path resolution
 ---------------
 
-The ``environment`` block carries the four downstream output roots:
+The ``environment`` block carries the four downstream output roots and the
+results index URL:
 
 - ``pds3_holdings_root`` — read root for PDS3 holdings (default
   ``$PDS3_HOLDINGS_DIR``, falling back to
@@ -208,12 +210,23 @@ The ``environment`` block carries the four downstream output roots:
   produced by ``sd_backplanes``.
 - ``bundle_results_root`` — write root for PDS4 bundles produced by
   ``sd_create_bundle``.
+- ``results_db`` — connection URL of the results index, a database built from
+  the navigation results tree by ``sd_stats_ingest``. A ``sqlite:`` URL names a
+  local filesystem path; a ``postgresql+psycopg:`` URL names a server. Leaving
+  it unset means "no index", which is the default mode of every program, and the
+  literal value ``none`` says so explicitly, overriding a URL set elsewhere.
 
-Each value may be a local path or a URL; ``filecache``-aware consumers handle
-both. Environment-variable overrides
+Each root may be a local path or a URL; ``filecache``-aware consumers handle
+both. ``results_db`` is the exception: it is a database connection URL, not a
+location ``filecache`` resolves. Environment-variable overrides
 (``PDS3_HOLDINGS_DIR``, ``NAV_RESULTS_ROOT``, ``BACKPLANE_RESULTS_ROOT``,
-``BUNDLE_RESULTS_ROOT``) take precedence over the YAML defaults; CLI flags
-take precedence over the env vars.
+``BUNDLE_RESULTS_ROOT``, ``NAV_RESULTS_DB``) take precedence over the YAML
+defaults; CLI flags take precedence over the env vars.
+
+The whole ``environment`` block is left out of the provenance configuration
+digest recorded with each navigation result. It says where a deployment keeps
+its files, never what the pipeline computes, so two results that differ only in
+it were produced by the same configuration.
 
 .. _static-data-citations:
 

--- a/docs/dev_guide/dev_guide_introduction.rst
+++ b/docs/dev_guide/dev_guide_introduction.rst
@@ -152,14 +152,18 @@ Quick smoke test:
 Running the test suite
 ======================
 
-Pytest defaults exclude integration tests; pass ``-m ""`` (empty marker filter) to
-include them. ``pyproject.toml`` sets ``addopts = ["-m", "not integration"]``.
+The suite has three tiers, separated by the ``integration`` and ``postgres``
+markers. ``pyproject.toml`` sets ``addopts = ["-m", "not integration and not
+postgres"]``, so a plain ``pytest`` runs the default tier alone; pass ``-m ""``
+(empty marker filter) to run every tier, or name one marker to run it by itself.
+:doc:`dev_guide_testing` describes what each tier holds and what it needs.
 
 .. code-block:: bash
 
-   pytest                                      # unit suite (fast)
-   pytest -m ""                                # full suite (incl. integration)
+   pytest                                      # default tier (fast)
+   pytest -m ""                                # full suite, every tier
    pytest -m integration                       # only integration
+   pytest -m postgres                          # only the postgres tier
    pytest -n auto --dist=loadfile              # parallel (matches CI)
    pytest tests/spindoctor/reproj/test_bodies.py      # one file
    pytest tests/spindoctor/reproj/test_bodies.py::test_foo  # one test
@@ -174,6 +178,11 @@ It needs the env vars listed above (in particular ``PDS3_HOLDINGS_DIR``,
 ``UCAC4_PATH``, ``YBSC_PATH``, ``OOPS_RESOURCES``) plus a ``SPICE_PATH``.
 ``scripts/run-all-checks.sh -i`` (or ``--integration``) flips the marker for the
 all-checks runner.
+
+The postgres tier re-asks the results-index questions against a real PostgreSQL
+server. It reads its connection URL from ``SPINDOCTOR_TEST_POSTGRES_URL`` and
+skips itself when that is unset. ``scripts/run-all-checks.sh -P`` (or
+``--postgres``) flips its marker.
 
 Test markers and layout
 -----------------------

--- a/docs/dev_guide/dev_guide_introduction.rst
+++ b/docs/dev_guide/dev_guide_introduction.rst
@@ -254,14 +254,20 @@ GitHub Actions defines three workflows under ``.github/workflows/``:
 
   - **Lint** — Python 3.13. ``ruff check``, ``ruff format --check``, ``mypy``.
   - **Test** — matrix across Python 3.11 / 3.12 / 3.13 / 3.14 on Ubuntu. Runs
-    ``pytest -m "not integration" -n auto --dist=loadfile`` with the holdings /
-    catalog env vars exported. Uploads coverage to Codecov from the 3.13 job
-    on pushes (PRs from forks are excluded for secrets reasons).
+    ``pytest -m "not integration and not postgres" -n auto --dist=loadfile``
+    with the holdings / catalog env vars exported. Uploads coverage to Codecov
+    from the 3.13 job on pushes (PRs from forks are excluded for secrets
+    reasons).
   - **Docs** — ``sphinx-build -W`` against the ``[docs]`` extra.
 
-  Integration tests are skipped in CI (slow, holdings-dependent). Maintainers
-  run them locally before merging anything that could plausibly regress
-  navigation accuracy.
+  Both opt-in tiers are excluded in CI, and the marker expression restates the
+  exclusion that ``addopts`` already carries, because a ``-m`` flag replaces
+  that expression rather than adding to it. The integration tier — of which the
+  operator-curated image-library regression tests are one part — needs real
+  PDS3 holdings, SPICE kernels and the star catalogs, and is slow. The postgres
+  tier needs a server named by ``SPINDOCTOR_TEST_POSTGRES_URL``, and CI runs no
+  service container for one. Maintainers run both locally before merging
+  anything that could plausibly regress navigation accuracy or the index.
 
 - ``publish_to_test_pypi.yml`` — runs on pushes to ``main`` once tests pass.
   Builds a wheel + sdist and uploads to TestPyPI under the dev version stamped

--- a/docs/dev_guide/dev_guide_testing.rst
+++ b/docs/dev_guide/dev_guide_testing.rst
@@ -59,7 +59,13 @@ The postgres tier additionally needs a server to point at:
 
 .. code-block:: bash
 
-   export SPINDOCTOR_TEST_POSTGRES_URL=postgresql+psycopg://user:pw@host:5432/spindoctor
+   export SPINDOCTOR_TEST_POSTGRES_URL=postgresql+psycopg://USER@HOST:5432/spindoctor
+
+Supply the credentials the way the server expects them -- a ``~/.pgpass`` entry,
+``PGPASSWORD``, or a peer-authenticated local socket -- rather than writing a
+password into a shell profile or a checked-in file. A password inside the URL
+works, and the tier masks it out of every message, but the URL itself is then a
+secret in the environment of every process the shell starts.
 
 ``pytest-xdist`` must run with ``--dist=loadfile``; the default scheduling
 crashes PyQt6 workers when tests from one file split across processes. Multi-test

--- a/docs/dev_guide/dev_guide_testing.rst
+++ b/docs/dev_guide/dev_guide_testing.rst
@@ -5,18 +5,31 @@ Testing
 Overview
 ========
 
-The test suite has two tiers, separated by the ``integration`` marker:
+The test suite has three tiers, separated by the ``integration`` and
+``postgres`` markers. ``addopts`` in ``pyproject.toml`` carries ``-m "not
+integration and not postgres"``, so a plain ``pytest`` runs the default tier
+alone:
 
 - The **default tier** runs on a plain ``pytest``. Everything in it is fast and
   self-contained: it needs no spacecraft holdings, no SPICE kernels, and no
   network. Unit tests live here, and so do the in-process simulator tests --
   every simulated frame is rendered and navigated in memory, so the whole
   simulator-driven invariant and structural coverage runs without external data.
-- The **integration tier** is excluded by default (``addopts = ["-m", "not
-  integration"]`` in ``pyproject.toml``) and opted into with ``-m ""`` or ``-m
-  integration``. It holds the slow and the archive-backed tests: the real-image
+- The **integration tier** is opted into with ``-m ""`` or ``-m integration``.
+  It holds the slow and the archive-backed tests: the real-image
   regression cohort (which fetches PDS holdings and resolves SPICE geometry) and
   the heavier or jitter-prone in-process simulator tests.
+- The **postgres tier** is opted into with ``-m postgres`` (or ``-m ""``). It
+  re-asks the results-index questions against a real PostgreSQL server, because
+  SQLite accepts spellings a server rejects: an integer compared against a
+  boolean, a single-precision float where a double was meant, a foreign key that
+  is only enforced when asked. The tests read their connection URL from
+  ``SPINDOCTOR_TEST_POSTGRES_URL`` and skip themselves when it is unset, so the
+  tier is runnable on any machine with a server and harmless on any machine
+  without one. Each test creates and drops a PostgreSQL schema of its own, so
+  repeat runs and parallel workers do not collide. CI has no service container
+  for it; run it locally before changing anything in ``spindoctor.results_index``
+  or the statistics programs.
 
 The simulator (:doc:`dev_guide_simulator`) is the engine behind several tiers: it
 lets the suite grow algorithmic-invariant and sensitivity coverage on frames
@@ -29,8 +42,9 @@ Running the suite
 .. code-block:: bash
 
    pytest                              # default tier (fast, no holdings)
-   pytest -m ""                        # full suite, including integration
+   pytest -m ""                        # full suite, every tier
    pytest -m integration               # only the integration tier
+   pytest -m postgres                  # only the postgres tier
    pytest -n auto --dist=loadfile      # parallel, matching CI (loadfile avoids
                                        #   PyQt6 worker crashes)
    pytest tests/spindoctor/sim/test_sim_noise.py            # one file
@@ -39,6 +53,13 @@ Running the suite
 
    ./scripts/run-all-checks.sh         # ruff + mypy + pytest + docs + markdown
    ./scripts/run-all-checks.sh -i      # the same, including integration tests
+   ./scripts/run-all-checks.sh -P      # the same, including the postgres tier
+
+The postgres tier additionally needs a server to point at:
+
+.. code-block:: bash
+
+   export SPINDOCTOR_TEST_POSTGRES_URL=postgresql+psycopg://user:pw@host:5432/spindoctor
 
 ``pytest-xdist`` must run with ``--dist=loadfile``; the default scheduling
 crashes PyQt6 workers when tests from one file split across processes. Multi-test
@@ -75,6 +96,12 @@ tests need none of the archive environment above.
      - nothing
      - One component in isolation (config, feature, dataset, obs, model,
        technique, orchestrator, reproj, support).
+   * - Results index on a server
+       (``tests/spindoctor/results_index/test_postgres.py``)
+     - postgres
+     - PostgreSQL
+     - The schema, the version gate, and the type discipline against a backend
+       that enforces them, rather than against SQLite's permissive typing.
    * - Simulator unit tests (``tests/spindoctor/sim/**``)
      - default
      - nothing

--- a/docs/introduction_configuration.rst
+++ b/docs/introduction_configuration.rst
@@ -74,10 +74,12 @@ Logging Configuration
 
 Logging is configured by the top-level ``logging`` section, described under
 `Logging Options`_ below, together with command-line options that override it.
-It is the one section excluded from the provenance configuration digest
+It is one of the two sections excluded from the provenance configuration digest
 recorded with each navigation result: what a run wrote down about itself
 cannot change what it concluded, so two results differing only in logging were
-produced by the same configuration and compare as such.
+produced by the same configuration and compare as such. The other is
+``environment``, which says where a deployment keeps its files rather than how
+it navigates.
 
 Two loggers write during a run: the main logger, covering one program run, and
 the image logger, covering one image inside one processing stage. A component

--- a/plans/RESULTS_DB_PLAN.md
+++ b/plans/RESULTS_DB_PLAN.md
@@ -223,6 +223,20 @@ that is down or misconfigured, would reach a consumer as a SQLAlchemy
 traceback naming neither the URL nor which of the three resolution levels
 supplied it.
 
+The translation is a catch-all rather than a list of expected types. A
+dialect coerces its own connect arguments and reports a bad one as a bare
+`ValueError` naming nothing: a non-numeric port, a non-numeric `timeout`. To
+a caller, such an escape is indistinguishable from the guarantee being
+broken, so everything that escapes the builder is translated, and only the
+messages this layer writes itself pass through untouched.
+
+**The URL a message names is rendered with its password masked.** These
+messages are written to run logs and pasted into bug reports, and a database
+password belongs in neither. Everything else about the URL survives, because
+naming the URL is what tells a reader which of the three resolution levels
+supplied the value. A URL the parser rejected cannot render itself, so its
+password is masked by pattern instead.
+
 The engine factory is the only opener:
 
 ```text
@@ -273,23 +287,55 @@ the C library directly. A SQLite URL whose path is on a filesystem that
 cannot honor its locking (probed at open with a `BEGIN IMMEDIATE` /
 rollback) is refused, naming PostgreSQL as the cross-machine option.
 
+That URL carries **no query string**. The driver derives the filename it
+opens from the whole URL, so `.../index.sqlite3?mode=ro` passes an existence
+check on `index.sqlite3` and then creates a second file whose name contains
+the query -- neither the database the operator named nor an index anything
+can read. Such a URL is refused, naming the URL and saying that a SQLite
+index URL is a plain local path.
+
 **A read-only database is a separate case from a locking failure**, and the
 two are told apart rather than merged. A read-only mount honors locking
 perfectly and a consumer cannot corrupt anything, so refusing one and
 blaming its filesystem is a false diagnosis of a deployment the index is
 meant to support -- an archived copy, or a file shipped to workers on
-read-only media. The two are distinguished at connect: selecting the journal
-mode writes the database header, so its refusal (any `SQLITE_READONLY*`
-result code) is the read-only answer, and it is recorded on the connection
-instead of raised. `BEGIN IMMEDIATE` cannot answer the question on its own,
-because a rollback-journal database SQLite will never write still grants the
-reserved lock it asks for. From that record:
+read-only media.
+
+**Whether ingest can write is asked of the filesystem, not of SQLite**:
+`os.access` on the file and on its parent directory, before the engine is
+built. SQLite does not answer the question at open. A write-ahead-logged
+database -- the shape this opener always leaves behind, having selected that
+journal mode -- accepts both the journal-mode selection, which its header
+already records, and the write lock `BEGIN IMMEDIATE` takes, on a file it
+will never write; it refuses only the first real write, in the middle of an
+ingest. A rollback-journal database refuses the journal-mode selection
+instead, so no single SQLite answer covers both shapes. The directory is
+asked about with the file, because SQLite writes the write-ahead log and its
+shared-memory index beside the database, and a writable file in a directory
+that permits nothing is still a database ingest cannot write. So:
 
 - `create=False` **accepts** a read-only database and reads it.
-- `create=True` refuses it, with a message naming read-only as the cause and
-  saying to ingest a writable copy -- not the filesystem-locking message.
+- `create=True` refuses it before anything is opened, with a message naming
+  read-only -- of the file, or of its directory -- as the cause and saying to
+  ingest a writable copy, not the filesystem-locking message.
 - A genuine `SQLITE_BUSY` or `SQLITE_IOERR` refuses in both modes, with the
   filesystem-and-PostgreSQL message.
+
+The connect-time journal-mode selection still has to tolerate a refusal (any
+`SQLITE_READONLY*` result code), because every connection to a read-only
+rollback-journal database would otherwise fail; the refusal is ignored rather
+than raised, and nothing is inferred from its absence.
+
+**A probe failure is classified by SQLite's own result code before a message
+is chosen.** One exception type covers several unrelated causes, and only one
+of them is a reason to move the index to a server. `SQLITE_NOTADB` says the
+file is not a SQLite database. `SQLITE_CANTOPEN` names the path and says
+which of its causes applies: a directory that does not exist, a path that is
+not a file, or a file this user cannot open -- prescribing PostgreSQL for an
+operator whose results directory has not been created yet is a wrong remedy
+for the most common first-run error there is. Only `SQLITE_BUSY`,
+`SQLITE_IOERR` and a code that names no cause at all keep the
+filesystem-and-PostgreSQL message.
 
 One read-only database cannot be read at all: SQLite reads a write-ahead-logged
 database through a shared-memory index it creates beside the file, so a
@@ -618,15 +664,26 @@ Tests: schema creation against SQLite; `create=False` raising on a missing
 database, a missing `schema_meta` row, and a version mismatch (each message
 asserted); a refused `create=True` open leaving the database unwritten; the
 `ValueError` guarantee on each route a driver exception takes (an absent
-driver, an unparseable URL, an unknown URL scheme, a server that refuses the
-connection), with the driver's exception kept as the `__cause__`; the
-missing-driver message, with the driver hidden by an import hook rather than
-by its happening to be absent from the environment; the read-only cases of
-section 2.5 (accepted by a consumer, refused by an ingest, and a
-write-ahead-logged copy that cannot be read) alongside a genuine lock failure
-in both modes; a refused open disposing the pool it built; Double-precision
-round-trip of a 15-significant-digit value; boolean round-trip; the
-config-hash exclusion.
+driver, an unparseable URL, an unknown URL scheme, a non-numeric port that
+reaches the caller as a bare `ValueError`, a server that refuses the
+connection, and an unexpected failure inside the engine factory), with the
+driver's exception kept as the `__cause__` on each; a password absent from
+every one of those messages while the rest of the URL survives, including on
+the `schema_meta` and version gates and against a server that rejects the
+password (`postgres` tier); the missing-driver message, with the driver
+hidden by an import hook rather than by its happening to be absent from the
+environment; the read-only cases of section 2.5 (accepted by a consumer,
+refused by an ingest, and a write-ahead-logged copy that cannot be read),
+each parametrized over both journal modes, plus an ingest into a read-only
+directory, alongside a genuine lock failure in both modes; the result-code
+classification of a probe failure (a file that is not a database, a path that
+is a directory, a directory that does not exist, a file this user cannot
+open, and an exception carrying no result code at all); a `sqlite:` URL with
+a query string refused without leaving a file behind; the connect-time
+settings read from a second connection held open beside the first, so a
+one-shot application fails the test; a refused open disposing the pool it
+built; Double-precision round-trip of a 15-significant-digit value; boolean
+round-trip; the config-hash exclusion.
 
 ### Phase 2 — Ingest and reporting onto the index
 
@@ -646,6 +703,14 @@ Reporting: move `sd_stats_report` onto the Core layer per sections 2.5 and
 2.9 -- named binds, composite-key joins, `COALESCE` for both the reason
 taxonomy and `TOTAL`, boolean spellings, the column-backed `image_number`,
 `--root`, and `--db` removed from both programs.
+
+The source scan that enforces criterion 10 reads only
+`src/spindoctor/results_index/`, which is the whole of the Core layer while
+that is all there is. The statistics programs move onto the Core layer here,
+so this phase widens the scan's `_SOURCE_ROOT` to cover
+`src/spindoctor/cli/stats/` as well, and updates the test that pins which
+modules the scan reaches. Left alone, criterion 10 would report green over a
+package that no longer holds the queries it exists to check.
 
 Tests: a two-volume tree with colliding basenames producing two rows; a
 bare-basename stub with NULL `volume`; the unrounded offset; the separated
@@ -755,7 +820,11 @@ add a column (increment the version). No issue numbers in any of it.
 10. No SQLite-only construct remains in any query: no UDF registration, no
     `TOTAL(`, no `executescript`, no `PRAGMA` outside a dialect event, no
     integer comparison or arithmetic against a Boolean column. Enforced by a
-    source-scanning test.
+    source-scanning test, whose root covers every package holding index
+    queries: `src/spindoctor/results_index/`, and from Phase 2 also
+    `src/spindoctor/cli/stats/`, where the report's queries live. A scan
+    aimed at one package while the queries live in another reports green
+    without reading them.
 11. The suite's index tests pass against PostgreSQL under a `postgres`
     marker: registered in `[tool.pytest.ini_options].markers`, excluded by
     default via `addopts` (`-m "not integration and not postgres"`), given a

--- a/plans/RESULTS_DB_PLAN.md
+++ b/plans/RESULTS_DB_PLAN.md
@@ -131,7 +131,21 @@ carries a non-unique index. Every consumer lookup filters on
 (repeatable, default: all ingested roots), since a report legitimately spans
 roots where a pipeline lookup never does.
 
-The child tables key on the same pair.
+`images` carries two further non-unique indexes, `image_date` and
+`instrument`, which the statistics report groups and filters on across a whole
+root. They are carried over from the indexes `cli/stats/schema.py` already
+declares, so the report does not lose an index in the move.
+
+The child tables key on the same pair, and each additionally declares the tuple
+that identifies one of its rows unique within an image:
+`(root_url, results_path_stub, technique_name)` on `techniques` and
+`(root_url, results_path_stub, feature_type, source_model, source_name)` on
+`feature_sources`. A technique reports once for an image and the feature
+inventory is aggregated by exactly that tuple, so a second row is a
+contradiction rather than more detail, and a retried or duplicated ingest that
+inserted one would change every count and average read from the table without
+replacing anything. Each constraint's index leads with the image key, so it is
+also the index a lookup by image uses and no separate one is declared.
 
 ### 2.3 Columns
 
@@ -199,10 +213,10 @@ Phase 2) as `COALESCE(status_reason, status_error)`, which reproduces
 today's report exactly.
 
 The `techniques` and `feature_sources` child tables keep their current
-column sets, re-keyed on `(root_url, results_path_stub)`. The feature
-inventory is aggregated, as today, by
-`(feature_type, source_model, source_name)`; per-feature `feature_id` and
-`gated` detail is not retained.
+column sets, re-keyed on `(root_url, results_path_stub)` and constrained to
+one row per logical key (section 2.2). The feature inventory is aggregated, as
+today, by `(feature_type, source_model, source_name)`; per-feature `feature_id`
+and `gated` detail is not retained.
 
 ### 2.4 Schema version, creation, and no migrations
 
@@ -234,12 +248,28 @@ messages this layer writes itself pass through untouched.
 messages are written to run logs and pasted into bug reports, and a database
 password belongs in neither. Everything else about the URL survives, because
 naming the URL is what tells a reader which of the three resolution levels
-supplied the value. A URL the parser rejected cannot render itself, so its
-password is masked by pattern instead. That pattern is anchored at the start
-of the URL and runs to the `@`, because a password may legally carry an
-unescaped `/`: one bounded by path separators leaves such a password in the
-message whole, and an unanchored one mangles a local path that happens to
-carry a colon and a later `@`.
+supplied the value.
+
+A URL the parser rejected cannot render itself, so its password is found
+structurally instead, by a stated rule rather than by a pattern:
+
+1. If the scheme -- the text before the first `:`, with any `+driver` suffix
+   and surrounding space removed -- is `sqlite`, the string is returned
+   unchanged. A SQLite URL names a local path, which has no credentials and is
+   free to carry the colons and at-signs that would otherwise read as some.
+2. Otherwise the authority begins after the slashes that follow the scheme
+   (one or two, since a hand-edited setting arrives with either). The user name
+   runs to the first `:` or `/`; only a `:` introduces a password, and that
+   password runs to the first `@` after it, because an `@` is what ends the
+   credentials. A `/` inside that span is part of the password, which is what
+   reaches a password written with an unescaped slash; an `@` inside the user
+   name is kept, which is what reaches the `user@servername` login form of a
+   managed server.
+3. `host:5432/path@name` is genuinely ambiguous -- a host with a port and a
+   path, or a user name with a slashed password. Digits decide it: a port is
+   digits and a password is not, and mangling a host, a port and half a
+   database name costs the identification these messages exist for.
+4. Only the password is replaced. Nothing outside it is touched.
 
 The engine factory is the only opener:
 
@@ -258,16 +288,20 @@ open_index(url: str, *, create: bool = False) -> Engine
 - Either way, a `schema_version` that does not match the version the code
   was built for raises, naming both versions and instructing the reader to
   delete the database and re-ingest. The stamped version is read and checked
-  before anything is written, so a refused `create=True` open leaves the
-  database untouched; creating this version's tables inside a database
+  before anything is written, so a refused `create=True` open creates no table
+  and writes no row; creating this version's tables inside a database
   stamped with another version would leave a mixture no single version number
-  describes.
+  describes. (The database file is not literally untouched: the connect-time
+  journal-mode selection rewrites a rollback-journal database's header before
+  the gate is reached. What the gate guarantees is the schema and the rows,
+  which is what a rebuild would otherwise have to undo.)
 
 There are no migrations. Ingest is cheap relative to navigation and entirely
 reproducible from the tree, so rebuilding is always available and always
-correct. Any change to the column set increments `schema_version`. This
-replaces the current column-set comparison, which detects a changed column
-set but not a changed meaning of an unchanged column.
+correct. Any change to the column set, or to the constraints over it,
+increments `schema_version`. This replaces the current column-set comparison,
+which detects a changed column set but not a changed meaning of an unchanged
+column.
 
 ### 2.5 Backend selection
 
@@ -671,7 +705,7 @@ Declare `sqlalchemy` in `[project] dependencies` and the `postgres` extra in
 
 Tests: schema creation against SQLite; `create=False` raising on a missing
 database, a missing `schema_meta` row, and a version mismatch (each message
-asserted); a refused `create=True` open leaving the database unwritten; the
+asserted); a refused `create=True` open creating no table; the
 `ValueError` guarantee on each route a driver exception takes (an absent
 driver, an unparseable URL, an unknown URL scheme, a non-numeric port that
 reaches the caller as a bare `ValueError`, a server that refuses the
@@ -679,7 +713,13 @@ connection, and an unexpected failure inside the engine factory), with the
 driver's exception kept as the `__cause__` on each; a password absent from
 every one of those messages while the rest of the URL survives, including on
 the `schema_meta` and version gates and against a server that rejects the
-password (`postgres` tier); the missing-driver message, with the driver
+password (`postgres` tier); the structural masking rule as a table of URLs and
+exactly what masking each produces -- a slashed password, an at-sign in the
+user name, a leading space, a hyphenated scheme, a two-line copy, and the
+non-credential strings it must leave alone (a port with a later at-sign, a
+user name with no password, a SQLite path, a scheme alone, the empty string)
+-- with every credential-bearing row driven through `open_index` itself and
+not only through the helper; the missing-driver message, with the driver
 hidden by an import hook rather than by its happening to be absent from the
 environment; the read-only cases of section 2.5 (accepted by a consumer,
 refused by an ingest, and a write-ahead-logged copy that cannot be read),
@@ -687,12 +727,21 @@ each parametrized over both journal modes, plus an ingest into a read-only
 directory, alongside a genuine lock failure in both modes; the result-code
 classification of a probe failure (a file that is not a database, a path that
 is a directory, a directory that does not exist, a file this user cannot
-open, and an exception carrying no result code at all); a `sqlite:` URL with
+open, an exception carrying no result code at all, one carrying a code that is
+not text, and an extended form of each classified family, since matching by
+equality rather than by prefix loses the family's remedy); the connect handler
+re-raising a driver error that is not a read-only refusal; a `sqlite:` URL with
 a query string refused without leaving a file behind; the connect-time
 settings read from a second connection held open beside the first, so a
 one-shot application fails the test; a refused open disposing the pool it
 built; Double-precision round-trip of a 15-significant-digit value; boolean
-round-trip; the config-hash exclusion.
+round-trip; a duplicate child row refused on both backends; the config-hash
+exclusion.
+
+The engine tests are three files, because one would run past the 1000-line
+module cap: the opener's contract (`test_engine.py`), what it does with a
+SQLite file (`test_engine_sqlite.py`), and how it names a URL without naming
+its password (`test_engine_masking.py`).
 
 ### Phase 2 — Ingest and reporting onto the index
 
@@ -784,8 +833,9 @@ the SQLite-is-local rule; the ingest workflow, including that it is never
 automatic; root normalization and the not-ingested failure; the version gate
 and delete-and-re-ingest; which programs consume the index, that
 `sd_stats_report` requires it, and which programs deliberately do not use
-it. New `docs/api_reference/api_results_index.rst` in the api-reference
-toctree. Updates: `user_guide_statistics.rst` (per section 2.9),
+it. `docs/api_reference/api_results_index.rst` -- created with the package in
+Phase 1, so the branch never carries an undocumented public package -- gains
+the modules the later phases add. Updates: `user_guide_statistics.rst` (per section 2.9),
 `user_guide_logging.rst` (program table), `introduction_configuration.rst`
 (`environment.results_db`), and a dev-guide section covering the Core
 layer, the concurrency model, the branch-local import exception, and how to
@@ -902,6 +952,13 @@ File as tracking issues alongside the implementation issue:
 - **A `--since` selector for ingest.** The stat-pair skip makes a re-scan
   cheap in reads but not in listings; a time-bounded scan would cut the
   listing too.
+- **The lockability probe takes a write lock on a consumer's open.** Section
+  2.5 has it refuse in both modes, so a consumer opening a SQLite index while
+  an ingest holds a write transaction waits out the busy timeout and can then
+  fail with the filesystem-and-PostgreSQL message though nothing is wrong. It
+  is the plan's own rule and is left as written here; whether a `create=False`
+  open should probe with a read instead belongs with the concurrent-ingest work
+  of Phase 3, which is what makes the collision likely.
 
 ---
 

--- a/plans/RESULTS_DB_PLAN.md
+++ b/plans/RESULTS_DB_PLAN.md
@@ -214,6 +214,14 @@ version gate has to resolve.
 
 Every failure `open_index` reports is a `ValueError` carrying the URL, so a
 consumer that wants to report the cause rather than crash catches one type.
+The exceptions a database driver raises are translated into that one --
+an unparseable URL, an unknown URL scheme, an absent driver, and the ordinary
+operational failures of a server that will not accept the connection -- each
+keeping the driver's own exception as its `__cause__`. Without the
+translation the most common operational failure of all, a PostgreSQL server
+that is down or misconfigured, would reach a consumer as a SQLAlchemy
+traceback naming neither the URL nor which of the three resolution levels
+supplied it.
 
 The engine factory is the only opener:
 
@@ -231,7 +239,11 @@ open_index(url: str, *, create: bool = False) -> Engine
   from the current opener's silent-create behavior.
 - Either way, a `schema_version` that does not match the version the code
   was built for raises, naming both versions and instructing the reader to
-  delete the database and re-ingest.
+  delete the database and re-ingest. The stamped version is read and checked
+  before anything is written, so a refused `create=True` open leaves the
+  database untouched; creating this version's tables inside a database
+  stamped with another version would leave a mixture no single version number
+  describes.
 
 There are no migrations. Ingest is cheap relative to navigation and entirely
 reproducible from the tree, so rebuilding is always available and always
@@ -260,6 +272,31 @@ this system that does not go through `FCPath` -- SQLAlchemy opens it with
 the C library directly. A SQLite URL whose path is on a filesystem that
 cannot honor its locking (probed at open with a `BEGIN IMMEDIATE` /
 rollback) is refused, naming PostgreSQL as the cross-machine option.
+
+**A read-only database is a separate case from a locking failure**, and the
+two are told apart rather than merged. A read-only mount honors locking
+perfectly and a consumer cannot corrupt anything, so refusing one and
+blaming its filesystem is a false diagnosis of a deployment the index is
+meant to support -- an archived copy, or a file shipped to workers on
+read-only media. The two are distinguished at connect: selecting the journal
+mode writes the database header, so its refusal (any `SQLITE_READONLY*`
+result code) is the read-only answer, and it is recorded on the connection
+instead of raised. `BEGIN IMMEDIATE` cannot answer the question on its own,
+because a rollback-journal database SQLite will never write still grants the
+reserved lock it asks for. From that record:
+
+- `create=False` **accepts** a read-only database and reads it.
+- `create=True` refuses it, with a message naming read-only as the cause and
+  saying to ingest a writable copy -- not the filesystem-locking message.
+- A genuine `SQLITE_BUSY` or `SQLITE_IOERR` refuses in both modes, with the
+  filesystem-and-PostgreSQL message.
+
+One read-only database cannot be read at all: SQLite reads a write-ahead-logged
+database through a shared-memory index it creates beside the file, so a
+write-ahead-logged copy in a directory that permits no writes is unreadable
+by construction. That is refused with a message saying exactly that and to
+copy the file somewhere writable, rather than letting a consumer's first
+query fail with a write error on a read.
 
 `sqlalchemy` becomes a runtime dependency in `[project] dependencies`. The
 PostgreSQL driver ships as an optional extra, `rms-spindoctor[postgres]`,
@@ -304,10 +341,10 @@ supplied the value, so a configuration file or an exported variable can opt out
 the same way; it is matched as the exact string, so a URL that merely contains
 the word is still a URL.
 
-There is no shared helper for the `--results-db` argument definition, because
-there is none for the results roots either: every program defines its own flag
-(the reprojection family shares `add_common_env_args` in
-`spindoctor/cli/reproj/args.py`, and that is the only grouping).
+The codebase convention for an argument of this kind is that each program
+defines its own, as it does for the results roots: the reprojection family
+shares `add_common_env_args` in `spindoctor/cli/reproj/args.py`, and that is
+the only grouping.
 
 A program that resolves a URL and cannot open it fails immediately with that
 error; it does not silently fall back to reading files. Falling back would
@@ -579,8 +616,17 @@ Declare `sqlalchemy` in `[project] dependencies` and the `postgres` extra in
 
 Tests: schema creation against SQLite; `create=False` raising on a missing
 database, a missing `schema_meta` row, and a version mismatch (each message
-asserted); the missing-driver message; Double-precision round-trip of a
-15-significant-digit value; boolean round-trip; the config-hash exclusion.
+asserted); a refused `create=True` open leaving the database unwritten; the
+`ValueError` guarantee on each route a driver exception takes (an absent
+driver, an unparseable URL, an unknown URL scheme, a server that refuses the
+connection), with the driver's exception kept as the `__cause__`; the
+missing-driver message, with the driver hidden by an import hook rather than
+by its happening to be absent from the environment; the read-only cases of
+section 2.5 (accepted by a consumer, refused by an ingest, and a
+write-ahead-logged copy that cannot be read) alongside a genuine lock failure
+in both modes; a refused open disposing the pool it built; Double-precision
+round-trip of a 15-significant-digit value; boolean round-trip; the
+config-hash exclusion.
 
 ### Phase 2 — Ingest and reporting onto the index
 

--- a/plans/RESULTS_DB_PLAN.md
+++ b/plans/RESULTS_DB_PLAN.md
@@ -178,7 +178,10 @@ Types: every pixel, ET, covariance and sigma column is declared
 `sqlalchemy.Double` (not bare `Float`, which a dialect may map to single
 precision); booleans are `sqlalchemy.Boolean`; `excluded_from_consensus` and
 the child tables' `source_names` / `diagnostics` are `sqlalchemy.JSON`
-(SQLite TEXT, PostgreSQL `jsonb`).
+(SQLite TEXT, PostgreSQL `jsonb`). `mtime_ns`, `size_bytes` and `image_number`
+are `sqlalchemy.BigInteger`: a nanosecond epoch is far past the 32-bit range a
+dialect is free to give a plain `Integer`, and an image-numbering scheme is
+free to run past it too.
 
 **Precision.** The top-level `offset` is stored as written, with no
 rounding. (It is written unrounded by `navigate_image_files`; the rounded
@@ -204,7 +207,13 @@ inventory is aggregated, as today, by
 ### 2.4 Schema version, creation, and no migrations
 
 The database carries a `schema_meta` table with a single row holding
-`schema_version` (an integer) and `created_utc`.
+`schema_version` (an integer) and `created_utc`. The single row is enforced by
+a constant primary key (`singleton`) with a `CHECK (singleton = 1)`
+constraint, so a second row is a database error rather than an ambiguity the
+version gate has to resolve.
+
+Every failure `open_index` reports is a `ValueError` carrying the URL, so a
+consumer that wants to report the cause rather than crash catches one type.
 
 The engine factory is the only opener:
 
@@ -290,7 +299,15 @@ Every consuming program accepts `--results-db URL`, and also
 `--results-db none`: the literal sentinel `none` resolves to no index,
 overriding the configuration key and the environment variable. Without an
 explicit opt-out, an exported `NAV_RESULTS_DB` would make file-mode runs
-impossible on that machine.
+impossible on that machine. The sentinel is recognized at whichever level
+supplied the value, so a configuration file or an exported variable can opt out
+the same way; it is matched as the exact string, so a URL that merely contains
+the word is still a URL.
+
+There is no shared helper for the `--results-db` argument definition, because
+there is none for the results roots either: every program defines its own flag
+(the reprojection family shares `add_common_env_args` in
+`spindoctor/cli/reproj/args.py`, and that is the only grouping).
 
 A program that resolves a URL and cannot open it fails immediately with that
 error; it does not silently fall back to reading files. Falling back would
@@ -322,8 +339,10 @@ degrades to `--force` behavior for that root, with a logged warning.
 pair is skipped without being read. `--force` re-reads everything.
 
 **Per-root bookkeeping.** An `ingest_runs` table records, per root:
-`root_url`, `started_utc`, `finished_utc` (NULL while running), files seen /
-ingested / skipped / failed, and `schema_version`. The row is written at
+`root_url`, `started_utc`, `finished_utc` (NULL while running),
+`files_seen` / `files_ingested` / `files_skipped` / `files_failed`, and
+`schema_version`, under a surrogate `run_id` primary key (a root legitimately
+has many runs, and a consumer reads the newest). The row is written at
 start and updated at completion, in both the interactive and cloud paths. A
 consumer treats a root whose newest row has `finished_utc IS NULL` -- or no
 row at all -- as not ingested, and fails with a message saying so.
@@ -694,8 +713,9 @@ add a column (increment the version). No issue numbers in any of it.
 11. The suite's index tests pass against PostgreSQL under a `postgres`
     marker: registered in `[tool.pytest.ini_options].markers`, excluded by
     default via `addopts` (`-m "not integration and not postgres"`), given a
-    `scripts/run-all-checks.sh` flag alongside `-i`, and named in the dev
-    guide as a locally-runnable tier if CI has no service container.
+    `scripts/run-all-checks.sh` flag alongside `-i` (`-P` / `--postgres`), and
+    named in the dev guide as a locally-runnable tier if CI has no service
+    container.
 12. `ruff check`, `ruff format --check`, `mypy --strict`, `sphinx-build -W`
     and `pymarkdown scan` all pass; suite coverage stays at or above 90%.
 

--- a/plans/RESULTS_DB_PLAN.md
+++ b/plans/RESULTS_DB_PLAN.md
@@ -235,7 +235,11 @@ messages are written to run logs and pasted into bug reports, and a database
 password belongs in neither. Everything else about the URL survives, because
 naming the URL is what tells a reader which of the three resolution levels
 supplied the value. A URL the parser rejected cannot render itself, so its
-password is masked by pattern instead.
+password is masked by pattern instead. That pattern is anchored at the start
+of the URL and runs to the `@`, because a password may legally carry an
+unescaped `/`: one bounded by path separators leaves such a password in the
+message whole, and an unanchored one mangles a local path that happens to
+carry a colon and a later `@`.
 
 The engine factory is the only opener:
 
@@ -335,7 +339,12 @@ not a file, or a file this user cannot open -- prescribing PostgreSQL for an
 operator whose results directory has not been created yet is a wrong remedy
 for the most common first-run error there is. Only `SQLITE_BUSY`,
 `SQLITE_IOERR` and a code that names no cause at all keep the
-filesystem-and-PostgreSQL message.
+filesystem-and-PostgreSQL message. Every other code -- a full disk, a corrupt
+file -- is reported as what SQLite said, naming the path and the code and
+prescribing nothing, because inventing a remedy for an unclassified failure is
+exactly how the wrong one gets prescribed. Codes are matched by prefix, since
+SQLite refines several of them into extended forms naming the same cause more
+precisely.
 
 One read-only database cannot be read at all: SQLite reads a write-ahead-logged
 database through a shared-memory index it creates beside the file, so a

--- a/plans/RESULTS_DB_PLAN.md
+++ b/plans/RESULTS_DB_PLAN.md
@@ -952,7 +952,8 @@ File as tracking issues alongside the implementation issue:
 - **A `--since` selector for ingest.** The stat-pair skip makes a re-scan
   cheap in reads but not in listings; a time-bounded scan would cut the
   listing too.
-- **The lockability probe takes a write lock on a consumer's open.** Section
+- **The lockability probe takes a write lock on a consumer's open** (#462).
+  Section
   2.5 has it refuse in both modes, so a consumer opening a SQLite index while
   an ingest holds a write transaction waits out the busy timeout and can then
   fail with the filesystem-and-PostgreSQL message though nothing is wrong. It

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
   "pytest-xdist",
   "ruff",
   "rms-spindoctor[docs]",
+  "rms-spindoctor[postgres]",
   "threadpoolctl",
 ]
 # Sphinx stack only. ``pip install -e ".[docs]"`` (ReadTheDocs: ``path: .`` +
@@ -74,7 +75,9 @@ docs = [
 ]
 # PostgreSQL driver for the results index. A SQLite index needs nothing beyond
 # the runtime dependencies; PostgreSQL is what a results index shared across
-# machines runs on.
+# machines runs on. The ``dev`` extra pulls this in so that the postgres test
+# tier type-checks and runs from a development checkout; the tier still skips
+# itself unless ``SPINDOCTOR_TEST_POSTGRES_URL`` names a server.
 postgres = [
   "psycopg[binary]>=3.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
   "rms-oops>=0.1.3",
   "rms-starcat>=1.0.1",
   "ruamel.yaml",
-  "scipy"
+  "scipy",
+  "sqlalchemy>=2.0"
 ]
 license = {text = "Apache-2.0"}
 maintainers = [
@@ -70,6 +71,12 @@ docs = [
   "sphinx>=7.4.7",
   "sphinxcontrib-mermaid>=0.9.2",
   "sphinx-rtd-theme>=2.0.0",
+]
+# PostgreSQL driver for the results index. A SQLite index needs nothing beyond
+# the runtime dependencies; PostgreSQL is what a results index shared across
+# machines runs on.
+postgres = [
+  "psycopg[binary]>=3.1",
 ]
 
 [project.urls]
@@ -148,7 +155,7 @@ pythonpath = [
   "src"
 ]
 testpaths = ["tests"]
-addopts = ["--strict-markers", "--strict-config", "-m", "not integration"]
+addopts = ["--strict-markers", "--strict-config", "-m", "not integration and not postgres"]
 filterwarnings = [
   "error",
   # Astropy's FITS reader can leave a file handle open while the cache
@@ -173,6 +180,7 @@ filterwarnings = [
 ]
 markers = [
   "integration: requires PDS3_HOLDINGS_DIR (real holdings on disk or via filecache)",
+  "postgres: requires a PostgreSQL server named by SPINDOCTOR_TEST_POSTGRES_URL",
   "slow: per-image library regression test",
 ]
 

--- a/scripts/run-all-checks.sh
+++ b/scripts/run-all-checks.sh
@@ -209,8 +209,17 @@ else
     print_info "Integration tests: SKIPPED (default; pass -i / --integration to include)"
 fi
 
+# An explicit -P with no server named would select the tier and then skip every
+# test in it, reporting a pass that ran no PostgreSQL coverage at all.  The
+# request is refused instead, because that is the one reading of -P nobody wants.
+if [ "$RUN_POSTGRES" = true ] && [ -z "${SPINDOCTOR_TEST_POSTGRES_URL:-}" ]; then
+    print_error "PostgreSQL tests were requested with -P / --postgres, but SPINDOCTOR_TEST_POSTGRES_URL is not set, so every test in that tier would skip."
+    print_info "Export it, for example: export SPINDOCTOR_TEST_POSTGRES_URL=postgresql+psycopg://USER@HOST:5432/spindoctor"
+    exit 1
+fi
+
 if [ "$RUN_POSTGRES" = true ]; then
-    print_info "PostgreSQL tests: ENABLED (require SPINDOCTOR_TEST_POSTGRES_URL)"
+    print_info "PostgreSQL tests: ENABLED (SPINDOCTOR_TEST_POSTGRES_URL is set)"
 else
     print_info "PostgreSQL tests: SKIPPED (default; pass -P / --postgres to include)"
 fi
@@ -297,7 +306,9 @@ run_code_checks() {
     if [ "$RUN_INTEGRATION" = true ]; then
         pytest_marker_args+=("--ignore=tests/integration/test_sim_perf.py")
     fi
-    if python -m pytest tests -q --cov -n auto "${pytest_marker_args[@]}"; then
+    # loadfile keeps every test of one file on one worker; the default scheduling
+    # splits a file across processes and has crashed the PyQt6 workers.
+    if python -m pytest tests -q --cov -n auto --dist=loadfile "${pytest_marker_args[@]}"; then
         print_success "Pytest passed"
     else
         print_error "Pytest failed"

--- a/scripts/run-all-checks.sh
+++ b/scripts/run-all-checks.sh
@@ -16,6 +16,8 @@
 #   -m, --markdown   Run only Markdown lint (PyMarkdown)
 #   -i, --integration Include integration tests (slow; require PDS3_HOLDINGS_DIR
 #                    + SPICE kernels).  Default: skipped.
+#   -P, --postgres   Include PostgreSQL results-index tests (require a server named
+#                    by SPINDOCTOR_TEST_POSTGRES_URL).  Default: skipped.
 #   -h, --help       Show this help message
 #
 # Environment:
@@ -53,6 +55,7 @@ RUN_DOCS=false
 RUN_MARKDOWN=false
 SCOPE_SPECIFIED=false
 RUN_INTEGRATION=false
+RUN_POSTGRES=false
 
 # Get script directory and project root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -167,6 +170,10 @@ while [[ $# -gt 0 ]]; do
             RUN_INTEGRATION=true
             shift
             ;;
+        -P|--postgres)
+            RUN_POSTGRES=true
+            shift
+            ;;
         -h|--help)
             show_usage
             exit 0
@@ -200,6 +207,12 @@ if [ "$RUN_INTEGRATION" = true ]; then
     print_info "Integration tests: ENABLED (will run; require PDS3_HOLDINGS_DIR + SPICE)"
 else
     print_info "Integration tests: SKIPPED (default; pass -i / --integration to include)"
+fi
+
+if [ "$RUN_POSTGRES" = true ]; then
+    print_info "PostgreSQL tests: ENABLED (require SPINDOCTOR_TEST_POSTGRES_URL)"
+else
+    print_info "PostgreSQL tests: SKIPPED (default; pass -P / --postgres to include)"
 fi
 
 # Function to run code checks (ruff, mypy, pytest)
@@ -257,20 +270,32 @@ run_code_checks() {
         failed_checks="${failed_checks}Code - Mypy"$'\n'
     fi
 
-    # Pytest.  ``addopts = ["-m", "not integration"]`` in pyproject.toml
-    # excludes integration tests by default; with --integration / -i,
-    # override by passing ``-m ""`` so the marker filter accepts every
-    # test (including ones marked ``integration``).
+    # Pytest.  ``addopts = ["-m", "not integration and not postgres"]`` in
+    # pyproject.toml excludes both opt-in tiers by default; -i and -P each
+    # override that filter by dropping their own term from it, and opting into
+    # both leaves an empty filter that accepts every test.
     # The render performance budgets assert single-core CPU time; the
     # parallel battery's workers contend for memory bandwidth and inflate
     # CPU time past the budgets, so the perf file is excluded from the
     # parallel run and executed as its own serial step afterwards.
-    if [ "$RUN_INTEGRATION" = true ]; then
+    marker_expr=""
+    pytest_marker_args=()
+    if [ "$RUN_INTEGRATION" = true ] && [ "$RUN_POSTGRES" = true ]; then
+        print_info "Running pytest (with integration and PostgreSQL tests)..."
+    elif [ "$RUN_INTEGRATION" = true ]; then
         print_info "Running pytest (with integration tests)..."
-        pytest_marker_args=("-m" "" "--ignore=tests/integration/test_sim_perf.py")
+        marker_expr="not postgres"
+    elif [ "$RUN_POSTGRES" = true ]; then
+        print_info "Running pytest (with PostgreSQL tests)..."
+        marker_expr="not integration"
     else
-        print_info "Running pytest (integration tests skipped — pass -i to include)..."
-        pytest_marker_args=()
+        print_info "Running pytest (integration and PostgreSQL tests skipped — pass -i / -P to include)..."
+    fi
+    if [ "$RUN_INTEGRATION" = true ] || [ "$RUN_POSTGRES" = true ]; then
+        pytest_marker_args=("-m" "$marker_expr")
+    fi
+    if [ "$RUN_INTEGRATION" = true ]; then
+        pytest_marker_args+=("--ignore=tests/integration/test_sim_perf.py")
     fi
     if python -m pytest tests -q --cov -n auto "${pytest_marker_args[@]}"; then
         print_success "Pytest passed"

--- a/src/spindoctor/config/config.py
+++ b/src/spindoctor/config/config.py
@@ -70,13 +70,17 @@ def _deep_merge(base: dict[Any, Any], overlay: dict[Any, Any]) -> dict[Any, Any]
     return merged
 
 
-HASH_EXCLUDED_SECTIONS = frozenset({'logging'})
+HASH_EXCLUDED_SECTIONS = frozenset({'environment', 'logging'})
 """Sections left out of :meth:`Config.resolved_config_hash`.
 
 A configuration section belongs here when it cannot change what the pipeline
 computes.  ``logging`` decides what is written down about a run, never what
 the run concludes, so two results that differ only in it were produced by the
-same configuration and should compare as such.
+same configuration and should compare as such.  ``environment`` holds
+deployment locations -- where the holdings are read from, where results are
+written, which database indexes them -- and moving a directory does not change
+a single number the pipeline produces, so a digest that shifted when it moved
+would answer its own question wrongly.
 
 Named explicitly rather than inferred, so that a section added later has to be
 a deliberate choice rather than inheriting one.  Adding a section here changes

--- a/src/spindoctor/config/config_helper.py
+++ b/src/spindoctor/config/config_helper.py
@@ -6,6 +6,13 @@ from filecache import FCPath
 from .config import Config
 from .logging_keys import validate_logging_config
 
+RESULTS_DB_NONE = 'none'
+"""Value of the results index URL that explicitly selects no index.
+
+An exported NAV_RESULTS_DB would otherwise make a file-mode run impossible on that
+machine, and a program that resolves a URL never falls back to reading files.
+"""
+
 
 def get_backplane_results_root(arguments: argparse.Namespace, config: Config) -> str:
     """Get the backplane results root from the arguments, configuration, or environment.
@@ -157,6 +164,44 @@ def get_pds4_bundle_results_root(arguments: argparse.Namespace, config: Config) 
             'environment variable must be set'
         )
     return pds4_bundle_root_str
+
+
+def get_results_db_url(arguments: argparse.Namespace, config: Config) -> str | None:
+    """Get the results index URL from the arguments, configuration, or environment.
+
+    First look in arguments.results_db, then in config.environment.results_db, then in
+    the environment variable NAV_RESULTS_DB.
+
+    Unlike the results roots, absence is not an error: it means "no index", which is
+    the default mode of every program.  The literal value ``none`` also means "no
+    index", so a run on a machine that exports NAV_RESULTS_DB can still be told to
+    read files by passing ``--results-db none``.  The sentinel is honored wherever the
+    value came from, so a configuration file can opt out of an exported variable in
+    the same way, and it is matched as the exact string, so a URL that merely contains
+    the word is still a URL.
+
+    Parameters:
+        arguments: The parsed arguments.
+        config: The configuration possibly containing the environment section.
+
+    Returns:
+        The results index connection URL, or None when no index was named.
+    """
+    results_db_str = None
+    try:
+        results_db_str = arguments.results_db
+    except AttributeError:
+        pass
+    if results_db_str is None:
+        try:
+            results_db_str = config.environment.results_db
+        except AttributeError:
+            pass
+    if results_db_str is None:
+        results_db_str = os.getenv('NAV_RESULTS_DB')
+    if results_db_str is None or results_db_str == RESULTS_DB_NONE:
+        return None
+    return str(results_db_str)
 
 
 def load_default_and_user_config(arguments: argparse.Namespace, config: Config) -> None:

--- a/src/spindoctor/config/config_helper.py
+++ b/src/spindoctor/config/config_helper.py
@@ -187,16 +187,13 @@ def get_results_db_url(arguments: argparse.Namespace, config: Config) -> str | N
     Returns:
         The results index connection URL, or None when no index was named.
     """
-    results_db_str = None
-    try:
-        results_db_str = arguments.results_db
-    except AttributeError:
-        pass
+    # Absence is the ordinary case at both levels -- most programs define no
+    # --results-db argument, and most configurations name no index -- so each is
+    # asked for the key rather than made to raise for it, which would also hide an
+    # AttributeError raised by something other than the lookup.
+    results_db_str = vars(arguments).get('results_db')
     if results_db_str is None:
-        try:
-            results_db_str = config.environment.results_db
-        except AttributeError:
-            pass
+        results_db_str = config.environment.get('results_db')
     if results_db_str is None:
         results_db_str = os.getenv('NAV_RESULTS_DB')
     if results_db_str is None or results_db_str == RESULTS_DB_NONE:

--- a/src/spindoctor/results_index/__init__.py
+++ b/src/spindoctor/results_index/__init__.py
@@ -1,0 +1,46 @@
+"""spindoctor.results_index -- an optional, rebuildable database over the results tree.
+
+The navigation pipeline writes one ``_metadata.json`` document per image.  Programs
+downstream of navigation need only a few fields from each, and reading a whole
+document per image costs a round trip per image on a cloud root.  This package
+defines a database whose rows carry those fields, built by one pass over the tree,
+so a consumer answers its questions with a query instead of a walk.
+
+The index is derived and disposable.  The documents remain the authoritative
+record, no program requires an index, and deleting one costs nothing but the time
+to rebuild it.  It is also a snapshot: it reflects the tree as of the last ingest,
+with no staleness detection and no automatic refresh.
+
+Public API:
+
+    SCHEMA_VERSION   -- column-set version a database is stamped with
+    METADATA         -- SQLAlchemy MetaData holding every table
+    IMAGES           -- one row per image, keyed by (root_url, results_path_stub)
+    TECHNIQUES       -- per-technique results for an image
+    FEATURE_SOURCES  -- aggregated feature inventory for an image
+    SCHEMA_META      -- the single row stamping the schema version
+    INGEST_RUNS      -- one row per ingest pass over one root
+    open_index       -- the only opener, with the version gate
+"""
+
+from spindoctor.results_index.engine import open_index
+from spindoctor.results_index.schema import (
+    FEATURE_SOURCES,
+    IMAGES,
+    INGEST_RUNS,
+    METADATA,
+    SCHEMA_META,
+    SCHEMA_VERSION,
+    TECHNIQUES,
+)
+
+__all__ = [
+    'FEATURE_SOURCES',
+    'IMAGES',
+    'INGEST_RUNS',
+    'METADATA',
+    'SCHEMA_META',
+    'SCHEMA_VERSION',
+    'TECHNIQUES',
+    'open_index',
+]

--- a/src/spindoctor/results_index/engine.py
+++ b/src/spindoctor/results_index/engine.py
@@ -59,11 +59,27 @@ _SQLITE_NOT_A_DATABASE = 'SQLITE_NOTADB'
 _SQLITE_CANNOT_OPEN = 'SQLITE_CANTOPEN'
 """Result code SQLite gives for a path it cannot open, whatever the reason."""
 
+_SQLITE_LOCK_REFUSED_PREFIXES = ('SQLITE_BUSY', 'SQLITE_IOERR')
+"""Prefixes of the result codes that say the write lock itself was not granted.
+
+These are the codes a filesystem that cannot honor SQLite locking produces, and
+the only ones for which moving the index to a server is the remedy.
+"""
+
 _HIDDEN_PASSWORD = '***'
 """What a password is replaced by, matching what a parsed URL renders itself as."""
 
-_PASSWORD_IN_URL = re.compile(r'(?P<credentials>//[^/@]*?:)[^/@]*@')
-"""The password of a URL string that could not be parsed, as text."""
+_PASSWORD_IN_URL = re.compile(r'(?P<credentials>\A(?:[^/@]*:)?/{1,2}[^/@]*:)[^@]*@')
+"""The password of a URL string that could not be parsed, as text.
+
+A password is matched only where a URL keeps one: at the very start of the
+string, after an optional scheme and the one or two slashes that open the
+authority section, and after the colon that follows the user name.  The password
+itself runs to the ``@``, since a URL permits an unescaped ``/`` in one and a
+pattern that stopped at a separator would leak such a password whole.  Anchoring
+is what keeps a local path that merely happens to carry a colon and a later
+``@`` from being read as credentials and mangled.
+"""
 
 _SUPPORTED_URL_FORMS = (
     'A results index is either a sqlite: URL naming a local path, or a '
@@ -324,10 +340,16 @@ def _sqlite_probe_failure(
     """Return the refusal that fits what SQLite actually said.
 
     One exception type covers a file that is not a database, a path that cannot
-    be opened at all, and a lock a filesystem would not grant.  Only the last is
-    a reason to move the index to a server, and prescribing that for the others
-    sends an operator to rebuild a deployment over a directory they had not
-    created yet.
+    be opened at all, a lock a filesystem would not grant, and every other way a
+    database can refuse a write.  Only the lock is a reason to move the index to
+    a server, and prescribing that for the others sends an operator to rebuild a
+    deployment over a directory they had not created yet, or over a disk that is
+    merely full.  A code this classification does not know is reported as what
+    SQLite said, with no remedy invented for it.
+
+    Codes are matched by prefix, because SQLite refines several of them into
+    extended forms -- ``SQLITE_IOERR_WRITE``, ``SQLITE_CANTOPEN_ISDIR`` -- that
+    name the same cause more precisely.
 
     Parameters:
         exc: The driver exception the probe raised.
@@ -338,17 +360,22 @@ def _sqlite_probe_failure(
         The refusal to raise.
     """
     error_name = _sqlite_error_name(exc)
-    if error_name == _SQLITE_NOT_A_DATABASE:
+    if error_name.startswith(_SQLITE_NOT_A_DATABASE):
         return _IndexOpenError(
             f'{url}: this file is not a SQLite database ({exc.orig}). Check the path: an '
             f'index is built by sd_stats_ingest, and this file holds something else.'
         )
-    if error_name == _SQLITE_CANNOT_OPEN:
+    if error_name.startswith(_SQLITE_CANNOT_OPEN):
         return _IndexOpenError(_cannot_open_message(exc, url, path))
+    if error_name == '' or error_name.startswith(_SQLITE_LOCK_REFUSED_PREFIXES):
+        return _IndexOpenError(
+            f'{url}: could not take a SQLite write lock ({exc.orig}). A SQLite index '
+            f'must live on a local filesystem that honors locking; use a '
+            f'postgresql+psycopg: URL to share one index across machines.'
+        )
     return _IndexOpenError(
-        f'{url}: could not take a SQLite write lock ({exc.orig}). A SQLite index '
-        f'must live on a local filesystem that honors locking; use a '
-        f'postgresql+psycopg: URL to share one index across machines.'
+        f'{url}: SQLite refused {"this database" if path is None else path} '
+        f'({error_name}: {exc.orig}).'
     )
 
 
@@ -596,8 +623,9 @@ def open_index(url: str, *, create: bool = False) -> Engine:
     Raises:
         ValueError: If the URL cannot be parsed, carries a query string a SQLite
             index may not have, names a backend with no driver installed, or
-            names a server that will not accept the connection; if a SQLite
-            file's filesystem cannot honor write locking, or the file cannot be
+            names a server that will not accept the connection; if SQLite
+            refuses the file -- because its filesystem cannot honor write
+            locking, or for any other cause it reports -- or the file cannot be
             written and ``create`` is true; if ``create`` is false and the
             database or its ``schema_meta`` row does not exist; or if the
             stamped schema version is not the one this code reads.

--- a/src/spindoctor/results_index/engine.py
+++ b/src/spindoctor/results_index/engine.py
@@ -1,0 +1,236 @@
+"""Engine factory and version gate for the navigation results index.
+
+:func:`open_index` is the only opener.  It selects the backend from the
+connection URL, applies the SQLite settings the concurrency model depends on,
+and refuses a database whose schema version is not the one this code reads.
+
+Two URL forms are supported::
+
+    sqlite:////data/nav-results/index.sqlite3
+    postgresql+psycopg://user@host/spindoctor
+
+A ``sqlite:`` URL names a **local filesystem path**.  It is the one path in this
+system that is not a cloud-capable location: the C library opens it directly, so
+a network filesystem that cannot honor its locking is refused at open rather than
+corrupted later.  PostgreSQL is the option for sharing one index across machines,
+and its driver ships as an optional extra.
+"""
+
+import datetime
+from pathlib import Path
+from typing import Any
+
+import sqlalchemy
+from sqlalchemy.engine import URL, Engine
+
+from spindoctor.results_index.schema import METADATA, SCHEMA_META, SCHEMA_VERSION
+
+__all__ = ['SQLITE_BUSY_TIMEOUT_MS', 'open_index']
+
+SQLITE_BUSY_TIMEOUT_MS = 30000
+"""How long a SQLite connection waits for a competing writer before failing.
+
+Multiple local writer processes are an ordinary case: several ingest workers on
+one machine share one file.  With write-ahead logging and short transactions they
+only contend briefly, so waiting is nearly always the right answer.
+"""
+
+_SQLITE_MEMORY = ':memory:'
+
+_POSTGRES_BACKEND = 'postgresql'
+
+_SQLITE_BACKEND = 'sqlite'
+
+
+def _sqlite_on_connect(dbapi_connection: Any, connection_record: Any) -> None:
+    """Apply the per-connection SQLite settings the index depends on.
+
+    Registered as a dialect connect-time event rather than issued as a query, so
+    every connection the pool hands out carries them, including ones opened long
+    after :func:`open_index` returned.
+
+    Foreign keys are off by default in SQLite, and without them the cascade that
+    makes an image's child rows disappear with it does nothing.  Write-ahead
+    logging lets a reader and a writer work at the same time, and the busy
+    timeout lets two writers queue instead of failing.
+
+    Parameters:
+        dbapi_connection: The freshly opened DBAPI connection.
+        connection_record: The pool's bookkeeping record, which is not used.
+    """
+    cursor = dbapi_connection.cursor()
+    try:
+        cursor.execute('PRAGMA foreign_keys = ON')
+        cursor.execute(f'PRAGMA busy_timeout = {SQLITE_BUSY_TIMEOUT_MS}')
+        cursor.execute('PRAGMA journal_mode = WAL')
+    finally:
+        cursor.close()
+
+
+def _sqlite_path(parsed: URL) -> Path | None:
+    """Return the local filesystem path a SQLite URL names.
+
+    Parameters:
+        parsed: A parsed URL whose backend is SQLite.
+
+    Returns:
+        The path, or None when the URL names an in-memory database.
+    """
+    database = parsed.database
+    if database is None or database == '' or database == _SQLITE_MEMORY:
+        return None
+    # pathlib rather than FCPath: SQLite is opened by the C library, which knows
+    # nothing of cloud locations, so a SQLite URL is always a local path.
+    return Path(database)
+
+
+def _make_engine(parsed: URL, url: str) -> Engine:
+    """Create the engine for a parsed URL, or explain a missing driver.
+
+    Parameters:
+        parsed: The parsed connection URL.
+        url: The URL as the caller wrote it, for error messages.
+
+    Returns:
+        The engine, not yet connected.
+
+    Raises:
+        ValueError: If the URL names PostgreSQL and its driver is not installed.
+    """
+    try:
+        return sqlalchemy.create_engine(parsed)
+    except ModuleNotFoundError as exc:
+        if parsed.get_backend_name() != _POSTGRES_BACKEND:
+            raise
+        raise ValueError(
+            f'{url}: the PostgreSQL driver is not installed. Install it with '
+            f'"pip install rms-spindoctor[postgres]", or use a sqlite: URL.'
+        ) from exc
+
+
+def _probe_lockability(engine: Engine, url: str) -> None:
+    """Verify that the SQLite file's filesystem can honor a write lock.
+
+    Taking and releasing a write lock is the cheapest question that distinguishes
+    a filesystem SQLite can be trusted on from one where concurrent writers
+    silently corrupt the file.  Asking it at open turns a data-loss bug into a
+    startup error.
+
+    Parameters:
+        engine: The engine to probe.
+        url: The URL as the caller wrote it, for error messages.
+
+    Raises:
+        ValueError: If the write lock cannot be taken.
+    """
+    try:
+        with engine.connect() as connection:
+            connection.exec_driver_sql('BEGIN IMMEDIATE')
+            connection.exec_driver_sql('ROLLBACK')
+    except sqlalchemy.exc.DBAPIError as exc:
+        raise ValueError(
+            f'{url}: could not take a SQLite write lock ({exc.orig}). A SQLite index must '
+            f'live on a local filesystem that honors locking; use a postgresql+psycopg: '
+            f'URL to share one index across machines.'
+        ) from exc
+
+
+def _create_schema(engine: Engine) -> None:
+    """Create every missing table and stamp the database with its version.
+
+    Parameters:
+        engine: The engine to create the schema in.
+    """
+    METADATA.create_all(engine)
+    with engine.begin() as connection:
+        stamped = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).first()
+        if stamped is None:
+            connection.execute(
+                SCHEMA_META.insert().values(
+                    singleton=1,
+                    schema_version=SCHEMA_VERSION,
+                    created_utc=datetime.datetime.now(datetime.UTC).isoformat(),
+                )
+            )
+
+
+def _verify_schema_version(engine: Engine, url: str) -> None:
+    """Verify that the database is an index of the version this code reads.
+
+    Parameters:
+        engine: The engine to inspect.
+        url: The URL as the caller wrote it, for error messages.
+
+    Raises:
+        ValueError: If the database carries no ``schema_meta`` row, or one whose
+            version differs from
+            :data:`~spindoctor.results_index.schema.SCHEMA_VERSION`.
+    """
+    stamped = None
+    if sqlalchemy.inspect(engine).has_table(SCHEMA_META.name):
+        with engine.connect() as connection:
+            stamped = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).first()
+    if stamped is None:
+        raise ValueError(
+            f'{url}: this is not a results index (it has no schema_meta row). '
+            f'Run sd_stats_ingest first to build one.'
+        )
+    if stamped.schema_version != SCHEMA_VERSION:
+        raise ValueError(
+            f'{url}: results index schema version {stamped.schema_version} is not the '
+            f'version {SCHEMA_VERSION} this code reads. There are no migrations: delete '
+            f'the database and re-run sd_stats_ingest.'
+        )
+
+
+def open_index(url: str, *, create: bool = False) -> Engine:
+    """Open the results index named by a connection URL.
+
+    This is the only opener.  Every program that reads or writes the index goes
+    through it, so the version gate cannot be bypassed.
+
+    With ``create`` false -- every consumer -- a database that does not exist, or
+    that carries no ``schema_meta`` row, is an error naming ``sd_stats_ingest``.
+    A consumer pointed at a SQLite path that does not exist fails; it does not
+    leave an empty database behind.  With ``create`` true -- the ingest programs
+    -- missing tables are created and the version row is written.
+
+    Either way a database stamped with a different schema version is refused,
+    naming both versions, because the index carries no migrations and rebuilding
+    it is always available and always correct.
+
+    Parameters:
+        url: A ``sqlite:`` URL naming a local filesystem path, or a
+            ``postgresql+psycopg:`` URL naming a server.
+        create: Whether to create missing tables and the version row.
+
+    Returns:
+        An open engine.  SQLite engines have foreign keys, write-ahead logging
+        and a busy timeout applied to every connection.
+
+    Raises:
+        ValueError: If a PostgreSQL URL's driver is not installed; if a SQLite
+            file's filesystem cannot honor write locking; if ``create`` is false
+            and the database or its ``schema_meta`` row does not exist; or if the
+            stamped schema version is not the one this code reads.
+    """
+    parsed = sqlalchemy.engine.make_url(url)
+    backend = parsed.get_backend_name()
+    if backend == _SQLITE_BACKEND and not create:
+        path = _sqlite_path(parsed)
+        if path is not None and not path.exists():
+            raise ValueError(
+                f'{url}: there is no results index at {path}. Run sd_stats_ingest to build one.'
+            )
+    engine = _make_engine(parsed, url)
+    try:
+        if backend == _SQLITE_BACKEND:
+            sqlalchemy.event.listen(engine, 'connect', _sqlite_on_connect)
+            _probe_lockability(engine, url)
+        if create:
+            _create_schema(engine)
+        _verify_schema_version(engine, url)
+    except Exception:
+        engine.dispose()
+        raise
+    return engine

--- a/src/spindoctor/results_index/engine.py
+++ b/src/spindoctor/results_index/engine.py
@@ -4,7 +4,9 @@
 connection URL, applies the SQLite settings the concurrency model depends on,
 and refuses a database whose schema version is not the one this code reads.
 Every refusal is a ``ValueError`` naming the URL, including the ones a database
-driver raises, so a caller that reports failures catches one type.
+driver raises, so a caller that reports failures catches one type.  The URL is
+named with its password masked: these messages are written to run logs and
+handed to operators, and a database password belongs in neither.
 
 Two URL forms are supported::
 
@@ -21,6 +23,8 @@ ships as an optional extra.
 """
 
 import datetime
+import os
+import re
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -49,8 +53,17 @@ _SQLITE_BACKEND = 'sqlite'
 _SQLITE_READONLY_PREFIX = 'SQLITE_READONLY'
 """Prefix shared by every SQLite result code meaning "this database is read-only"."""
 
-_SQLITE_READ_ONLY_KEY = 'spindoctor_sqlite_read_only'
-"""Key under which a connection records whether SQLite will write its database."""
+_SQLITE_NOT_A_DATABASE = 'SQLITE_NOTADB'
+"""Result code SQLite gives for a file that is not a database at all."""
+
+_SQLITE_CANNOT_OPEN = 'SQLITE_CANTOPEN'
+"""Result code SQLite gives for a path it cannot open, whatever the reason."""
+
+_HIDDEN_PASSWORD = '***'
+"""What a password is replaced by, matching what a parsed URL renders itself as."""
+
+_PASSWORD_IN_URL = re.compile(r'(?P<credentials>//[^/@]*?:)[^/@]*@')
+"""The password of a URL string that could not be parsed, as text."""
 
 _SUPPORTED_URL_FORMS = (
     'A results index is either a sqlite: URL naming a local path, or a '
@@ -58,24 +71,84 @@ _SUPPORTED_URL_FORMS = (
 )
 
 
-def _sqlite_refused_a_write(exc: BaseException | None) -> bool:
-    """Report whether a SQLite error says the database itself will not be written.
+class _IndexOpenError(ValueError):
+    """A failure this module has already diagnosed.
 
-    SQLite distinguishes a database it may never write -- a read-only file, or one
-    whose directory it cannot create its side files in -- from a write it could
-    not take at this moment, such as a busy lock or an I/O error.  Every result
-    code in the first group shares one name prefix, and only that group describes
-    a database a reader can still use.
+    :func:`open_index` turns whatever escapes the builder into a ``ValueError``
+    naming the URL, and that catch-all cannot tell a message this module wrote
+    from a bare ``ValueError`` a driver raised deep inside itself.  Raising this
+    subclass from the failures diagnosed here keeps a complete message from
+    being wrapped in a second one, while a caller still catches the
+    ``ValueError`` the contract promises.
+    """
+
+
+def _masked_url(url: str) -> str:
+    """Return a URL string with any password in it replaced.
+
+    Used for a URL whose parsing is what failed, since an unparsed URL cannot
+    render itself.  Everything else survives, because naming the URL is what
+    tells a reader which of the resolution levels supplied the bad value.
 
     Parameters:
-        exc: The driver exception to classify, or None.
+        url: The URL as the caller wrote it.
 
     Returns:
-        True when the error says the database is read-only.
+        The URL with its password, if any, masked.
     """
-    return isinstance(exc, sqlite3.Error) and exc.sqlite_errorname.startswith(
-        _SQLITE_READONLY_PREFIX
-    )
+    return _PASSWORD_IN_URL.sub(rf'\g<credentials>{_HIDDEN_PASSWORD}@', url)
+
+
+def _display_url(url: str) -> str:
+    """Return the form of a URL that messages name it by.
+
+    Parameters:
+        url: The URL as the caller wrote it.
+
+    Returns:
+        The parsed URL rendered with its password hidden, or the text form
+        masked by pattern when the URL is one the parser rejects.
+    """
+    try:
+        return sqlalchemy.engine.make_url(url).render_as_string()
+    except Exception:
+        # Any failure at all: this runs while reporting another failure, and a
+        # display string is never worth raising over.
+        return _masked_url(url)
+
+
+def _sqlite_error_name(exc: BaseException) -> str:
+    """Return the SQLite result-code name a driver exception carries.
+
+    Parameters:
+        exc: The exception to read, either a driver exception or the wrapper
+            SQLAlchemy raised around one.
+
+    Returns:
+        The result-code name, or an empty string when the exception carries
+        none -- an exception from another driver, or one whose original is
+        absent, which the caller diagnoses generically rather than crashing on.
+    """
+    original = getattr(exc, 'orig', exc)
+    name = getattr(original, 'sqlite_errorname', '')
+    return name if isinstance(name, str) else ''
+
+
+def _is_read_only_error(error_name: str) -> bool:
+    """Report whether a SQLite result code says the database will not be written.
+
+    SQLite distinguishes a database it may never write -- a read-only file, or
+    one whose directory it cannot create its side files in -- from a write it
+    could not take at this moment, such as a busy lock or an I/O error.  Every
+    result code in the first group shares one name prefix.
+
+    Parameters:
+        error_name: The result-code name to classify, possibly empty.
+
+    Returns:
+        True when the code says the database is read-only.
+    """
+    return error_name.startswith(_SQLITE_READONLY_PREFIX)
 
 
 def _sqlite_on_connect(dbapi_connection: Any, connection_record: Any) -> None:
@@ -90,18 +163,19 @@ def _sqlite_on_connect(dbapi_connection: Any, connection_record: Any) -> None:
     logging lets a reader and a writer work at the same time, and the busy
     timeout lets two writers queue instead of failing.
 
-    Selecting the journal mode writes the database header, so a read-only
-    database refuses it.  That refusal is the cheapest read-only test there is,
-    so it is recorded on the connection rather than raised: a database SQLite
-    will never write has no writers for a journal to protect, and
-    :func:`open_index` decides from the record whether this caller needed one.
+    Selecting the journal mode writes the database header, so a database SQLite
+    will never write refuses it.  That refusal is tolerated rather than raised,
+    because such a database has no writers for a journal to protect and a
+    consumer reading an archived copy is a deployment this index supports.
+    Nothing is inferred from its absence: whether this caller needed a writable
+    database is asked of the filesystem instead, in
+    :func:`_require_writable_sqlite_database`.
 
     Parameters:
         dbapi_connection: The freshly opened DBAPI connection.
-        connection_record: The pool's bookkeeping record, which carries the
-            read-only answer back to the opener.
+        connection_record: The pool's bookkeeping record, which these settings
+            do not use.
     """
-    read_only = False
     cursor = dbapi_connection.cursor()
     try:
         cursor.execute('PRAGMA foreign_keys = ON')
@@ -109,12 +183,10 @@ def _sqlite_on_connect(dbapi_connection: Any, connection_record: Any) -> None:
         try:
             cursor.execute('PRAGMA journal_mode = WAL')
         except sqlite3.Error as exc:
-            if not _sqlite_refused_a_write(exc):
+            if not _is_read_only_error(_sqlite_error_name(exc)):
                 raise
-            read_only = True
     finally:
         cursor.close()
-    connection_record.info[_SQLITE_READ_ONLY_KEY] = read_only
 
 
 def _sqlite_path(parsed: URL) -> Path | None:
@@ -139,7 +211,7 @@ def _make_engine(parsed: URL, url: str) -> Engine:
 
     Parameters:
         parsed: The parsed connection URL.
-        url: The URL as the caller wrote it, for error messages.
+        url: The URL as messages name it.
 
     Returns:
         The engine, not yet connected.
@@ -153,65 +225,173 @@ def _make_engine(parsed: URL, url: str) -> Engine:
         return sqlalchemy.create_engine(parsed)
     except ModuleNotFoundError as exc:
         if parsed.get_backend_name() == _POSTGRES_BACKEND:
-            raise ValueError(
+            raise _IndexOpenError(
                 f'{url}: the PostgreSQL driver is not installed. Install it with '
                 f'"pip install rms-spindoctor[postgres]", or use a sqlite: URL.'
             ) from exc
-        raise ValueError(
+        raise _IndexOpenError(
             f'{url}: the driver this URL names is not installed ({exc}), and SpinDoctor '
             f'ships no driver for that backend. {_SUPPORTED_URL_FORMS}'
         ) from exc
 
 
-def _probe_sqlite_access(engine: Engine, url: str, *, create: bool) -> None:
-    """Verify that a SQLite database can be locked, and written when it must be.
+def _read_only_refusal(url: str) -> _IndexOpenError:
+    """Return the refusal for a database ingest is never going to be able to write.
+
+    Parameters:
+        url: The URL as messages name it.
+
+    Returns:
+        The refusal to raise.
+    """
+    return _IndexOpenError(
+        f'{url}: this SQLite database is read-only, and ingest has to write it. '
+        f'Ingest a writable copy; a consumer reads this one as it is.'
+    )
+
+
+def _require_writable_sqlite_database(path: Path, url: str) -> None:
+    """Verify that ingest can write the SQLite database a URL names.
+
+    The question is put to the filesystem rather than to SQLite, because SQLite
+    does not answer it at open.  A write-ahead-logged database -- the shape this
+    opener always leaves behind, having selected that journal mode -- accepts
+    both the journal-mode selection, which its header already records, and the
+    write lock ``BEGIN IMMEDIATE`` takes, on a file it will never write.  It
+    refuses only the first real write, in the middle of an ingest.
+
+    The directory is asked about too: SQLite writes the write-ahead log and its
+    shared-memory index beside the database, so a writable file in a directory
+    that permits nothing is a database ingest still cannot write.
+
+    Parameters:
+        path: The database file's path.
+        url: The URL as messages name it.
+
+    Raises:
+        ValueError: If the file exists and cannot be written, or if its
+            directory exists and cannot be written.
+    """
+    if path.exists() and not os.access(path, os.W_OK):
+        raise _read_only_refusal(url)
+    directory = path.parent
+    if directory.is_dir() and not os.access(directory, os.W_OK):
+        raise _IndexOpenError(
+            f'{url}: the directory {directory} is read-only, and ingest has to write the '
+            f'write-ahead log beside the database. Ingest into a writable directory; a '
+            f'consumer reads this one as it is.'
+        )
+
+
+def _cannot_open_message(exc: sqlalchemy.exc.DBAPIError, url: str, path: Path | None) -> str:
+    """Return the message for a path SQLite could not open.
+
+    One result code covers a directory that was never created, a path naming
+    something that is not a file, and a file this user may not touch.  Each has
+    a different remedy, and none of them is PostgreSQL.
+
+    Parameters:
+        exc: The driver exception, for what SQLite itself said.
+        url: The URL as messages name it.
+        path: The database file's path, or None for an in-memory database.
+
+    Returns:
+        The message.
+    """
+    if path is None:
+        return f'{url}: SQLite could not open this database ({exc.orig}).'
+    directory = path.parent
+    if not directory.is_dir():
+        return (
+            f'{url}: the directory {directory} does not exist, so SQLite cannot open a '
+            f'database in it. Create the directory first, or name a path inside one that '
+            f'already exists.'
+        )
+    if path.exists() and not path.is_file():
+        return (
+            f'{url}: {path} is not a file, so it cannot be a SQLite database. Name the '
+            f'database file itself.'
+        )
+    return (
+        f'{url}: SQLite could not open {path} ({exc.orig}). Check that this user may read '
+        f'and write both that file and its directory.'
+    )
+
+
+def _sqlite_probe_failure(
+    exc: sqlalchemy.exc.DBAPIError, url: str, path: Path | None
+) -> _IndexOpenError:
+    """Return the refusal that fits what SQLite actually said.
+
+    One exception type covers a file that is not a database, a path that cannot
+    be opened at all, and a lock a filesystem would not grant.  Only the last is
+    a reason to move the index to a server, and prescribing that for the others
+    sends an operator to rebuild a deployment over a directory they had not
+    created yet.
+
+    Parameters:
+        exc: The driver exception the probe raised.
+        url: The URL as messages name it.
+        path: The database file's path, or None for an in-memory database.
+
+    Returns:
+        The refusal to raise.
+    """
+    error_name = _sqlite_error_name(exc)
+    if error_name == _SQLITE_NOT_A_DATABASE:
+        return _IndexOpenError(
+            f'{url}: this file is not a SQLite database ({exc.orig}). Check the path: an '
+            f'index is built by sd_stats_ingest, and this file holds something else.'
+        )
+    if error_name == _SQLITE_CANNOT_OPEN:
+        return _IndexOpenError(_cannot_open_message(exc, url, path))
+    return _IndexOpenError(
+        f'{url}: could not take a SQLite write lock ({exc.orig}). A SQLite index '
+        f'must live on a local filesystem that honors locking; use a '
+        f'postgresql+psycopg: URL to share one index across machines.'
+    )
+
+
+def _probe_sqlite_access(engine: Engine, url: str, path: Path | None, *, create: bool) -> None:
+    """Verify that a SQLite database can be locked, and read when that is all it is.
 
     Taking and releasing a write lock is the cheapest question that distinguishes
     a filesystem SQLite can be trusted on from one where concurrent writers
     silently corrupt the file.  Asking it at open turns a data-loss bug into a
     startup error.
 
-    Read-only is a different answer, and the connection carries it: the journal
-    mode :func:`_sqlite_on_connect` selects writes the database header, so its
-    refusal is the read-only test, and the answer is recorded there.  The lock
-    cannot be asked instead, because a rollback-journal database SQLite will
-    never write still grants the reserved lock ``BEGIN IMMEDIATE`` asks for.
-
-    Read-only is refused only when the caller means to write.  A consumer reads,
-    and an archived or read-only-mounted index serves it, so the refusal an
-    ingest deserves would be a false one here.
+    A read-only database answers this question in two ways depending on its
+    journal mode, so neither answer is read as a verdict on whether the caller
+    may write: that is settled from the filesystem before the engine is built.
+    What matters here is that a read-only refusal is not reported as a locking
+    failure, and that a database whose write-ahead logging makes it unreadable
+    says so rather than failing a consumer's first query.  A refusal that
+    reaches an ingest here is still reported as read-only, since a network
+    filesystem answers the permission question from mode bits it does not
+    itself enforce, and SQLite is the one that finds out.
 
     Parameters:
         engine: The engine to probe.
-        url: The URL as the caller wrote it, for error messages.
+        url: The URL as messages name it.
+        path: The database file's path, or None for an in-memory database.
         create: Whether the caller intends to write the database.
 
     Raises:
-        ValueError: If the write lock cannot be taken; if the database is
-            read-only and the caller means to write it; or if it is read-only and
-            cannot be read either.
+        ValueError: If the write lock cannot be taken, if the path is not a
+            database this code can open, if the database is read-only and the
+            caller means to write it, or if it is read-only and cannot be read
+            either.
     """
-    read_only = False
     try:
         with engine.connect() as connection:
-            read_only = bool(connection.info.get(_SQLITE_READ_ONLY_KEY))
-            if not read_only:
-                connection.exec_driver_sql('BEGIN IMMEDIATE')
-                connection.exec_driver_sql('ROLLBACK')
+            connection.exec_driver_sql('BEGIN IMMEDIATE')
+            connection.exec_driver_sql('ROLLBACK')
     except sqlalchemy.exc.DBAPIError as exc:
-        raise ValueError(
-            f'{url}: could not take a SQLite write lock ({exc.orig}). A SQLite index '
-            f'must live on a local filesystem that honors locking; use a '
-            f'postgresql+psycopg: URL to share one index across machines.'
-        ) from exc
-    if not read_only:
-        return
-    if create:
-        raise ValueError(
-            f'{url}: this SQLite database is read-only, and ingest has to write it. '
-            f'Ingest a writable copy; a consumer reads this one as it is.'
-        )
-    _require_sqlite_readable(engine, url)
+        if not _is_read_only_error(_sqlite_error_name(exc)):
+            raise _sqlite_probe_failure(exc, url, path) from exc
+        if create:
+            raise _read_only_refusal(url) from exc
+        _require_sqlite_readable(engine, url)
 
 
 def _require_sqlite_readable(engine: Engine, url: str) -> None:
@@ -224,7 +404,7 @@ def _require_sqlite_readable(engine: Engine, url: str) -> None:
 
     Parameters:
         engine: The engine to probe.
-        url: The URL as the caller wrote it, for error messages.
+        url: The URL as messages name it.
 
     Raises:
         ValueError: If the database cannot be read.
@@ -233,7 +413,7 @@ def _require_sqlite_readable(engine: Engine, url: str) -> None:
         with engine.connect() as connection:
             connection.exec_driver_sql('SELECT count(*) FROM sqlite_master')
     except sqlalchemy.exc.DBAPIError as exc:
-        raise ValueError(
+        raise _IndexOpenError(
             f'{url}: this SQLite database is read-only and cannot be read either '
             f'({exc.orig}). A write-ahead-logged database creates an index file beside '
             f'itself even to be read, so copy it somewhere writable.'
@@ -283,7 +463,7 @@ def _verify_schema_version(stamped: int | None, url: str) -> None:
     Parameters:
         stamped: The version read from the database, or None when it carries no
             ``schema_meta`` row.
-        url: The URL as the caller wrote it, for error messages.
+        url: The URL as messages name it.
 
     Raises:
         ValueError: If the database carries no ``schema_meta`` row, or one whose
@@ -291,16 +471,51 @@ def _verify_schema_version(stamped: int | None, url: str) -> None:
             :data:`~spindoctor.results_index.schema.SCHEMA_VERSION`.
     """
     if stamped is None:
-        raise ValueError(
+        raise _IndexOpenError(
             f'{url}: this is not a results index (it has no schema_meta row). '
             f'Run sd_stats_ingest first to build one.'
         )
     if stamped != SCHEMA_VERSION:
-        raise ValueError(
+        raise _IndexOpenError(
             f'{url}: results index schema version {stamped} is not the '
             f'version {SCHEMA_VERSION} this code reads. There are no migrations: delete '
             f'the database and re-run sd_stats_ingest.'
         )
+
+
+def _sqlite_target(parsed: URL, url: str, *, create: bool) -> Path | None:
+    """Return the local path a SQLite URL names, refusing one it cannot serve.
+
+    Parameters:
+        parsed: The parsed connection URL, whose backend is SQLite.
+        url: The URL as messages name it.
+        create: Whether the caller intends to write the database.
+
+    Returns:
+        The database file's path, or None for an in-memory database.
+
+    Raises:
+        ValueError: If the URL carries a query string; if the caller means to
+            write a database the filesystem will not let it write; or if the
+            caller means to read one that is not there.
+    """
+    if parsed.query:
+        carried = ', '.join(sorted(parsed.query))
+        raise _IndexOpenError(
+            f'{url}: a SQLite index URL is a plain local path, and this one carries a '
+            f'query string ({carried}). The driver would open a file named after the '
+            f'query rather than the one named here, so name the file alone.'
+        )
+    path = _sqlite_path(parsed)
+    if path is None:
+        return None
+    if create:
+        _require_writable_sqlite_database(path, url)
+    elif not path.exists():
+        raise _IndexOpenError(
+            f'{url}: there is no results index at {path}. Run sd_stats_ingest to build one.'
+        )
+    return path
 
 
 def _build_engine(url: str, *, create: bool) -> Engine:
@@ -321,28 +536,24 @@ def _build_engine(url: str, *, create: bool) -> Engine:
         ValueError: For the failures this module diagnoses itself.
     """
     parsed = sqlalchemy.engine.make_url(url)
+    safe_url = parsed.render_as_string()
     backend = parsed.get_backend_name()
-    if backend == _SQLITE_BACKEND and not create:
-        path = _sqlite_path(parsed)
-        if path is not None and not path.exists():
-            raise ValueError(
-                f'{url}: there is no results index at {path}. Run sd_stats_ingest to build one.'
-            )
-    engine = _make_engine(parsed, url)
+    path = _sqlite_target(parsed, safe_url, create=create) if backend == _SQLITE_BACKEND else None
+    engine = _make_engine(parsed, safe_url)
     try:
         if backend == _SQLITE_BACKEND:
             sqlalchemy.event.listen(engine, 'connect', _sqlite_on_connect)
-            _probe_sqlite_access(engine, url, create=create)
+            _probe_sqlite_access(engine, safe_url, path, create=create)
         # The stamped version is checked before anything is written: creating
         # this version's tables inside a database stamped with another version
         # would leave a mixture no single version number describes.
         stamped = _stamped_version(engine)
         if stamped is not None:
-            _verify_schema_version(stamped, url)
+            _verify_schema_version(stamped, safe_url)
         if create:
             _create_schema(engine)
             stamped = _stamped_version(engine)
-        _verify_schema_version(stamped, url)
+        _verify_schema_version(stamped, safe_url)
     except Exception:
         engine.dispose()
         raise
@@ -359,7 +570,9 @@ def open_index(url: str, *, create: bool = False) -> Engine:
     that carries no ``schema_meta`` row, is an error naming ``sd_stats_ingest``.
     A consumer pointed at a SQLite path that does not exist fails; it does not
     leave an empty database behind.  With ``create`` true -- the ingest programs
-    -- missing tables are created and the version row is written.
+    -- missing tables are created and the version row is written, and a database
+    the filesystem will not let this user write is refused before anything is
+    opened.
 
     Either way a database stamped with a different schema version is refused,
     naming both versions, because the index carries no migrations and rebuilding
@@ -369,7 +582,7 @@ def open_index(url: str, *, create: bool = False) -> Engine:
     Every failure is a ``ValueError`` naming the URL, including the ones a
     database driver raises: a consumer that wants to report the cause rather than
     crash catches one type, and the driver's own exception is kept as the
-    ``__cause__``.
+    ``__cause__``.  The URL is named with its password masked.
 
     Parameters:
         url: A ``sqlite:`` URL naming a local filesystem path, or a
@@ -381,21 +594,27 @@ def open_index(url: str, *, create: bool = False) -> Engine:
         and a busy timeout applied to every connection.
 
     Raises:
-        ValueError: If the URL cannot be parsed, names a backend with no driver
-            installed, or names a server that will not accept the connection; if
-            a SQLite file's filesystem cannot honor write locking, or the file is
-            read-only and ``create`` is true; if ``create`` is false and the
-            database or its ``schema_meta`` row does not exist; or if the stamped
-            schema version is not the one this code reads.
+        ValueError: If the URL cannot be parsed, carries a query string a SQLite
+            index may not have, names a backend with no driver installed, or
+            names a server that will not accept the connection; if a SQLite
+            file's filesystem cannot honor write locking, or the file cannot be
+            written and ``create`` is true; if ``create`` is false and the
+            database or its ``schema_meta`` row does not exist; or if the
+            stamped schema version is not the one this code reads.
     """
     try:
         return _build_engine(url, create=create)
+    except _IndexOpenError:
+        raise
     except sqlalchemy.exc.NoSuchModuleError as exc:
         raise ValueError(
-            f'{url}: there is no database driver for this URL scheme ({exc}). '
+            f'{_display_url(url)}: there is no database driver for this URL scheme ({exc}). '
             f'{_SUPPORTED_URL_FORMS}'
         ) from exc
-    except sqlalchemy.exc.SQLAlchemyError as exc:
+    except Exception as exc:
+        # Everything else, not only SQLAlchemy's own exceptions: a dialect
+        # reports a malformed port or an uncoercible connect argument as a bare
+        # ValueError naming neither the URL nor the setting that supplied it.
         raise ValueError(
-            f'{url}: could not open the results index ({type(exc).__name__}: {exc}).'
+            f'{_display_url(url)}: could not open the results index ({type(exc).__name__}: {exc}).'
         ) from exc

--- a/src/spindoctor/results_index/engine.py
+++ b/src/spindoctor/results_index/engine.py
@@ -3,6 +3,8 @@
 :func:`open_index` is the only opener.  It selects the backend from the
 connection URL, applies the SQLite settings the concurrency model depends on,
 and refuses a database whose schema version is not the one this code reads.
+Every refusal is a ``ValueError`` naming the URL, including the ones a database
+driver raises, so a caller that reports failures catches one type.
 
 Two URL forms are supported::
 
@@ -12,11 +14,14 @@ Two URL forms are supported::
 A ``sqlite:`` URL names a **local filesystem path**.  It is the one path in this
 system that is not a cloud-capable location: the C library opens it directly, so
 a network filesystem that cannot honor its locking is refused at open rather than
-corrupted later.  PostgreSQL is the option for sharing one index across machines,
-and its driver ships as an optional extra.
+corrupted later.  A read-only database is not that case and is not refused for
+it: a consumer reads one, and only an opener meaning to write is turned away.
+PostgreSQL is the option for sharing one index across machines, and its driver
+ships as an optional extra.
 """
 
 import datetime
+import sqlite3
 from pathlib import Path
 from typing import Any
 
@@ -41,6 +46,37 @@ _POSTGRES_BACKEND = 'postgresql'
 
 _SQLITE_BACKEND = 'sqlite'
 
+_SQLITE_READONLY_PREFIX = 'SQLITE_READONLY'
+"""Prefix shared by every SQLite result code meaning "this database is read-only"."""
+
+_SQLITE_READ_ONLY_KEY = 'spindoctor_sqlite_read_only'
+"""Key under which a connection records whether SQLite will write its database."""
+
+_SUPPORTED_URL_FORMS = (
+    'A results index is either a sqlite: URL naming a local path, or a '
+    'postgresql+psycopg: URL naming a server.'
+)
+
+
+def _sqlite_refused_a_write(exc: BaseException | None) -> bool:
+    """Report whether a SQLite error says the database itself will not be written.
+
+    SQLite distinguishes a database it may never write -- a read-only file, or one
+    whose directory it cannot create its side files in -- from a write it could
+    not take at this moment, such as a busy lock or an I/O error.  Every result
+    code in the first group shares one name prefix, and only that group describes
+    a database a reader can still use.
+
+    Parameters:
+        exc: The driver exception to classify, or None.
+
+    Returns:
+        True when the error says the database is read-only.
+    """
+    return isinstance(exc, sqlite3.Error) and exc.sqlite_errorname.startswith(
+        _SQLITE_READONLY_PREFIX
+    )
+
 
 def _sqlite_on_connect(dbapi_connection: Any, connection_record: Any) -> None:
     """Apply the per-connection SQLite settings the index depends on.
@@ -54,17 +90,31 @@ def _sqlite_on_connect(dbapi_connection: Any, connection_record: Any) -> None:
     logging lets a reader and a writer work at the same time, and the busy
     timeout lets two writers queue instead of failing.
 
+    Selecting the journal mode writes the database header, so a read-only
+    database refuses it.  That refusal is the cheapest read-only test there is,
+    so it is recorded on the connection rather than raised: a database SQLite
+    will never write has no writers for a journal to protect, and
+    :func:`open_index` decides from the record whether this caller needed one.
+
     Parameters:
         dbapi_connection: The freshly opened DBAPI connection.
-        connection_record: The pool's bookkeeping record, which is not used.
+        connection_record: The pool's bookkeeping record, which carries the
+            read-only answer back to the opener.
     """
+    read_only = False
     cursor = dbapi_connection.cursor()
     try:
         cursor.execute('PRAGMA foreign_keys = ON')
         cursor.execute(f'PRAGMA busy_timeout = {SQLITE_BUSY_TIMEOUT_MS}')
-        cursor.execute('PRAGMA journal_mode = WAL')
+        try:
+            cursor.execute('PRAGMA journal_mode = WAL')
+        except sqlite3.Error as exc:
+            if not _sqlite_refused_a_write(exc):
+                raise
+            read_only = True
     finally:
         cursor.close()
+    connection_record.info[_SQLITE_READ_ONLY_KEY] = read_only
 
 
 def _sqlite_path(parsed: URL) -> Path | None:
@@ -95,43 +145,98 @@ def _make_engine(parsed: URL, url: str) -> Engine:
         The engine, not yet connected.
 
     Raises:
-        ValueError: If the URL names PostgreSQL and its driver is not installed.
+        ValueError: If the URL names a backend whose driver is not installed,
+            distinguishing PostgreSQL -- whose driver SpinDoctor ships as an
+            extra -- from a backend it does not support at all.
     """
     try:
         return sqlalchemy.create_engine(parsed)
     except ModuleNotFoundError as exc:
-        if parsed.get_backend_name() != _POSTGRES_BACKEND:
-            raise
+        if parsed.get_backend_name() == _POSTGRES_BACKEND:
+            raise ValueError(
+                f'{url}: the PostgreSQL driver is not installed. Install it with '
+                f'"pip install rms-spindoctor[postgres]", or use a sqlite: URL.'
+            ) from exc
         raise ValueError(
-            f'{url}: the PostgreSQL driver is not installed. Install it with '
-            f'"pip install rms-spindoctor[postgres]", or use a sqlite: URL.'
+            f'{url}: the driver this URL names is not installed ({exc}), and SpinDoctor '
+            f'ships no driver for that backend. {_SUPPORTED_URL_FORMS}'
         ) from exc
 
 
-def _probe_lockability(engine: Engine, url: str) -> None:
-    """Verify that the SQLite file's filesystem can honor a write lock.
+def _probe_sqlite_access(engine: Engine, url: str, *, create: bool) -> None:
+    """Verify that a SQLite database can be locked, and written when it must be.
 
     Taking and releasing a write lock is the cheapest question that distinguishes
     a filesystem SQLite can be trusted on from one where concurrent writers
     silently corrupt the file.  Asking it at open turns a data-loss bug into a
     startup error.
 
+    Read-only is a different answer, and the connection carries it: the journal
+    mode :func:`_sqlite_on_connect` selects writes the database header, so its
+    refusal is the read-only test, and the answer is recorded there.  The lock
+    cannot be asked instead, because a rollback-journal database SQLite will
+    never write still grants the reserved lock ``BEGIN IMMEDIATE`` asks for.
+
+    Read-only is refused only when the caller means to write.  A consumer reads,
+    and an archived or read-only-mounted index serves it, so the refusal an
+    ingest deserves would be a false one here.
+
+    Parameters:
+        engine: The engine to probe.
+        url: The URL as the caller wrote it, for error messages.
+        create: Whether the caller intends to write the database.
+
+    Raises:
+        ValueError: If the write lock cannot be taken; if the database is
+            read-only and the caller means to write it; or if it is read-only and
+            cannot be read either.
+    """
+    read_only = False
+    try:
+        with engine.connect() as connection:
+            read_only = bool(connection.info.get(_SQLITE_READ_ONLY_KEY))
+            if not read_only:
+                connection.exec_driver_sql('BEGIN IMMEDIATE')
+                connection.exec_driver_sql('ROLLBACK')
+    except sqlalchemy.exc.DBAPIError as exc:
+        raise ValueError(
+            f'{url}: could not take a SQLite write lock ({exc.orig}). A SQLite index '
+            f'must live on a local filesystem that honors locking; use a '
+            f'postgresql+psycopg: URL to share one index across machines.'
+        ) from exc
+    if not read_only:
+        return
+    if create:
+        raise ValueError(
+            f'{url}: this SQLite database is read-only, and ingest has to write it. '
+            f'Ingest a writable copy; a consumer reads this one as it is.'
+        )
+    _require_sqlite_readable(engine, url)
+
+
+def _require_sqlite_readable(engine: Engine, url: str) -> None:
+    """Verify that a read-only SQLite database can at least be read.
+
+    SQLite reads a write-ahead-logged database through a shared-memory index it
+    creates beside the file, so such a database on a filesystem that permits no
+    writes at all cannot be read either.  Saying that here beats letting the
+    first query fail with a write error on what the caller asked to be a read.
+
     Parameters:
         engine: The engine to probe.
         url: The URL as the caller wrote it, for error messages.
 
     Raises:
-        ValueError: If the write lock cannot be taken.
+        ValueError: If the database cannot be read.
     """
     try:
         with engine.connect() as connection:
-            connection.exec_driver_sql('BEGIN IMMEDIATE')
-            connection.exec_driver_sql('ROLLBACK')
+            connection.exec_driver_sql('SELECT count(*) FROM sqlite_master')
     except sqlalchemy.exc.DBAPIError as exc:
         raise ValueError(
-            f'{url}: could not take a SQLite write lock ({exc.orig}). A SQLite index must '
-            f'live on a local filesystem that honors locking; use a postgresql+psycopg: '
-            f'URL to share one index across machines.'
+            f'{url}: this SQLite database is read-only and cannot be read either '
+            f'({exc.orig}). A write-ahead-logged database creates an index file beside '
+            f'itself even to be read, so copy it somewhere writable.'
         ) from exc
 
 
@@ -154,11 +259,30 @@ def _create_schema(engine: Engine) -> None:
             )
 
 
-def _verify_schema_version(engine: Engine, url: str) -> None:
-    """Verify that the database is an index of the version this code reads.
+def _stamped_version(engine: Engine) -> int | None:
+    """Return the schema version the database is stamped with.
 
     Parameters:
         engine: The engine to inspect.
+
+    Returns:
+        The stamped version, or None when the database carries no
+        ``schema_meta`` row -- because the table is absent, or because it is
+        empty after an interrupted creation.
+    """
+    if not sqlalchemy.inspect(engine).has_table(SCHEMA_META.name):
+        return None
+    with engine.connect() as connection:
+        row = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).first()
+    return None if row is None else int(row.schema_version)
+
+
+def _verify_schema_version(stamped: int | None, url: str) -> None:
+    """Verify that a stamped version is the one this code reads.
+
+    Parameters:
+        stamped: The version read from the database, or None when it carries no
+            ``schema_meta`` row.
         url: The URL as the caller wrote it, for error messages.
 
     Raises:
@@ -166,21 +290,63 @@ def _verify_schema_version(engine: Engine, url: str) -> None:
             version differs from
             :data:`~spindoctor.results_index.schema.SCHEMA_VERSION`.
     """
-    stamped = None
-    if sqlalchemy.inspect(engine).has_table(SCHEMA_META.name):
-        with engine.connect() as connection:
-            stamped = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).first()
     if stamped is None:
         raise ValueError(
             f'{url}: this is not a results index (it has no schema_meta row). '
             f'Run sd_stats_ingest first to build one.'
         )
-    if stamped.schema_version != SCHEMA_VERSION:
+    if stamped != SCHEMA_VERSION:
         raise ValueError(
-            f'{url}: results index schema version {stamped.schema_version} is not the '
+            f'{url}: results index schema version {stamped} is not the '
             f'version {SCHEMA_VERSION} this code reads. There are no migrations: delete '
             f'the database and re-run sd_stats_ingest.'
         )
+
+
+def _build_engine(url: str, *, create: bool) -> Engine:
+    """Open the index, letting a driver's own exceptions escape untranslated.
+
+    :func:`open_index` wraps this so that every escape becomes a ``ValueError``.
+    The separation keeps the translation in one place rather than repeated around
+    each call a driver can fail inside.
+
+    Parameters:
+        url: The connection URL.
+        create: Whether to create missing tables and the version row.
+
+    Returns:
+        An open engine.
+
+    Raises:
+        ValueError: For the failures this module diagnoses itself.
+    """
+    parsed = sqlalchemy.engine.make_url(url)
+    backend = parsed.get_backend_name()
+    if backend == _SQLITE_BACKEND and not create:
+        path = _sqlite_path(parsed)
+        if path is not None and not path.exists():
+            raise ValueError(
+                f'{url}: there is no results index at {path}. Run sd_stats_ingest to build one.'
+            )
+    engine = _make_engine(parsed, url)
+    try:
+        if backend == _SQLITE_BACKEND:
+            sqlalchemy.event.listen(engine, 'connect', _sqlite_on_connect)
+            _probe_sqlite_access(engine, url, create=create)
+        # The stamped version is checked before anything is written: creating
+        # this version's tables inside a database stamped with another version
+        # would leave a mixture no single version number describes.
+        stamped = _stamped_version(engine)
+        if stamped is not None:
+            _verify_schema_version(stamped, url)
+        if create:
+            _create_schema(engine)
+            stamped = _stamped_version(engine)
+        _verify_schema_version(stamped, url)
+    except Exception:
+        engine.dispose()
+        raise
+    return engine
 
 
 def open_index(url: str, *, create: bool = False) -> Engine:
@@ -197,7 +363,13 @@ def open_index(url: str, *, create: bool = False) -> Engine:
 
     Either way a database stamped with a different schema version is refused,
     naming both versions, because the index carries no migrations and rebuilding
-    it is always available and always correct.
+    it is always available and always correct.  Nothing is written to a database
+    whose version is refused.
+
+    Every failure is a ``ValueError`` naming the URL, including the ones a
+    database driver raises: a consumer that wants to report the cause rather than
+    crash catches one type, and the driver's own exception is kept as the
+    ``__cause__``.
 
     Parameters:
         url: A ``sqlite:`` URL naming a local filesystem path, or a
@@ -209,28 +381,21 @@ def open_index(url: str, *, create: bool = False) -> Engine:
         and a busy timeout applied to every connection.
 
     Raises:
-        ValueError: If a PostgreSQL URL's driver is not installed; if a SQLite
-            file's filesystem cannot honor write locking; if ``create`` is false
-            and the database or its ``schema_meta`` row does not exist; or if the
-            stamped schema version is not the one this code reads.
+        ValueError: If the URL cannot be parsed, names a backend with no driver
+            installed, or names a server that will not accept the connection; if
+            a SQLite file's filesystem cannot honor write locking, or the file is
+            read-only and ``create`` is true; if ``create`` is false and the
+            database or its ``schema_meta`` row does not exist; or if the stamped
+            schema version is not the one this code reads.
     """
-    parsed = sqlalchemy.engine.make_url(url)
-    backend = parsed.get_backend_name()
-    if backend == _SQLITE_BACKEND and not create:
-        path = _sqlite_path(parsed)
-        if path is not None and not path.exists():
-            raise ValueError(
-                f'{url}: there is no results index at {path}. Run sd_stats_ingest to build one.'
-            )
-    engine = _make_engine(parsed, url)
     try:
-        if backend == _SQLITE_BACKEND:
-            sqlalchemy.event.listen(engine, 'connect', _sqlite_on_connect)
-            _probe_lockability(engine, url)
-        if create:
-            _create_schema(engine)
-        _verify_schema_version(engine, url)
-    except Exception:
-        engine.dispose()
-        raise
-    return engine
+        return _build_engine(url, create=create)
+    except sqlalchemy.exc.NoSuchModuleError as exc:
+        raise ValueError(
+            f'{url}: there is no database driver for this URL scheme ({exc}). '
+            f'{_SUPPORTED_URL_FORMS}'
+        ) from exc
+    except sqlalchemy.exc.SQLAlchemyError as exc:
+        raise ValueError(
+            f'{url}: could not open the results index ({type(exc).__name__}: {exc}).'
+        ) from exc

--- a/src/spindoctor/results_index/engine.py
+++ b/src/spindoctor/results_index/engine.py
@@ -24,7 +24,6 @@ ships as an optional extra.
 
 import datetime
 import os
-import re
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -69,18 +68,6 @@ the only ones for which moving the index to a server is the remedy.
 _HIDDEN_PASSWORD = '***'
 """What a password is replaced by, matching what a parsed URL renders itself as."""
 
-_PASSWORD_IN_URL = re.compile(r'(?P<credentials>\A(?:[^/@]*:)?/{1,2}[^/@]*:)[^@]*@')
-"""The password of a URL string that could not be parsed, as text.
-
-A password is matched only where a URL keeps one: at the very start of the
-string, after an optional scheme and the one or two slashes that open the
-authority section, and after the colon that follows the user name.  The password
-itself runs to the ``@``, since a URL permits an unescaped ``/`` in one and a
-pattern that stopped at a separator would leak such a password whole.  Anchoring
-is what keeps a local path that merely happens to carry a colon and a later
-``@`` from being read as credentials and mangled.
-"""
-
 _SUPPORTED_URL_FORMS = (
     'A results index is either a sqlite: URL naming a local path, or a '
     'postgresql+psycopg: URL naming a server.'
@@ -99,12 +86,106 @@ class _IndexOpenError(ValueError):
     """
 
 
+def _scheme_base(url: str) -> str:
+    """Return the backend a URL's scheme names, whatever driver it asks for.
+
+    Parameters:
+        url: The URL as the caller wrote it.
+
+    Returns:
+        The scheme with any ``+driver`` suffix and surrounding space removed and
+        lower cased, or an empty string when the string carries no scheme.
+    """
+    scheme, separator, _remainder = url.partition(':')
+    if not separator:
+        return ''
+    return scheme.strip().split('+', 1)[0].lower()
+
+
+def _authority_start(url: str) -> int:
+    """Return the index at which a URL's authority section begins.
+
+    The authority opens after the slashes that follow the scheme, and a URL
+    written with one slash instead of two is the shape a hand-edited setting
+    arrives in.
+
+    Parameters:
+        url: The URL as the caller wrote it.
+
+    Returns:
+        The index just past those slashes, or -1 when the string carries no
+        slash at all and so has no authority to read.
+    """
+    slash = url.find('/')
+    if slash < 0:
+        return -1
+    return slash + 2 if url[slash + 1 : slash + 2] == '/' else slash + 1
+
+
+def _is_a_port(text: str) -> bool:
+    """Whether the text after a colon in an authority is a port and not a password.
+
+    Parameters:
+        text: The characters between the colon and the slash that follows it.
+
+    Returns:
+        True when every character is a digit, an empty run included.
+    """
+    return text == '' or text.isdigit()
+
+
+def _password_span(url: str) -> tuple[int, int] | None:
+    """Return the half-open range of characters holding a URL's password.
+
+    The rule is the one a URL's own grammar states.  The user name runs from the
+    start of the authority to the first ``:`` or ``/``; only a ``:`` introduces a
+    password, and that password runs to the first ``@`` after it, since an ``@``
+    is what ends the credentials.  A ``/`` inside the span is therefore part of
+    the password rather than the end of the authority, which is what reaches a
+    password written with an unescaped slash.
+
+    One shape is genuinely ambiguous: ``host:5432/path@name`` reads equally as a
+    host with a port and a path, or as a user name with a slashed password.  The
+    digits decide it, because a port is digits and a password almost never is,
+    and mangling a host, a port and half a database name costs the very
+    identification these messages exist for.
+
+    Parameters:
+        url: The URL as the caller wrote it.
+
+    Returns:
+        The first and last-plus-one index of the password, or None when the URL
+        carries no password to hide.
+    """
+    start = _authority_start(url)
+    if start < 0:
+        return None
+    colon = url.find(':', start)
+    if colon < 0:
+        return None
+    slash = url.find('/', start)
+    if 0 <= slash < colon:
+        # The authority ended before any colon, so what follows is a path.
+        return None
+    at = url.find('@', colon)
+    if at < 0:
+        return None
+    if 0 <= slash < at and _is_a_port(url[colon + 1 : slash]):
+        return None
+    return colon + 1, at
+
+
 def _masked_url(url: str) -> str:
     """Return a URL string with any password in it replaced.
 
     Used for a URL whose parsing is what failed, since an unparsed URL cannot
-    render itself.  Everything else survives, because naming the URL is what
-    tells a reader which of the resolution levels supplied the bad value.
+    render itself.  Everything outside the password survives, because naming the
+    URL is what tells a reader which of the resolution levels supplied the bad
+    value.
+
+    A ``sqlite:`` URL is returned exactly as it came.  It names a local
+    filesystem path, which has no credentials at all, and a path is free to carry
+    the colons and at-signs that would otherwise read as credentials.
 
     Parameters:
         url: The URL as the caller wrote it.
@@ -112,7 +193,13 @@ def _masked_url(url: str) -> str:
     Returns:
         The URL with its password, if any, masked.
     """
-    return _PASSWORD_IN_URL.sub(rf'\g<credentials>{_HIDDEN_PASSWORD}@', url)
+    if _scheme_base(url) == _SQLITE_BACKEND:
+        return url
+    span = _password_span(url)
+    if span is None:
+        return url
+    first, past_last = span
+    return f'{url[:first]}{_HIDDEN_PASSWORD}{url[past_last:]}'
 
 
 def _display_url(url: str) -> str:
@@ -123,7 +210,7 @@ def _display_url(url: str) -> str:
 
     Returns:
         The parsed URL rendered with its password hidden, or the text form
-        masked by pattern when the URL is one the parser rejects.
+        masked structurally when the URL is one the parser rejects.
     """
     try:
         return sqlalchemy.engine.make_url(url).render_as_string()
@@ -580,6 +667,9 @@ def _build_engine(url: str, *, create: bool) -> Engine:
         if create:
             _create_schema(engine)
             stamped = _stamped_version(engine)
+        # The gate a non-creating open is refused by.  Reached after the create
+        # branch too, where it re-reads the row that branch has just written and
+        # so cannot fail; no test can observe that call refusing anything.
         _verify_schema_version(stamped, safe_url)
     except Exception:
         engine.dispose()
@@ -603,8 +693,8 @@ def open_index(url: str, *, create: bool = False) -> Engine:
 
     Either way a database stamped with a different schema version is refused,
     naming both versions, because the index carries no migrations and rebuilding
-    it is always available and always correct.  Nothing is written to a database
-    whose version is refused.
+    it is always available and always correct.  No table is created and no row is
+    written in a database whose version is refused.
 
     Every failure is a ``ValueError`` naming the URL, including the ones a
     database driver raises: a consumer that wants to report the cause rather than

--- a/src/spindoctor/results_index/schema.py
+++ b/src/spindoctor/results_index/schema.py
@@ -17,9 +17,15 @@ identifier unique across volumes, because two volumes may hold images with the
 same basename.  ``root_url`` is the ingested results root in normalized form, so
 one database can serve several roots without a consumer seeing another root's
 rows.  The child tables ``techniques`` and ``feature_sources`` key on the same
-pair and cascade on delete, so re-ingesting an image replaces its children.
-``results_path_stub`` additionally carries a non-unique index of its own, for
-lookups that already know the root.
+pair and cascade on delete, so re-ingesting an image replaces its children.  Each
+of them also declares the tuple that identifies one of its rows -- the technique
+name, or the feature type and its source -- unique within an image, so a repeated
+or retried insert is refused rather than silently doubling every count read from
+it.
+
+``results_path_stub`` carries a non-unique index of its own, for lookups that
+already know the root, and ``image_date`` and ``instrument`` carry one each,
+because the report groups and filters on both across a whole root.
 
 Types
 -----
@@ -55,11 +61,12 @@ __all__ = [
     'TECHNIQUES',
 ]
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 """Column-set version of the index.
 
-Incremented by any change to the column set of any table.  A database stamped
-with a different version is refused rather than migrated.
+Incremented by any change to the column set of any table, and by any change to
+the constraints over it.  A database stamped with a different version is refused
+rather than migrated.
 """
 
 # TEXT on SQLite, jsonb on PostgreSQL.  jsonb is the type PostgreSQL's array and
@@ -200,7 +207,14 @@ TECHNIQUES = sqlalchemy.Table(
     sqlalchemy.Column('source_names', _JSON),
     sqlalchemy.Column('diagnostics', _JSON),
     _image_foreign_key(),
-    sqlalchemy.Index('ix_techniques_image', 'root_url', 'results_path_stub'),
+    # One row per technique per image, enforced rather than assumed: a technique
+    # reports once for an image, and a retried or duplicated ingest that inserted
+    # a second row would change every count and average read from this table
+    # without replacing anything.  The constraint's index also serves the lookup
+    # by image, whose columns are its leading pair.
+    sqlalchemy.UniqueConstraint(
+        'root_url', 'results_path_stub', 'technique_name', name='uq_techniques_image_technique'
+    ),
 )
 """One row per technique that produced a result for an image."""
 
@@ -214,7 +228,17 @@ FEATURE_SOURCES = sqlalchemy.Table(
     sqlalchemy.Column('n_features', sqlalchemy.Integer, nullable=False),
     sqlalchemy.Column('n_gated', sqlalchemy.Integer, nullable=False),
     _image_foreign_key(),
-    sqlalchemy.Index('ix_feature_sources_image', 'root_url', 'results_path_stub'),
+    # The inventory is aggregated by exactly this tuple, so a second row for one
+    # of them is a contradiction rather than more detail.  As on techniques, the
+    # constraint's index leads with the image key and serves the lookup by image.
+    sqlalchemy.UniqueConstraint(
+        'root_url',
+        'results_path_stub',
+        'feature_type',
+        'source_model',
+        'source_name',
+        name='uq_feature_sources_image_source',
+    ),
 )
 """Feature inventory of an image, aggregated per feature type and source."""
 

--- a/src/spindoctor/results_index/schema.py
+++ b/src/spindoctor/results_index/schema.py
@@ -1,0 +1,250 @@
+"""SQLAlchemy Core schema for the navigation results index.
+
+The index is a database whose rows are derived from the navigation results tree
+by a separate ingest step.  It is not authoritative: the per-image
+``_metadata.json`` documents are, and the index can be deleted and rebuilt from
+them at any time.  Consumers that only need a few fields per image read one row
+instead of one document.
+
+Keying
+------
+
+The primary key of ``images`` is the pair ``(root_url, results_path_stub)``.
+``results_path_stub`` is the volume-and-filespec fragment every consumer already
+uses to address a result (for example
+``COISS_2001/data/1294561143_1295221348/N1294561202_1_CALIB``); it is the only
+identifier unique across volumes, because two volumes may hold images with the
+same basename.  ``root_url`` is the ingested results root in normalized form, so
+one database can serve several roots without a consumer seeing another root's
+rows.  The child tables ``techniques`` and ``feature_sources`` key on the same
+pair and cascade on delete, so re-ingesting an image replaces its children.
+``results_path_stub`` additionally carries a non-unique index of its own, for
+lookups that already know the root.
+
+Types
+-----
+
+Every pixel, ET, covariance and sigma column is ``Double`` rather than ``Float``,
+because a dialect is free to map ``Float`` to single precision and the stored
+offset must round-trip the document's value bit for bit.  Booleans are
+``Boolean``, never an integer flag, so that a PostgreSQL backend rejects integer
+arithmetic on them.  Structured values are ``JSON``, which is TEXT on SQLite and
+``jsonb`` on PostgreSQL.
+
+Versioning
+----------
+
+``schema_meta`` holds a single row carrying :data:`SCHEMA_VERSION`.  There are no
+migrations: ingest is cheap relative to navigation and entirely reproducible from
+the tree, so any change to the column set increments the version and the operator
+deletes the database and re-ingests.
+"""
+
+from typing import Any
+
+import sqlalchemy
+from sqlalchemy.dialects import postgresql
+
+__all__ = [
+    'FEATURE_SOURCES',
+    'IMAGES',
+    'INGEST_RUNS',
+    'METADATA',
+    'SCHEMA_META',
+    'SCHEMA_VERSION',
+    'TECHNIQUES',
+]
+
+SCHEMA_VERSION = 1
+"""Column-set version of the index.
+
+Incremented by any change to the column set of any table.  A database stamped
+with a different version is refused rather than migrated.
+"""
+
+# TEXT on SQLite, jsonb on PostgreSQL.  jsonb is the type PostgreSQL's array and
+# object accessors operate on, so a direct-SQL query against the index can reach
+# inside these values without a cast.
+_JSON = sqlalchemy.JSON().with_variant(postgresql.JSONB(), 'postgresql')
+
+METADATA = sqlalchemy.MetaData()
+"""Container for every table of the index; the source of all DDL."""
+
+
+def _image_key_columns() -> tuple[sqlalchemy.Column[Any], sqlalchemy.Column[Any]]:
+    """Return a fresh pair of columns naming the image a child row belongs to.
+
+    A ``Column`` object binds to exactly one table, so each child table needs its
+    own pair rather than a shared constant.
+
+    Returns:
+        The ``root_url`` and ``results_path_stub`` columns, both NOT NULL.
+    """
+    return (
+        sqlalchemy.Column('root_url', sqlalchemy.Text, nullable=False),
+        sqlalchemy.Column('results_path_stub', sqlalchemy.Text, nullable=False),
+    )
+
+
+def _image_foreign_key() -> sqlalchemy.ForeignKeyConstraint:
+    """Return a fresh composite foreign key from a child table to ``images``.
+
+    Deleting an image row deletes its children, which is what makes the
+    delete-then-insert upsert of one image atomic and complete.
+
+    Returns:
+        The constraint, which the caller passes to its ``Table``.
+    """
+    return sqlalchemy.ForeignKeyConstraint(
+        ['root_url', 'results_path_stub'],
+        ['images.root_url', 'images.results_path_stub'],
+        ondelete='CASCADE',
+    )
+
+
+IMAGES = sqlalchemy.Table(
+    'images',
+    METADATA,
+    # Identity.  Derived from the file's own location under the ingest root, not
+    # from the document, so it is exact by construction.
+    sqlalchemy.Column('root_url', sqlalchemy.Text, primary_key=True),
+    sqlalchemy.Column('results_path_stub', sqlalchemy.Text, primary_key=True),
+    # First path segment of the stub; NULL when the stub has no separator, which
+    # is what the simulated dataset's bare scene basenames produce.
+    sqlalchemy.Column('volume', sqlalchemy.Text),
+    # Observation.
+    sqlalchemy.Column('image_name', sqlalchemy.Text, nullable=False),
+    sqlalchemy.Column('instrument', sqlalchemy.Text, nullable=False),
+    sqlalchemy.Column('camera', sqlalchemy.Text),
+    sqlalchemy.Column('image_path', sqlalchemy.Text),
+    sqlalchemy.Column('image_et', sqlalchemy.Double),
+    sqlalchemy.Column('image_date', sqlalchemy.Text),
+    # Outcome.  status_error and status_reason are different vocabularies:
+    # status_error is what the SPICE-error selection filter matches verbatim,
+    # status_reason is the navigator's explanation of a non-success outcome.
+    sqlalchemy.Column('status', sqlalchemy.Text, nullable=False),
+    sqlalchemy.Column('status_error', sqlalchemy.Text),
+    sqlalchemy.Column('status_reason', sqlalchemy.Text),
+    # The authoritative offset every consumer applies, stored unrounded.
+    sqlalchemy.Column('offset_dv', sqlalchemy.Double),
+    sqlalchemy.Column('offset_du', sqlalchemy.Double),
+    sqlalchemy.Column('sigma_dv', sqlalchemy.Double),
+    sqlalchemy.Column('sigma_du', sqlalchemy.Double),
+    # The 2x2 offset block only.  For a twist-fitted result the rotation row and
+    # column of the 3x3 matrix are deliberately not indexed; sigma_rotation_deg
+    # is the only twist uncertainty the index carries.
+    sqlalchemy.Column('covariance_vv', sqlalchemy.Double),
+    sqlalchemy.Column('covariance_vu', sqlalchemy.Double),
+    sqlalchemy.Column('covariance_uu', sqlalchemy.Double),
+    sqlalchemy.Column('sigma_along_unobservable_px', sqlalchemy.Double),
+    sqlalchemy.Column('rotation_deg', sqlalchemy.Double),
+    sqlalchemy.Column('sigma_rotation_deg', sqlalchemy.Double),
+    # Quality.
+    sqlalchemy.Column('confidence', sqlalchemy.Double),
+    sqlalchemy.Column('confidence_rank', sqlalchemy.Text),
+    sqlalchemy.Column('n_techniques', sqlalchemy.Integer, nullable=False),
+    sqlalchemy.Column('excluded_from_consensus', _JSON),
+    sqlalchemy.Column('image_class', sqlalchemy.Text),
+    sqlalchemy.Column('noise_sigma', sqlalchemy.Double),
+    sqlalchemy.Column('image_shape_v', sqlalchemy.Integer),
+    sqlalchemy.Column('image_shape_u', sqlalchemy.Integer),
+    # Run provenance.
+    sqlalchemy.Column('run_start', sqlalchemy.Text),
+    sqlalchemy.Column('run_end', sqlalchemy.Text),
+    sqlalchemy.Column('elapsed_s', sqlalchemy.Double),
+    sqlalchemy.Column('config_hash', sqlalchemy.Text),
+    sqlalchemy.Column('git_sha', sqlalchemy.Text),
+    sqlalchemy.Column('pipeline_run', sqlalchemy.Text),
+    # The numeric portion of the image name, so a range filter compares against a
+    # column instead of calling a function.  BigInteger because an instrument
+    # naming scheme is free to run past the 32-bit range a dialect may impose.
+    sqlalchemy.Column('image_number', sqlalchemy.BigInteger),
+    # Whether the ingest walk saw a summary PNG beside the metadata file.
+    sqlalchemy.Column('has_summary_png', sqlalchemy.Boolean),
+    # Corrected-pointing fields.  Declared with the names and shapes their
+    # producer specifies and NULL until it lands, because a column-set change
+    # costs every operator a rebuild.
+    sqlalchemy.Column('start_et', sqlalchemy.Double),
+    sqlalchemy.Column('stop_et', sqlalchemy.Double),
+    sqlalchemy.Column('exposure_s', sqlalchemy.Double),
+    sqlalchemy.Column('sclk_start', sqlalchemy.Text),
+    sqlalchemy.Column('sclk_midtime', sqlalchemy.Text),
+    sqlalchemy.Column('sclk_stop', sqlalchemy.Text),
+    sqlalchemy.Column('camera_frame_id', sqlalchemy.Integer),
+    sqlalchemy.Column('ck_frame_id', sqlalchemy.Integer),
+    sqlalchemy.Column('cmatrix', _JSON),
+    sqlalchemy.Column('cmatrix_original', _JSON),
+    # File provenance.  mtime_ns and size_bytes drive the incremental skip, and
+    # both need 64 bits: a nanosecond epoch alone is far past the 32-bit range.
+    sqlalchemy.Column('source_file', sqlalchemy.Text),
+    sqlalchemy.Column('mtime_ns', sqlalchemy.BigInteger),
+    sqlalchemy.Column('size_bytes', sqlalchemy.BigInteger),
+    sqlalchemy.Index('ix_images_results_path_stub', 'results_path_stub'),
+    sqlalchemy.Index('ix_images_image_date', 'image_date'),
+    sqlalchemy.Index('ix_images_instrument', 'instrument'),
+)
+"""One row per navigated image, keyed by ``(root_url, results_path_stub)``."""
+
+TECHNIQUES = sqlalchemy.Table(
+    'techniques',
+    METADATA,
+    *_image_key_columns(),
+    sqlalchemy.Column('technique_name', sqlalchemy.Text, nullable=False),
+    sqlalchemy.Column('offset_dv', sqlalchemy.Double),
+    sqlalchemy.Column('offset_du', sqlalchemy.Double),
+    sqlalchemy.Column('sigma_dv', sqlalchemy.Double),
+    sqlalchemy.Column('sigma_du', sqlalchemy.Double),
+    sqlalchemy.Column('confidence', sqlalchemy.Double),
+    sqlalchemy.Column('spurious', sqlalchemy.Boolean, nullable=False),
+    sqlalchemy.Column('at_edge', sqlalchemy.Boolean, nullable=False),
+    sqlalchemy.Column('source_names', _JSON),
+    sqlalchemy.Column('diagnostics', _JSON),
+    _image_foreign_key(),
+    sqlalchemy.Index('ix_techniques_image', 'root_url', 'results_path_stub'),
+)
+"""One row per technique that produced a result for an image."""
+
+FEATURE_SOURCES = sqlalchemy.Table(
+    'feature_sources',
+    METADATA,
+    *_image_key_columns(),
+    sqlalchemy.Column('feature_type', sqlalchemy.Text, nullable=False),
+    sqlalchemy.Column('source_model', sqlalchemy.Text, nullable=False),
+    sqlalchemy.Column('source_name', sqlalchemy.Text, nullable=False),
+    sqlalchemy.Column('n_features', sqlalchemy.Integer, nullable=False),
+    sqlalchemy.Column('n_gated', sqlalchemy.Integer, nullable=False),
+    _image_foreign_key(),
+    sqlalchemy.Index('ix_feature_sources_image', 'root_url', 'results_path_stub'),
+)
+"""Feature inventory of an image, aggregated per feature type and source."""
+
+SCHEMA_META = sqlalchemy.Table(
+    'schema_meta',
+    METADATA,
+    # A constant primary key with a check constraint: the table describes the
+    # database, so a second row would describe a contradiction.
+    sqlalchemy.Column('singleton', sqlalchemy.Integer, primary_key=True, autoincrement=False),
+    sqlalchemy.Column('schema_version', sqlalchemy.Integer, nullable=False),
+    sqlalchemy.Column('created_utc', sqlalchemy.Text, nullable=False),
+    sqlalchemy.CheckConstraint('singleton = 1', name='ck_schema_meta_singleton'),
+)
+"""Single row stamping the database with the column-set version that wrote it."""
+
+INGEST_RUNS = sqlalchemy.Table(
+    'ingest_runs',
+    METADATA,
+    sqlalchemy.Column('run_id', sqlalchemy.Integer, primary_key=True, autoincrement=True),
+    sqlalchemy.Column('root_url', sqlalchemy.Text, nullable=False),
+    sqlalchemy.Column('started_utc', sqlalchemy.Text, nullable=False),
+    # NULL while the run is in flight.  A root whose newest row has no finish
+    # time, or has no row at all, has not been ingested, and a consumer must say
+    # so rather than read absence as "nothing was navigated".
+    sqlalchemy.Column('finished_utc', sqlalchemy.Text),
+    sqlalchemy.Column('files_seen', sqlalchemy.Integer),
+    sqlalchemy.Column('files_ingested', sqlalchemy.Integer),
+    sqlalchemy.Column('files_skipped', sqlalchemy.Integer),
+    sqlalchemy.Column('files_failed', sqlalchemy.Integer),
+    sqlalchemy.Column('schema_version', sqlalchemy.Integer, nullable=False),
+    sqlalchemy.Index('ix_ingest_runs_root_url', 'root_url'),
+)
+"""One row per ingest pass over one root, recording what it covered."""

--- a/tests/spindoctor/config/test_config_hash.py
+++ b/tests/spindoctor/config/test_config_hash.py
@@ -54,6 +54,26 @@ def test_a_logging_setting_does_not_change_the_digest(tmp_path: Path, body: str)
     assert _hash(tmp_path, body) == _hash(tmp_path)
 
 
+@pytest.mark.parametrize(
+    'body',
+    [
+        'environment:\n  nav_results_root: /somewhere/else\n',
+        'environment:\n  pds3_holdings_root: /mnt/other/holdings\n',
+        'environment:\n  results_db: sqlite:////data/nav-results/index.sqlite3\n',
+        'environment:\n  results_db: postgresql+psycopg://user@host/spindoctor\n',
+    ],
+)
+def test_an_environment_setting_does_not_change_the_digest(tmp_path: Path, body: str) -> None:
+    """Where a deployment keeps its files is not part of how it navigates.
+
+    Moving a results directory, pointing at a different holdings mirror, or
+    naming a database to index the results with cannot move an offset by a pixel,
+    so a digest that shifted would report every result of that run as differently
+    configured from the archive it belongs to.
+    """
+    assert _hash(tmp_path, body) == _hash(tmp_path)
+
+
 def test_a_setting_that_can_change_a_result_does_change_the_digest(tmp_path: Path) -> None:
     """The exclusion is narrow: anything the pipeline reads still counts."""
     assert _hash(tmp_path, 'offset:\n  correlation_fft_upsample_factor: 256\n') != _hash(tmp_path)
@@ -64,17 +84,18 @@ def test_the_digest_is_stable_across_repeated_resolution(tmp_path: Path) -> None
     assert _hash(tmp_path) == _hash(tmp_path)
 
 
-def test_only_logging_is_excluded() -> None:
+def test_only_the_two_argued_sections_are_excluded() -> None:
     """The excluded set is exactly what was argued for, not a growing list.
 
     Every section added to it stops being able to distinguish two results, so
     growth wants the same argument made again rather than a quiet append.
     """
-    assert sorted(HASH_EXCLUDED_SECTIONS) == ['logging']
+    assert sorted(HASH_EXCLUDED_SECTIONS) == ['environment', 'logging']
 
 
-def test_an_excluded_section_is_still_present_in_the_configuration() -> None:
+@pytest.mark.parametrize('section', ['environment', 'logging'])
+def test_an_excluded_section_is_still_present_in_the_configuration(section: str) -> None:
     """Excluding a section from the digest does not remove it from the config."""
     config = Config()
     config.read_config()
-    assert config.logging is not None
+    assert getattr(config, section) is not None

--- a/tests/spindoctor/config/test_config_helper.py
+++ b/tests/spindoctor/config/test_config_helper.py
@@ -1,12 +1,16 @@
 """Tests for :mod:`spindoctor.config.config_helper`.
 
-Covers the documented resolution order of the three results-root getters
-(explicit argument, then ``config.environment``, then environment variable)
-and the user-config loading behavior of ``load_default_and_user_config``
-(bundled defaults always; explicit ``--config-file`` paths when given;
-otherwise ``nav_default_config.yaml`` from the current directory).
+Covers the documented resolution order of the getters (explicit argument, then
+``config.environment``, then environment variable) and the user-config loading
+behavior of ``load_default_and_user_config`` (bundled defaults always; explicit
+``--config-file`` paths when given; otherwise ``nav_default_config.yaml`` from
+the current directory).
 
-The tests are hermetic: every test clears the three ``NAV_*_RESULTS_ROOT``
+The results-root getters and the results-index getter share that order and part
+ways at the end of it: an unresolved root is an error, while an unresolved index
+URL means "no index", which is every program's default mode.
+
+The tests are hermetic: every test clears the results-root and results-index
 environment variables via ``monkeypatch``, seeds ``Config`` instances
 directly (never the ``DEFAULT_CONFIG`` singleton), and changes into
 ``tmp_path`` before exercising the relative ``nav_default_config.yaml``
@@ -23,9 +27,11 @@ import pytest
 
 from spindoctor.config import Config
 from spindoctor.config.config_helper import (
+    RESULTS_DB_NONE,
     get_backplane_results_root,
     get_nav_results_root,
     get_pds4_bundle_results_root,
+    get_results_db_url,
     load_default_and_user_config,
 )
 
@@ -36,7 +42,12 @@ ALL_ENV_VARS = (
     'NAV_BACKPLANE_RESULTS_ROOT',
     'NAV_BUNDLE_RESULTS_ROOT',
     'BUNDLE_RESULTS_ROOT',
+    'NAV_RESULTS_DB',
 )
+
+SQLITE_URL = 'sqlite:////data/nav-results/index.sqlite3'
+
+POSTGRES_URL = 'postgresql+psycopg://user@host/spindoctor'
 
 # (getter, argparse attribute, environment-section key, env var, CLI flag)
 GETTER_CASES = [
@@ -69,7 +80,7 @@ GETTER_CASES = [
 
 @pytest.fixture(autouse=True)
 def _clear_root_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Remove every results-root environment variable before each test.
+    """Remove every results-root and results-index environment variable.
 
     Parameters:
         monkeypatch: Pytest fixture used to delete the environment variables
@@ -367,6 +378,154 @@ def test_bundle_getter_ignores_unprefixed_env_var(monkeypatch: pytest.MonkeyPatc
     config = _config_with_environment(None)
     with pytest.raises(ValueError, match='NAV_BUNDLE_RESULTS_ROOT'):
         get_pds4_bundle_results_root(argparse.Namespace(), config)
+
+
+# ---------------------------------------------------------------------------
+# get_results_db_url
+# ---------------------------------------------------------------------------
+
+
+def test_results_db_argument_wins_over_config_and_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The parsed-argument value takes precedence over config and env var.
+
+    Parameters:
+        monkeypatch: Pytest fixture for environment isolation.
+    """
+
+    monkeypatch.setenv('NAV_RESULTS_DB', POSTGRES_URL)
+    config = _config_with_environment({'results_db': 'sqlite:///from-config.sqlite3'})
+    arguments = argparse.Namespace(results_db=SQLITE_URL)
+    assert get_results_db_url(arguments, config) == SQLITE_URL
+
+
+def test_results_db_config_wins_over_env_when_argument_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the argument None, ``config.environment`` beats the env var.
+
+    Parameters:
+        monkeypatch: Pytest fixture for environment isolation.
+    """
+
+    monkeypatch.setenv('NAV_RESULTS_DB', POSTGRES_URL)
+    config = _config_with_environment({'results_db': SQLITE_URL})
+    assert get_results_db_url(argparse.Namespace(results_db=None), config) == SQLITE_URL
+
+
+def test_results_db_missing_argument_attribute_uses_config() -> None:
+    """A namespace without the attribute at all falls through to the config.
+
+    A program that has not yet grown the flag still honors the configuration key.
+    """
+
+    config = _config_with_environment({'results_db': SQLITE_URL})
+    assert get_results_db_url(argparse.Namespace(), config) == SQLITE_URL
+
+
+def test_results_db_env_var_used_when_argument_and_config_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The env var is the last place looked before answering "no index".
+
+    Parameters:
+        monkeypatch: Pytest fixture for environment isolation.
+    """
+
+    monkeypatch.setenv('NAV_RESULTS_DB', POSTGRES_URL)
+    config = _config_with_environment(None)
+    assert get_results_db_url(argparse.Namespace(), config) == POSTGRES_URL
+
+
+def test_results_db_config_key_none_falls_through_to_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A config key explicitly set to null is treated as unset, not as opted out.
+
+    Parameters:
+        monkeypatch: Pytest fixture for environment isolation.
+    """
+
+    monkeypatch.setenv('NAV_RESULTS_DB', POSTGRES_URL)
+    config = _config_with_environment({'results_db': None})
+    assert get_results_db_url(argparse.Namespace(), config) == POSTGRES_URL
+
+
+def test_results_db_unset_everywhere_is_not_an_error() -> None:
+    """No index is the default mode of every program, so absence is an answer.
+
+    This is the one way this getter differs from the results-root getters, which
+    raise when nothing is set.
+    """
+
+    config = _config_with_environment(None)
+    assert get_results_db_url(argparse.Namespace(results_db=None), config) is None
+
+
+def test_results_db_sentinel_on_the_command_line_overrides_the_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the sentinel an exported variable would make file mode impossible.
+
+    Parameters:
+        monkeypatch: Pytest fixture for environment isolation.
+    """
+
+    monkeypatch.setenv('NAV_RESULTS_DB', POSTGRES_URL)
+    config = _config_with_environment(None)
+    arguments = argparse.Namespace(results_db=RESULTS_DB_NONE)
+    assert get_results_db_url(arguments, config) is None
+
+
+def test_results_db_sentinel_on_the_command_line_overrides_the_config_key() -> None:
+    """The sentinel outranks a configured URL for the same reason."""
+
+    config = _config_with_environment({'results_db': SQLITE_URL})
+    arguments = argparse.Namespace(results_db=RESULTS_DB_NONE)
+    assert get_results_db_url(arguments, config) is None
+
+
+def test_results_db_sentinel_in_the_config_opts_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The sentinel is honored wherever the value came from, not only on argv.
+
+    Parameters:
+        monkeypatch: Pytest fixture for environment isolation.
+    """
+
+    monkeypatch.setenv('NAV_RESULTS_DB', POSTGRES_URL)
+    config = _config_with_environment({'results_db': RESULTS_DB_NONE})
+    assert get_results_db_url(argparse.Namespace(), config) is None
+
+
+def test_results_db_sentinel_in_the_env_var_opts_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exporting the sentinel is how a machine turns the index off by default.
+
+    Parameters:
+        monkeypatch: Pytest fixture for environment isolation.
+    """
+
+    monkeypatch.setenv('NAV_RESULTS_DB', RESULTS_DB_NONE)
+    config = _config_with_environment(None)
+    assert get_results_db_url(argparse.Namespace(), config) is None
+
+
+def test_results_db_sentinel_is_the_exact_literal() -> None:
+    """A URL that merely contains the word is a URL, not an opt-out."""
+
+    config = _config_with_environment(None)
+    arguments = argparse.Namespace(results_db='sqlite:///none.sqlite3')
+    assert get_results_db_url(arguments, config) == 'sqlite:///none.sqlite3'
+
+
+@pytest.mark.parametrize('url', [SQLITE_URL, POSTGRES_URL])
+def test_results_db_returns_the_url_verbatim(url: str) -> None:
+    """Both URL forms pass through unchanged; the opener parses them, not this.
+
+    Parameters:
+        url: The URL to round-trip.
+    """
+
+    config = _config_with_environment(None)
+    assert get_results_db_url(argparse.Namespace(results_db=url), config) == url
 
 
 # ---------------------------------------------------------------------------

--- a/tests/spindoctor/config/test_logging_static_invariants.py
+++ b/tests/spindoctor/config/test_logging_static_invariants.py
@@ -46,6 +46,14 @@ _NO_STDLIB_LOGGING = [
     'support',
 ]
 
+# The results index is a data-access layer with no voice of its own: what it did
+# is reported by whichever program called it, in that program's log.  It is also
+# built on a third-party library that logs through the stdlib module, so a logger
+# here would be the one place those two ladders could be wired together.
+_NO_LOGGER_AT_ALL = [
+    'results_index',
+]
+
 
 def _python_files(relative: str) -> list[FCPath]:
     """Return the Python files a target names.
@@ -110,7 +118,7 @@ def _dotted_prefixes(dotted: str) -> set[str]:
     return {'.'.join(parts[: index + 1]) for index in range(len(parts))}
 
 
-@pytest.mark.parametrize('relative', _PRINT_ONLY + _NO_STDLIB_LOGGING)
+@pytest.mark.parametrize('relative', _PRINT_ONLY + _NO_STDLIB_LOGGING + _NO_LOGGER_AT_ALL)
 def test_every_target_of_these_checks_exists(relative: str) -> None:
     """A target that has moved would make its check pass by finding nothing.
 
@@ -163,6 +171,23 @@ def test_core_code_does_not_import_stdlib_logging(package: str) -> None:
     task it would reach the worker's terminal by a path isolation never sees.
     """
     offenders = [path.name for path in _python_files(package) if 'logging' in _imported_names(path)]
+    assert offenders == []
+
+
+@pytest.mark.parametrize('package', _NO_LOGGER_AT_ALL)
+def test_a_data_access_layer_holds_no_logger_of_any_kind(package: str) -> None:
+    """Neither of the two loggers, nor pdslogger, nor the stdlib module.
+
+    Reaching for any of the three would give a library layer a voice its caller
+    did not configure, and the stdlib one would additionally turn on whatever the
+    database library it sits over decided to say.
+    """
+    forbidden = _LOGGER_NAMES | {'logging', 'pdslogger'}
+    offenders = [
+        f'{path.name}:{sorted(forbidden & _imported_names(path))}'
+        for path in _python_files(package)
+        if forbidden & _imported_names(path)
+    ]
     assert offenders == []
 
 

--- a/tests/spindoctor/config/test_logging_static_invariants.py
+++ b/tests/spindoctor/config/test_logging_static_invariants.py
@@ -181,12 +181,15 @@ def test_a_data_access_layer_holds_no_logger_of_any_kind(package: str) -> None:
     Reaching for any of the three would give a library layer a voice its caller
     did not configure, and the stdlib one would additionally turn on whatever the
     database library it sits over decided to say.
+
+    Parameters:
+        package: Path, relative to the source root, of the package to scan.
     """
     forbidden = _LOGGER_NAMES | {'logging', 'pdslogger'}
     offenders = [
-        f'{path.name}:{sorted(forbidden & _imported_names(path))}'
+        f'{path.name}:{sorted(found)}'
         for path in _python_files(package)
-        if forbidden & _imported_names(path)
+        if (found := forbidden & _imported_names(path))
     ]
     assert offenders == []
 

--- a/tests/spindoctor/results_index/__init__.py
+++ b/tests/spindoctor/results_index/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for :mod:`spindoctor.results_index`."""

--- a/tests/spindoctor/results_index/conftest.py
+++ b/tests/spindoctor/results_index/conftest.py
@@ -9,10 +9,12 @@ run, or two runs against the same server, otherwise share one set of tables and
 see one another's rows.
 """
 
+import builtins
 import contextlib
 import os
 import uuid
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -26,6 +28,61 @@ POSTGRES_URL_ENV_VAR = 'SPINDOCTOR_TEST_POSTGRES_URL'
 ROOT_URL = 'file:///data/nav-results'
 
 STUB = 'COISS_2001/data/1294561143_1295221348/N1294561202_1_CALIB'
+
+EXPLODING_FACTORY_MESSAGE = 'the dialect exploded'
+"""What the stand-in engine factory raises, standing for any escape from one."""
+
+
+def sqlite_url_for(path: Path) -> str:
+    """Return the SQLite URL naming a filesystem path.
+
+    Parameters:
+        path: The database file's path.
+
+    Returns:
+        The URL.
+    """
+    # as_posix rather than str: SQLAlchemy takes a URL, and a Windows path
+    # separator in one is not a path separator.
+    return f'sqlite:///{path.as_posix()}'
+
+
+def without_module(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
+    """Make one module unimportable, as it is on a machine without it installed.
+
+    Asserting on a driver that merely happens to be absent from the current
+    virtual environment is a test that stops testing the moment something pulls
+    that driver in as a transitive dependency.
+
+    Parameters:
+        monkeypatch: Fixture the import hook is installed through.
+        name: Dotted name of the module to hide, together with its submodules.
+    """
+    real_import = builtins.__import__
+
+    def blocked(module_name: str, *args: Any, **kwargs: Any) -> Any:
+        if module_name == name or module_name.startswith(f'{name}.'):
+            raise ModuleNotFoundError(f'No module named {name!r}', name=name)
+        return real_import(module_name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', blocked)
+
+
+def exploding_factory(*args: Any, **kwargs: Any) -> Engine:
+    """Stand in for an engine factory that fails in a way nobody enumerated.
+
+    A dialect coerces its own connect arguments and reports a bad one as a bare
+    exception naming nothing, so the translation has to be a catch-all rather
+    than a list of types.
+
+    Parameters:
+        args: Whatever the caller passed, all of it ignored.
+        kwargs: Whatever the caller passed, all of it ignored.
+
+    Raises:
+        RuntimeError: Always.
+    """
+    raise RuntimeError(EXPLODING_FACTORY_MESSAGE)
 
 
 def image_row(**overrides: Any) -> dict[str, Any]:
@@ -64,6 +121,28 @@ def technique_row(**overrides: Any) -> dict[str, Any]:
         'technique_name': 'star_field_from_catalog',
         'spurious': False,
         'at_edge': False,
+    }
+    row.update(overrides)
+    return row
+
+
+def feature_source_row(**overrides: Any) -> dict[str, Any]:
+    """Return a minimally valid ``feature_sources`` row, with overrides applied.
+
+    Parameters:
+        overrides: Column values replacing (or adding to) the defaults.
+
+    Returns:
+        A mapping ready to pass to a ``feature_sources`` insert.
+    """
+    row: dict[str, Any] = {
+        'root_url': ROOT_URL,
+        'results_path_stub': STUB,
+        'feature_type': 'STAR',
+        'source_model': 'NavModelStars',
+        'source_name': 'UCAC4',
+        'n_features': 41,
+        'n_gated': 3,
     }
     row.update(overrides)
     return row

--- a/tests/spindoctor/results_index/conftest.py
+++ b/tests/spindoctor/results_index/conftest.py
@@ -101,7 +101,22 @@ def postgres_server_url() -> str:
 
 
 @pytest.fixture
-def postgres_url(postgres_server_url: str) -> Iterator[str]:
+def postgres_schema() -> str:
+    """Return the name of the private schema this test's tables live in.
+
+    Requested alongside ``postgres_url`` by a test that reads the server's
+    catalog, where a query scoped by table name alone would answer from whatever
+    schema happened to hold a table of that name -- another worker's, or a
+    leftover in ``public``.
+
+    Returns:
+        A schema name no other test uses.
+    """
+    return f'ri_test_{uuid.uuid4().hex}'
+
+
+@pytest.fixture
+def postgres_url(postgres_server_url: str, postgres_schema: str) -> Iterator[str]:
     """Yield a PostgreSQL URL scoped to a schema of this test's own.
 
     The schema is created before the test and dropped after it, so repeated runs
@@ -109,11 +124,12 @@ def postgres_url(postgres_server_url: str) -> Iterator[str]:
 
     Parameters:
         postgres_server_url: The server URL the schema is created on.
+        postgres_schema: Name of the schema to create.
 
     Yields:
         A URL whose search path names the private schema.
     """
-    schema = f'ri_test_{uuid.uuid4().hex}'
+    schema = postgres_schema
     scoped = sqlalchemy.engine.make_url(postgres_server_url).update_query_dict(
         {'options': f'-csearch_path={schema}'}
     )

--- a/tests/spindoctor/results_index/conftest.py
+++ b/tests/spindoctor/results_index/conftest.py
@@ -1,0 +1,130 @@
+"""Shared fixtures and row factories for the results-index tests.
+
+The row factories exist so a test that cares about one column does not have to
+restate the NOT NULL columns around it, and so a column gaining a constraint
+fails in one place rather than in every test.
+
+The PostgreSQL fixtures give each test its own schema.  Two workers of a parallel
+run, or two runs against the same server, otherwise share one set of tables and
+see one another's rows.
+"""
+
+import contextlib
+import os
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+import sqlalchemy
+from sqlalchemy.engine import Engine
+
+from spindoctor.results_index import open_index
+
+POSTGRES_URL_ENV_VAR = 'SPINDOCTOR_TEST_POSTGRES_URL'
+
+ROOT_URL = 'file:///data/nav-results'
+
+STUB = 'COISS_2001/data/1294561143_1295221348/N1294561202_1_CALIB'
+
+
+def image_row(**overrides: Any) -> dict[str, Any]:
+    """Return a minimally valid ``images`` row, with overrides applied.
+
+    Parameters:
+        overrides: Column values replacing (or adding to) the defaults.
+
+    Returns:
+        A mapping ready to pass to an ``images`` insert.
+    """
+    row: dict[str, Any] = {
+        'root_url': ROOT_URL,
+        'results_path_stub': STUB,
+        'image_name': 'N1294561202_1_CALIB.IMG',
+        'instrument': 'COISS',
+        'status': 'success',
+        'n_techniques': 2,
+    }
+    row.update(overrides)
+    return row
+
+
+def technique_row(**overrides: Any) -> dict[str, Any]:
+    """Return a minimally valid ``techniques`` row, with overrides applied.
+
+    Parameters:
+        overrides: Column values replacing (or adding to) the defaults.
+
+    Returns:
+        A mapping ready to pass to a ``techniques`` insert.
+    """
+    row: dict[str, Any] = {
+        'root_url': ROOT_URL,
+        'results_path_stub': STUB,
+        'technique_name': 'star_field_from_catalog',
+        'spurious': False,
+        'at_edge': False,
+    }
+    row.update(overrides)
+    return row
+
+
+@contextlib.contextmanager
+def opened(url: str, *, create: bool = False) -> Iterator[Engine]:
+    """Open an index and dispose of the engine afterwards.
+
+    Parameters:
+        url: The connection URL to open.
+        create: Whether to create missing tables and the version row.
+
+    Yields:
+        The open engine.
+    """
+    engine = open_index(url, create=create)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture
+def postgres_server_url() -> str:
+    """Return the PostgreSQL URL the postgres tier runs against.
+
+    Returns:
+        The URL named by the environment.
+    """
+    url = os.environ.get(POSTGRES_URL_ENV_VAR)
+    if url is None:
+        pytest.skip(f'{POSTGRES_URL_ENV_VAR} is not set')
+    return url
+
+
+@pytest.fixture
+def postgres_url(postgres_server_url: str) -> Iterator[str]:
+    """Yield a PostgreSQL URL scoped to a schema of this test's own.
+
+    The schema is created before the test and dropped after it, so repeated runs
+    and parallel workers never see one another's tables.
+
+    Parameters:
+        postgres_server_url: The server URL the schema is created on.
+
+    Yields:
+        A URL whose search path names the private schema.
+    """
+    schema = f'ri_test_{uuid.uuid4().hex}'
+    scoped = sqlalchemy.engine.make_url(postgres_server_url).update_query_dict(
+        {'options': f'-csearch_path={schema}'}
+    )
+    admin = sqlalchemy.create_engine(postgres_server_url)
+    try:
+        with admin.begin() as connection:
+            connection.exec_driver_sql(f'CREATE SCHEMA "{schema}"')
+        try:
+            yield scoped.render_as_string(hide_password=False)
+        finally:
+            with admin.begin() as connection:
+                connection.exec_driver_sql(f'DROP SCHEMA "{schema}" CASCADE')
+    finally:
+        admin.dispose()

--- a/tests/spindoctor/results_index/test_engine.py
+++ b/tests/spindoctor/results_index/test_engine.py
@@ -1,0 +1,358 @@
+"""Tests for the results-index opener, its version gate, and its SQLite settings.
+
+Every one of these is about a failure an operator meets on a bad day: an index
+that was never built, one built by different code, a driver that is not
+installed, a file on a filesystem that cannot lock. Each has to say what went
+wrong and what to do about it, because the alternative is a stack trace from
+inside a database driver, or -- worse -- a run that quietly reads nothing.
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+import sqlalchemy
+from tests.spindoctor.results_index.conftest import image_row, opened
+
+from spindoctor.results_index import IMAGES, SCHEMA_META, SCHEMA_VERSION, open_index
+from spindoctor.results_index import engine as engine_module
+
+MISSING_DRIVER_URL = 'postgresql+psycopg2://user:pw@localhost:5432/spindoctor'
+
+
+def _url_for(path: Path) -> str:
+    """Return the SQLite URL naming a filesystem path.
+
+    Parameters:
+        path: The database file's path.
+
+    Returns:
+        The URL.
+    """
+    return f'sqlite:///{path}'
+
+
+# ---------------------------------------------------------------------------
+# A database that is not there
+# ---------------------------------------------------------------------------
+
+
+def test_a_consumer_refuses_a_database_that_does_not_exist(tmp_path: Path) -> None:
+    """Absence is an error, not an empty answer.
+
+    Parameters:
+        tmp_path: Directory the database would have lived in.
+    """
+    missing = tmp_path / 'index.sqlite3'
+    with pytest.raises(ValueError, match='there is no results index at'):
+        open_index(_url_for(missing))
+
+
+def test_the_missing_database_message_names_the_ingest_program(tmp_path: Path) -> None:
+    """The reader is told the one command that fixes it.
+
+    Parameters:
+        tmp_path: Directory the database would have lived in.
+    """
+    missing = tmp_path / 'index.sqlite3'
+    with pytest.raises(ValueError, match='sd_stats_ingest'):
+        open_index(_url_for(missing))
+
+
+def test_a_consumer_does_not_create_the_database_it_refused(tmp_path: Path) -> None:
+    """A consumer that created an empty index would answer every later run wrongly.
+
+    Parameters:
+        tmp_path: Directory the database would have lived in.
+    """
+    missing = tmp_path / 'index.sqlite3'
+    with pytest.raises(ValueError, match='there is no results index at'):
+        open_index(_url_for(missing))
+    assert missing.exists() is False
+
+
+def test_an_ingest_run_does_create_the_database(tmp_path: Path) -> None:
+    """The creating flag is what separates a builder from a reader.
+
+    Parameters:
+        tmp_path: Directory the database is created in.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True):
+        pass
+    assert path.exists() is True
+
+
+# ---------------------------------------------------------------------------
+# A database that is there but is not an index
+# ---------------------------------------------------------------------------
+
+
+def test_a_database_with_no_schema_meta_table_is_refused(tmp_path: Path) -> None:
+    """A file that happens to be SQLite is not therefore a results index.
+
+    Parameters:
+        tmp_path: Directory holding the unrelated database.
+    """
+    path = tmp_path / 'index.sqlite3'
+    connection = sqlite3.connect(path)
+    connection.execute('CREATE TABLE unrelated (x INTEGER)')
+    connection.commit()
+    connection.close()
+    with pytest.raises(ValueError, match='not a results index'):
+        open_index(_url_for(path))
+
+
+def test_a_database_with_no_schema_meta_row_is_refused(tmp_path: Path) -> None:
+    """An interrupted creation leaves tables with nothing stamped in them.
+
+    Parameters:
+        tmp_path: Directory holding the half-built database.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True) as engine, engine.begin() as connection:
+        connection.execute(SCHEMA_META.delete())
+    with pytest.raises(ValueError, match='no schema_meta row'):
+        open_index(_url_for(path))
+
+
+def test_an_in_memory_database_is_refused_by_a_consumer() -> None:
+    """An in-memory URL starts empty every time, so it is never an index."""
+    with pytest.raises(ValueError, match='not a results index'):
+        open_index('sqlite://')
+
+
+# ---------------------------------------------------------------------------
+# The version gate
+# ---------------------------------------------------------------------------
+
+
+def test_a_database_stamped_with_another_version_is_refused(tmp_path: Path) -> None:
+    """A column whose meaning changed reads as valid until someone checks.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True) as engine, engine.begin() as connection:
+        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    with pytest.raises(ValueError, match=f'schema version {SCHEMA_VERSION + 1}'):
+        open_index(_url_for(path))
+
+
+def test_the_version_message_names_the_version_this_code_reads(tmp_path: Path) -> None:
+    """Both numbers appear, so the reader can tell which side is stale.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True) as engine, engine.begin() as connection:
+        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    with pytest.raises(ValueError, match=f'version {SCHEMA_VERSION} this code reads'):
+        open_index(_url_for(path))
+
+
+def test_the_version_message_says_to_delete_and_re_ingest(tmp_path: Path) -> None:
+    """There are no migrations, so the instruction is the whole remedy.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True) as engine, engine.begin() as connection:
+        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    with pytest.raises(ValueError, match='delete the database and re-run sd_stats_ingest'):
+        open_index(_url_for(path))
+
+
+def test_the_version_gate_applies_to_a_creating_open_too(tmp_path: Path) -> None:
+    """Ingest reads an existing database as much as it writes one.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True) as engine, engine.begin() as connection:
+        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    with pytest.raises(ValueError, match='is not the version'):
+        open_index(_url_for(path), create=True)
+
+
+def test_creating_twice_keeps_one_version_row(tmp_path: Path) -> None:
+    """A second ingest opens the same database; it does not re-stamp it.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True):
+        pass
+    with opened(_url_for(path), create=True) as engine, engine.connect() as connection:
+        rows = connection.execute(
+            sqlalchemy.select(sqlalchemy.func.count()).select_from(SCHEMA_META)
+        ).scalar()
+    assert rows == 1
+
+
+def test_creating_twice_keeps_the_rows_already_ingested(tmp_path: Path) -> None:
+    """Creation is idempotent: an incremental ingest depends on it.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True) as engine, engine.begin() as connection:
+        connection.execute(IMAGES.insert(), image_row())
+    with opened(_url_for(path), create=True) as engine, engine.connect() as connection:
+        rows = connection.execute(
+            sqlalchemy.select(sqlalchemy.func.count()).select_from(IMAGES)
+        ).scalar()
+    assert rows == 1
+
+
+# ---------------------------------------------------------------------------
+# Backend selection
+# ---------------------------------------------------------------------------
+
+
+def test_a_postgres_url_without_its_driver_names_the_extra() -> None:
+    """An import traceback would not tell an operator what to install."""
+    with pytest.raises(ValueError, match=r'rms-spindoctor\[postgres\]'):
+        open_index(MISSING_DRIVER_URL)
+
+
+def test_the_missing_driver_message_names_the_url() -> None:
+    """A program may resolve its URL from three places; the message says which."""
+    with pytest.raises(ValueError, match='postgresql\\+psycopg2'):
+        open_index(MISSING_DRIVER_URL)
+
+
+def test_a_missing_driver_for_another_backend_is_not_disguised() -> None:
+    """Only PostgreSQL ships as an extra; other backends are not supported.
+
+    Reporting a MySQL driver as a missing SpinDoctor extra would send the reader
+    to install something that would still not work.
+    """
+    with pytest.raises(ModuleNotFoundError, match='MySQLdb'):
+        open_index('mysql+mysqldb://user@localhost/spindoctor')
+
+
+def test_engine_echo_is_off(tmp_path: Path) -> None:
+    """Engine echo writes SQL through stdlib logging, which nothing here configures.
+
+    The unset value is None rather than False, so the assertion is on the flag
+    being off rather than on the identity of the default.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+    """
+    with opened(_url_for(tmp_path / 'index.sqlite3'), create=True) as engine:
+        echo = engine.echo
+    assert bool(echo) is False
+
+
+# ---------------------------------------------------------------------------
+# SQLite connect-time settings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ('pragma', 'expected'),
+    [
+        ('foreign_keys', 1),
+        ('busy_timeout', engine_module.SQLITE_BUSY_TIMEOUT_MS),
+        ('journal_mode', 'wal'),
+    ],
+)
+def test_every_sqlite_connection_carries_the_pragma(
+    tmp_path: Path, pragma: str, expected: object
+) -> None:
+    """The settings are applied per connection, not once at open.
+
+    A pool hands out connections opened long after the engine was built, and a
+    connection without these is a connection without the cascade, without
+    concurrent readers, and without the wait that keeps two writers from failing.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+        pragma: The pragma to read back.
+        expected: Its expected value.
+    """
+    with opened(_url_for(tmp_path / 'index.sqlite3'), create=True) as engine:
+        # A fresh connection, so a value set only on the first one would not show.
+        with engine.connect():
+            pass
+        with engine.connect() as connection:
+            found = connection.exec_driver_sql(f'PRAGMA {pragma}').scalar()
+    assert found == expected
+
+
+def test_a_locked_database_file_is_refused_at_open(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The probe takes a write lock at open so a bad location fails early.
+
+    A filesystem that cannot honor SQLite locking corrupts the file under
+    concurrent writers instead of erroring, so the lock is taken while there is
+    still something useful to say. Here the lock is denied by an exclusive holder
+    rather than by a filesystem, which is the same refusal by a cheaper route.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+        monkeypatch: Fixture used to shorten the busy timeout.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True):
+        pass
+    monkeypatch.setattr(engine_module, 'SQLITE_BUSY_TIMEOUT_MS', 50)
+    blocker = sqlite3.connect(path)
+    try:
+        blocker.execute('BEGIN EXCLUSIVE')
+        with pytest.raises(ValueError, match='could not take a SQLite write lock'):
+            open_index(_url_for(path))
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+
+def test_the_lock_failure_names_postgresql_as_the_shared_option(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reader who put the file on a network share needs the alternative.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+        monkeypatch: Fixture used to shorten the busy timeout.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True):
+        pass
+    monkeypatch.setattr(engine_module, 'SQLITE_BUSY_TIMEOUT_MS', 50)
+    blocker = sqlite3.connect(path)
+    try:
+        blocker.execute('BEGIN EXCLUSIVE')
+        with pytest.raises(ValueError, match='postgresql\\+psycopg'):
+            open_index(_url_for(path))
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+
+def test_a_refused_open_leaves_no_usable_engine_behind(tmp_path: Path) -> None:
+    """A failed open disposes its engine rather than leaking the connection.
+
+    Proven by deleting the file afterwards: a pooled connection still holding it
+    open would keep a Windows-style lock, and on any platform an undisposed pool
+    is a file descriptor nobody closes.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True) as engine, engine.begin() as connection:
+        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    with pytest.raises(ValueError, match='is not the version'):
+        open_index(_url_for(path))
+    path.unlink()
+    assert path.exists() is False

--- a/tests/spindoctor/results_index/test_engine.py
+++ b/tests/spindoctor/results_index/test_engine.py
@@ -1,41 +1,36 @@
-"""Tests for the results-index opener, its version gate, and its SQLite settings.
+"""Tests for what the results-index opener will and will not open.
 
 Every one of these is about a failure an operator meets on a bad day: an index
 that was never built, one built by different code, a driver that is not
-installed, a file on a filesystem that cannot lock. Each has to say what went
-wrong and what to do about it, because the alternative is a stack trace from
-inside a database driver, or -- worse -- a run that quietly reads nothing.
+installed, a server that will not answer. Each has to say what went wrong and
+what to do about it, because the alternative is a stack trace from inside a
+database driver, or -- worse -- a run that quietly reads nothing.
+
+What the opener does with a SQLite file specifically is in
+``test_engine_sqlite.py``; how it names a URL without naming its password is in
+``test_engine_masking.py``.
 """
 
-import builtins
 import dataclasses
-import os
 import re
 import sqlite3
-from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
 
 import pytest
 import sqlalchemy
-from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.engine import Engine
 from sqlalchemy.pool import QueuePool
-from tests.spindoctor.results_index.conftest import image_row, opened
+from tests.spindoctor.results_index.conftest import (
+    EXPLODING_FACTORY_MESSAGE,
+    exploding_factory,
+    image_row,
+    opened,
+    sqlite_url_for,
+    without_module,
+)
 
 from spindoctor.results_index import IMAGES, SCHEMA_META, SCHEMA_VERSION, open_index
-from spindoctor.results_index import engine as engine_module
-
-PASSWORD = 'sup3rs3cr3t'
-"""A password distinctive enough that finding it anywhere is proof of a leak."""
-
-SLASHED_PASSWORD = 'aB3/xY9z'
-"""A password carrying a slash, which a URL permits unescaped.
-
-The route that masks by pattern is the one that runs on a URL nothing could
-parse, so nothing there knows where the password ends except the ``@``. A
-pattern that stopped at a path separator would leave this one in the message
-whole.
-"""
 
 MISSING_DRIVER_URL = 'postgresql+psycopg://user@localhost:5432/spindoctor'
 
@@ -46,100 +41,6 @@ UNKNOWN_BACKEND_URL = 'frobnicate://user@localhost/spindoctor'
 MALFORMED_URL = 'this is not a connection url :::'
 
 UNREACHABLE_SERVER_URL = 'postgresql+psycopg://spindoctor@127.0.0.1:1/spindoctor'
-
-EXPLODING_FACTORY_MESSAGE = 'the dialect exploded'
-"""What the stand-in engine factory raises, standing for any escape from one."""
-
-
-def _url_for(path: Path) -> str:
-    """Return the SQLite URL naming a filesystem path.
-
-    Parameters:
-        path: The database file's path.
-
-    Returns:
-        The URL.
-    """
-    return f'sqlite:///{path}'
-
-
-def _without_module(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
-    """Make one module unimportable, as it is on a machine without it installed.
-
-    Asserting on a driver that merely happens to be absent from the current
-    virtual environment is a test that stops testing the moment something pulls
-    that driver in as a transitive dependency.
-
-    Parameters:
-        monkeypatch: Fixture the import hook is installed through.
-        name: Dotted name of the module to hide, together with its submodules.
-    """
-    real_import = builtins.__import__
-
-    def blocked(module_name: str, *args: Any, **kwargs: Any) -> Any:
-        if module_name == name or module_name.startswith(f'{name}.'):
-            raise ModuleNotFoundError(f'No module named {name!r}', name=name)
-        return real_import(module_name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, '__import__', blocked)
-
-
-class _DriverError(Exception):
-    """A driver exception carrying the result code SQLite would have set on it.
-
-    The codes worth testing are the ones that are hard to provoke on demand: a
-    disk that filled during an ingest, a file that corrupted under a crash. The
-    classification reads the code off the driver's exception, so an exception
-    carrying the code is the whole of what it needs.
-
-    Attributes:
-        sqlite_errorname: The result-code name, under the attribute the SQLite
-            driver publishes it as.
-    """
-
-    def __init__(self, message: str, error_name: str) -> None:
-        """Build the refusal.
-
-        Parameters:
-            message: What the driver would have said.
-            error_name: The result-code name to carry.
-        """
-        super().__init__(message)
-        self.sqlite_errorname = error_name
-
-
-def _refusing_with(original: Exception) -> Callable[..., Any]:
-    """Return a statement executor that fails every statement with one error.
-
-    Parameters:
-        original: The driver exception to wrap, standing in for what SQLite
-            itself raised.
-
-    Returns:
-        A replacement for ``Connection.exec_driver_sql``.
-    """
-
-    def refusing(self: Any, statement: Any, *args: Any, **kwargs: Any) -> Any:
-        raise sqlalchemy.exc.OperationalError(str(statement), None, original)
-
-    return refusing
-
-
-def _exploding_factory(*args: Any, **kwargs: Any) -> Engine:
-    """Stand in for an engine factory that fails in a way nobody enumerated.
-
-    A dialect coerces its own connect arguments and reports a bad one as a bare
-    exception naming nothing, so the translation has to be a catch-all rather
-    than a list of types.
-
-    Parameters:
-        args: Whatever the caller passed, all of it ignored.
-        kwargs: Whatever the caller passed, all of it ignored.
-
-    Raises:
-        RuntimeError: Always.
-    """
-    raise RuntimeError(EXPLODING_FACTORY_MESSAGE)
 
 
 def _index_stamped_with_another_version(tmp_path: Path) -> Path:
@@ -152,7 +53,7 @@ def _index_stamped_with_another_version(tmp_path: Path) -> Path:
         Path of the database file.
     """
     path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True) as engine, engine.begin() as connection:
+    with opened(sqlite_url_for(path), create=True) as engine, engine.begin() as connection:
         connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
     return path
 
@@ -177,177 +78,6 @@ def _table_names(path: Path) -> set[str]:
         connection.close()
 
 
-@pytest.fixture(params=['wal', 'delete'])
-def read_only_index(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[Path]:
-    """Yield an index file SQLite can read but will never write.
-
-    Both journal modes are covered, because the two answer a would-be writer
-    differently and neither answer may be the one the opener depends on.
-    Write-ahead logging is the mode this opener always leaves behind, and it is
-    the permissive one: the journal-mode selection and a write lock both succeed
-    on a file SQLite will never write. The rollback journal, which an index
-    arrives in after a tool that checkpoints and vacuums it, refuses the journal
-    mode outright.
-
-    Parameters:
-        request: Fixture carrying the journal mode of this case.
-        tmp_path: Directory the database is created in.
-
-    Yields:
-        Path of the read-only database file.
-    """
-    path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True):
-        pass
-    connection = sqlite3.connect(path)
-    try:
-        connection.execute(f'PRAGMA journal_mode = {request.param}')
-    finally:
-        connection.close()
-    path.chmod(0o444)
-    try:
-        if os.access(path, os.W_OK):
-            pytest.skip('this user can write a file whose mode forbids writing')
-        yield path
-    finally:
-        # Every file the fixture is responsible for, not only the database:
-        # SQLite copies the database's mode onto the write-ahead log and the
-        # shared-memory index it creates beside it, so a test that reads this
-        # database leaves those behind read-only too. The skip is inside the
-        # try for the same reason: a run on a user who can write anything must
-        # still leave the directory as it found it.
-        for made_read_only in path.parent.glob(f'{path.name}*'):
-            made_read_only.chmod(0o644)
-
-
-@dataclasses.dataclass(frozen=True)
-class _Route:
-    """One way a URL is refused, and what its refusal has to say.
-
-    Attributes:
-        url: The URL to open, carrying a password.
-        message: Pattern the refusal message must match.
-        identifies: Text of the URL the message must keep, so a reader can tell
-            which of the resolution levels supplied the value.
-        cause: Exception type the refusal keeps as its ``__cause__``.
-        password: The password this route's URL carries, which its refusal may
-            not repeat.
-        hidden_module: Module to make unimportable first, or None.
-        needs_psycopg: Whether the route reaches the PostgreSQL driver itself.
-        breaks_the_factory: Whether the engine factory is replaced by one that
-            raises, standing for a failure inside a dialect that no enumeration
-            of exception types would have caught.
-    """
-
-    url: str
-    message: str
-    identifies: str
-    cause: type[BaseException]
-    password: str = PASSWORD
-    hidden_module: str | None = None
-    needs_psycopg: bool = False
-    breaks_the_factory: bool = False
-
-
-REFUSAL_ROUTES = [
-    pytest.param(
-        _Route(
-            url=f'postgresql+psycopg://user:{PASSWORD}@localhost:5432/spindoctor',
-            message=r'rms-spindoctor\[postgres\]',
-            identifies='localhost:5432',
-            cause=ModuleNotFoundError,
-            hidden_module='psycopg',
-        ),
-        id='driver-not-installed',
-    ),
-    pytest.param(
-        _Route(
-            url=f'mysql+mysqldb://user:{PASSWORD}@localhost/spindoctor',
-            message='MySQLdb',
-            identifies='mysql+mysqldb',
-            cause=ModuleNotFoundError,
-            hidden_module='MySQLdb',
-        ),
-        id='unsupported-backend',
-    ),
-    pytest.param(
-        _Route(
-            url=f'frobnicate://user:{PASSWORD}@localhost/spindoctor',
-            message='no database driver for this URL scheme',
-            identifies='frobnicate',
-            cause=sqlalchemy.exc.NoSuchModuleError,
-        ),
-        id='unknown-scheme',
-    ),
-    pytest.param(
-        _Route(
-            url=f'postgresql+psycopg://user:{PASSWORD}@localhost:notaport/spindoctor',
-            message='could not open the results index',
-            identifies='localhost:notaport',
-            cause=ValueError,
-        ),
-        id='unparseable-port',
-    ),
-    pytest.param(
-        _Route(
-            # A stray space in the scheme, which is what a URL copied across two
-            # lines of a configuration file arrives as. Nothing parses it, so
-            # nothing can render it either: this is the route on which the
-            # password is masked by pattern, and the only one on which the
-            # pattern is what stands between the password and the run log.
-            url=f'postgresql psycopg://svc:{SLASHED_PASSWORD}@db.example/spindoctor',
-            message='could not open the results index',
-            identifies='db.example',
-            cause=sqlalchemy.exc.ArgumentError,
-            password=SLASHED_PASSWORD,
-        ),
-        id='unparseable-url',
-    ),
-    pytest.param(
-        _Route(
-            url=f'postgresql+psycopg://spindoctor:{PASSWORD}@127.0.0.1:1/spindoctor',
-            message='could not open the results index',
-            identifies='127.0.0.1:1',
-            cause=sqlalchemy.exc.OperationalError,
-            needs_psycopg=True,
-        ),
-        id='server-refuses-the-connection',
-    ),
-    pytest.param(
-        _Route(
-            url=f'postgresql+psycopg://user:{PASSWORD}@db.example:5432/spindoctor',
-            message=EXPLODING_FACTORY_MESSAGE,
-            identifies='db.example:5432',
-            cause=RuntimeError,
-            breaks_the_factory=True,
-        ),
-        id='failure-inside-the-engine-factory',
-    ),
-]
-"""Every route by which a URL carrying a password reaches a refusal."""
-
-
-def _refusal_of(route: _Route, monkeypatch: pytest.MonkeyPatch) -> ValueError:
-    """Open a route's URL and return the refusal it raised.
-
-    Parameters:
-        route: The route to drive.
-        monkeypatch: Fixture the import hook is installed through.
-
-    Returns:
-        The refusal, for assertions on what it says.
-    """
-    if route.needs_psycopg:
-        pytest.importorskip('psycopg')
-    if route.hidden_module is not None:
-        _without_module(monkeypatch, route.hidden_module)
-    if route.breaks_the_factory:
-        monkeypatch.setattr(sqlalchemy, 'create_engine', _exploding_factory)
-    with pytest.raises(ValueError, match=route.message) as excinfo:
-        open_index(route.url)
-    return excinfo.value
-
-
 # ---------------------------------------------------------------------------
 # A database that is not there
 # ---------------------------------------------------------------------------
@@ -361,7 +91,7 @@ def test_a_consumer_refuses_a_database_that_does_not_exist(tmp_path: Path) -> No
     """
     missing = tmp_path / 'index.sqlite3'
     with pytest.raises(ValueError, match='there is no results index at'):
-        open_index(_url_for(missing))
+        open_index(sqlite_url_for(missing))
 
 
 def test_the_missing_database_message_names_the_ingest_program(tmp_path: Path) -> None:
@@ -372,7 +102,7 @@ def test_the_missing_database_message_names_the_ingest_program(tmp_path: Path) -
     """
     missing = tmp_path / 'index.sqlite3'
     with pytest.raises(ValueError, match='sd_stats_ingest'):
-        open_index(_url_for(missing))
+        open_index(sqlite_url_for(missing))
 
 
 def test_a_consumer_does_not_create_the_database_it_refused(tmp_path: Path) -> None:
@@ -383,7 +113,7 @@ def test_a_consumer_does_not_create_the_database_it_refused(tmp_path: Path) -> N
     """
     missing = tmp_path / 'index.sqlite3'
     with pytest.raises(ValueError, match='there is no results index at'):
-        open_index(_url_for(missing))
+        open_index(sqlite_url_for(missing))
     assert missing.exists() is False
 
 
@@ -394,7 +124,7 @@ def test_an_ingest_run_does_create_the_database(tmp_path: Path) -> None:
         tmp_path: Directory the database is created in.
     """
     path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True):
+    with opened(sqlite_url_for(path), create=True):
         pass
     assert path.exists() is True
 
@@ -416,7 +146,7 @@ def test_a_database_with_no_schema_meta_table_is_refused(tmp_path: Path) -> None
     connection.commit()
     connection.close()
     with pytest.raises(ValueError, match='not a results index'):
-        open_index(_url_for(path))
+        open_index(sqlite_url_for(path))
 
 
 def test_a_database_with_no_schema_meta_row_is_refused(tmp_path: Path) -> None:
@@ -426,10 +156,10 @@ def test_a_database_with_no_schema_meta_row_is_refused(tmp_path: Path) -> None:
         tmp_path: Directory holding the half-built database.
     """
     path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True) as engine, engine.begin() as connection:
+    with opened(sqlite_url_for(path), create=True) as engine, engine.begin() as connection:
         connection.execute(SCHEMA_META.delete())
     with pytest.raises(ValueError, match='no schema_meta row'):
-        open_index(_url_for(path))
+        open_index(sqlite_url_for(path))
 
 
 def test_an_in_memory_database_is_refused_by_a_consumer() -> None:
@@ -449,11 +179,9 @@ def test_a_database_stamped_with_another_version_is_refused(tmp_path: Path) -> N
     Parameters:
         tmp_path: Directory holding the database.
     """
-    path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True) as engine, engine.begin() as connection:
-        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    path = _index_stamped_with_another_version(tmp_path)
     with pytest.raises(ValueError, match=f'schema version {SCHEMA_VERSION + 1}'):
-        open_index(_url_for(path))
+        open_index(sqlite_url_for(path))
 
 
 def test_the_version_message_names_the_version_this_code_reads(tmp_path: Path) -> None:
@@ -462,11 +190,9 @@ def test_the_version_message_names_the_version_this_code_reads(tmp_path: Path) -
     Parameters:
         tmp_path: Directory holding the database.
     """
-    path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True) as engine, engine.begin() as connection:
-        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    path = _index_stamped_with_another_version(tmp_path)
     with pytest.raises(ValueError, match=f'version {SCHEMA_VERSION} this code reads'):
-        open_index(_url_for(path))
+        open_index(sqlite_url_for(path))
 
 
 def test_the_version_message_says_to_delete_and_re_ingest(tmp_path: Path) -> None:
@@ -475,11 +201,9 @@ def test_the_version_message_says_to_delete_and_re_ingest(tmp_path: Path) -> Non
     Parameters:
         tmp_path: Directory holding the database.
     """
-    path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True) as engine, engine.begin() as connection:
-        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    path = _index_stamped_with_another_version(tmp_path)
     with pytest.raises(ValueError, match='delete the database and re-run sd_stats_ingest'):
-        open_index(_url_for(path))
+        open_index(sqlite_url_for(path))
 
 
 def test_the_version_gate_applies_to_a_creating_open_too(tmp_path: Path) -> None:
@@ -490,11 +214,11 @@ def test_the_version_gate_applies_to_a_creating_open_too(tmp_path: Path) -> None
     """
     path = _index_stamped_with_another_version(tmp_path)
     with pytest.raises(ValueError, match='is not the version'):
-        open_index(_url_for(path), create=True)
+        open_index(sqlite_url_for(path), create=True)
 
 
-def test_a_creating_open_writes_nothing_to_the_version_it_refuses(tmp_path: Path) -> None:
-    """The gate runs before creation, so a refused open leaves the file alone.
+def test_a_creating_open_creates_no_table_in_the_version_it_refuses(tmp_path: Path) -> None:
+    """The gate runs before creation, so a refused open builds nothing.
 
     Otherwise a version bump writes this version's tables into a database
     stamped as another version, on the way to reporting that it will not read it.
@@ -513,7 +237,7 @@ def test_a_creating_open_writes_nothing_to_the_version_it_refuses(tmp_path: Path
     finally:
         connection.close()
     with pytest.raises(ValueError, match='is not the version'):
-        open_index(_url_for(path), create=True)
+        open_index(sqlite_url_for(path), create=True)
     assert 'ingest_runs' not in _table_names(path)
 
 
@@ -524,9 +248,9 @@ def test_creating_twice_keeps_one_version_row(tmp_path: Path) -> None:
         tmp_path: Directory holding the database.
     """
     path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True):
+    with opened(sqlite_url_for(path), create=True):
         pass
-    with opened(_url_for(path), create=True) as engine, engine.connect() as connection:
+    with opened(sqlite_url_for(path), create=True) as engine, engine.connect() as connection:
         rows = connection.execute(
             sqlalchemy.select(sqlalchemy.func.count()).select_from(SCHEMA_META)
         ).scalar()
@@ -540,9 +264,9 @@ def test_creating_twice_keeps_the_rows_already_ingested(tmp_path: Path) -> None:
         tmp_path: Directory holding the database.
     """
     path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True) as engine, engine.begin() as connection:
+    with opened(sqlite_url_for(path), create=True) as engine, engine.begin() as connection:
         connection.execute(IMAGES.insert(), image_row())
-    with opened(_url_for(path), create=True) as engine, engine.connect() as connection:
+    with opened(sqlite_url_for(path), create=True) as engine, engine.connect() as connection:
         rows = connection.execute(
             sqlalchemy.select(sqlalchemy.func.count()).select_from(IMAGES)
         ).scalar()
@@ -562,7 +286,7 @@ def test_a_postgres_url_without_its_driver_names_the_extra(
     Parameters:
         monkeypatch: Fixture used to hide the driver.
     """
-    _without_module(monkeypatch, 'psycopg')
+    without_module(monkeypatch, 'psycopg')
     with pytest.raises(ValueError, match=r'rms-spindoctor\[postgres\]'):
         open_index(MISSING_DRIVER_URL)
 
@@ -573,7 +297,7 @@ def test_the_missing_driver_message_names_the_url(monkeypatch: pytest.MonkeyPatc
     Parameters:
         monkeypatch: Fixture used to hide the driver.
     """
-    _without_module(monkeypatch, 'psycopg')
+    without_module(monkeypatch, 'psycopg')
     with pytest.raises(ValueError, match=r'postgresql\+psycopg'):
         open_index(MISSING_DRIVER_URL)
 
@@ -586,7 +310,7 @@ def test_a_missing_driver_for_another_backend_is_a_value_error(
     Parameters:
         monkeypatch: Fixture used to hide the driver.
     """
-    _without_module(monkeypatch, 'MySQLdb')
+    without_module(monkeypatch, 'MySQLdb')
     with pytest.raises(ValueError, match=r'mysql\+mysqldb'):
         open_index(UNSUPPORTED_BACKEND_URL)
 
@@ -599,7 +323,7 @@ def test_a_missing_driver_for_another_backend_names_the_driver(
     Parameters:
         monkeypatch: Fixture used to hide the driver.
     """
-    _without_module(monkeypatch, 'MySQLdb')
+    without_module(monkeypatch, 'MySQLdb')
     with pytest.raises(ValueError, match='MySQLdb'):
         open_index(UNSUPPORTED_BACKEND_URL)
 
@@ -615,7 +339,7 @@ def test_a_missing_driver_for_another_backend_is_not_disguised(
     Parameters:
         monkeypatch: Fixture used to hide the driver.
     """
-    _without_module(monkeypatch, 'MySQLdb')
+    without_module(monkeypatch, 'MySQLdb')
     with pytest.raises(ValueError, match='ships no driver for that backend') as excinfo:
         open_index(UNSUPPORTED_BACKEND_URL)
     assert 'rms-spindoctor[postgres]' not in str(excinfo.value)
@@ -663,141 +387,25 @@ def test_the_refused_connection_message_names_the_url() -> None:
         open_index(UNREACHABLE_SERVER_URL)
 
 
-@pytest.mark.parametrize('route', REFUSAL_ROUTES)
-def test_a_translated_failure_keeps_the_driver_error_as_its_cause(
-    route: _Route, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Translating the type must not throw away what the driver actually said.
-
-    Parameters:
-        route: The refusal route under test.
-        monkeypatch: Fixture the import hook is installed through.
-    """
-    assert isinstance(_refusal_of(route, monkeypatch).__cause__, route.cause)
-
-
-@pytest.mark.parametrize('route', REFUSAL_ROUTES)
-def test_a_refusal_does_not_repeat_the_password(
-    route: _Route, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """These messages reach run logs and operators; a password reaches neither.
-
-    Parameters:
-        route: The refusal route under test.
-        monkeypatch: Fixture the import hook is installed through.
-    """
-    assert route.password not in str(_refusal_of(route, monkeypatch))
-
-
-@pytest.mark.parametrize('route', REFUSAL_ROUTES)
-def test_a_masked_refusal_still_names_the_rest_of_the_url(
-    route: _Route, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Masking a password must not cost the identification the message is for.
-
-    A program resolves its URL from a command line, a configuration file or the
-    environment, and the URL is what says which of them supplied this one.
-
-    Parameters:
-        route: The refusal route under test.
-        monkeypatch: Fixture the import hook is installed through.
-    """
-    assert route.identifies in str(_refusal_of(route, monkeypatch))
-
-
-MASKING_CASES = [
-    pytest.param(
-        'postgresql+psycopg://svc:aB3/xY9z@db.example:5432x/spindoctor',
-        'postgresql+psycopg://svc:***@db.example:5432x/spindoctor',
-        id='a-password-carrying-a-slash',
-    ),
-    pytest.param(
-        'postgresql+psycopg:/svc:aB3xY9z@db.example/spindoctor',
-        'postgresql+psycopg:/svc:***@db.example/spindoctor',
-        id='one-slash-after-the-scheme',
-    ),
-    pytest.param('//user:pa/ss@h', '//user:***@h', id='no-scheme-at-all'),
-    pytest.param('//:pw@h', '//:***@h', id='no-user-name'),
-    pytest.param('/user:pw@h', '/user:***@h', id='one-slash-and-no-scheme'),
-    pytest.param(
-        'sqlite:////data/a:b/index.sqlite3',
-        'sqlite:////data/a:b/index.sqlite3',
-        id='a-local-path-carrying-a-colon',
-    ),
-    pytest.param(
-        'sqlite:////data/a:b/i@dex.sqlite3',
-        'sqlite:////data/a:b/i@dex.sqlite3',
-        id='a-local-path-carrying-a-colon-and-an-at-sign',
-    ),
-    pytest.param(
-        'postgresql+psycopg://user@host/spindoctor',
-        'postgresql+psycopg://user@host/spindoctor',
-        id='no-password-to-mask',
-    ),
-]
-"""URLs the pattern masks, and URLs it must leave exactly as they are."""
-
-
-@pytest.mark.parametrize(('url', 'expected'), MASKING_CASES)
-def test_the_pattern_masks_a_password_and_nothing_else(url: str, expected: str) -> None:
-    """The pattern is the only defense on the route where the URL did not parse.
-
-    It has to reach a password whatever the password contains -- a URL permits an
-    unescaped slash in one -- and it has to leave alone a local path that merely
-    happens to carry a colon and a later at-sign, since mangling the path costs
-    the identification these messages exist for.
-
-    Parameters:
-        url: The URL as a caller wrote it.
-        expected: What masking it must produce.
-    """
-    assert engine_module._masked_url(url) == expected
-
-
-def test_an_unexpected_failure_inside_the_driver_is_still_a_value_error(
+def test_an_unexpected_failure_inside_the_driver_is_a_value_error_naming_the_url(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The translation is a catch-all, because the escapes are not enumerable.
 
     A dialect coerces its own connect arguments and reports a bad one as a bare
     ``ValueError`` naming nothing; only catching everything keeps the promise
-    that a caller reporting the cause has one type to catch and a URL to name.
+    that a caller reporting the cause has one type to catch, a URL to name, and
+    the driver's own exception still attached to debug from.
 
     Parameters:
         tmp_path: Directory the database would have lived in.
         monkeypatch: Fixture the failing engine factory is installed through.
     """
-    monkeypatch.setattr(sqlalchemy, 'create_engine', _exploding_factory)
-    with pytest.raises(ValueError, match=EXPLODING_FACTORY_MESSAGE):
-        open_index(_url_for(tmp_path / 'index.sqlite3'), create=True)
-
-
-def test_an_unexpected_failure_names_the_url(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A refusal that names no URL leaves the reader with nothing to correct.
-
-    Parameters:
-        tmp_path: Directory the database would have lived in.
-        monkeypatch: Fixture the failing engine factory is installed through.
-    """
-    monkeypatch.setattr(sqlalchemy, 'create_engine', _exploding_factory)
-    with pytest.raises(ValueError, match=re.escape(str(tmp_path / 'index.sqlite3'))):
-        open_index(_url_for(tmp_path / 'index.sqlite3'), create=True)
-
-
-def test_an_unexpected_failure_keeps_the_factory_error_as_its_cause(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A translated type that dropped the original leaves nothing to debug from.
-
-    Parameters:
-        tmp_path: Directory the database would have lived in.
-        monkeypatch: Fixture the failing engine factory is installed through.
-    """
-    monkeypatch.setattr(sqlalchemy, 'create_engine', _exploding_factory)
+    path = tmp_path / 'index.sqlite3'
+    monkeypatch.setattr(sqlalchemy, 'create_engine', exploding_factory)
     with pytest.raises(ValueError, match=EXPLODING_FACTORY_MESSAGE) as excinfo:
-        open_index(_url_for(tmp_path / 'index.sqlite3'), create=True)
+        open_index(sqlite_url_for(path), create=True)
+    assert str(path) in str(excinfo.value)
     assert isinstance(excinfo.value.__cause__, RuntimeError)
 
 
@@ -810,522 +418,9 @@ def test_engine_echo_is_off(tmp_path: Path) -> None:
     Parameters:
         tmp_path: Directory holding the database.
     """
-    with opened(_url_for(tmp_path / 'index.sqlite3'), create=True) as engine:
+    with opened(sqlite_url_for(tmp_path / 'index.sqlite3'), create=True) as engine:
         echo = engine.echo
     assert bool(echo) is False
-
-
-# ---------------------------------------------------------------------------
-# SQLite connect-time settings
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    ('pragma', 'expected'),
-    [
-        ('foreign_keys', 1),
-        ('busy_timeout', engine_module.SQLITE_BUSY_TIMEOUT_MS),
-    ],
-)
-def test_every_sqlite_connection_carries_the_pragma(
-    tmp_path: Path, pragma: str, expected: object
-) -> None:
-    """The settings are applied per connection, not once at open.
-
-    A pool hands out connections opened long after the engine was built, and a
-    connection without these is a connection without the cascade and without the
-    wait that keeps two writers from failing. Both are per-connection state that
-    a connection the settings missed simply does not have, which is what makes
-    reading them back on a second connection a real test. The journal mode is
-    not: it is a property of the database file, so it reads back the same
-    whether or not this connection asked for it, and it is asserted separately
-    as the persistent thing it is.
-
-    Parameters:
-        tmp_path: Directory holding the database.
-        pragma: The pragma to read back.
-        expected: Its expected value.
-    """
-    # Both connections held at once, so the pool cannot hand the second request
-    # the connection it made for the first: it has to open another one.
-    with (
-        opened(_url_for(tmp_path / 'index.sqlite3'), create=True) as engine,
-        engine.connect() as first,
-        engine.connect() as second,
-    ):
-        reused = first.connection.dbapi_connection is second.connection.dbapi_connection
-        found = second.exec_driver_sql(f'PRAGMA {pragma}').scalar()
-    assert reused is False
-    assert found == expected
-
-
-def test_the_opener_leaves_the_database_write_ahead_logged(tmp_path: Path) -> None:
-    """Write-ahead logging is what lets a reader and a writer work at once.
-
-    The journal mode lives in the database header rather than in a connection,
-    so it is read back from the closed file with the standard library: that is
-    the state a later ingest, and every consumer, actually meets.
-
-    Parameters:
-        tmp_path: Directory holding the database.
-    """
-    path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True):
-        pass
-    connection = sqlite3.connect(path)
-    try:
-        (mode,) = connection.execute('PRAGMA journal_mode').fetchone()
-    finally:
-        connection.close()
-    assert mode == 'wal'
-
-
-def test_a_locked_database_file_is_refused_at_open(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The probe takes a write lock at open so a bad location fails early.
-
-    A filesystem that cannot honor SQLite locking corrupts the file under
-    concurrent writers instead of erroring, so the lock is taken while there is
-    still something useful to say. Here the lock is denied by an exclusive holder
-    rather than by a filesystem, which is the same refusal by a cheaper route.
-
-    Parameters:
-        tmp_path: Directory holding the database.
-        monkeypatch: Fixture used to shorten the busy timeout.
-    """
-    path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True):
-        pass
-    monkeypatch.setattr(engine_module, 'SQLITE_BUSY_TIMEOUT_MS', 50)
-    blocker = sqlite3.connect(path)
-    try:
-        blocker.execute('BEGIN EXCLUSIVE')
-        with pytest.raises(ValueError, match='could not take a SQLite write lock'):
-            open_index(_url_for(path))
-    finally:
-        blocker.rollback()
-        blocker.close()
-
-
-def test_the_lock_failure_names_postgresql_as_the_shared_option(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The reader who put the file on a network share needs the alternative.
-
-    Parameters:
-        tmp_path: Directory holding the database.
-        monkeypatch: Fixture used to shorten the busy timeout.
-    """
-    path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True):
-        pass
-    monkeypatch.setattr(engine_module, 'SQLITE_BUSY_TIMEOUT_MS', 50)
-    blocker = sqlite3.connect(path)
-    try:
-        blocker.execute('BEGIN EXCLUSIVE')
-        with pytest.raises(ValueError, match='postgresql\\+psycopg'):
-            open_index(_url_for(path))
-    finally:
-        blocker.rollback()
-        blocker.close()
-
-
-def test_a_locked_database_file_is_refused_by_a_creating_open(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A writer meets the same refusal a reader does, for the same reason.
-
-    Parameters:
-        tmp_path: Directory holding the database.
-        monkeypatch: Fixture used to shorten the busy timeout.
-    """
-    path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True):
-        pass
-    monkeypatch.setattr(engine_module, 'SQLITE_BUSY_TIMEOUT_MS', 50)
-    blocker = sqlite3.connect(path)
-    try:
-        blocker.execute('BEGIN EXCLUSIVE')
-        with pytest.raises(ValueError, match='could not take a SQLite write lock'):
-            open_index(_url_for(path), create=True)
-    finally:
-        blocker.rollback()
-        blocker.close()
-
-
-# ---------------------------------------------------------------------------
-# What SQLite could not open, and why
-# ---------------------------------------------------------------------------
-
-
-def test_a_path_that_is_a_directory_is_not_reported_as_a_locking_failure(tmp_path: Path) -> None:
-    """SQLite refuses a directory with the code it refuses a missing one with.
-
-    Parameters:
-        tmp_path: Directory the misnamed path is created in.
-    """
-    directory = tmp_path / 'index.sqlite3'
-    directory.mkdir()
-    with pytest.raises(ValueError, match='is not a file'):
-        open_index(_url_for(directory))
-
-
-def test_a_file_that_is_not_a_database_says_so(tmp_path: Path) -> None:
-    """A file at the index path is not therefore an index, or even a database.
-
-    Parameters:
-        tmp_path: Directory holding the file.
-    """
-    path = tmp_path / 'index.sqlite3'
-    path.write_text('this is a note somebody left here\n')
-    with pytest.raises(ValueError, match='not a SQLite database'):
-        open_index(_url_for(path))
-
-
-def test_a_file_that_is_not_a_database_is_not_blamed_on_the_filesystem(tmp_path: Path) -> None:
-    """Moving to PostgreSQL would not make this file a database.
-
-    Parameters:
-        tmp_path: Directory holding the file.
-    """
-    path = tmp_path / 'index.sqlite3'
-    path.write_text('this is a note somebody left here\n')
-    with pytest.raises(ValueError, match='not a SQLite database') as excinfo:
-        open_index(_url_for(path))
-    assert 'honors locking' not in str(excinfo.value)
-
-
-def test_an_ingest_into_a_directory_that_does_not_exist_names_the_directory(
-    tmp_path: Path,
-) -> None:
-    """The likeliest first-run error there is: ingest before the tree exists.
-
-    Parameters:
-        tmp_path: Directory the missing directory would have lived in.
-    """
-    path = tmp_path / 'results' / 'index.sqlite3'
-    with pytest.raises(ValueError, match=re.escape(f'{tmp_path / "results"} does not exist')):
-        open_index(_url_for(path), create=True)
-
-
-def test_a_directory_that_does_not_exist_is_not_answered_with_postgresql(
-    tmp_path: Path,
-) -> None:
-    """Prescribing a database server for a directory nobody created is a wrong remedy.
-
-    Parameters:
-        tmp_path: Directory the missing directory would have lived in.
-    """
-    path = tmp_path / 'results' / 'index.sqlite3'
-    with pytest.raises(ValueError, match='does not exist') as excinfo:
-        open_index(_url_for(path), create=True)
-    assert 'postgresql' not in str(excinfo.value)
-
-
-def test_a_file_this_user_cannot_open_names_the_permissions(tmp_path: Path) -> None:
-    """An unreadable file is a permissions problem, not a locking one.
-
-    Parameters:
-        tmp_path: Directory holding the database.
-    """
-    path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True):
-        pass
-    path.chmod(0o000)
-    try:
-        if os.access(path, os.R_OK):
-            pytest.skip('this user can read a file whose mode forbids reading')
-        with pytest.raises(ValueError, match='Check that this user may read'):
-            open_index(_url_for(path))
-    finally:
-        path.chmod(0o644)
-
-
-def test_a_driver_error_carrying_no_result_code_keeps_the_lock_message(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Classifying by result code must not fail on an exception that carries none.
-
-    Parameters:
-        tmp_path: Directory holding the database.
-        monkeypatch: Fixture the failing statement execution is installed through.
-    """
-    path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True):
-        pass
-    refusing = _refusing_with(Exception('nothing to go on'))
-    monkeypatch.setattr(Connection, 'exec_driver_sql', refusing)
-    with pytest.raises(ValueError, match='could not take a SQLite write lock'):
-        open_index(_url_for(path))
-
-
-@pytest.mark.parametrize(
-    ('error_name', 'detail'),
-    [
-        ('SQLITE_FULL', 'database or disk is full'),
-        ('SQLITE_CORRUPT', 'database disk image is malformed'),
-    ],
-)
-def test_an_unclassified_result_code_is_reported_as_what_sqlite_said(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, error_name: str, detail: str
-) -> None:
-    """A code with no classification gets SQLite's own words, not a guess.
-
-    Parameters:
-        tmp_path: Directory holding the database.
-        monkeypatch: Fixture the failing statement execution is installed through.
-        error_name: The result code SQLite reports.
-        detail: What the driver says alongside it.
-    """
-    path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True):
-        pass
-    monkeypatch.setattr(
-        Connection, 'exec_driver_sql', _refusing_with(_DriverError(detail, error_name))
-    )
-    with pytest.raises(ValueError, match=f'SQLite refused .*{error_name}'):
-        open_index(_url_for(path))
-
-
-@pytest.mark.parametrize(
-    ('error_name', 'detail'),
-    [
-        ('SQLITE_FULL', 'database or disk is full'),
-        ('SQLITE_CORRUPT', 'database disk image is malformed'),
-    ],
-)
-def test_an_unclassified_result_code_is_not_answered_with_postgresql(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, error_name: str, detail: str
-) -> None:
-    """A full disk and a corrupt file are not reasons to rebuild on a server.
-
-    That remedy belongs to a filesystem that will not honor locking, and to
-    nothing else; prescribing it for every unrecognized code is how an operator
-    ends up migrating a deployment over a disk that needed emptying.
-
-    Parameters:
-        tmp_path: Directory holding the database.
-        monkeypatch: Fixture the failing statement execution is installed through.
-        error_name: The result code SQLite reports.
-        detail: What the driver says alongside it.
-    """
-    path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True):
-        pass
-    monkeypatch.setattr(
-        Connection, 'exec_driver_sql', _refusing_with(_DriverError(detail, error_name))
-    )
-    with pytest.raises(ValueError, match='SQLite refused') as excinfo:
-        open_index(_url_for(path))
-    assert 'postgresql' not in str(excinfo.value)
-
-
-def test_an_in_memory_database_that_cannot_be_opened_says_only_that(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """An in-memory URL names no path, so the message that names one cannot be used.
-
-    Parameters:
-        monkeypatch: Fixture the failing statement execution is installed through.
-    """
-    monkeypatch.setattr(
-        Connection,
-        'exec_driver_sql',
-        _refusing_with(_DriverError('unable to open database file', 'SQLITE_CANTOPEN')),
-    )
-    with pytest.raises(ValueError, match='could not open this database'):
-        open_index('sqlite://')
-
-
-# ---------------------------------------------------------------------------
-# A SQLite URL is a plain path
-# ---------------------------------------------------------------------------
-
-
-def test_a_sqlite_url_with_a_query_string_is_refused(tmp_path: Path) -> None:
-    """The driver opens a file named after the query, not the file named here.
-
-    Parameters:
-        tmp_path: Directory holding the database.
-    """
-    path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True):
-        pass
-    with pytest.raises(ValueError, match='carries a query string'):
-        open_index(f'{_url_for(path)}?uri=true&mode=ro')
-
-
-def test_a_refused_query_string_leaves_no_file_behind(tmp_path: Path) -> None:
-    """Such a URL passes the existence check and then creates a second file.
-
-    The stray file is named for the query, so it is neither the database the
-    operator meant nor an index anything can read.
-
-    Parameters:
-        tmp_path: Directory the database would have lived in.
-    """
-    path = tmp_path / 'index.sqlite3'
-    with pytest.raises(ValueError, match='carries a query string'):
-        open_index(f'{_url_for(path)}?uri=true&mode=ro', create=True)
-    assert list(tmp_path.iterdir()) == []
-
-
-def test_a_query_argument_the_driver_would_reject_is_refused_as_a_query_string(
-    tmp_path: Path,
-) -> None:
-    """The driver coerces its connect arguments and reports a bad one bare.
-
-    ``?timeout=abc`` reaches a float conversion inside the dialect, whose
-    ``ValueError`` names neither the URL nor the setting; the rule that a SQLite
-    index URL is a plain path refuses it before it gets there.
-
-    Parameters:
-        tmp_path: Directory the database would have lived in.
-    """
-    with pytest.raises(ValueError, match='carries a query string'):
-        open_index(f'{_url_for(tmp_path / "index.sqlite3")}?timeout=abc', create=True)
-
-
-# ---------------------------------------------------------------------------
-# A read-only index
-# ---------------------------------------------------------------------------
-
-
-def test_a_read_only_index_is_opened_by_a_consumer(read_only_index: Path) -> None:
-    """A reader cannot corrupt anything, so read-only media serve it.
-
-    An archived copy, or one on a read-only mount, honors locking perfectly; the
-    write it refuses is a write nobody on this path was going to make.
-
-    Parameters:
-        read_only_index: A database file this user cannot write.
-    """
-    with opened(_url_for(read_only_index)) as engine, engine.connect() as connection:
-        stamped = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).scalar()
-    assert stamped == SCHEMA_VERSION
-
-
-def test_a_read_only_index_is_refused_by_a_creating_open(read_only_index: Path) -> None:
-    """Ingest writes, so a database it can never write is refused at open.
-
-    Parameters:
-        read_only_index: A database file this user cannot write.
-    """
-    with pytest.raises(ValueError, match='read-only, and ingest has to write it'):
-        open_index(_url_for(read_only_index), create=True)
-
-
-def test_the_read_only_refusal_does_not_blame_the_filesystem(read_only_index: Path) -> None:
-    """The message names read-only rather than the filesystem's locking.
-
-    Sending an operator to fix locking on a filesystem that locks correctly costs
-    the whole diagnosis.
-
-    Parameters:
-        read_only_index: A database file this user cannot write.
-    """
-    with pytest.raises(ValueError, match='read-only, and ingest has to write it') as excinfo:
-        open_index(_url_for(read_only_index), create=True)
-    assert 'honors locking' not in str(excinfo.value)
-
-
-def test_a_read_only_index_is_refused_before_anything_is_opened(read_only_index: Path) -> None:
-    """The refusal comes from the filesystem, so no side file is left behind.
-
-    A write-ahead-logged database that has been connected to leaves a
-    shared-memory index beside itself; refusing before the engine connects is
-    what keeps an ingest that will not run from touching the directory at all.
-
-    Parameters:
-        read_only_index: A database file this user cannot write.
-    """
-    with pytest.raises(ValueError, match='read-only, and ingest has to write it'):
-        open_index(_url_for(read_only_index), create=True)
-    assert sorted(path.name for path in read_only_index.parent.iterdir()) == ['index.sqlite3']
-
-
-def test_an_ingest_into_a_read_only_directory_is_refused(tmp_path: Path) -> None:
-    """SQLite writes its write-ahead log beside the database, so the directory counts.
-
-    A writable file in a directory that permits nothing is a database ingest
-    still cannot write, and SQLite grants the write lock on it anyway.
-
-    Parameters:
-        tmp_path: Directory the read-only directory is created in.
-    """
-    directory = tmp_path / 'archive'
-    directory.mkdir()
-    path = directory / 'index.sqlite3'
-    with opened(_url_for(path), create=True):
-        pass
-    directory.chmod(0o555)
-    try:
-        if os.access(directory, os.W_OK):
-            pytest.skip('this user can write a directory whose mode forbids writing')
-        with pytest.raises(ValueError, match='is read-only, and ingest has to write the'):
-            open_index(_url_for(path), create=True)
-    finally:
-        directory.chmod(0o755)
-
-
-def test_an_ingest_is_refused_by_sqlite_when_the_mode_bits_said_it_could_write(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A network filesystem answers from mode bits it does not itself enforce.
-
-    The filesystem check ahead of the engine is the ordinary diagnosis, and here
-    it is made to answer wrongly on purpose, because that is what an NFS or SMB
-    mount does: it reports a database this user may write, and SQLite is the one
-    that finds out otherwise. The refusal has to say read-only anyway, rather
-    than sending the operator to fix locking on a filesystem that locks fine.
-
-    Parameters:
-        tmp_path: Directory the read-only directory is created in.
-        monkeypatch: Fixture the lying access check is installed through.
-    """
-    directory = tmp_path / 'archive'
-    directory.mkdir()
-    path = directory / 'index.sqlite3'
-    with opened(_url_for(path), create=True):
-        pass
-    directory.chmod(0o555)
-    try:
-        if os.access(directory, os.W_OK):
-            pytest.skip('this user can write a directory whose mode forbids writing')
-        monkeypatch.setattr(os, 'access', lambda *args, **kwargs: True)
-        with pytest.raises(ValueError, match='read-only, and ingest has to write it'):
-            open_index(_url_for(path), create=True)
-    finally:
-        directory.chmod(0o755)
-
-
-def test_a_write_ahead_logged_index_in_a_read_only_directory_cannot_be_read(
-    tmp_path: Path,
-) -> None:
-    """SQLite reads such a database through a file it creates beside it.
-
-    A copy whose directory forbids writing therefore cannot be read either, and
-    saying so beats letting a consumer's first query fail with a write error.
-
-    Parameters:
-        tmp_path: Directory the read-only directory is created in.
-    """
-    directory = tmp_path / 'read-only'
-    directory.mkdir()
-    path = directory / 'index.sqlite3'
-    with opened(_url_for(path), create=True):
-        pass
-    path.chmod(0o444)
-    directory.chmod(0o555)
-    try:
-        if os.access(path, os.W_OK):
-            pytest.skip('this user can write a file whose mode forbids writing')
-        with pytest.raises(ValueError, match='cannot be read either'):
-            open_index(_url_for(path))
-    finally:
-        directory.chmod(0o755)
-        path.chmod(0o644)
 
 
 # ---------------------------------------------------------------------------
@@ -1375,7 +470,7 @@ def _refuse_an_open(path: Path, monkeypatch: pytest.MonkeyPatch) -> _RefusedOpen
 
     monkeypatch.setattr(sqlalchemy, 'create_engine', recording)
     with pytest.raises(ValueError, match='is not the version'):
-        open_index(_url_for(path))
+        open_index(sqlite_url_for(path))
     return _RefusedOpen(engine=engines[0], pool=pools[0])
 
 

--- a/tests/spindoctor/results_index/test_engine.py
+++ b/tests/spindoctor/results_index/test_engine.py
@@ -12,7 +12,7 @@ import dataclasses
 import os
 import re
 import sqlite3
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +28,15 @@ from spindoctor.results_index import engine as engine_module
 PASSWORD = 'sup3rs3cr3t'
 """A password distinctive enough that finding it anywhere is proof of a leak."""
 
+SLASHED_PASSWORD = 'aB3/xY9z'
+"""A password carrying a slash, which a URL permits unescaped.
+
+The route that masks by pattern is the one that runs on a URL nothing could
+parse, so nothing there knows where the password ends except the ``@``. A
+pattern that stopped at a path separator would leave this one in the message
+whole.
+"""
+
 MISSING_DRIVER_URL = 'postgresql+psycopg://user@localhost:5432/spindoctor'
 
 UNSUPPORTED_BACKEND_URL = 'mysql+mysqldb://user@localhost/spindoctor'
@@ -37,6 +46,9 @@ UNKNOWN_BACKEND_URL = 'frobnicate://user@localhost/spindoctor'
 MALFORMED_URL = 'this is not a connection url :::'
 
 UNREACHABLE_SERVER_URL = 'postgresql+psycopg://spindoctor@127.0.0.1:1/spindoctor'
+
+EXPLODING_FACTORY_MESSAGE = 'the dialect exploded'
+"""What the stand-in engine factory raises, standing for any escape from one."""
 
 
 def _url_for(path: Path) -> str:
@@ -70,6 +82,64 @@ def _without_module(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
         return real_import(module_name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, '__import__', blocked)
+
+
+class _DriverError(Exception):
+    """A driver exception carrying the result code SQLite would have set on it.
+
+    The codes worth testing are the ones that are hard to provoke on demand: a
+    disk that filled during an ingest, a file that corrupted under a crash. The
+    classification reads the code off the driver's exception, so an exception
+    carrying the code is the whole of what it needs.
+
+    Attributes:
+        sqlite_errorname: The result-code name, under the attribute the SQLite
+            driver publishes it as.
+    """
+
+    def __init__(self, message: str, error_name: str) -> None:
+        """Build the refusal.
+
+        Parameters:
+            message: What the driver would have said.
+            error_name: The result-code name to carry.
+        """
+        super().__init__(message)
+        self.sqlite_errorname = error_name
+
+
+def _refusing_with(original: Exception) -> Callable[..., Any]:
+    """Return a statement executor that fails every statement with one error.
+
+    Parameters:
+        original: The driver exception to wrap, standing in for what SQLite
+            itself raised.
+
+    Returns:
+        A replacement for ``Connection.exec_driver_sql``.
+    """
+
+    def refusing(self: Any, statement: Any, *args: Any, **kwargs: Any) -> Any:
+        raise sqlalchemy.exc.OperationalError(str(statement), None, original)
+
+    return refusing
+
+
+def _exploding_factory(*args: Any, **kwargs: Any) -> Engine:
+    """Stand in for an engine factory that fails in a way nobody enumerated.
+
+    A dialect coerces its own connect arguments and reports a bad one as a bare
+    exception naming nothing, so the translation has to be a catch-all rather
+    than a list of types.
+
+    Parameters:
+        args: Whatever the caller passed, all of it ignored.
+        kwargs: Whatever the caller passed, all of it ignored.
+
+    Raises:
+        RuntimeError: Always.
+    """
+    raise RuntimeError(EXPLODING_FACTORY_MESSAGE)
 
 
 def _index_stamped_with_another_version(tmp_path: Path) -> Path:
@@ -135,13 +205,19 @@ def read_only_index(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[
     finally:
         connection.close()
     path.chmod(0o444)
-    if os.access(path, os.W_OK):
-        pytest.skip('this user can write a file whose mode forbids writing')
     try:
+        if os.access(path, os.W_OK):
+            pytest.skip('this user can write a file whose mode forbids writing')
         yield path
     finally:
-        # Restored so the temporary directory can be removed by a later run.
-        path.chmod(0o644)
+        # Every file the fixture is responsible for, not only the database:
+        # SQLite copies the database's mode onto the write-ahead log and the
+        # shared-memory index it creates beside it, so a test that reads this
+        # database leaves those behind read-only too. The skip is inside the
+        # try for the same reason: a run on a user who can write anything must
+        # still leave the directory as it found it.
+        for made_read_only in path.parent.glob(f'{path.name}*'):
+            made_read_only.chmod(0o644)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -154,16 +230,23 @@ class _Route:
         identifies: Text of the URL the message must keep, so a reader can tell
             which of the resolution levels supplied the value.
         cause: Exception type the refusal keeps as its ``__cause__``.
+        password: The password this route's URL carries, which its refusal may
+            not repeat.
         hidden_module: Module to make unimportable first, or None.
         needs_psycopg: Whether the route reaches the PostgreSQL driver itself.
+        breaks_the_factory: Whether the engine factory is replaced by one that
+            raises, standing for a failure inside a dialect that no enumeration
+            of exception types would have caught.
     """
 
     url: str
     message: str
     identifies: str
     cause: type[BaseException]
+    password: str = PASSWORD
     hidden_module: str | None = None
     needs_psycopg: bool = False
+    breaks_the_factory: bool = False
 
 
 REFUSAL_ROUTES = [
@@ -207,6 +290,21 @@ REFUSAL_ROUTES = [
     ),
     pytest.param(
         _Route(
+            # A stray space in the scheme, which is what a URL copied across two
+            # lines of a configuration file arrives as. Nothing parses it, so
+            # nothing can render it either: this is the route on which the
+            # password is masked by pattern, and the only one on which the
+            # pattern is what stands between the password and the run log.
+            url=f'postgresql psycopg://svc:{SLASHED_PASSWORD}@db.example/spindoctor',
+            message='could not open the results index',
+            identifies='db.example',
+            cause=sqlalchemy.exc.ArgumentError,
+            password=SLASHED_PASSWORD,
+        ),
+        id='unparseable-url',
+    ),
+    pytest.param(
+        _Route(
             url=f'postgresql+psycopg://spindoctor:{PASSWORD}@127.0.0.1:1/spindoctor',
             message='could not open the results index',
             identifies='127.0.0.1:1',
@@ -214,6 +312,16 @@ REFUSAL_ROUTES = [
             needs_psycopg=True,
         ),
         id='server-refuses-the-connection',
+    ),
+    pytest.param(
+        _Route(
+            url=f'postgresql+psycopg://user:{PASSWORD}@db.example:5432/spindoctor',
+            message=EXPLODING_FACTORY_MESSAGE,
+            identifies='db.example:5432',
+            cause=RuntimeError,
+            breaks_the_factory=True,
+        ),
+        id='failure-inside-the-engine-factory',
     ),
 ]
 """Every route by which a URL carrying a password reaches a refusal."""
@@ -233,6 +341,8 @@ def _refusal_of(route: _Route, monkeypatch: pytest.MonkeyPatch) -> ValueError:
         pytest.importorskip('psycopg')
     if route.hidden_module is not None:
         _without_module(monkeypatch, route.hidden_module)
+    if route.breaks_the_factory:
+        monkeypatch.setattr(sqlalchemy, 'create_engine', _exploding_factory)
     with pytest.raises(ValueError, match=route.message) as excinfo:
         open_index(route.url)
     return excinfo.value
@@ -506,7 +616,7 @@ def test_a_missing_driver_for_another_backend_is_not_disguised(
         monkeypatch: Fixture used to hide the driver.
     """
     _without_module(monkeypatch, 'MySQLdb')
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match='ships no driver for that backend') as excinfo:
         open_index(UNSUPPORTED_BACKEND_URL)
     assert 'rms-spindoctor[postgres]' not in str(excinfo.value)
 
@@ -576,7 +686,7 @@ def test_a_refusal_does_not_repeat_the_password(
         route: The refusal route under test.
         monkeypatch: Fixture the import hook is installed through.
     """
-    assert PASSWORD not in str(_refusal_of(route, monkeypatch))
+    assert route.password not in str(_refusal_of(route, monkeypatch))
 
 
 @pytest.mark.parametrize('route', REFUSAL_ROUTES)
@@ -595,6 +705,55 @@ def test_a_masked_refusal_still_names_the_rest_of_the_url(
     assert route.identifies in str(_refusal_of(route, monkeypatch))
 
 
+MASKING_CASES = [
+    pytest.param(
+        'postgresql+psycopg://svc:aB3/xY9z@db.example:5432x/spindoctor',
+        'postgresql+psycopg://svc:***@db.example:5432x/spindoctor',
+        id='a-password-carrying-a-slash',
+    ),
+    pytest.param(
+        'postgresql+psycopg:/svc:aB3xY9z@db.example/spindoctor',
+        'postgresql+psycopg:/svc:***@db.example/spindoctor',
+        id='one-slash-after-the-scheme',
+    ),
+    pytest.param('//user:pa/ss@h', '//user:***@h', id='no-scheme-at-all'),
+    pytest.param('//:pw@h', '//:***@h', id='no-user-name'),
+    pytest.param('/user:pw@h', '/user:***@h', id='one-slash-and-no-scheme'),
+    pytest.param(
+        'sqlite:////data/a:b/index.sqlite3',
+        'sqlite:////data/a:b/index.sqlite3',
+        id='a-local-path-carrying-a-colon',
+    ),
+    pytest.param(
+        'sqlite:////data/a:b/i@dex.sqlite3',
+        'sqlite:////data/a:b/i@dex.sqlite3',
+        id='a-local-path-carrying-a-colon-and-an-at-sign',
+    ),
+    pytest.param(
+        'postgresql+psycopg://user@host/spindoctor',
+        'postgresql+psycopg://user@host/spindoctor',
+        id='no-password-to-mask',
+    ),
+]
+"""URLs the pattern masks, and URLs it must leave exactly as they are."""
+
+
+@pytest.mark.parametrize(('url', 'expected'), MASKING_CASES)
+def test_the_pattern_masks_a_password_and_nothing_else(url: str, expected: str) -> None:
+    """The pattern is the only defense on the route where the URL did not parse.
+
+    It has to reach a password whatever the password contains -- a URL permits an
+    unescaped slash in one -- and it has to leave alone a local path that merely
+    happens to carry a colon and a later at-sign, since mangling the path costs
+    the identification these messages exist for.
+
+    Parameters:
+        url: The URL as a caller wrote it.
+        expected: What masking it must produce.
+    """
+    assert engine_module._masked_url(url) == expected
+
+
 def test_an_unexpected_failure_inside_the_driver_is_still_a_value_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -608,12 +767,8 @@ def test_an_unexpected_failure_inside_the_driver_is_still_a_value_error(
         tmp_path: Directory the database would have lived in.
         monkeypatch: Fixture the failing engine factory is installed through.
     """
-
-    def exploding(*args: Any, **kwargs: Any) -> Engine:
-        raise RuntimeError('the dialect exploded')
-
-    monkeypatch.setattr(sqlalchemy, 'create_engine', exploding)
-    with pytest.raises(ValueError, match='the dialect exploded'):
+    monkeypatch.setattr(sqlalchemy, 'create_engine', _exploding_factory)
+    with pytest.raises(ValueError, match=EXPLODING_FACTORY_MESSAGE):
         open_index(_url_for(tmp_path / 'index.sqlite3'), create=True)
 
 
@@ -626,13 +781,24 @@ def test_an_unexpected_failure_names_the_url(
         tmp_path: Directory the database would have lived in.
         monkeypatch: Fixture the failing engine factory is installed through.
     """
-
-    def exploding(*args: Any, **kwargs: Any) -> Engine:
-        raise RuntimeError('the dialect exploded')
-
-    monkeypatch.setattr(sqlalchemy, 'create_engine', exploding)
+    monkeypatch.setattr(sqlalchemy, 'create_engine', _exploding_factory)
     with pytest.raises(ValueError, match=re.escape(str(tmp_path / 'index.sqlite3'))):
         open_index(_url_for(tmp_path / 'index.sqlite3'), create=True)
+
+
+def test_an_unexpected_failure_keeps_the_factory_error_as_its_cause(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A translated type that dropped the original leaves nothing to debug from.
+
+    Parameters:
+        tmp_path: Directory the database would have lived in.
+        monkeypatch: Fixture the failing engine factory is installed through.
+    """
+    monkeypatch.setattr(sqlalchemy, 'create_engine', _exploding_factory)
+    with pytest.raises(ValueError, match=EXPLODING_FACTORY_MESSAGE) as excinfo:
+        open_index(_url_for(tmp_path / 'index.sqlite3'), create=True)
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
 
 
 def test_engine_echo_is_off(tmp_path: Path) -> None:
@@ -659,7 +825,6 @@ def test_engine_echo_is_off(tmp_path: Path) -> None:
     [
         ('foreign_keys', 1),
         ('busy_timeout', engine_module.SQLITE_BUSY_TIMEOUT_MS),
-        ('journal_mode', 'wal'),
     ],
 )
 def test_every_sqlite_connection_carries_the_pragma(
@@ -668,8 +833,13 @@ def test_every_sqlite_connection_carries_the_pragma(
     """The settings are applied per connection, not once at open.
 
     A pool hands out connections opened long after the engine was built, and a
-    connection without these is a connection without the cascade, without
-    concurrent readers, and without the wait that keeps two writers from failing.
+    connection without these is a connection without the cascade and without the
+    wait that keeps two writers from failing. Both are per-connection state that
+    a connection the settings missed simply does not have, which is what makes
+    reading them back on a second connection a real test. The journal mode is
+    not: it is a property of the database file, so it reads back the same
+    whether or not this connection asked for it, and it is asserted separately
+    as the persistent thing it is.
 
     Parameters:
         tmp_path: Directory holding the database.
@@ -687,6 +857,27 @@ def test_every_sqlite_connection_carries_the_pragma(
         found = second.exec_driver_sql(f'PRAGMA {pragma}').scalar()
     assert reused is False
     assert found == expected
+
+
+def test_the_opener_leaves_the_database_write_ahead_logged(tmp_path: Path) -> None:
+    """Write-ahead logging is what lets a reader and a writer work at once.
+
+    The journal mode lives in the database header rather than in a connection,
+    so it is read back from the closed file with the standard library: that is
+    the state a later ingest, and every consumer, actually meets.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True):
+        pass
+    connection = sqlite3.connect(path)
+    try:
+        (mode,) = connection.execute('PRAGMA journal_mode').fetchone()
+    finally:
+        connection.close()
+    assert mode == 'wal'
 
 
 def test_a_locked_database_file_is_refused_at_open(
@@ -800,7 +991,7 @@ def test_a_file_that_is_not_a_database_is_not_blamed_on_the_filesystem(tmp_path:
     """
     path = tmp_path / 'index.sqlite3'
     path.write_text('this is a note somebody left here\n')
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match='not a SQLite database') as excinfo:
         open_index(_url_for(path))
     assert 'honors locking' not in str(excinfo.value)
 
@@ -827,7 +1018,7 @@ def test_a_directory_that_does_not_exist_is_not_answered_with_postgresql(
         tmp_path: Directory the missing directory would have lived in.
     """
     path = tmp_path / 'results' / 'index.sqlite3'
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match='does not exist') as excinfo:
         open_index(_url_for(path), create=True)
     assert 'postgresql' not in str(excinfo.value)
 
@@ -863,13 +1054,88 @@ def test_a_driver_error_carrying_no_result_code_keeps_the_lock_message(
     path = tmp_path / 'index.sqlite3'
     with opened(_url_for(path), create=True):
         pass
-
-    def refusing(self: Any, statement: Any, *args: Any, **kwargs: Any) -> Any:
-        raise sqlalchemy.exc.OperationalError(str(statement), None, Exception('nothing to go on'))
-
+    refusing = _refusing_with(Exception('nothing to go on'))
     monkeypatch.setattr(Connection, 'exec_driver_sql', refusing)
     with pytest.raises(ValueError, match='could not take a SQLite write lock'):
         open_index(_url_for(path))
+
+
+@pytest.mark.parametrize(
+    ('error_name', 'detail'),
+    [
+        ('SQLITE_FULL', 'database or disk is full'),
+        ('SQLITE_CORRUPT', 'database disk image is malformed'),
+    ],
+)
+def test_an_unclassified_result_code_is_reported_as_what_sqlite_said(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, error_name: str, detail: str
+) -> None:
+    """A code with no classification gets SQLite's own words, not a guess.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+        monkeypatch: Fixture the failing statement execution is installed through.
+        error_name: The result code SQLite reports.
+        detail: What the driver says alongside it.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True):
+        pass
+    monkeypatch.setattr(
+        Connection, 'exec_driver_sql', _refusing_with(_DriverError(detail, error_name))
+    )
+    with pytest.raises(ValueError, match=f'SQLite refused .*{error_name}'):
+        open_index(_url_for(path))
+
+
+@pytest.mark.parametrize(
+    ('error_name', 'detail'),
+    [
+        ('SQLITE_FULL', 'database or disk is full'),
+        ('SQLITE_CORRUPT', 'database disk image is malformed'),
+    ],
+)
+def test_an_unclassified_result_code_is_not_answered_with_postgresql(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, error_name: str, detail: str
+) -> None:
+    """A full disk and a corrupt file are not reasons to rebuild on a server.
+
+    That remedy belongs to a filesystem that will not honor locking, and to
+    nothing else; prescribing it for every unrecognized code is how an operator
+    ends up migrating a deployment over a disk that needed emptying.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+        monkeypatch: Fixture the failing statement execution is installed through.
+        error_name: The result code SQLite reports.
+        detail: What the driver says alongside it.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True):
+        pass
+    monkeypatch.setattr(
+        Connection, 'exec_driver_sql', _refusing_with(_DriverError(detail, error_name))
+    )
+    with pytest.raises(ValueError, match='SQLite refused') as excinfo:
+        open_index(_url_for(path))
+    assert 'postgresql' not in str(excinfo.value)
+
+
+def test_an_in_memory_database_that_cannot_be_opened_says_only_that(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An in-memory URL names no path, so the message that names one cannot be used.
+
+    Parameters:
+        monkeypatch: Fixture the failing statement execution is installed through.
+    """
+    monkeypatch.setattr(
+        Connection,
+        'exec_driver_sql',
+        _refusing_with(_DriverError('unable to open database file', 'SQLITE_CANTOPEN')),
+    )
+    with pytest.raises(ValueError, match='could not open this database'):
+        open_index('sqlite://')
 
 
 # ---------------------------------------------------------------------------
@@ -946,7 +1212,7 @@ def test_a_read_only_index_is_refused_by_a_creating_open(read_only_index: Path) 
     Parameters:
         read_only_index: A database file this user cannot write.
     """
-    with pytest.raises(ValueError, match='this SQLite database is read-only'):
+    with pytest.raises(ValueError, match='read-only, and ingest has to write it'):
         open_index(_url_for(read_only_index), create=True)
 
 
@@ -959,7 +1225,7 @@ def test_the_read_only_refusal_does_not_blame_the_filesystem(read_only_index: Pa
     Parameters:
         read_only_index: A database file this user cannot write.
     """
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match='read-only, and ingest has to write it') as excinfo:
         open_index(_url_for(read_only_index), create=True)
     assert 'honors locking' not in str(excinfo.value)
 
@@ -974,7 +1240,7 @@ def test_a_read_only_index_is_refused_before_anything_is_opened(read_only_index:
     Parameters:
         read_only_index: A database file this user cannot write.
     """
-    with pytest.raises(ValueError, match='this SQLite database is read-only'):
+    with pytest.raises(ValueError, match='read-only, and ingest has to write it'):
         open_index(_url_for(read_only_index), create=True)
     assert sorted(path.name for path in read_only_index.parent.iterdir()) == ['index.sqlite3']
 
@@ -998,6 +1264,37 @@ def test_an_ingest_into_a_read_only_directory_is_refused(tmp_path: Path) -> None
         if os.access(directory, os.W_OK):
             pytest.skip('this user can write a directory whose mode forbids writing')
         with pytest.raises(ValueError, match='is read-only, and ingest has to write the'):
+            open_index(_url_for(path), create=True)
+    finally:
+        directory.chmod(0o755)
+
+
+def test_an_ingest_is_refused_by_sqlite_when_the_mode_bits_said_it_could_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A network filesystem answers from mode bits it does not itself enforce.
+
+    The filesystem check ahead of the engine is the ordinary diagnosis, and here
+    it is made to answer wrongly on purpose, because that is what an NFS or SMB
+    mount does: it reports a database this user may write, and SQLite is the one
+    that finds out otherwise. The refusal has to say read-only anyway, rather
+    than sending the operator to fix locking on a filesystem that locks fine.
+
+    Parameters:
+        tmp_path: Directory the read-only directory is created in.
+        monkeypatch: Fixture the lying access check is installed through.
+    """
+    directory = tmp_path / 'archive'
+    directory.mkdir()
+    path = directory / 'index.sqlite3'
+    with opened(_url_for(path), create=True):
+        pass
+    directory.chmod(0o555)
+    try:
+        if os.access(directory, os.W_OK):
+            pytest.skip('this user can write a directory whose mode forbids writing')
+        monkeypatch.setattr(os, 'access', lambda *args, **kwargs: True)
+        with pytest.raises(ValueError, match='read-only, and ingest has to write it'):
             open_index(_url_for(path), create=True)
     finally:
         directory.chmod(0o755)

--- a/tests/spindoctor/results_index/test_engine.py
+++ b/tests/spindoctor/results_index/test_engine.py
@@ -7,17 +7,32 @@ wrong and what to do about it, because the alternative is a stack trace from
 inside a database driver, or -- worse -- a run that quietly reads nothing.
 """
 
+import builtins
+import dataclasses
+import os
+import re
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 import pytest
 import sqlalchemy
+from sqlalchemy.engine import Engine
+from sqlalchemy.pool import QueuePool
 from tests.spindoctor.results_index.conftest import image_row, opened
 
 from spindoctor.results_index import IMAGES, SCHEMA_META, SCHEMA_VERSION, open_index
 from spindoctor.results_index import engine as engine_module
 
-MISSING_DRIVER_URL = 'postgresql+psycopg2://user:pw@localhost:5432/spindoctor'
+MISSING_DRIVER_URL = 'postgresql+psycopg://user:pw@localhost:5432/spindoctor'
+
+UNSUPPORTED_BACKEND_URL = 'mysql+mysqldb://user@localhost/spindoctor'
+
+UNKNOWN_BACKEND_URL = 'frobnicate://user@localhost/spindoctor'
+
+MALFORMED_URL = 'this is not a connection url :::'
+
+UNREACHABLE_SERVER_URL = 'postgresql+psycopg://spindoctor:pw@127.0.0.1:1/spindoctor'
 
 
 def _url_for(path: Path) -> str:
@@ -30,6 +45,90 @@ def _url_for(path: Path) -> str:
         The URL.
     """
     return f'sqlite:///{path}'
+
+
+def _without_module(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
+    """Make one module unimportable, as it is on a machine without it installed.
+
+    Asserting on a driver that merely happens to be absent from the current
+    virtual environment is a test that stops testing the moment something pulls
+    that driver in as a transitive dependency.
+
+    Parameters:
+        monkeypatch: Fixture the import hook is installed through.
+        name: Dotted name of the module to hide, together with its submodules.
+    """
+    real_import = builtins.__import__
+
+    def blocked(module_name: str, *args: Any, **kwargs: Any) -> Any:
+        if module_name == name or module_name.startswith(f'{name}.'):
+            raise ModuleNotFoundError(f'No module named {name!r}', name=name)
+        return real_import(module_name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', blocked)
+
+
+def _index_stamped_with_another_version(tmp_path: Path) -> Path:
+    """Build an index stamped with a version this code does not read.
+
+    Parameters:
+        tmp_path: Directory the database is created in.
+
+    Returns:
+        Path of the database file.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True) as engine, engine.begin() as connection:
+        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    return path
+
+
+def _table_names(path: Path) -> set[str]:
+    """Return the names of the tables a SQLite file holds.
+
+    Read with the standard library rather than through the opener, so a database
+    the opener refuses can still be inspected.
+
+    Parameters:
+        path: Path of the database file.
+
+    Returns:
+        The table names.
+    """
+    connection = sqlite3.connect(path)
+    try:
+        rows = connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        return {str(name) for (name,) in rows}
+    finally:
+        connection.close()
+
+
+def _read_only_index(tmp_path: Path) -> Path:
+    """Build an index file SQLite can read but will never write.
+
+    The journal mode is moved off write-ahead logging first: SQLite creates a
+    file beside a write-ahead-logged database even to read it, so one that is
+    read-only in a read-only directory cannot be read at all, which is a
+    different case from this one.
+
+    Parameters:
+        tmp_path: Directory the database is created in.
+
+    Returns:
+        Path of the read-only database file.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True):
+        pass
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute('PRAGMA journal_mode = DELETE')
+    finally:
+        connection.close()
+    path.chmod(0o444)
+    if os.access(path, os.W_OK):
+        pytest.skip('this user can write a file whose mode forbids writing')
+    return path
 
 
 # ---------------------------------------------------------------------------
@@ -172,11 +271,33 @@ def test_the_version_gate_applies_to_a_creating_open_too(tmp_path: Path) -> None
     Parameters:
         tmp_path: Directory holding the database.
     """
-    path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True) as engine, engine.begin() as connection:
-        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    path = _index_stamped_with_another_version(tmp_path)
     with pytest.raises(ValueError, match='is not the version'):
         open_index(_url_for(path), create=True)
+
+
+def test_a_creating_open_writes_nothing_to_the_version_it_refuses(tmp_path: Path) -> None:
+    """The gate runs before creation, so a refused open leaves the file alone.
+
+    Otherwise a version bump writes this version's tables into a database
+    stamped as another version, on the way to reporting that it will not read it.
+
+    The refusal is checked against a table removed beforehand: table creation
+    skips what is already there, so only a missing one shows whether it ran.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+    """
+    path = _index_stamped_with_another_version(tmp_path)
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute('DROP TABLE ingest_runs')
+        connection.commit()
+    finally:
+        connection.close()
+    with pytest.raises(ValueError, match='is not the version'):
+        open_index(_url_for(path), create=True)
+    assert 'ingest_runs' not in _table_names(path)
 
 
 def test_creating_twice_keeps_one_version_row(tmp_path: Path) -> None:
@@ -216,26 +337,121 @@ def test_creating_twice_keeps_the_rows_already_ingested(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_a_postgres_url_without_its_driver_names_the_extra() -> None:
-    """An import traceback would not tell an operator what to install."""
+def test_a_postgres_url_without_its_driver_names_the_extra(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An import traceback would not tell an operator what to install.
+
+    Parameters:
+        monkeypatch: Fixture used to hide the driver.
+    """
+    _without_module(monkeypatch, 'psycopg')
     with pytest.raises(ValueError, match=r'rms-spindoctor\[postgres\]'):
         open_index(MISSING_DRIVER_URL)
 
 
-def test_the_missing_driver_message_names_the_url() -> None:
-    """A program may resolve its URL from three places; the message says which."""
-    with pytest.raises(ValueError, match='postgresql\\+psycopg2'):
+def test_the_missing_driver_message_names_the_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A program may resolve its URL from three places; the message says which.
+
+    Parameters:
+        monkeypatch: Fixture used to hide the driver.
+    """
+    _without_module(monkeypatch, 'psycopg')
+    with pytest.raises(ValueError, match=r'postgresql\+psycopg'):
         open_index(MISSING_DRIVER_URL)
 
 
-def test_a_missing_driver_for_another_backend_is_not_disguised() -> None:
+def test_a_missing_driver_for_another_backend_is_a_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One exception type covers every refusal, whichever backend was named.
+
+    Parameters:
+        monkeypatch: Fixture used to hide the driver.
+    """
+    _without_module(monkeypatch, 'MySQLdb')
+    with pytest.raises(ValueError, match=r'mysql\+mysqldb'):
+        open_index(UNSUPPORTED_BACKEND_URL)
+
+
+def test_a_missing_driver_for_another_backend_names_the_driver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reader is told which import failed, not merely that one did.
+
+    Parameters:
+        monkeypatch: Fixture used to hide the driver.
+    """
+    _without_module(monkeypatch, 'MySQLdb')
+    with pytest.raises(ValueError, match='MySQLdb'):
+        open_index(UNSUPPORTED_BACKEND_URL)
+
+
+def test_a_missing_driver_for_another_backend_is_not_disguised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Only PostgreSQL ships as an extra; other backends are not supported.
 
     Reporting a MySQL driver as a missing SpinDoctor extra would send the reader
     to install something that would still not work.
+
+    Parameters:
+        monkeypatch: Fixture used to hide the driver.
     """
-    with pytest.raises(ModuleNotFoundError, match='MySQLdb'):
-        open_index('mysql+mysqldb://user@localhost/spindoctor')
+    _without_module(monkeypatch, 'MySQLdb')
+    with pytest.raises(ValueError) as excinfo:
+        open_index(UNSUPPORTED_BACKEND_URL)
+    assert 'rms-spindoctor[postgres]' not in str(excinfo.value)
+
+
+def test_an_unknown_backend_is_a_value_error() -> None:
+    """A URL scheme no driver claims is a configuration error like any other."""
+    with pytest.raises(ValueError, match='no database driver for this URL scheme'):
+        open_index(UNKNOWN_BACKEND_URL)
+
+
+def test_the_unknown_backend_message_names_the_url_forms_that_work() -> None:
+    """Naming the two supported forms is the whole remedy for a typed scheme."""
+    with pytest.raises(ValueError, match=r'postgresql\+psycopg: URL naming a server'):
+        open_index(UNKNOWN_BACKEND_URL)
+
+
+def test_a_malformed_url_is_a_value_error() -> None:
+    """A URL the parser rejects reaches the caller as the one type it catches."""
+    with pytest.raises(ValueError, match='could not open the results index'):
+        open_index(MALFORMED_URL)
+
+
+def test_the_malformed_url_message_names_the_url() -> None:
+    """The text the operator typed is what identifies which setting was wrong."""
+    with pytest.raises(ValueError, match='this is not a connection url'):
+        open_index(MALFORMED_URL)
+
+
+def test_a_server_that_refuses_the_connection_is_a_value_error() -> None:
+    """The common operational failure -- server down, wrong password -- is one type.
+
+    A driver's own exception escaping here would defeat every consumer that
+    reports the cause instead of crashing, and it is the failure they meet most.
+    """
+    pytest.importorskip('psycopg')
+    with pytest.raises(ValueError, match='could not open the results index'):
+        open_index(UNREACHABLE_SERVER_URL)
+
+
+def test_the_refused_connection_message_names_the_url() -> None:
+    """A driver's connection error names the server, never which setting supplied it."""
+    pytest.importorskip('psycopg')
+    with pytest.raises(ValueError, match=re.escape('127.0.0.1:1')):
+        open_index(UNREACHABLE_SERVER_URL)
+
+
+def test_a_translated_failure_keeps_the_driver_error_as_its_cause() -> None:
+    """Translating the type must not throw away what the driver actually said."""
+    pytest.importorskip('psycopg')
+    with pytest.raises(ValueError) as excinfo:
+        open_index(UNREACHABLE_SERVER_URL)
+    assert isinstance(excinfo.value.__cause__, sqlalchemy.exc.SQLAlchemyError)
 
 
 def test_engine_echo_is_off(tmp_path: Path) -> None:
@@ -339,20 +555,179 @@ def test_the_lock_failure_names_postgresql_as_the_shared_option(
         blocker.close()
 
 
-def test_a_refused_open_leaves_no_usable_engine_behind(tmp_path: Path) -> None:
-    """A failed open disposes its engine rather than leaking the connection.
+def test_a_locked_database_file_is_refused_by_a_creating_open(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A writer meets the same refusal a reader does, for the same reason.
 
-    Proven by deleting the file afterwards: a pooled connection still holding it
-    open would keep a Windows-style lock, and on any platform an undisposed pool
-    is a file descriptor nobody closes.
+    Parameters:
+        tmp_path: Directory holding the database.
+        monkeypatch: Fixture used to shorten the busy timeout.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True):
+        pass
+    monkeypatch.setattr(engine_module, 'SQLITE_BUSY_TIMEOUT_MS', 50)
+    blocker = sqlite3.connect(path)
+    try:
+        blocker.execute('BEGIN EXCLUSIVE')
+        with pytest.raises(ValueError, match='could not take a SQLite write lock'):
+            open_index(_url_for(path), create=True)
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+
+# ---------------------------------------------------------------------------
+# A read-only index
+# ---------------------------------------------------------------------------
+
+
+def test_a_read_only_index_is_opened_by_a_consumer(tmp_path: Path) -> None:
+    """A reader cannot corrupt anything, so read-only media serve it.
+
+    An archived copy, or one on a read-only mount, honors locking perfectly; the
+    write it refuses is a write nobody on this path was going to make.
 
     Parameters:
         tmp_path: Directory holding the database.
     """
-    path = tmp_path / 'index.sqlite3'
-    with opened(_url_for(path), create=True) as engine, engine.begin() as connection:
-        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    path = _read_only_index(tmp_path)
+    with opened(_url_for(path)) as engine, engine.connect() as connection:
+        stamped = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).scalar()
+    assert stamped == SCHEMA_VERSION
+
+
+def test_a_read_only_index_is_refused_by_a_creating_open(tmp_path: Path) -> None:
+    """Ingest writes, so a database it can never write is refused at open.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+    """
+    path = _read_only_index(tmp_path)
+    with pytest.raises(ValueError, match='this SQLite database is read-only'):
+        open_index(_url_for(path), create=True)
+
+
+def test_the_read_only_refusal_does_not_blame_the_filesystem(tmp_path: Path) -> None:
+    """The message names read-only rather than the filesystem's locking.
+
+    Sending an operator to fix locking on a filesystem that locks correctly costs
+    the whole diagnosis.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+    """
+    path = _read_only_index(tmp_path)
+    with pytest.raises(ValueError) as excinfo:
+        open_index(_url_for(path), create=True)
+    assert 'honors locking' not in str(excinfo.value)
+
+
+def test_a_write_ahead_logged_index_in_a_read_only_directory_cannot_be_read(
+    tmp_path: Path,
+) -> None:
+    """SQLite reads such a database through a file it creates beside it.
+
+    A copy whose directory forbids writing therefore cannot be read either, and
+    saying so beats letting a consumer's first query fail with a write error.
+
+    Parameters:
+        tmp_path: Directory the read-only directory is created in.
+    """
+    directory = tmp_path / 'read-only'
+    directory.mkdir()
+    path = directory / 'index.sqlite3'
+    with opened(_url_for(path), create=True):
+        pass
+    path.chmod(0o444)
+    directory.chmod(0o555)
+    try:
+        if os.access(path, os.W_OK):
+            pytest.skip('this user can write a file whose mode forbids writing')
+        with pytest.raises(ValueError, match='cannot be read either'):
+            open_index(_url_for(path))
+    finally:
+        directory.chmod(0o755)
+        path.chmod(0o644)
+
+
+# ---------------------------------------------------------------------------
+# Engine disposal
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class _RefusedOpen:
+    """What a refused open left behind.
+
+    Attributes:
+        engine: The engine the refused open built.
+        pool: The pool that engine held before the open failed.
+    """
+
+    engine: Engine
+    pool: QueuePool
+
+
+def _refuse_an_open(path: Path, monkeypatch: pytest.MonkeyPatch) -> _RefusedOpen:
+    """Refuse one open on a version mismatch and capture the engine it built.
+
+    A caller of the opener never sees the engine of an open that raised, so it is
+    recorded as it is created; the pool is recorded with it, because disposal
+    replaces the one the engine holds.
+
+    Parameters:
+        path: Path of an index stamped with a version this code does not read.
+        monkeypatch: Fixture the recording hook is installed through.
+
+    Returns:
+        The recorded engine and its pool.
+    """
+    engines: list[Engine] = []
+    pools: list[QueuePool] = []
+    real_create_engine = sqlalchemy.create_engine
+
+    def recording(*args: Any, **kwargs: Any) -> Engine:
+        made = real_create_engine(*args, **kwargs)
+        engines.append(made)
+        # A file-backed SQLite engine pools its connections; the assertion states
+        # that, because only a pooling implementation can report what it holds.
+        assert isinstance(made.pool, QueuePool)
+        pools.append(made.pool)
+        return made
+
+    monkeypatch.setattr(sqlalchemy, 'create_engine', recording)
     with pytest.raises(ValueError, match='is not the version'):
         open_index(_url_for(path))
-    path.unlink()
-    assert path.exists() is False
+    return _RefusedOpen(engine=engines[0], pool=pools[0])
+
+
+def test_a_refused_open_disposes_the_pool_it_built(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed open closes its connections rather than leaking them.
+
+    The version gate reads through a connection, which returns to the pool; an
+    undisposed pool is that connection's descriptor with no owner left to close
+    it, and a caller that retries in a loop runs out of them.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+        monkeypatch: Fixture the recording hook is installed through.
+    """
+    refused = _refuse_an_open(_index_stamped_with_another_version(tmp_path), monkeypatch)
+    assert refused.pool.checkedin() == 0
+
+
+def test_a_refused_open_does_not_hand_back_the_pool_it_disposed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Disposal replaces the pool, which is the observable proof it happened.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+        monkeypatch: Fixture the recording hook is installed through.
+    """
+    refused = _refuse_an_open(_index_stamped_with_another_version(tmp_path), monkeypatch)
+    assert refused.engine.pool is not refused.pool

--- a/tests/spindoctor/results_index/test_engine.py
+++ b/tests/spindoctor/results_index/test_engine.py
@@ -12,19 +12,23 @@ import dataclasses
 import os
 import re
 import sqlite3
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
 import pytest
 import sqlalchemy
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.pool import QueuePool
 from tests.spindoctor.results_index.conftest import image_row, opened
 
 from spindoctor.results_index import IMAGES, SCHEMA_META, SCHEMA_VERSION, open_index
 from spindoctor.results_index import engine as engine_module
 
-MISSING_DRIVER_URL = 'postgresql+psycopg://user:pw@localhost:5432/spindoctor'
+PASSWORD = 'sup3rs3cr3t'
+"""A password distinctive enough that finding it anywhere is proof of a leak."""
+
+MISSING_DRIVER_URL = 'postgresql+psycopg://user@localhost:5432/spindoctor'
 
 UNSUPPORTED_BACKEND_URL = 'mysql+mysqldb://user@localhost/spindoctor'
 
@@ -32,7 +36,7 @@ UNKNOWN_BACKEND_URL = 'frobnicate://user@localhost/spindoctor'
 
 MALFORMED_URL = 'this is not a connection url :::'
 
-UNREACHABLE_SERVER_URL = 'postgresql+psycopg://spindoctor:pw@127.0.0.1:1/spindoctor'
+UNREACHABLE_SERVER_URL = 'postgresql+psycopg://spindoctor@127.0.0.1:1/spindoctor'
 
 
 def _url_for(path: Path) -> str:
@@ -103,18 +107,23 @@ def _table_names(path: Path) -> set[str]:
         connection.close()
 
 
-def _read_only_index(tmp_path: Path) -> Path:
-    """Build an index file SQLite can read but will never write.
+@pytest.fixture(params=['wal', 'delete'])
+def read_only_index(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[Path]:
+    """Yield an index file SQLite can read but will never write.
 
-    The journal mode is moved off write-ahead logging first: SQLite creates a
-    file beside a write-ahead-logged database even to read it, so one that is
-    read-only in a read-only directory cannot be read at all, which is a
-    different case from this one.
+    Both journal modes are covered, because the two answer a would-be writer
+    differently and neither answer may be the one the opener depends on.
+    Write-ahead logging is the mode this opener always leaves behind, and it is
+    the permissive one: the journal-mode selection and a write lock both succeed
+    on a file SQLite will never write. The rollback journal, which an index
+    arrives in after a tool that checkpoints and vacuums it, refuses the journal
+    mode outright.
 
     Parameters:
+        request: Fixture carrying the journal mode of this case.
         tmp_path: Directory the database is created in.
 
-    Returns:
+    Yields:
         Path of the read-only database file.
     """
     path = tmp_path / 'index.sqlite3'
@@ -122,13 +131,111 @@ def _read_only_index(tmp_path: Path) -> Path:
         pass
     connection = sqlite3.connect(path)
     try:
-        connection.execute('PRAGMA journal_mode = DELETE')
+        connection.execute(f'PRAGMA journal_mode = {request.param}')
     finally:
         connection.close()
     path.chmod(0o444)
     if os.access(path, os.W_OK):
         pytest.skip('this user can write a file whose mode forbids writing')
-    return path
+    try:
+        yield path
+    finally:
+        # Restored so the temporary directory can be removed by a later run.
+        path.chmod(0o644)
+
+
+@dataclasses.dataclass(frozen=True)
+class _Route:
+    """One way a URL is refused, and what its refusal has to say.
+
+    Attributes:
+        url: The URL to open, carrying a password.
+        message: Pattern the refusal message must match.
+        identifies: Text of the URL the message must keep, so a reader can tell
+            which of the resolution levels supplied the value.
+        cause: Exception type the refusal keeps as its ``__cause__``.
+        hidden_module: Module to make unimportable first, or None.
+        needs_psycopg: Whether the route reaches the PostgreSQL driver itself.
+    """
+
+    url: str
+    message: str
+    identifies: str
+    cause: type[BaseException]
+    hidden_module: str | None = None
+    needs_psycopg: bool = False
+
+
+REFUSAL_ROUTES = [
+    pytest.param(
+        _Route(
+            url=f'postgresql+psycopg://user:{PASSWORD}@localhost:5432/spindoctor',
+            message=r'rms-spindoctor\[postgres\]',
+            identifies='localhost:5432',
+            cause=ModuleNotFoundError,
+            hidden_module='psycopg',
+        ),
+        id='driver-not-installed',
+    ),
+    pytest.param(
+        _Route(
+            url=f'mysql+mysqldb://user:{PASSWORD}@localhost/spindoctor',
+            message='MySQLdb',
+            identifies='mysql+mysqldb',
+            cause=ModuleNotFoundError,
+            hidden_module='MySQLdb',
+        ),
+        id='unsupported-backend',
+    ),
+    pytest.param(
+        _Route(
+            url=f'frobnicate://user:{PASSWORD}@localhost/spindoctor',
+            message='no database driver for this URL scheme',
+            identifies='frobnicate',
+            cause=sqlalchemy.exc.NoSuchModuleError,
+        ),
+        id='unknown-scheme',
+    ),
+    pytest.param(
+        _Route(
+            url=f'postgresql+psycopg://user:{PASSWORD}@localhost:notaport/spindoctor',
+            message='could not open the results index',
+            identifies='localhost:notaport',
+            cause=ValueError,
+        ),
+        id='unparseable-port',
+    ),
+    pytest.param(
+        _Route(
+            url=f'postgresql+psycopg://spindoctor:{PASSWORD}@127.0.0.1:1/spindoctor',
+            message='could not open the results index',
+            identifies='127.0.0.1:1',
+            cause=sqlalchemy.exc.OperationalError,
+            needs_psycopg=True,
+        ),
+        id='server-refuses-the-connection',
+    ),
+]
+"""Every route by which a URL carrying a password reaches a refusal."""
+
+
+def _refusal_of(route: _Route, monkeypatch: pytest.MonkeyPatch) -> ValueError:
+    """Open a route's URL and return the refusal it raised.
+
+    Parameters:
+        route: The route to drive.
+        monkeypatch: Fixture the import hook is installed through.
+
+    Returns:
+        The refusal, for assertions on what it says.
+    """
+    if route.needs_psycopg:
+        pytest.importorskip('psycopg')
+    if route.hidden_module is not None:
+        _without_module(monkeypatch, route.hidden_module)
+    with pytest.raises(ValueError, match=route.message) as excinfo:
+        open_index(route.url)
+    return excinfo.value
 
 
 # ---------------------------------------------------------------------------
@@ -446,12 +553,86 @@ def test_the_refused_connection_message_names_the_url() -> None:
         open_index(UNREACHABLE_SERVER_URL)
 
 
-def test_a_translated_failure_keeps_the_driver_error_as_its_cause() -> None:
-    """Translating the type must not throw away what the driver actually said."""
-    pytest.importorskip('psycopg')
-    with pytest.raises(ValueError) as excinfo:
-        open_index(UNREACHABLE_SERVER_URL)
-    assert isinstance(excinfo.value.__cause__, sqlalchemy.exc.SQLAlchemyError)
+@pytest.mark.parametrize('route', REFUSAL_ROUTES)
+def test_a_translated_failure_keeps_the_driver_error_as_its_cause(
+    route: _Route, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Translating the type must not throw away what the driver actually said.
+
+    Parameters:
+        route: The refusal route under test.
+        monkeypatch: Fixture the import hook is installed through.
+    """
+    assert isinstance(_refusal_of(route, monkeypatch).__cause__, route.cause)
+
+
+@pytest.mark.parametrize('route', REFUSAL_ROUTES)
+def test_a_refusal_does_not_repeat_the_password(
+    route: _Route, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """These messages reach run logs and operators; a password reaches neither.
+
+    Parameters:
+        route: The refusal route under test.
+        monkeypatch: Fixture the import hook is installed through.
+    """
+    assert PASSWORD not in str(_refusal_of(route, monkeypatch))
+
+
+@pytest.mark.parametrize('route', REFUSAL_ROUTES)
+def test_a_masked_refusal_still_names_the_rest_of_the_url(
+    route: _Route, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Masking a password must not cost the identification the message is for.
+
+    A program resolves its URL from a command line, a configuration file or the
+    environment, and the URL is what says which of them supplied this one.
+
+    Parameters:
+        route: The refusal route under test.
+        monkeypatch: Fixture the import hook is installed through.
+    """
+    assert route.identifies in str(_refusal_of(route, monkeypatch))
+
+
+def test_an_unexpected_failure_inside_the_driver_is_still_a_value_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The translation is a catch-all, because the escapes are not enumerable.
+
+    A dialect coerces its own connect arguments and reports a bad one as a bare
+    ``ValueError`` naming nothing; only catching everything keeps the promise
+    that a caller reporting the cause has one type to catch and a URL to name.
+
+    Parameters:
+        tmp_path: Directory the database would have lived in.
+        monkeypatch: Fixture the failing engine factory is installed through.
+    """
+
+    def exploding(*args: Any, **kwargs: Any) -> Engine:
+        raise RuntimeError('the dialect exploded')
+
+    monkeypatch.setattr(sqlalchemy, 'create_engine', exploding)
+    with pytest.raises(ValueError, match='the dialect exploded'):
+        open_index(_url_for(tmp_path / 'index.sqlite3'), create=True)
+
+
+def test_an_unexpected_failure_names_the_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A refusal that names no URL leaves the reader with nothing to correct.
+
+    Parameters:
+        tmp_path: Directory the database would have lived in.
+        monkeypatch: Fixture the failing engine factory is installed through.
+    """
+
+    def exploding(*args: Any, **kwargs: Any) -> Engine:
+        raise RuntimeError('the dialect exploded')
+
+    monkeypatch.setattr(sqlalchemy, 'create_engine', exploding)
+    with pytest.raises(ValueError, match=re.escape(str(tmp_path / 'index.sqlite3'))):
+        open_index(_url_for(tmp_path / 'index.sqlite3'), create=True)
 
 
 def test_engine_echo_is_off(tmp_path: Path) -> None:
@@ -495,12 +676,16 @@ def test_every_sqlite_connection_carries_the_pragma(
         pragma: The pragma to read back.
         expected: Its expected value.
     """
-    with opened(_url_for(tmp_path / 'index.sqlite3'), create=True) as engine:
-        # A fresh connection, so a value set only on the first one would not show.
-        with engine.connect():
-            pass
-        with engine.connect() as connection:
-            found = connection.exec_driver_sql(f'PRAGMA {pragma}').scalar()
+    # Both connections held at once, so the pool cannot hand the second request
+    # the connection it made for the first: it has to open another one.
+    with (
+        opened(_url_for(tmp_path / 'index.sqlite3'), create=True) as engine,
+        engine.connect() as first,
+        engine.connect() as second,
+    ):
+        reused = first.connection.dbapi_connection is second.connection.dbapi_connection
+        found = second.exec_driver_sql(f'PRAGMA {pragma}').scalar()
+    assert reused is False
     assert found == expected
 
 
@@ -579,49 +764,243 @@ def test_a_locked_database_file_is_refused_by_a_creating_open(
 
 
 # ---------------------------------------------------------------------------
+# What SQLite could not open, and why
+# ---------------------------------------------------------------------------
+
+
+def test_a_path_that_is_a_directory_is_not_reported_as_a_locking_failure(tmp_path: Path) -> None:
+    """SQLite refuses a directory with the code it refuses a missing one with.
+
+    Parameters:
+        tmp_path: Directory the misnamed path is created in.
+    """
+    directory = tmp_path / 'index.sqlite3'
+    directory.mkdir()
+    with pytest.raises(ValueError, match='is not a file'):
+        open_index(_url_for(directory))
+
+
+def test_a_file_that_is_not_a_database_says_so(tmp_path: Path) -> None:
+    """A file at the index path is not therefore an index, or even a database.
+
+    Parameters:
+        tmp_path: Directory holding the file.
+    """
+    path = tmp_path / 'index.sqlite3'
+    path.write_text('this is a note somebody left here\n')
+    with pytest.raises(ValueError, match='not a SQLite database'):
+        open_index(_url_for(path))
+
+
+def test_a_file_that_is_not_a_database_is_not_blamed_on_the_filesystem(tmp_path: Path) -> None:
+    """Moving to PostgreSQL would not make this file a database.
+
+    Parameters:
+        tmp_path: Directory holding the file.
+    """
+    path = tmp_path / 'index.sqlite3'
+    path.write_text('this is a note somebody left here\n')
+    with pytest.raises(ValueError) as excinfo:
+        open_index(_url_for(path))
+    assert 'honors locking' not in str(excinfo.value)
+
+
+def test_an_ingest_into_a_directory_that_does_not_exist_names_the_directory(
+    tmp_path: Path,
+) -> None:
+    """The likeliest first-run error there is: ingest before the tree exists.
+
+    Parameters:
+        tmp_path: Directory the missing directory would have lived in.
+    """
+    path = tmp_path / 'results' / 'index.sqlite3'
+    with pytest.raises(ValueError, match=re.escape(f'{tmp_path / "results"} does not exist')):
+        open_index(_url_for(path), create=True)
+
+
+def test_a_directory_that_does_not_exist_is_not_answered_with_postgresql(
+    tmp_path: Path,
+) -> None:
+    """Prescribing a database server for a directory nobody created is a wrong remedy.
+
+    Parameters:
+        tmp_path: Directory the missing directory would have lived in.
+    """
+    path = tmp_path / 'results' / 'index.sqlite3'
+    with pytest.raises(ValueError) as excinfo:
+        open_index(_url_for(path), create=True)
+    assert 'postgresql' not in str(excinfo.value)
+
+
+def test_a_file_this_user_cannot_open_names_the_permissions(tmp_path: Path) -> None:
+    """An unreadable file is a permissions problem, not a locking one.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True):
+        pass
+    path.chmod(0o000)
+    try:
+        if os.access(path, os.R_OK):
+            pytest.skip('this user can read a file whose mode forbids reading')
+        with pytest.raises(ValueError, match='Check that this user may read'):
+            open_index(_url_for(path))
+    finally:
+        path.chmod(0o644)
+
+
+def test_a_driver_error_carrying_no_result_code_keeps_the_lock_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Classifying by result code must not fail on an exception that carries none.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+        monkeypatch: Fixture the failing statement execution is installed through.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True):
+        pass
+
+    def refusing(self: Any, statement: Any, *args: Any, **kwargs: Any) -> Any:
+        raise sqlalchemy.exc.OperationalError(str(statement), None, Exception('nothing to go on'))
+
+    monkeypatch.setattr(Connection, 'exec_driver_sql', refusing)
+    with pytest.raises(ValueError, match='could not take a SQLite write lock'):
+        open_index(_url_for(path))
+
+
+# ---------------------------------------------------------------------------
+# A SQLite URL is a plain path
+# ---------------------------------------------------------------------------
+
+
+def test_a_sqlite_url_with_a_query_string_is_refused(tmp_path: Path) -> None:
+    """The driver opens a file named after the query, not the file named here.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(_url_for(path), create=True):
+        pass
+    with pytest.raises(ValueError, match='carries a query string'):
+        open_index(f'{_url_for(path)}?uri=true&mode=ro')
+
+
+def test_a_refused_query_string_leaves_no_file_behind(tmp_path: Path) -> None:
+    """Such a URL passes the existence check and then creates a second file.
+
+    The stray file is named for the query, so it is neither the database the
+    operator meant nor an index anything can read.
+
+    Parameters:
+        tmp_path: Directory the database would have lived in.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with pytest.raises(ValueError, match='carries a query string'):
+        open_index(f'{_url_for(path)}?uri=true&mode=ro', create=True)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_a_query_argument_the_driver_would_reject_is_refused_as_a_query_string(
+    tmp_path: Path,
+) -> None:
+    """The driver coerces its connect arguments and reports a bad one bare.
+
+    ``?timeout=abc`` reaches a float conversion inside the dialect, whose
+    ``ValueError`` names neither the URL nor the setting; the rule that a SQLite
+    index URL is a plain path refuses it before it gets there.
+
+    Parameters:
+        tmp_path: Directory the database would have lived in.
+    """
+    with pytest.raises(ValueError, match='carries a query string'):
+        open_index(f'{_url_for(tmp_path / "index.sqlite3")}?timeout=abc', create=True)
+
+
+# ---------------------------------------------------------------------------
 # A read-only index
 # ---------------------------------------------------------------------------
 
 
-def test_a_read_only_index_is_opened_by_a_consumer(tmp_path: Path) -> None:
+def test_a_read_only_index_is_opened_by_a_consumer(read_only_index: Path) -> None:
     """A reader cannot corrupt anything, so read-only media serve it.
 
     An archived copy, or one on a read-only mount, honors locking perfectly; the
     write it refuses is a write nobody on this path was going to make.
 
     Parameters:
-        tmp_path: Directory holding the database.
+        read_only_index: A database file this user cannot write.
     """
-    path = _read_only_index(tmp_path)
-    with opened(_url_for(path)) as engine, engine.connect() as connection:
+    with opened(_url_for(read_only_index)) as engine, engine.connect() as connection:
         stamped = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).scalar()
     assert stamped == SCHEMA_VERSION
 
 
-def test_a_read_only_index_is_refused_by_a_creating_open(tmp_path: Path) -> None:
+def test_a_read_only_index_is_refused_by_a_creating_open(read_only_index: Path) -> None:
     """Ingest writes, so a database it can never write is refused at open.
 
     Parameters:
-        tmp_path: Directory holding the database.
+        read_only_index: A database file this user cannot write.
     """
-    path = _read_only_index(tmp_path)
     with pytest.raises(ValueError, match='this SQLite database is read-only'):
-        open_index(_url_for(path), create=True)
+        open_index(_url_for(read_only_index), create=True)
 
 
-def test_the_read_only_refusal_does_not_blame_the_filesystem(tmp_path: Path) -> None:
+def test_the_read_only_refusal_does_not_blame_the_filesystem(read_only_index: Path) -> None:
     """The message names read-only rather than the filesystem's locking.
 
     Sending an operator to fix locking on a filesystem that locks correctly costs
     the whole diagnosis.
 
     Parameters:
-        tmp_path: Directory holding the database.
+        read_only_index: A database file this user cannot write.
     """
-    path = _read_only_index(tmp_path)
     with pytest.raises(ValueError) as excinfo:
-        open_index(_url_for(path), create=True)
+        open_index(_url_for(read_only_index), create=True)
     assert 'honors locking' not in str(excinfo.value)
+
+
+def test_a_read_only_index_is_refused_before_anything_is_opened(read_only_index: Path) -> None:
+    """The refusal comes from the filesystem, so no side file is left behind.
+
+    A write-ahead-logged database that has been connected to leaves a
+    shared-memory index beside itself; refusing before the engine connects is
+    what keeps an ingest that will not run from touching the directory at all.
+
+    Parameters:
+        read_only_index: A database file this user cannot write.
+    """
+    with pytest.raises(ValueError, match='this SQLite database is read-only'):
+        open_index(_url_for(read_only_index), create=True)
+    assert sorted(path.name for path in read_only_index.parent.iterdir()) == ['index.sqlite3']
+
+
+def test_an_ingest_into_a_read_only_directory_is_refused(tmp_path: Path) -> None:
+    """SQLite writes its write-ahead log beside the database, so the directory counts.
+
+    A writable file in a directory that permits nothing is a database ingest
+    still cannot write, and SQLite grants the write lock on it anyway.
+
+    Parameters:
+        tmp_path: Directory the read-only directory is created in.
+    """
+    directory = tmp_path / 'archive'
+    directory.mkdir()
+    path = directory / 'index.sqlite3'
+    with opened(_url_for(path), create=True):
+        pass
+    directory.chmod(0o555)
+    try:
+        if os.access(directory, os.W_OK):
+            pytest.skip('this user can write a directory whose mode forbids writing')
+        with pytest.raises(ValueError, match='is read-only, and ingest has to write the'):
+            open_index(_url_for(path), create=True)
+    finally:
+        directory.chmod(0o755)
 
 
 def test_a_write_ahead_logged_index_in_a_read_only_directory_cannot_be_read(

--- a/tests/spindoctor/results_index/test_engine_masking.py
+++ b/tests/spindoctor/results_index/test_engine_masking.py
@@ -200,45 +200,26 @@ def _refusal_of(route: _Route, monkeypatch: pytest.MonkeyPatch) -> ValueError:
 
 
 @pytest.mark.parametrize('route', REFUSAL_ROUTES)
-def test_a_translated_failure_keeps_the_driver_error_as_its_cause(
+def test_every_refusal_route_masks_its_password_and_keeps_everything_else(
     route: _Route, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Translating the type must not throw away what the driver actually said.
+    """Three things are true of every refusal, and one open shows all three.
+
+    Translating the type must not throw away what the driver actually said, so
+    the driver's exception stays the cause. The password reaches neither a run
+    log nor an operator. And masking must not cost the identification the
+    message exists for: a program resolves its URL from a command line, a
+    configuration file or the environment, and the URL is what says which of
+    them supplied this one.
 
     Parameters:
         route: The refusal route under test.
         monkeypatch: Fixture the import hook is installed through.
     """
-    assert isinstance(_refusal_of(route, monkeypatch).__cause__, route.cause)
-
-
-@pytest.mark.parametrize('route', REFUSAL_ROUTES)
-def test_a_refusal_does_not_repeat_the_password(
-    route: _Route, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """These messages reach run logs and operators; a password reaches neither.
-
-    Parameters:
-        route: The refusal route under test.
-        monkeypatch: Fixture the import hook is installed through.
-    """
-    assert route.password not in str(_refusal_of(route, monkeypatch))
-
-
-@pytest.mark.parametrize('route', REFUSAL_ROUTES)
-def test_a_masked_refusal_still_names_the_rest_of_the_url(
-    route: _Route, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Masking a password must not cost the identification the message is for.
-
-    A program resolves its URL from a command line, a configuration file or the
-    environment, and the URL is what says which of them supplied this one.
-
-    Parameters:
-        route: The refusal route under test.
-        monkeypatch: Fixture the import hook is installed through.
-    """
-    assert route.identifies in str(_refusal_of(route, monkeypatch))
+    refusal = _refusal_of(route, monkeypatch)
+    assert isinstance(refusal.__cause__, route.cause)
+    assert route.password not in str(refusal)
+    assert route.identifies in str(refusal)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -376,34 +357,23 @@ def test_the_rule_masks_a_password_and_nothing_else(case: _MaskingCase) -> None:
 
 
 @pytest.mark.parametrize(('url', 'expected', 'secret'), CREDENTIAL_PARAMS)
-def test_the_opener_does_not_repeat_a_password_it_could_not_parse(
+def test_the_opener_names_a_url_it_could_not_parse_by_its_masked_form(
     url: str, expected: str, secret: str
 ) -> None:
     """The rule is only worth anything where the opener actually reaches it.
 
     Asserting on the helper alone leaves the opener free to name the URL by some
     other route, which is exactly how a leak survived three reviews of the
-    helper.
+    helper. Both directions are asserted on the one refusal: the password is
+    gone, and what is left is the whole URL, which is what would otherwise leave
+    the reader nothing to correct.
 
     Parameters:
         url: The URL under test, carrying a password.
-        expected: What masking it produces, which this test does not read.
+        expected: The masked form the refusal must name it by.
         secret: The password that must not survive into the refusal.
     """
     with pytest.raises(ValueError) as excinfo:
         open_index(url)
     assert secret not in str(excinfo.value)
-
-
-@pytest.mark.parametrize(('url', 'expected', 'secret'), CREDENTIAL_PARAMS)
-def test_the_opener_still_names_the_url_it_masked(url: str, expected: str, secret: str) -> None:
-    """A message that named no URL would leave the reader nothing to correct.
-
-    Parameters:
-        url: The URL under test, carrying a password.
-        expected: The masked form the refusal must name it by.
-        secret: The password it carries, which this test does not read.
-    """
-    with pytest.raises(ValueError) as excinfo:
-        open_index(url)
     assert expected in str(excinfo.value)

--- a/tests/spindoctor/results_index/test_engine_masking.py
+++ b/tests/spindoctor/results_index/test_engine_masking.py
@@ -1,0 +1,409 @@
+"""Tests that a results-index refusal names its URL without its password.
+
+These messages are written to run logs and pasted into bug reports, so a
+database password may not survive into one. Everything else about the URL has
+to, because naming the URL is what tells a reader which of the three resolution
+levels supplied the bad value.
+
+Two routes produce the name. A URL SQLAlchemy can parse renders itself with the
+password hidden. A URL it cannot parse -- a stray space from a value copied
+across two lines, a hyphen in the scheme, a missing scheme -- cannot render
+itself at all, and is masked structurally instead. The structural rule is
+covered here twice: directly, as a table of URLs and exactly what masking each
+must produce, and again through the real opener, because the gap between the two
+is where a leak survived three review rounds.
+"""
+
+import dataclasses
+
+import pytest
+import sqlalchemy
+from tests.spindoctor.results_index.conftest import (
+    EXPLODING_FACTORY_MESSAGE,
+    exploding_factory,
+    without_module,
+)
+
+from spindoctor.results_index import engine as engine_module
+from spindoctor.results_index import open_index
+
+PASSWORD = 'sup3rs3cr3t'
+"""A password distinctive enough that finding it anywhere is proof of a leak."""
+
+SLASHED_PASSWORD = 'aB3/xY9z'
+"""A password carrying a slash, which a URL permits unescaped.
+
+The route that masks structurally is the one that runs on a URL nothing could
+parse, so nothing there knows where the password ends except the ``@``. A rule
+that stopped at a path separator would leave this one in the message whole.
+"""
+
+AT_SIGN_USER = 'admin@pgsrv'
+"""A user name carrying an at-sign, which is how a managed server names one.
+
+``user@servername`` is the standard login form of a hosted PostgreSQL, and
+SQLAlchemy's own parser accepts it. A rule that took the first at-sign as the
+end of the credentials would find no password after it and leak the whole URL.
+"""
+
+
+@dataclasses.dataclass(frozen=True)
+class _Route:
+    """One way a URL is refused, and what its refusal has to say.
+
+    Attributes:
+        url: The URL to open, carrying a password.
+        message: Pattern the refusal message must match.
+        identifies: Text of the URL the message must keep, so a reader can tell
+            which of the resolution levels supplied the value.
+        cause: Exception type the refusal keeps as its ``__cause__``.
+        password: The password this route's URL carries, which its refusal may
+            not repeat.
+        hidden_module: Module to make unimportable first, or None.
+        needs_psycopg: Whether the route reaches the PostgreSQL driver itself.
+        breaks_the_factory: Whether the engine factory is replaced by one that
+            raises, standing for a failure inside a dialect that no enumeration
+            of exception types would have caught.
+    """
+
+    url: str
+    message: str
+    identifies: str
+    cause: type[BaseException]
+    password: str = PASSWORD
+    hidden_module: str | None = None
+    needs_psycopg: bool = False
+    breaks_the_factory: bool = False
+
+
+REFUSAL_ROUTES = [
+    pytest.param(
+        _Route(
+            url=f'postgresql+psycopg://user:{PASSWORD}@localhost:5432/spindoctor',
+            message=r'rms-spindoctor\[postgres\]',
+            identifies='localhost:5432',
+            cause=ModuleNotFoundError,
+            hidden_module='psycopg',
+        ),
+        id='driver-not-installed',
+    ),
+    pytest.param(
+        _Route(
+            url=f'mysql+mysqldb://user:{PASSWORD}@localhost/spindoctor',
+            message='MySQLdb',
+            identifies='mysql+mysqldb',
+            cause=ModuleNotFoundError,
+            hidden_module='MySQLdb',
+        ),
+        id='unsupported-backend',
+    ),
+    pytest.param(
+        _Route(
+            url=f'frobnicate://user:{PASSWORD}@localhost/spindoctor',
+            message='no database driver for this URL scheme',
+            identifies='frobnicate',
+            cause=sqlalchemy.exc.NoSuchModuleError,
+        ),
+        id='unknown-scheme',
+    ),
+    pytest.param(
+        _Route(
+            url=f'postgresql+psycopg://user:{PASSWORD}@localhost:notaport/spindoctor',
+            message='could not open the results index',
+            identifies='localhost:notaport',
+            cause=ValueError,
+        ),
+        id='unparseable-port',
+    ),
+    pytest.param(
+        _Route(
+            # A stray space in the scheme, which is what a URL copied across two
+            # lines of a configuration file arrives as. Nothing parses it, so
+            # nothing can render it either: this is the route on which the
+            # password is masked structurally, and the only one on which that
+            # rule is what stands between the password and the run log.
+            url=f'postgresql psycopg://svc:{SLASHED_PASSWORD}@db.example/spindoctor',
+            message='could not open the results index',
+            identifies='db.example',
+            cause=sqlalchemy.exc.ArgumentError,
+            password=SLASHED_PASSWORD,
+        ),
+        id='unparseable-url',
+    ),
+    pytest.param(
+        _Route(
+            # The managed-server login form, whose at-sign in the user name puts
+            # a second at-sign in the URL, together with a port nothing can
+            # parse. Both routes have to reach the password that lies between
+            # them.
+            url=f'postgresql+psycopg://{AT_SIGN_USER}:{PASSWORD}@host:notaport/spindoctor',
+            message='could not open the results index',
+            identifies='host:notaport',
+            cause=ValueError,
+        ),
+        id='an-at-sign-in-the-user-name',
+    ),
+    pytest.param(
+        _Route(
+            # The same login form on a URL that does not parse at all, which is
+            # the route with no rendering to fall back on.
+            url=f'postgresql psycopg://{AT_SIGN_USER}:{PASSWORD}@host:5432/spindoctor',
+            message='could not open the results index',
+            identifies='host:5432',
+            cause=sqlalchemy.exc.ArgumentError,
+        ),
+        id='an-at-sign-in-the-user-name-of-an-unparseable-url',
+    ),
+    pytest.param(
+        _Route(
+            url=f'postgresql+psycopg://spindoctor:{PASSWORD}@127.0.0.1:1/spindoctor',
+            message='could not open the results index',
+            identifies='127.0.0.1:1',
+            cause=sqlalchemy.exc.OperationalError,
+            needs_psycopg=True,
+        ),
+        id='server-refuses-the-connection',
+    ),
+    pytest.param(
+        _Route(
+            url=f'postgresql+psycopg://user:{PASSWORD}@db.example:5432/spindoctor',
+            message=EXPLODING_FACTORY_MESSAGE,
+            identifies='db.example:5432',
+            cause=RuntimeError,
+            breaks_the_factory=True,
+        ),
+        id='failure-inside-the-engine-factory',
+    ),
+]
+"""Every route by which a URL carrying a password reaches a refusal."""
+
+
+def _refusal_of(route: _Route, monkeypatch: pytest.MonkeyPatch) -> ValueError:
+    """Open a route's URL and return the refusal it raised.
+
+    Parameters:
+        route: The route to drive.
+        monkeypatch: Fixture the import hook is installed through.
+
+    Returns:
+        The refusal, for assertions on what it says.
+    """
+    if route.needs_psycopg:
+        pytest.importorskip('psycopg')
+    if route.hidden_module is not None:
+        without_module(monkeypatch, route.hidden_module)
+    if route.breaks_the_factory:
+        monkeypatch.setattr(sqlalchemy, 'create_engine', exploding_factory)
+    with pytest.raises(ValueError, match=route.message) as excinfo:
+        open_index(route.url)
+    return excinfo.value
+
+
+@pytest.mark.parametrize('route', REFUSAL_ROUTES)
+def test_a_translated_failure_keeps_the_driver_error_as_its_cause(
+    route: _Route, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Translating the type must not throw away what the driver actually said.
+
+    Parameters:
+        route: The refusal route under test.
+        monkeypatch: Fixture the import hook is installed through.
+    """
+    assert isinstance(_refusal_of(route, monkeypatch).__cause__, route.cause)
+
+
+@pytest.mark.parametrize('route', REFUSAL_ROUTES)
+def test_a_refusal_does_not_repeat_the_password(
+    route: _Route, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """These messages reach run logs and operators; a password reaches neither.
+
+    Parameters:
+        route: The refusal route under test.
+        monkeypatch: Fixture the import hook is installed through.
+    """
+    assert route.password not in str(_refusal_of(route, monkeypatch))
+
+
+@pytest.mark.parametrize('route', REFUSAL_ROUTES)
+def test_a_masked_refusal_still_names_the_rest_of_the_url(
+    route: _Route, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Masking a password must not cost the identification the message is for.
+
+    A program resolves its URL from a command line, a configuration file or the
+    environment, and the URL is what says which of them supplied this one.
+
+    Parameters:
+        route: The refusal route under test.
+        monkeypatch: Fixture the import hook is installed through.
+    """
+    assert route.identifies in str(_refusal_of(route, monkeypatch))
+
+
+@dataclasses.dataclass(frozen=True)
+class _MaskingCase:
+    """One URL the structural rule is asked about, and what it must return.
+
+    Attributes:
+        name: Identifier the case is reported under.
+        url: The URL as a caller wrote it.
+        expected: Exactly what masking it must produce, which states both
+            directions at once -- that no password survives, and that nothing
+            which is not a password was touched.
+        secret: Text that is a password in this URL and must therefore be gone
+            from the result, or None when the URL carries no password at all.
+    """
+
+    name: str
+    url: str
+    expected: str
+    secret: str | None = None
+
+
+MASKING_CASES = [
+    _MaskingCase('a-password-carrying-a-slash', '//user:pa/ss@h', '//user:***@h', 'pa/ss'),
+    _MaskingCase('no-user-name', '//:pw@h', '//:***@h', 'pw'),
+    _MaskingCase('one-slash-and-no-scheme', '/user:pw@h', '/user:***@h', 'pw'),
+    _MaskingCase(
+        'an-at-sign-in-the-user-name',
+        f'//{AT_SIGN_USER}:{PASSWORD}@host:5432/db',
+        f'//{AT_SIGN_USER}:***@host:5432/db',
+        PASSWORD,
+    ),
+    _MaskingCase(
+        'an-at-sign-in-the-user-name-and-an-unparseable-port',
+        f'//{AT_SIGN_USER}:{PASSWORD}@host:notaport/db',
+        f'//{AT_SIGN_USER}:***@host:notaport/db',
+        PASSWORD,
+    ),
+    _MaskingCase(
+        'a-leading-space',
+        f' postgresql+psycopg://{AT_SIGN_USER}:{PASSWORD}@host:5432/db',
+        f' postgresql+psycopg://{AT_SIGN_USER}:***@host:5432/db',
+        PASSWORD,
+    ),
+    _MaskingCase(
+        'a-hyphen-in-the-scheme',
+        f'postgresql-psycopg://{AT_SIGN_USER}:{PASSWORD}@host:5432/db',
+        f'postgresql-psycopg://{AT_SIGN_USER}:***@host:5432/db',
+        PASSWORD,
+    ),
+    _MaskingCase(
+        'a-url-copied-across-two-lines',
+        f'postgresql psycopg://{AT_SIGN_USER}:{PASSWORD}@host:5432/db',
+        f'postgresql psycopg://{AT_SIGN_USER}:***@host:5432/db',
+        PASSWORD,
+    ),
+    _MaskingCase(
+        'a-slashed-password-on-an-unparseable-url',
+        f'postgresql psycopg://svc:{SLASHED_PASSWORD}@db.example/spindoctor',
+        'postgresql psycopg://svc:***@db.example/spindoctor',
+        SLASHED_PASSWORD,
+    ),
+    _MaskingCase(
+        'a-slashed-password-and-an-unparseable-port',
+        f'postgresql+psycopg://svc:{SLASHED_PASSWORD}@db.example:5432x/spindoctor',
+        'postgresql+psycopg://svc:***@db.example:5432x/spindoctor',
+        SLASHED_PASSWORD,
+    ),
+    _MaskingCase(
+        'one-slash-after-the-scheme',
+        'postgresql+psycopg:/svc:aB3xY9z@db.example/spindoctor',
+        'postgresql+psycopg:/svc:***@db.example/spindoctor',
+        'aB3xY9z',
+    ),
+    _MaskingCase(
+        'a-port-and-an-at-sign-in-the-database-name',
+        'postgresql psycopg://host:5432/my@db',
+        'postgresql psycopg://host:5432/my@db',
+    ),
+    _MaskingCase(
+        'a-user-name-and-no-password',
+        'postgresql+psycopg://user@host/spindoctor',
+        'postgresql+psycopg://user@host/spindoctor',
+    ),
+    _MaskingCase(
+        'a-local-path-carrying-a-colon',
+        'sqlite:////data/a:b/index.sqlite3',
+        'sqlite:////data/a:b/index.sqlite3',
+    ),
+    _MaskingCase(
+        'a-local-path-carrying-a-colon-and-an-at-sign',
+        'sqlite:////data/a:b/i@dex.sqlite3',
+        'sqlite:////data/a:b/i@dex.sqlite3',
+    ),
+    _MaskingCase(
+        'a-local-path-carrying-a-drive-letter',
+        'sqlite:///C:/data/index.sqlite3',
+        'sqlite:///C:/data/index.sqlite3',
+    ),
+    _MaskingCase('a-scheme-and-nothing-else', 'postgresql+psycopg:', 'postgresql+psycopg:'),
+    _MaskingCase('the-empty-string', '', ''),
+]
+"""URLs the structural rule masks, and URLs it must leave exactly as they are."""
+
+
+MASKING_PARAMS = [pytest.param(case, id=case.name) for case in MASKING_CASES]
+
+CREDENTIAL_PARAMS = [
+    pytest.param(case.url, case.expected, case.secret, id=case.name)
+    for case in MASKING_CASES
+    if case.secret is not None
+]
+"""The subset carrying a password, which the opener itself is driven with.
+
+Every one of these is a URL SQLAlchemy cannot parse, which is what puts the
+structural rule on the path an operator's message actually takes.
+"""
+
+
+@pytest.mark.parametrize('case', MASKING_PARAMS)
+def test_the_rule_masks_a_password_and_nothing_else(case: _MaskingCase) -> None:
+    """The structural rule is the only defense where the URL did not parse.
+
+    It has to reach a password whatever the password contains -- a URL permits an
+    unescaped slash in one -- and whatever the user name contains, since the
+    managed-server login form puts an at-sign in it. It has to leave alone a
+    local path that merely happens to carry a colon and a later at-sign, and a
+    server URL whose database name carries one, since mangling either costs the
+    identification these messages exist for.
+
+    Parameters:
+        case: The URL under test and exactly what masking it must produce.
+    """
+    assert engine_module._masked_url(case.url) == case.expected
+
+
+@pytest.mark.parametrize(('url', 'expected', 'secret'), CREDENTIAL_PARAMS)
+def test_the_opener_does_not_repeat_a_password_it_could_not_parse(
+    url: str, expected: str, secret: str
+) -> None:
+    """The rule is only worth anything where the opener actually reaches it.
+
+    Asserting on the helper alone leaves the opener free to name the URL by some
+    other route, which is exactly how a leak survived three reviews of the
+    helper.
+
+    Parameters:
+        url: The URL under test, carrying a password.
+        expected: What masking it produces, which this test does not read.
+        secret: The password that must not survive into the refusal.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        open_index(url)
+    assert secret not in str(excinfo.value)
+
+
+@pytest.mark.parametrize(('url', 'expected', 'secret'), CREDENTIAL_PARAMS)
+def test_the_opener_still_names_the_url_it_masked(url: str, expected: str, secret: str) -> None:
+    """A message that named no URL would leave the reader nothing to correct.
+
+    Parameters:
+        url: The URL under test, carrying a password.
+        expected: The masked form the refusal must name it by.
+        secret: The password it carries, which this test does not read.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        open_index(url)
+    assert expected in str(excinfo.value)

--- a/tests/spindoctor/results_index/test_engine_sqlite.py
+++ b/tests/spindoctor/results_index/test_engine_sqlite.py
@@ -1,0 +1,811 @@
+"""Tests for what the results-index opener does with a SQLite database file.
+
+A SQLite index is a local file, and almost everything that can go wrong with one
+is a property of the filesystem rather than of the database: a directory nobody
+created, a file that is not a database, a mount that will not honor a write lock,
+an archived copy nothing may write. SQLite reports most of those through one
+exception type, and only one of them is a reason to move the index to a server.
+These pin which message each cause gets, and pin the per-connection settings the
+concurrency model depends on.
+"""
+
+import os
+import re
+import sqlite3
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+import sqlalchemy
+from sqlalchemy.engine import Connection
+from tests.spindoctor.results_index.conftest import opened, sqlite_url_for
+
+from spindoctor.results_index import SCHEMA_META, SCHEMA_VERSION, open_index
+from spindoctor.results_index import engine as engine_module
+
+
+class _DriverError(Exception):
+    """A driver exception carrying the result code SQLite would have set on it.
+
+    The codes worth testing are the ones that are hard to provoke on demand: a
+    disk that filled during an ingest, a file that corrupted under a crash, an
+    I/O error from a mount that stopped answering. The classification reads the
+    code off the driver's exception, so an exception carrying the code is the
+    whole of what it needs.
+
+    Attributes:
+        sqlite_errorname: The result-code name, under the attribute the SQLite
+            driver publishes it as.
+    """
+
+    def __init__(self, message: str, error_name: object) -> None:
+        """Build the refusal.
+
+        Parameters:
+            message: What the driver would have said.
+            error_name: The result-code name to carry, or any other value, since
+                the classification has to survive an exception carrying
+                something that is not a name at all.
+        """
+        super().__init__(message)
+        self.sqlite_errorname = error_name
+
+
+def _refusing_with(original: Exception) -> Callable[..., Any]:
+    """Return a statement executor that fails every statement with one error.
+
+    Parameters:
+        original: The driver exception to wrap, standing in for what SQLite
+            itself raised.
+
+    Returns:
+        A replacement for ``Connection.exec_driver_sql``.
+    """
+
+    def refusing(self: Any, statement: Any, *args: Any, **kwargs: Any) -> Any:
+        raise sqlalchemy.exc.OperationalError(str(statement), None, original)
+
+    return refusing
+
+
+def _sqlite_error(message: str, error_name: str) -> sqlite3.Error:
+    """Return a driver error carrying a result-code name.
+
+    Parameters:
+        message: What the driver would have said.
+        error_name: The result-code name to carry.
+
+    Returns:
+        The error, of the type the connect handler catches.
+    """
+    error = sqlite3.OperationalError(message)
+    error.sqlite_errorname = error_name
+    return error
+
+
+class _FailingCursor:
+    """A cursor that records its statements and refuses the journal-mode one.
+
+    Attributes:
+        statements: Every statement handed to it, in order.
+    """
+
+    def __init__(self, error: sqlite3.Error, statements: list[str]) -> None:
+        """Build the cursor.
+
+        Parameters:
+            error: What to raise for the journal-mode selection.
+            statements: The list to record statements into.
+        """
+        self._error = error
+        self.statements = statements
+
+    def execute(self, statement: str) -> None:
+        """Record a statement, refusing the journal-mode selection.
+
+        Parameters:
+            statement: The statement to run.
+
+        Raises:
+            sqlite3.Error: For the journal-mode selection, and only it.
+        """
+        self.statements.append(statement)
+        if 'journal_mode' in statement:
+            raise self._error
+
+    def close(self) -> None:
+        """Close the cursor, which holds nothing to release."""
+
+
+class _FailingConnection:
+    """A stand-in for the DBAPI connection the pool hands the connect handler.
+
+    The driver's own cursor type is immutable and a failing disk cannot be
+    arranged, so the handler is given a connection whose cursor fails instead.
+
+    Attributes:
+        statements: Every statement its cursors were given, in order.
+    """
+
+    def __init__(self, error: sqlite3.Error) -> None:
+        """Build the connection.
+
+        Parameters:
+            error: What its cursor raises for the journal-mode selection.
+        """
+        self._error = error
+        self.statements: list[str] = []
+
+    def cursor(self) -> _FailingCursor:
+        """Return a cursor recording into this connection.
+
+        Returns:
+            The cursor.
+        """
+        return _FailingCursor(self._error, self.statements)
+
+
+@pytest.fixture(params=['wal', 'delete'])
+def read_only_index(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[Path]:
+    """Yield an index file SQLite can read but will never write.
+
+    Both journal modes are covered, because the two answer a would-be writer
+    differently and neither answer may be the one the opener depends on.
+    Write-ahead logging is the mode this opener always leaves behind, and it is
+    the permissive one: the journal-mode selection and a write lock both succeed
+    on a file SQLite will never write. The rollback journal, which an index
+    arrives in after a tool that checkpoints and vacuums it, refuses the journal
+    mode outright.
+
+    Parameters:
+        request: Fixture carrying the journal mode of this case.
+        tmp_path: Directory the database is created in.
+
+    Yields:
+        Path of the read-only database file.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute(f'PRAGMA journal_mode = {request.param}')
+    finally:
+        connection.close()
+    path.chmod(0o444)
+    try:
+        if os.access(path, os.W_OK):
+            pytest.skip('this user can write a file whose mode forbids writing')
+        yield path
+    finally:
+        # Every file the fixture is responsible for, not only the database:
+        # SQLite copies the database's mode onto the write-ahead log and the
+        # shared-memory index it creates beside it, so a test that reads this
+        # database leaves those behind read-only too. The skip is inside the
+        # try for the same reason: a run on a user who can write anything must
+        # still leave the directory as it found it.
+        for made_read_only in path.parent.glob(f'{path.name}*'):
+            made_read_only.chmod(0o644)
+
+
+# ---------------------------------------------------------------------------
+# Connect-time settings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ('pragma', 'expected'),
+    [
+        ('foreign_keys', 1),
+        ('busy_timeout', engine_module.SQLITE_BUSY_TIMEOUT_MS),
+    ],
+)
+def test_every_sqlite_connection_carries_the_pragma(
+    tmp_path: Path, pragma: str, expected: object
+) -> None:
+    """The settings are applied per connection, not once at open.
+
+    A pool hands out connections opened long after the engine was built, and a
+    connection without these is a connection without the cascade and without the
+    wait that keeps two writers from failing. Both are per-connection state that
+    a connection the settings missed simply does not have, which is what makes
+    reading them back on a second connection a real test. The journal mode is
+    not: it is a property of the database file, so it reads back the same
+    whether or not this connection asked for it, and it is asserted separately
+    as the persistent thing it is.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+        pragma: The pragma to read back.
+        expected: Its expected value.
+    """
+    # Both connections held at once, so the pool cannot hand the second request
+    # the connection it made for the first: it has to open another one.
+    with (
+        opened(sqlite_url_for(tmp_path / 'index.sqlite3'), create=True) as engine,
+        engine.connect() as first,
+        engine.connect() as second,
+    ):
+        reused = first.connection.dbapi_connection is second.connection.dbapi_connection
+        found = second.exec_driver_sql(f'PRAGMA {pragma}').scalar()
+    assert reused is False
+    assert found == expected
+
+
+def test_the_opener_leaves_the_database_write_ahead_logged(tmp_path: Path) -> None:
+    """Write-ahead logging is what lets a reader and a writer work at once.
+
+    The journal mode lives in the database header rather than in a connection,
+    so it is read back from the closed file with the standard library: that is
+    the state a later ingest, and every consumer, actually meets.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    connection = sqlite3.connect(path)
+    try:
+        (mode,) = connection.execute('PRAGMA journal_mode').fetchone()
+    finally:
+        connection.close()
+    assert mode == 'wal'
+
+
+def test_a_connect_time_failure_that_is_not_read_only_is_not_swallowed() -> None:
+    """Only a read-only refusal of the journal-mode selection is tolerated.
+
+    The connect handler ignores the refusal a database SQLite will never write
+    gives that selection, because such a database has no writers for a journal to
+    protect. Widening the tolerance to every driver error would swallow a failing
+    disk at the one moment the opener could still report it. The handler is
+    called directly, because the driver's own cursor type cannot be replaced and
+    a real disk cannot be made to fail on demand.
+    """
+    refusing = _FailingConnection(_sqlite_error('disk I/O error', 'SQLITE_IOERR_WRITE'))
+    with pytest.raises(sqlite3.Error, match='disk I/O error'):
+        engine_module._sqlite_on_connect(refusing, None)
+
+
+def test_the_connect_time_settings_are_all_issued() -> None:
+    """The journal mode is selected last, after the two per-connection settings.
+
+    A handler that stopped early would leave a connection without the cascade or
+    without the wait, which no read of the database file can show.
+    """
+    connection = _FailingConnection(_sqlite_error('database is locked', 'SQLITE_READONLY'))
+    engine_module._sqlite_on_connect(connection, None)
+    assert connection.statements == [
+        'PRAGMA foreign_keys = ON',
+        f'PRAGMA busy_timeout = {engine_module.SQLITE_BUSY_TIMEOUT_MS}',
+        'PRAGMA journal_mode = WAL',
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The lock probe
+# ---------------------------------------------------------------------------
+
+
+def test_a_locked_database_file_is_refused_at_open(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The probe takes a write lock at open so a bad location fails early.
+
+    A filesystem that cannot honor SQLite locking corrupts the file under
+    concurrent writers instead of erroring, so the lock is taken while there is
+    still something useful to say. Here the lock is denied by an exclusive holder
+    rather than by a filesystem, which is the same refusal by a cheaper route.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+        monkeypatch: Fixture used to shorten the busy timeout.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    monkeypatch.setattr(engine_module, 'SQLITE_BUSY_TIMEOUT_MS', 50)
+    blocker = sqlite3.connect(path)
+    try:
+        blocker.execute('BEGIN EXCLUSIVE')
+        with pytest.raises(ValueError, match='could not take a SQLite write lock'):
+            open_index(sqlite_url_for(path))
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+
+def test_the_lock_failure_names_postgresql_as_the_shared_option(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reader who put the file on a network share needs the alternative.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+        monkeypatch: Fixture used to shorten the busy timeout.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    monkeypatch.setattr(engine_module, 'SQLITE_BUSY_TIMEOUT_MS', 50)
+    blocker = sqlite3.connect(path)
+    try:
+        blocker.execute('BEGIN EXCLUSIVE')
+        with pytest.raises(ValueError, match='postgresql\\+psycopg'):
+            open_index(sqlite_url_for(path))
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+
+def test_a_locked_database_file_is_refused_by_a_creating_open(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A writer meets the same refusal a reader does, for the same reason.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+        monkeypatch: Fixture used to shorten the busy timeout.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    monkeypatch.setattr(engine_module, 'SQLITE_BUSY_TIMEOUT_MS', 50)
+    blocker = sqlite3.connect(path)
+    try:
+        blocker.execute('BEGIN EXCLUSIVE')
+        with pytest.raises(ValueError, match='could not take a SQLite write lock'):
+            open_index(sqlite_url_for(path), create=True)
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+
+# ---------------------------------------------------------------------------
+# What SQLite could not open, and why
+# ---------------------------------------------------------------------------
+
+
+def test_a_path_that_is_a_directory_is_not_reported_as_a_locking_failure(tmp_path: Path) -> None:
+    """SQLite refuses a directory with the code it refuses a missing one with.
+
+    Parameters:
+        tmp_path: Directory the misnamed path is created in.
+    """
+    directory = tmp_path / 'index.sqlite3'
+    directory.mkdir()
+    with pytest.raises(ValueError, match='is not a file'):
+        open_index(sqlite_url_for(directory))
+
+
+def test_a_file_that_is_not_a_database_says_so(tmp_path: Path) -> None:
+    """A file at the index path is not therefore an index, or even a database.
+
+    Parameters:
+        tmp_path: Directory holding the file.
+    """
+    path = tmp_path / 'index.sqlite3'
+    path.write_text('this is a note somebody left here\n')
+    with pytest.raises(ValueError, match='not a SQLite database'):
+        open_index(sqlite_url_for(path))
+
+
+def test_a_file_that_is_not_a_database_is_not_blamed_on_the_filesystem(tmp_path: Path) -> None:
+    """Moving to PostgreSQL would not make this file a database.
+
+    Parameters:
+        tmp_path: Directory holding the file.
+    """
+    path = tmp_path / 'index.sqlite3'
+    path.write_text('this is a note somebody left here\n')
+    with pytest.raises(ValueError, match='not a SQLite database') as excinfo:
+        open_index(sqlite_url_for(path))
+    assert 'honors locking' not in str(excinfo.value)
+
+
+def test_an_ingest_into_a_directory_that_does_not_exist_names_the_directory(
+    tmp_path: Path,
+) -> None:
+    """The likeliest first-run error there is: ingest before the tree exists.
+
+    Parameters:
+        tmp_path: Directory the missing directory would have lived in.
+    """
+    path = tmp_path / 'results' / 'index.sqlite3'
+    with pytest.raises(ValueError, match=re.escape(f'{tmp_path / "results"} does not exist')):
+        open_index(sqlite_url_for(path), create=True)
+
+
+def test_a_directory_that_does_not_exist_is_not_answered_with_postgresql(
+    tmp_path: Path,
+) -> None:
+    """Prescribing a database server for a directory nobody created is a wrong remedy.
+
+    Parameters:
+        tmp_path: Directory the missing directory would have lived in.
+    """
+    path = tmp_path / 'results' / 'index.sqlite3'
+    with pytest.raises(ValueError, match='does not exist') as excinfo:
+        open_index(sqlite_url_for(path), create=True)
+    assert 'postgresql' not in str(excinfo.value)
+
+
+def test_a_file_this_user_cannot_open_names_the_permissions(tmp_path: Path) -> None:
+    """An unreadable file is a permissions problem, not a locking one.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    path.chmod(0o000)
+    try:
+        if os.access(path, os.R_OK):
+            pytest.skip('this user can read a file whose mode forbids reading')
+        with pytest.raises(ValueError, match='Check that this user may read'):
+            open_index(sqlite_url_for(path))
+    finally:
+        path.chmod(0o644)
+
+
+def test_a_driver_error_carrying_no_result_code_keeps_the_lock_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Classifying by result code must not fail on an exception that carries none.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+        monkeypatch: Fixture the failing statement execution is installed through.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    refusing = _refusing_with(Exception('nothing to go on'))
+    monkeypatch.setattr(Connection, 'exec_driver_sql', refusing)
+    with pytest.raises(ValueError, match='could not take a SQLite write lock'):
+        open_index(sqlite_url_for(path))
+
+
+def test_a_result_code_that_is_not_a_name_keeps_the_lock_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A code that is not text at all is as unclassifiable as no code.
+
+    The attribute is read off whatever exception a driver raised, and nothing
+    guarantees a string is what it holds. Comparing a non-string against the
+    prefixes would raise from inside the code that exists to report a failure.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+        monkeypatch: Fixture the failing statement execution is installed through.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    refusing = _refusing_with(_DriverError('disk I/O error', 5386))
+    monkeypatch.setattr(Connection, 'exec_driver_sql', refusing)
+    with pytest.raises(ValueError, match='could not take a SQLite write lock'):
+        open_index(sqlite_url_for(path))
+
+
+@pytest.mark.parametrize(
+    ('error_name', 'detail', 'message'),
+    [
+        pytest.param(
+            'SQLITE_IOERR_WRITE',
+            'disk I/O error',
+            'could not take a SQLite write lock',
+            id='an-extended-io-error',
+        ),
+        pytest.param(
+            'SQLITE_BUSY_SNAPSHOT',
+            'database is locked',
+            'could not take a SQLite write lock',
+            id='an-extended-busy',
+        ),
+        pytest.param(
+            'SQLITE_CANTOPEN_ISDIR',
+            'unable to open database file',
+            'Check that this user may read',
+            id='an-extended-cannot-open',
+        ),
+    ],
+)
+def test_an_extended_result_code_gets_the_remedy_of_its_family(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, error_name: str, detail: str, message: str
+) -> None:
+    """SQLite refines several codes into extended forms naming the same cause.
+
+    ``SQLITE_CANTOPEN`` alone has six of them and ``SQLITE_IOERR`` has more than
+    twenty. Matching a code by equality rather than by prefix would send every
+    one of those to the fall-through, which prescribes nothing, and would lose
+    the diagnosis the family is entitled to. Which extended form a platform
+    happens to produce is not something a test can arrange, so the codes are
+    handed to the classification directly.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+        monkeypatch: Fixture the failing statement execution is installed through.
+        error_name: The extended result code SQLite reports.
+        detail: What the driver says alongside it.
+        message: Text the refusal must carry, which is its family's remedy.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    monkeypatch.setattr(
+        Connection, 'exec_driver_sql', _refusing_with(_DriverError(detail, error_name))
+    )
+    with pytest.raises(ValueError, match=message):
+        open_index(sqlite_url_for(path))
+
+
+@pytest.mark.parametrize(
+    ('error_name', 'detail'),
+    [
+        ('SQLITE_FULL', 'database or disk is full'),
+        ('SQLITE_CORRUPT', 'database disk image is malformed'),
+    ],
+)
+def test_an_unclassified_result_code_is_reported_as_what_sqlite_said(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, error_name: str, detail: str
+) -> None:
+    """A code with no classification gets SQLite's own words, not a guess.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+        monkeypatch: Fixture the failing statement execution is installed through.
+        error_name: The result code SQLite reports.
+        detail: What the driver says alongside it.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    monkeypatch.setattr(
+        Connection, 'exec_driver_sql', _refusing_with(_DriverError(detail, error_name))
+    )
+    with pytest.raises(ValueError, match=f'SQLite refused .*{error_name}'):
+        open_index(sqlite_url_for(path))
+
+
+@pytest.mark.parametrize(
+    ('error_name', 'detail'),
+    [
+        ('SQLITE_FULL', 'database or disk is full'),
+        ('SQLITE_CORRUPT', 'database disk image is malformed'),
+    ],
+)
+def test_an_unclassified_result_code_is_not_answered_with_postgresql(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, error_name: str, detail: str
+) -> None:
+    """A full disk and a corrupt file are not reasons to rebuild on a server.
+
+    That remedy belongs to a filesystem that will not honor locking, and to
+    nothing else; prescribing it for every unrecognized code is how an operator
+    ends up migrating a deployment over a disk that needed emptying.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+        monkeypatch: Fixture the failing statement execution is installed through.
+        error_name: The result code SQLite reports.
+        detail: What the driver says alongside it.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    monkeypatch.setattr(
+        Connection, 'exec_driver_sql', _refusing_with(_DriverError(detail, error_name))
+    )
+    with pytest.raises(ValueError, match='SQLite refused') as excinfo:
+        open_index(sqlite_url_for(path))
+    assert 'postgresql' not in str(excinfo.value)
+
+
+def test_an_in_memory_database_that_cannot_be_opened_says_only_that(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An in-memory URL names no path, so the message that names one cannot be used.
+
+    Parameters:
+        monkeypatch: Fixture the failing statement execution is installed through.
+    """
+    monkeypatch.setattr(
+        Connection,
+        'exec_driver_sql',
+        _refusing_with(_DriverError('unable to open database file', 'SQLITE_CANTOPEN')),
+    )
+    with pytest.raises(ValueError, match='could not open this database'):
+        open_index('sqlite://')
+
+
+# ---------------------------------------------------------------------------
+# A SQLite URL is a plain path
+# ---------------------------------------------------------------------------
+
+
+def test_a_sqlite_url_with_a_query_string_is_refused(tmp_path: Path) -> None:
+    """The driver opens a file named after the query, not the file named here.
+
+    Parameters:
+        tmp_path: Directory holding the database.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    with pytest.raises(ValueError, match='carries a query string'):
+        open_index(f'{sqlite_url_for(path)}?uri=true&mode=ro')
+
+
+def test_a_refused_query_string_leaves_no_file_behind(tmp_path: Path) -> None:
+    """Such a URL passes the existence check and then creates a second file.
+
+    The stray file is named for the query, so it is neither the database the
+    operator meant nor an index anything can read.
+
+    Parameters:
+        tmp_path: Directory the database would have lived in.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with pytest.raises(ValueError, match='carries a query string'):
+        open_index(f'{sqlite_url_for(path)}?uri=true&mode=ro', create=True)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_a_query_argument_the_driver_would_reject_is_refused_as_a_query_string(
+    tmp_path: Path,
+) -> None:
+    """The driver coerces its connect arguments and reports a bad one bare.
+
+    ``?timeout=abc`` reaches a float conversion inside the dialect, whose
+    ``ValueError`` names neither the URL nor the setting; the rule that a SQLite
+    index URL is a plain path refuses it before it gets there.
+
+    Parameters:
+        tmp_path: Directory the database would have lived in.
+    """
+    with pytest.raises(ValueError, match='carries a query string'):
+        open_index(f'{sqlite_url_for(tmp_path / "index.sqlite3")}?timeout=abc', create=True)
+
+
+# ---------------------------------------------------------------------------
+# A read-only index
+# ---------------------------------------------------------------------------
+
+
+def test_a_read_only_index_is_opened_by_a_consumer(read_only_index: Path) -> None:
+    """A reader cannot corrupt anything, so read-only media serve it.
+
+    An archived copy, or one on a read-only mount, honors locking perfectly; the
+    write it refuses is a write nobody on this path was going to make.
+
+    Parameters:
+        read_only_index: A database file this user cannot write.
+    """
+    with opened(sqlite_url_for(read_only_index)) as engine, engine.connect() as connection:
+        stamped = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).scalar()
+    assert stamped == SCHEMA_VERSION
+
+
+def test_a_read_only_index_is_refused_by_a_creating_open(read_only_index: Path) -> None:
+    """Ingest writes, so a database it can never write is refused at open.
+
+    Parameters:
+        read_only_index: A database file this user cannot write.
+    """
+    with pytest.raises(ValueError, match='read-only, and ingest has to write it'):
+        open_index(sqlite_url_for(read_only_index), create=True)
+
+
+def test_the_read_only_refusal_does_not_blame_the_filesystem(read_only_index: Path) -> None:
+    """The message names read-only rather than the filesystem's locking.
+
+    Sending an operator to fix locking on a filesystem that locks correctly costs
+    the whole diagnosis.
+
+    Parameters:
+        read_only_index: A database file this user cannot write.
+    """
+    with pytest.raises(ValueError, match='read-only, and ingest has to write it') as excinfo:
+        open_index(sqlite_url_for(read_only_index), create=True)
+    assert 'honors locking' not in str(excinfo.value)
+
+
+def test_a_read_only_index_is_refused_before_anything_is_opened(read_only_index: Path) -> None:
+    """The refusal comes from the filesystem, so no side file is left behind.
+
+    A write-ahead-logged database that has been connected to leaves a
+    shared-memory index beside itself; refusing before the engine connects is
+    what keeps an ingest that will not run from touching the directory at all.
+
+    Parameters:
+        read_only_index: A database file this user cannot write.
+    """
+    with pytest.raises(ValueError, match='read-only, and ingest has to write it'):
+        open_index(sqlite_url_for(read_only_index), create=True)
+    assert sorted(path.name for path in read_only_index.parent.iterdir()) == ['index.sqlite3']
+
+
+def test_an_ingest_into_a_read_only_directory_is_refused(tmp_path: Path) -> None:
+    """SQLite writes its write-ahead log beside the database, so the directory counts.
+
+    A writable file in a directory that permits nothing is a database ingest
+    still cannot write, and SQLite grants the write lock on it anyway.
+
+    Parameters:
+        tmp_path: Directory the read-only directory is created in.
+    """
+    directory = tmp_path / 'archive'
+    directory.mkdir()
+    path = directory / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    directory.chmod(0o555)
+    try:
+        if os.access(directory, os.W_OK):
+            pytest.skip('this user can write a directory whose mode forbids writing')
+        with pytest.raises(ValueError, match='is read-only, and ingest has to write the'):
+            open_index(sqlite_url_for(path), create=True)
+    finally:
+        directory.chmod(0o755)
+
+
+def test_an_ingest_is_refused_by_sqlite_when_the_mode_bits_said_it_could_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A network filesystem answers from mode bits it does not itself enforce.
+
+    The filesystem check ahead of the engine is the ordinary diagnosis, and here
+    it is made to answer wrongly on purpose, because that is what an NFS or SMB
+    mount does: it reports a database this user may write, and SQLite is the one
+    that finds out otherwise. The refusal has to say read-only anyway, rather
+    than sending the operator to fix locking on a filesystem that locks fine.
+
+    Parameters:
+        tmp_path: Directory the read-only directory is created in.
+        monkeypatch: Fixture the lying access check is installed through.
+    """
+    directory = tmp_path / 'archive'
+    directory.mkdir()
+    path = directory / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    directory.chmod(0o555)
+    try:
+        if os.access(directory, os.W_OK):
+            pytest.skip('this user can write a directory whose mode forbids writing')
+        monkeypatch.setattr(os, 'access', lambda *args, **kwargs: True)
+        with pytest.raises(ValueError, match='read-only, and ingest has to write it'):
+            open_index(sqlite_url_for(path), create=True)
+    finally:
+        directory.chmod(0o755)
+
+
+def test_a_write_ahead_logged_index_in_a_read_only_directory_cannot_be_read(
+    tmp_path: Path,
+) -> None:
+    """SQLite reads such a database through a file it creates beside it.
+
+    A copy whose directory forbids writing therefore cannot be read either, and
+    saying so beats letting a consumer's first query fail with a write error.
+
+    Parameters:
+        tmp_path: Directory the read-only directory is created in.
+    """
+    directory = tmp_path / 'read-only'
+    directory.mkdir()
+    path = directory / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    path.chmod(0o444)
+    directory.chmod(0o555)
+    try:
+        if os.access(path, os.W_OK):
+            pytest.skip('this user can write a file whose mode forbids writing')
+        with pytest.raises(ValueError, match='cannot be read either'):
+            open_index(sqlite_url_for(path))
+    finally:
+        directory.chmod(0o755)
+        path.chmod(0o644)

--- a/tests/spindoctor/results_index/test_postgres.py
+++ b/tests/spindoctor/results_index/test_postgres.py
@@ -27,6 +27,52 @@ OTHER_STUB = 'COISS_2002/data/1295221349_1296000000/N1294561202_1_CALIB'
 
 FIFTEEN_DIGIT_OFFSET = -1234.56789012345
 
+BOGUS_PASSWORD = 'sup3rs3cr3t'
+"""A password distinctive enough that finding it anywhere is proof of a leak."""
+
+
+def _password_of(url: str) -> str:
+    """Return the password a URL carries.
+
+    Parameters:
+        url: The URL to read.
+
+    Returns:
+        The password, or an empty string when the URL carries none.
+    """
+    return sqlalchemy.engine.make_url(url).password or ''
+
+
+def _with_password(url: str, password: str) -> str:
+    """Return a URL carrying a different password.
+
+    Parameters:
+        url: The URL to rewrite.
+        password: The password to put in it.
+
+    Returns:
+        The rewritten URL, with the password in plain text as a caller writes it.
+    """
+    rewritten = sqlalchemy.engine.make_url(url).set(password=password)
+    return rewritten.render_as_string(hide_password=False)
+
+
+def _refusal_without_the_password(url: str, message: str) -> str:
+    """Open a URL, require the refusal it raises, and return that message.
+
+    Parameters:
+        url: The URL to open.
+        message: Pattern the refusal message must match.
+
+    Returns:
+        The refusal message.
+    """
+    if not _password_of(url):
+        pytest.skip('the configured server URL carries no password to mask')
+    with pytest.raises(ValueError, match=message) as excinfo:
+        open_index(url)
+    return str(excinfo.value)
+
 
 def test_creating_the_schema_creates_every_table(postgres_url: str) -> None:
     """The metadata emits DDL a server accepts, not just DDL SQLite accepts.
@@ -82,6 +128,49 @@ def test_the_version_message_says_to_delete_and_re_ingest(postgres_url: str) -> 
         connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
     with pytest.raises(ValueError, match='delete the database and re-run sd_stats_ingest'):
         open_index(postgres_url)
+
+
+def test_the_not_an_index_refusal_does_not_repeat_the_password(postgres_url: str) -> None:
+    """A server URL is the one that carries a password, and this gate names it.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    message = _refusal_without_the_password(postgres_url, 'not a results index')
+    assert f':{_password_of(postgres_url)}@' not in message
+
+
+def test_the_version_refusal_does_not_repeat_the_password(postgres_url: str) -> None:
+    """Every route names the URL, so every route has to mask it.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True) as engine, engine.begin() as connection:
+        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    message = _refusal_without_the_password(postgres_url, 'is not the version')
+    assert f':{_password_of(postgres_url)}@' not in message
+
+
+def test_a_masked_refusal_still_names_the_server(postgres_url: str) -> None:
+    """Masking must not cost the identification the message exists for.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    message = _refusal_without_the_password(postgres_url, 'not a results index')
+    assert str(sqlalchemy.engine.make_url(postgres_url).host) in message
+
+
+def test_a_rejected_password_is_not_repeated_in_the_refusal(postgres_server_url: str) -> None:
+    """The failure most likely to carry a password is the one that is about it.
+
+    Parameters:
+        postgres_server_url: URL of the server the tier runs against.
+    """
+    with pytest.raises(ValueError, match='could not open the results index') as excinfo:
+        open_index(_with_password(postgres_server_url, BOGUS_PASSWORD))
+    assert BOGUS_PASSWORD not in str(excinfo.value)
 
 
 def test_the_offset_round_trips_bit_for_bit(postgres_url: str) -> None:

--- a/tests/spindoctor/results_index/test_postgres.py
+++ b/tests/spindoctor/results_index/test_postgres.py
@@ -1,0 +1,213 @@
+"""Results-index tests that run against a real PostgreSQL server.
+
+SQLite accepts almost anything: it stores a boolean as an integer, a double as
+whatever the value looked like, and a foreign key as a comment unless asked
+otherwise. A schema that behaves on SQLite therefore proves very little about
+the backend an index shared across machines actually runs on. These re-ask the
+questions that the type discipline exists to answer, against a server that
+enforces them.
+
+The tier is opt-in: it is excluded by the default marker filter and skips itself
+when ``SPINDOCTOR_TEST_POSTGRES_URL`` is unset, so a checkout with no server
+still runs a green suite.
+
+Each test gets a schema of its own from the ``postgres_url`` fixture, so a
+repeated run, or two workers of a parallel run, never share a table.
+"""
+
+import pytest
+import sqlalchemy
+from tests.spindoctor.results_index.conftest import STUB, image_row, opened, technique_row
+
+from spindoctor.results_index import IMAGES, SCHEMA_META, SCHEMA_VERSION, TECHNIQUES, open_index
+
+pytestmark = pytest.mark.postgres
+
+OTHER_STUB = 'COISS_2002/data/1295221349_1296000000/N1294561202_1_CALIB'
+
+FIFTEEN_DIGIT_OFFSET = -1234.56789012345
+
+
+def test_creating_the_schema_creates_every_table(postgres_url: str) -> None:
+    """The metadata emits DDL a server accepts, not just DDL SQLite accepts.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True) as engine:
+        found = sorted(sqlalchemy.inspect(engine).get_table_names())
+    assert found == ['feature_sources', 'images', 'ingest_runs', 'schema_meta', 'techniques']
+
+
+def test_creating_the_schema_stamps_the_version(postgres_url: str) -> None:
+    """The stamp is what the version gate reads on every later open.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True) as engine, engine.connect() as connection:
+        stamped = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).scalar()
+    assert stamped == SCHEMA_VERSION
+
+
+def test_a_consumer_refuses_a_schema_that_was_never_ingested(postgres_url: str) -> None:
+    """An empty database is not an index, and absence is not "nothing navigated".
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with pytest.raises(ValueError, match='not a results index'):
+        open_index(postgres_url)
+
+
+def test_a_database_stamped_with_another_version_is_refused(postgres_url: str) -> None:
+    """The gate is the whole migration strategy, so it has to hold here too.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True) as engine, engine.begin() as connection:
+        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    with pytest.raises(ValueError, match=f'schema version {SCHEMA_VERSION + 1}'):
+        open_index(postgres_url)
+
+
+def test_the_version_message_says_to_delete_and_re_ingest(postgres_url: str) -> None:
+    """There are no migrations, so the instruction is the whole remedy.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True) as engine, engine.begin() as connection:
+        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    with pytest.raises(ValueError, match='delete the database and re-run sd_stats_ingest'):
+        open_index(postgres_url)
+
+
+def test_the_offset_round_trips_bit_for_bit(postgres_url: str) -> None:
+    """Double precision on the server, not the single precision Float may give.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row(offset_dv=FIFTEEN_DIGIT_OFFSET))
+        with engine.connect() as connection:
+            stored = connection.execute(sqlalchemy.select(IMAGES.c.offset_dv)).scalar()
+    assert repr(stored) == repr(FIFTEEN_DIGIT_OFFSET)
+
+
+def test_a_boolean_column_round_trips_true(postgres_url: str) -> None:
+    """A native boolean, not an integer flag that happens to read back as one.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row())
+            connection.execute(TECHNIQUES.insert(), technique_row(spurious=True))
+        with engine.connect() as connection:
+            stored = connection.execute(sqlalchemy.select(TECHNIQUES.c.spurious)).scalar()
+    assert stored is True
+
+
+def test_comparing_a_boolean_column_to_an_integer_is_an_error(postgres_url: str) -> None:
+    """This is why the integer spellings had to go, demonstrated rather than asserted.
+
+    ``spurious = 0`` is ordinary SQLite and a type error here, so a query that
+    kept the SQLite spelling would fail the moment an operator moved the index to
+    a server.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True) as engine:  # noqa: SIM117
+        with pytest.raises(sqlalchemy.exc.ProgrammingError, match='boolean'):
+            with engine.connect() as connection:
+                connection.execute(sqlalchemy.text('SELECT * FROM techniques WHERE spurious = 0'))
+
+
+def test_the_same_basename_in_two_volumes_produces_two_rows(postgres_url: str) -> None:
+    """The composite key is a real constraint on the server, not a convention.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row())
+            connection.execute(IMAGES.insert(), image_row(results_path_stub=OTHER_STUB))
+        with engine.connect() as connection:
+            stubs = connection.execute(
+                sqlalchemy.select(IMAGES.c.results_path_stub).order_by(IMAGES.c.results_path_stub)
+            ).scalars()
+            found = list(stubs)
+    assert found == [STUB, OTHER_STUB]
+
+
+def test_deleting_an_image_deletes_its_technique_rows(postgres_url: str) -> None:
+    """The cascade is enforced natively here, with no pragma to remember.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row())
+            connection.execute(TECHNIQUES.insert(), technique_row())
+            connection.execute(IMAGES.delete().where(IMAGES.c.results_path_stub == STUB))
+        with engine.connect() as connection:
+            remaining = connection.execute(
+                sqlalchemy.select(sqlalchemy.func.count()).select_from(TECHNIQUES)
+            ).scalar()
+    assert remaining == 0
+
+
+def test_a_json_column_round_trips_a_list(postgres_url: str) -> None:
+    """The JSON columns are jsonb here, which the direct-SQL examples rely on.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row(excluded_from_consensus=['ring_edge']))
+        with engine.connect() as connection:
+            stored = connection.execute(
+                sqlalchemy.select(IMAGES.c.excluded_from_consensus)
+            ).scalar()
+    assert stored == ['ring_edge']
+
+
+def test_a_json_column_is_jsonb(postgres_url: str) -> None:
+    """A plain ``json`` column would reject ``jsonb_array_elements_text``.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True) as engine, engine.connect() as connection:
+        found = connection.execute(
+            sqlalchemy.text(
+                'SELECT data_type FROM information_schema.columns '
+                'WHERE table_name = :table AND column_name = :column'
+            ),
+            {'table': 'images', 'column': 'excluded_from_consensus'},
+        ).scalar()
+    assert found == 'jsonb'
+
+
+def test_a_nanosecond_mtime_round_trips(postgres_url: str) -> None:
+    """A 32-bit integer column would refuse this value outright.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    mtime_ns = 1755000000123456789
+    with opened(postgres_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row(mtime_ns=mtime_ns))
+        with engine.connect() as connection:
+            stored = connection.execute(sqlalchemy.select(IMAGES.c.mtime_ns)).scalar()
+    assert stored == mtime_ns

--- a/tests/spindoctor/results_index/test_postgres.py
+++ b/tests/spindoctor/results_index/test_postgres.py
@@ -20,9 +20,22 @@ alone answers from whichever schema happens to hold a table of that name.
 
 import pytest
 import sqlalchemy
-from tests.spindoctor.results_index.conftest import STUB, image_row, opened, technique_row
+from tests.spindoctor.results_index.conftest import (
+    STUB,
+    feature_source_row,
+    image_row,
+    opened,
+    technique_row,
+)
 
-from spindoctor.results_index import IMAGES, SCHEMA_META, SCHEMA_VERSION, TECHNIQUES, open_index
+from spindoctor.results_index import (
+    FEATURE_SOURCES,
+    IMAGES,
+    SCHEMA_META,
+    SCHEMA_VERSION,
+    TECHNIQUES,
+    open_index,
+)
 
 pytestmark = pytest.mark.postgres
 
@@ -32,6 +45,12 @@ FIFTEEN_DIGIT_OFFSET = -1234.56789012345
 
 BOGUS_PASSWORD = 'sup3rs3cr3t'
 """A password distinctive enough that finding it anywhere is proof of a leak."""
+
+UNDEFINED_FUNCTION = '42883'
+"""SQLSTATE for an operator the server has no definition of.
+
+Stable across every server locale, which the message text is not.
+"""
 
 
 def _password_of(url: str) -> str:
@@ -60,7 +79,7 @@ def _with_password(url: str, password: str) -> str:
     return rewritten.render_as_string(hide_password=False)
 
 
-def _refusal_without_the_password(url: str, message: str) -> str:
+def _refusal_of(url: str, message: str) -> str:
     """Open a URL, require the refusal it raises, and return that message.
 
     Parameters:
@@ -70,11 +89,43 @@ def _refusal_without_the_password(url: str, message: str) -> str:
     Returns:
         The refusal message.
     """
-    if not _password_of(url):
-        pytest.skip('the configured server URL carries no password to mask')
     with pytest.raises(ValueError, match=message) as excinfo:
         open_index(url)
     return str(excinfo.value)
+
+
+def _extra_password_appearances(message: str, url: str) -> list[str]:
+    """Return the appearances of a URL's password a refusal does not account for.
+
+    The bare password is searched for, rather than the ``:password@`` form alone,
+    because a leak is a leak whatever shape it arrives in.  It is counted rather
+    than merely looked for, because the password a server is configured with is
+    also, on an ordinary local server, the role name and the database name, and
+    those the message names legitimately: what proves masking is that the
+    password appears no more often than the password-hiding rendering of the
+    same URL accounts for.
+
+    Parameters:
+        message: The refusal message to read.
+        url: The URL the refusal names.
+
+    Returns:
+        One entry per unaccounted appearance, empty when nothing leaked.
+    """
+    password = _password_of(url)
+    masked = sqlalchemy.engine.make_url(url).render_as_string()
+    extra = message.count(password) - masked.count(password)
+    return [password] * max(extra, 0)
+
+
+def _skip_without_a_password(url: str) -> None:
+    """Skip the calling test when the configured URL carries no password.
+
+    Parameters:
+        url: The URL the test drives.
+    """
+    if not _password_of(url):
+        pytest.skip('the configured server URL carries no password to mask')
 
 
 def test_creating_the_schema_creates_every_table(postgres_url: str, postgres_schema: str) -> None:
@@ -144,8 +195,9 @@ def test_the_not_an_index_refusal_does_not_repeat_the_password(postgres_url: str
     Parameters:
         postgres_url: URL of an empty schema of this test's own.
     """
-    message = _refusal_without_the_password(postgres_url, 'not a results index')
-    assert f':{_password_of(postgres_url)}@' not in message
+    _skip_without_a_password(postgres_url)
+    message = _refusal_of(postgres_url, 'not a results index')
+    assert _extra_password_appearances(message, postgres_url) == []
 
 
 def test_the_version_refusal_does_not_repeat_the_password(postgres_url: str) -> None:
@@ -154,10 +206,11 @@ def test_the_version_refusal_does_not_repeat_the_password(postgres_url: str) -> 
     Parameters:
         postgres_url: URL of an empty schema of this test's own.
     """
+    _skip_without_a_password(postgres_url)
     with opened(postgres_url, create=True) as engine, engine.begin() as connection:
         connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
-    message = _refusal_without_the_password(postgres_url, 'is not the version')
-    assert f':{_password_of(postgres_url)}@' not in message
+    message = _refusal_of(postgres_url, 'is not the version')
+    assert _extra_password_appearances(message, postgres_url) == []
 
 
 def test_a_masked_refusal_still_names_the_server(postgres_url: str) -> None:
@@ -166,7 +219,7 @@ def test_a_masked_refusal_still_names_the_server(postgres_url: str) -> None:
     Parameters:
         postgres_url: URL of an empty schema of this test's own.
     """
-    message = _refusal_without_the_password(postgres_url, 'not a results index')
+    message = _refusal_of(postgres_url, 'not a results index')
     assert str(sqlalchemy.engine.make_url(postgres_url).host) in message
 
 
@@ -217,13 +270,21 @@ def test_comparing_a_boolean_column_to_an_integer_is_an_error(postgres_url: str)
     kept the SQLite spelling would fail the moment an operator moved the index to
     a server.
 
+    The SQLSTATE is what is asserted, not the message: a server translates its
+    messages according to ``lc_messages``, so the word "boolean" is absent from
+    the text on a server configured for another language, and the test would then
+    fail for a reason that has nothing to do with the type discipline.
+
     Parameters:
         postgres_url: URL of an empty schema of this test's own.
     """
     with opened(postgres_url, create=True) as engine:  # noqa: SIM117
-        with pytest.raises(sqlalchemy.exc.ProgrammingError, match='boolean'):
+        with pytest.raises(sqlalchemy.exc.ProgrammingError) as excinfo:
             with engine.connect() as connection:
                 connection.execute(sqlalchemy.text('SELECT * FROM techniques WHERE spurious = 0'))
+    # 42883 is "undefined function", which is how the server reports that no
+    # boolean-to-integer equality operator exists.
+    assert getattr(excinfo.value.orig, 'sqlstate', None) == UNDEFINED_FUNCTION
 
 
 def test_the_same_basename_in_two_volumes_produces_two_rows(postgres_url: str) -> None:
@@ -260,6 +321,36 @@ def test_deleting_an_image_deletes_its_technique_rows(postgres_url: str) -> None
                 sqlalchemy.select(sqlalchemy.func.count()).select_from(TECHNIQUES)
             ).scalar()
     assert remaining == 0
+
+
+def test_a_second_row_for_one_technique_of_one_image_is_refused(postgres_url: str) -> None:
+    """The uniqueness is a server constraint here, not a SQLite convention.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row())
+            connection.execute(TECHNIQUES.insert(), technique_row())
+        with pytest.raises(sqlalchemy.exc.IntegrityError, match='uq_techniques_image_technique'):  # noqa: SIM117
+            with engine.begin() as connection:
+                connection.execute(TECHNIQUES.insert(), technique_row(confidence=0.5))
+
+
+def test_a_second_row_for_one_feature_source_of_one_image_is_refused(postgres_url: str) -> None:
+    """And the wider tuple the feature inventory is aggregated by.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row())
+            connection.execute(FEATURE_SOURCES.insert(), feature_source_row())
+        with pytest.raises(sqlalchemy.exc.IntegrityError, match='uq_feature_sources_image_source'):  # noqa: SIM117
+            with engine.begin() as connection:
+                connection.execute(FEATURE_SOURCES.insert(), feature_source_row(n_features=7))
 
 
 def test_a_json_column_round_trips_a_list(postgres_url: str) -> None:

--- a/tests/spindoctor/results_index/test_postgres.py
+++ b/tests/spindoctor/results_index/test_postgres.py
@@ -18,6 +18,7 @@ it: the catalog spans every schema on the server, so a lookup by table name
 alone answers from whichever schema happens to hold a table of that name.
 """
 
+import psycopg
 import pytest
 import sqlalchemy
 from tests.spindoctor.results_index.conftest import (
@@ -282,9 +283,13 @@ def test_comparing_a_boolean_column_to_an_integer_is_an_error(postgres_url: str)
         with pytest.raises(sqlalchemy.exc.ProgrammingError) as excinfo:
             with engine.connect() as connection:
                 connection.execute(sqlalchemy.text('SELECT * FROM techniques WHERE spurious = 0'))
+    original = excinfo.value.orig
+    # SQLAlchemy types the wrapped exception as any exception at all, so the
+    # driver's own class is stated before its result code is read.
+    assert isinstance(original, psycopg.Error)
     # 42883 is "undefined function", which is how the server reports that no
     # boolean-to-integer equality operator exists.
-    assert getattr(excinfo.value.orig, 'sqlstate', None) == UNDEFINED_FUNCTION
+    assert original.sqlstate == UNDEFINED_FUNCTION
 
 
 def test_the_same_basename_in_two_volumes_produces_two_rows(postgres_url: str) -> None:

--- a/tests/spindoctor/results_index/test_postgres.py
+++ b/tests/spindoctor/results_index/test_postgres.py
@@ -12,7 +12,10 @@ when ``SPINDOCTOR_TEST_POSTGRES_URL`` is unset, so a checkout with no server
 still runs a green suite.
 
 Each test gets a schema of its own from the ``postgres_url`` fixture, so a
-repeated run, or two workers of a parallel run, never share a table.
+repeated run, or two workers of a parallel run, never share a table.  A test
+that reads the server's catalog takes ``postgres_schema`` as well and filters on
+it: the catalog spans every schema on the server, so a lookup by table name
+alone answers from whichever schema happens to hold a table of that name.
 """
 
 import pytest
@@ -74,14 +77,19 @@ def _refusal_without_the_password(url: str, message: str) -> str:
     return str(excinfo.value)
 
 
-def test_creating_the_schema_creates_every_table(postgres_url: str) -> None:
+def test_creating_the_schema_creates_every_table(postgres_url: str, postgres_schema: str) -> None:
     """The metadata emits DDL a server accepts, not just DDL SQLite accepts.
+
+    The listing is scoped to this test's own schema rather than to whatever the
+    connection's search path resolves to, so a table another worker left in
+    ``public`` cannot answer for one this test was supposed to create.
 
     Parameters:
         postgres_url: URL of an empty schema of this test's own.
+        postgres_schema: Name of that schema.
     """
     with opened(postgres_url, create=True) as engine:
-        found = sorted(sqlalchemy.inspect(engine).get_table_names())
+        found = sorted(sqlalchemy.inspect(engine).get_table_names(schema=postgres_schema))
     assert found == ['feature_sources', 'images', 'ingest_runs', 'schema_meta', 'techniques']
 
 
@@ -270,19 +278,26 @@ def test_a_json_column_round_trips_a_list(postgres_url: str) -> None:
     assert stored == ['ring_edge']
 
 
-def test_a_json_column_is_jsonb(postgres_url: str) -> None:
+def test_a_json_column_is_jsonb(postgres_url: str, postgres_schema: str) -> None:
     """A plain ``json`` column would reject ``jsonb_array_elements_text``.
+
+    The catalog is server-wide, so the lookup is scoped to this test's own
+    schema: filtered by table and column alone it would read whichever
+    ``images`` row the catalog returned first, which under parallel workers is
+    somebody else's.
 
     Parameters:
         postgres_url: URL of an empty schema of this test's own.
+        postgres_schema: Name of that schema.
     """
     with opened(postgres_url, create=True) as engine, engine.connect() as connection:
         found = connection.execute(
             sqlalchemy.text(
                 'SELECT data_type FROM information_schema.columns '
-                'WHERE table_name = :table AND column_name = :column'
+                'WHERE table_schema = :schema AND table_name = :table '
+                'AND column_name = :column'
             ),
-            {'table': 'images', 'column': 'excluded_from_consensus'},
+            {'schema': postgres_schema, 'table': 'images', 'column': 'excluded_from_consensus'},
         ).scalar()
     assert found == 'jsonb'
 

--- a/tests/spindoctor/results_index/test_schema.py
+++ b/tests/spindoctor/results_index/test_schema.py
@@ -8,6 +8,7 @@ that an image is identified by its root and stub rather than its basename, and
 that a child row belongs to exactly one image.
 """
 
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -15,8 +16,10 @@ import sqlalchemy
 from tests.spindoctor.results_index.conftest import (
     ROOT_URL,
     STUB,
+    feature_source_row,
     image_row,
     opened,
+    sqlite_url_for,
     technique_row,
 )
 
@@ -144,7 +147,7 @@ FIFTEEN_DIGIT_OFFSET = -1234.56789012345
 
 
 @pytest.fixture
-def sqlite_url(tmp_path: Any) -> str:
+def sqlite_url(tmp_path: Path) -> str:
     """Return a SQLite URL for a database file of this test's own.
 
     Parameters:
@@ -153,7 +156,7 @@ def sqlite_url(tmp_path: Any) -> str:
     Returns:
         The URL.
     """
-    return f'sqlite:///{tmp_path / "index.sqlite3"}'
+    return sqlite_url_for(tmp_path / 'index.sqlite3')
 
 
 # ---------------------------------------------------------------------------
@@ -280,6 +283,49 @@ def test_the_stub_index_is_not_unique() -> None:
     assert stub_index.unique is False
 
 
+@pytest.mark.parametrize(
+    ('table', 'expected'),
+    [
+        pytest.param(
+            TECHNIQUES,
+            [['root_url', 'results_path_stub', 'technique_name']],
+            id='techniques',
+        ),
+        pytest.param(
+            FEATURE_SOURCES,
+            [
+                [
+                    'root_url',
+                    'results_path_stub',
+                    'feature_type',
+                    'source_model',
+                    'source_name',
+                ]
+            ],
+            id='sources',
+        ),
+    ],
+)
+def test_a_child_table_declares_one_row_per_logical_key(
+    table: sqlalchemy.Table, expected: list[list[str]]
+) -> None:
+    """A second row for one logical key is a contradiction, not more detail.
+
+    The tuple leads with the image key, so the constraint's own index is also
+    the index a lookup by image uses; a separate one would be redundant.
+
+    Parameters:
+        table: The child table under test.
+        expected: The column names of the unique constraints it must declare.
+    """
+    found = [
+        [column.name for column in constraint.columns]
+        for constraint in sorted(table.constraints, key=lambda one: str(one.name))
+        if isinstance(constraint, sqlalchemy.UniqueConstraint)
+    ]
+    assert found == expected
+
+
 # ---------------------------------------------------------------------------
 # Behavior against a real SQLite database
 # ---------------------------------------------------------------------------
@@ -376,6 +422,72 @@ def test_a_child_row_without_its_image_is_rejected(sqlite_url: str) -> None:
         with pytest.raises(sqlalchemy.exc.IntegrityError, match='FOREIGN KEY constraint failed'):
             with engine.begin() as connection:
                 connection.execute(TECHNIQUES.insert(), technique_row())
+
+
+def test_a_second_row_for_one_technique_of_one_image_is_refused(sqlite_url: str) -> None:
+    """A retried or duplicated ingest must not double what the table reports.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row())
+            connection.execute(TECHNIQUES.insert(), technique_row())
+        with pytest.raises(sqlalchemy.exc.IntegrityError, match='UNIQUE constraint failed'):  # noqa: SIM117
+            with engine.begin() as connection:
+                connection.execute(TECHNIQUES.insert(), technique_row(confidence=0.5))
+
+
+def test_two_techniques_of_one_image_are_accepted(sqlite_url: str) -> None:
+    """The constraint binds the technique name, not the number of rows per image.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row())
+            connection.execute(TECHNIQUES.insert(), technique_row())
+            connection.execute(TECHNIQUES.insert(), technique_row(technique_name='ring_edge'))
+        with engine.connect() as connection:
+            stored = connection.execute(
+                sqlalchemy.select(sqlalchemy.func.count()).select_from(TECHNIQUES)
+            ).scalar()
+    assert stored == 2
+
+
+def test_a_second_row_for_one_feature_source_of_one_image_is_refused(sqlite_url: str) -> None:
+    """The inventory is aggregated by this tuple, so it appears once.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row())
+            connection.execute(FEATURE_SOURCES.insert(), feature_source_row())
+        with pytest.raises(sqlalchemy.exc.IntegrityError, match='UNIQUE constraint failed'):  # noqa: SIM117
+            with engine.begin() as connection:
+                connection.execute(FEATURE_SOURCES.insert(), feature_source_row(n_features=7))
+
+
+def test_two_feature_sources_of_one_image_are_accepted(sqlite_url: str) -> None:
+    """One image legitimately reports several sources of one feature type.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row())
+            connection.execute(FEATURE_SOURCES.insert(), feature_source_row())
+            connection.execute(FEATURE_SOURCES.insert(), feature_source_row(source_name='YBSC'))
+        with engine.connect() as connection:
+            stored = connection.execute(
+                sqlalchemy.select(sqlalchemy.func.count()).select_from(FEATURE_SOURCES)
+            ).scalar()
+    assert stored == 2
 
 
 def test_the_offset_round_trips_at_fifteen_significant_digits(sqlite_url: str) -> None:

--- a/tests/spindoctor/results_index/test_schema.py
+++ b/tests/spindoctor/results_index/test_schema.py
@@ -1,0 +1,563 @@
+"""Tests for the results-index schema.
+
+The column set is the whole contract between ingest and every consumer, and it
+carries no migrations: a column that quietly changed name, type or nullability
+would be discovered by an operator whose report came out empty. These pin it
+column by column, and pin the two properties the keying argument rests on --
+that an image is identified by its root and stub rather than its basename, and
+that a child row belongs to exactly one image.
+"""
+
+from typing import Any
+
+import pytest
+import sqlalchemy
+from tests.spindoctor.results_index.conftest import (
+    ROOT_URL,
+    STUB,
+    image_row,
+    opened,
+    technique_row,
+)
+
+from spindoctor.results_index import (
+    FEATURE_SOURCES,
+    IMAGES,
+    INGEST_RUNS,
+    METADATA,
+    SCHEMA_META,
+    SCHEMA_VERSION,
+    TECHNIQUES,
+)
+
+ColumnType = type[sqlalchemy.types.TypeEngine[Any]]
+
+# (name, type, nullable), in schema order.
+IMAGES_COLUMNS: tuple[tuple[str, ColumnType, bool], ...] = (
+    ('root_url', sqlalchemy.Text, False),
+    ('results_path_stub', sqlalchemy.Text, False),
+    ('volume', sqlalchemy.Text, True),
+    ('image_name', sqlalchemy.Text, False),
+    ('instrument', sqlalchemy.Text, False),
+    ('camera', sqlalchemy.Text, True),
+    ('image_path', sqlalchemy.Text, True),
+    ('image_et', sqlalchemy.Double, True),
+    ('image_date', sqlalchemy.Text, True),
+    ('status', sqlalchemy.Text, False),
+    ('status_error', sqlalchemy.Text, True),
+    ('status_reason', sqlalchemy.Text, True),
+    ('offset_dv', sqlalchemy.Double, True),
+    ('offset_du', sqlalchemy.Double, True),
+    ('sigma_dv', sqlalchemy.Double, True),
+    ('sigma_du', sqlalchemy.Double, True),
+    ('covariance_vv', sqlalchemy.Double, True),
+    ('covariance_vu', sqlalchemy.Double, True),
+    ('covariance_uu', sqlalchemy.Double, True),
+    ('sigma_along_unobservable_px', sqlalchemy.Double, True),
+    ('rotation_deg', sqlalchemy.Double, True),
+    ('sigma_rotation_deg', sqlalchemy.Double, True),
+    ('confidence', sqlalchemy.Double, True),
+    ('confidence_rank', sqlalchemy.Text, True),
+    ('n_techniques', sqlalchemy.Integer, False),
+    ('excluded_from_consensus', sqlalchemy.JSON, True),
+    ('image_class', sqlalchemy.Text, True),
+    ('noise_sigma', sqlalchemy.Double, True),
+    ('image_shape_v', sqlalchemy.Integer, True),
+    ('image_shape_u', sqlalchemy.Integer, True),
+    ('run_start', sqlalchemy.Text, True),
+    ('run_end', sqlalchemy.Text, True),
+    ('elapsed_s', sqlalchemy.Double, True),
+    ('config_hash', sqlalchemy.Text, True),
+    ('git_sha', sqlalchemy.Text, True),
+    ('pipeline_run', sqlalchemy.Text, True),
+    ('image_number', sqlalchemy.BigInteger, True),
+    ('has_summary_png', sqlalchemy.Boolean, True),
+    ('start_et', sqlalchemy.Double, True),
+    ('stop_et', sqlalchemy.Double, True),
+    ('exposure_s', sqlalchemy.Double, True),
+    ('sclk_start', sqlalchemy.Text, True),
+    ('sclk_midtime', sqlalchemy.Text, True),
+    ('sclk_stop', sqlalchemy.Text, True),
+    ('camera_frame_id', sqlalchemy.Integer, True),
+    ('ck_frame_id', sqlalchemy.Integer, True),
+    ('cmatrix', sqlalchemy.JSON, True),
+    ('cmatrix_original', sqlalchemy.JSON, True),
+    ('source_file', sqlalchemy.Text, True),
+    ('mtime_ns', sqlalchemy.BigInteger, True),
+    ('size_bytes', sqlalchemy.BigInteger, True),
+)
+
+TECHNIQUES_COLUMNS: tuple[tuple[str, ColumnType, bool], ...] = (
+    ('root_url', sqlalchemy.Text, False),
+    ('results_path_stub', sqlalchemy.Text, False),
+    ('technique_name', sqlalchemy.Text, False),
+    ('offset_dv', sqlalchemy.Double, True),
+    ('offset_du', sqlalchemy.Double, True),
+    ('sigma_dv', sqlalchemy.Double, True),
+    ('sigma_du', sqlalchemy.Double, True),
+    ('confidence', sqlalchemy.Double, True),
+    ('spurious', sqlalchemy.Boolean, False),
+    ('at_edge', sqlalchemy.Boolean, False),
+    ('source_names', sqlalchemy.JSON, True),
+    ('diagnostics', sqlalchemy.JSON, True),
+)
+
+FEATURE_SOURCES_COLUMNS: tuple[tuple[str, ColumnType, bool], ...] = (
+    ('root_url', sqlalchemy.Text, False),
+    ('results_path_stub', sqlalchemy.Text, False),
+    ('feature_type', sqlalchemy.Text, False),
+    ('source_model', sqlalchemy.Text, False),
+    ('source_name', sqlalchemy.Text, False),
+    ('n_features', sqlalchemy.Integer, False),
+    ('n_gated', sqlalchemy.Integer, False),
+)
+
+INGEST_RUNS_COLUMNS: tuple[tuple[str, ColumnType, bool], ...] = (
+    ('run_id', sqlalchemy.Integer, False),
+    ('root_url', sqlalchemy.Text, False),
+    ('started_utc', sqlalchemy.Text, False),
+    ('finished_utc', sqlalchemy.Text, True),
+    ('files_seen', sqlalchemy.Integer, True),
+    ('files_ingested', sqlalchemy.Integer, True),
+    ('files_skipped', sqlalchemy.Integer, True),
+    ('files_failed', sqlalchemy.Integer, True),
+    ('schema_version', sqlalchemy.Integer, False),
+)
+
+SCHEMA_META_COLUMNS: tuple[tuple[str, ColumnType, bool], ...] = (
+    ('singleton', sqlalchemy.Integer, False),
+    ('schema_version', sqlalchemy.Integer, False),
+    ('created_utc', sqlalchemy.Text, False),
+)
+
+TABLE_CASES = [
+    pytest.param(IMAGES, IMAGES_COLUMNS, id='images'),
+    pytest.param(TECHNIQUES, TECHNIQUES_COLUMNS, id='techniques'),
+    pytest.param(FEATURE_SOURCES, FEATURE_SOURCES_COLUMNS, id='feature_sources'),
+    pytest.param(INGEST_RUNS, INGEST_RUNS_COLUMNS, id='ingest_runs'),
+    pytest.param(SCHEMA_META, SCHEMA_META_COLUMNS, id='schema_meta'),
+]
+
+OTHER_STUB = 'COISS_2002/data/1295221349_1296000000/N1294561202_1_CALIB'
+
+FIFTEEN_DIGIT_OFFSET = -1234.56789012345
+
+
+@pytest.fixture
+def sqlite_url(tmp_path: Any) -> str:
+    """Return a SQLite URL for a database file of this test's own.
+
+    Parameters:
+        tmp_path: Pytest-provided directory unique to the test.
+
+    Returns:
+        The URL.
+    """
+    return f'sqlite:///{tmp_path / "index.sqlite3"}'
+
+
+# ---------------------------------------------------------------------------
+# The declared column set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(('table', 'expected'), TABLE_CASES)
+def test_table_declares_exactly_these_columns_in_this_order(
+    table: sqlalchemy.Table, expected: tuple[tuple[str, ColumnType, bool], ...]
+) -> None:
+    """The column set and its order are the contract, so both are pinned.
+
+    Order matters because the CSV export writes columns in schema order.
+
+    Parameters:
+        table: The table under test.
+        expected: The declared (name, type, nullable) triples in schema order.
+    """
+    assert tuple(table.columns.keys()) == tuple(name for name, _type, _null in expected)
+
+
+@pytest.mark.parametrize(('table', 'expected'), TABLE_CASES)
+def test_every_column_has_the_declared_type(
+    table: sqlalchemy.Table, expected: tuple[tuple[str, ColumnType, bool], ...]
+) -> None:
+    """Types are compared exactly, not by subclass.
+
+    ``Double`` is a subclass of ``Float``, so an ``isinstance`` check would
+    accept the bare ``Float`` a dialect is free to map to single precision.
+
+    Parameters:
+        table: The table under test.
+        expected: The declared (name, type, nullable) triples.
+    """
+    found = {name: type(table.columns[name].type) for name, _type, _null in expected}
+    assert found == {name: column_type for name, column_type, _null in expected}
+
+
+@pytest.mark.parametrize(('table', 'expected'), TABLE_CASES)
+def test_every_column_has_the_declared_nullability(
+    table: sqlalchemy.Table, expected: tuple[tuple[str, ColumnType, bool], ...]
+) -> None:
+    """A column that is NOT NULL rejects a document that omits it.
+
+    Parameters:
+        table: The table under test.
+        expected: The declared (name, type, nullable) triples.
+    """
+    found = {name: table.columns[name].nullable for name, _type, _null in expected}
+    assert found == {name: nullable for name, _type, nullable in expected}
+
+
+def test_no_column_anywhere_is_a_bare_float() -> None:
+    """Bare ``Float`` may be single precision, which loses the stored offset.
+
+    Checked across every table rather than per column, so a column added later
+    cannot reintroduce it without this failing.
+    """
+    bare = sorted(
+        f'{table.name}.{column.name}'
+        for table in METADATA.tables.values()
+        for column in table.columns
+        if type(column.type) is sqlalchemy.Float
+    )
+    assert bare == []
+
+
+# ---------------------------------------------------------------------------
+# Keying
+# ---------------------------------------------------------------------------
+
+
+def test_images_is_keyed_by_root_and_stub() -> None:
+    """The basename is not the key: two volumes may hold the same basename."""
+    assert [column.name for column in IMAGES.primary_key.columns] == [
+        'root_url',
+        'results_path_stub',
+    ]
+
+
+@pytest.mark.parametrize('table', [TECHNIQUES, FEATURE_SOURCES], ids=['techniques', 'sources'])
+def test_a_child_table_cascades_from_the_composite_key(table: sqlalchemy.Table) -> None:
+    """Child rows are keyed on the same pair and go when their image goes.
+
+    Parameters:
+        table: The child table under test.
+    """
+    constraint = next(iter(table.foreign_key_constraints))
+    assert constraint.ondelete == 'CASCADE'
+
+
+@pytest.mark.parametrize('table', [TECHNIQUES, FEATURE_SOURCES], ids=['techniques', 'sources'])
+def test_a_child_table_references_both_key_columns(table: sqlalchemy.Table) -> None:
+    """Referencing the stub alone would let one root's child join another's.
+
+    Parameters:
+        table: The child table under test.
+    """
+    constraint = next(iter(table.foreign_key_constraints))
+    assert [element.parent.name for element in constraint.elements] == [
+        'root_url',
+        'results_path_stub',
+    ]
+
+
+def test_the_stub_alone_carries_an_index() -> None:
+    """A lookup that already knows the root still needs the stub indexed."""
+    stub_indexes = [
+        index
+        for index in IMAGES.indexes
+        if [c.name for c in index.columns] == ['results_path_stub']
+    ]
+    assert len(stub_indexes) == 1
+
+
+def test_the_stub_index_is_not_unique() -> None:
+    """One stub legitimately appears once per ingested root."""
+    stub_index = next(
+        index
+        for index in IMAGES.indexes
+        if [c.name for c in index.columns] == ['results_path_stub']
+    )
+    assert stub_index.unique is False
+
+
+# ---------------------------------------------------------------------------
+# Behavior against a real SQLite database
+# ---------------------------------------------------------------------------
+
+
+def test_creating_the_schema_creates_every_table(sqlite_url: str) -> None:
+    """Opening with create writes the whole schema, not part of it.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:
+        found = sorted(sqlalchemy.inspect(engine).get_table_names())
+    assert found == ['feature_sources', 'images', 'ingest_runs', 'schema_meta', 'techniques']
+
+
+def test_creating_the_schema_stamps_the_version(sqlite_url: str) -> None:
+    """The stamp is what the version gate reads on every later open.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine, engine.connect() as connection:
+        stamped = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).scalar()
+    assert stamped == SCHEMA_VERSION
+
+
+def test_the_same_basename_in_two_volumes_produces_two_rows(sqlite_url: str) -> None:
+    """The defect the composite key exists to fix: no silent overwrite.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row())
+            connection.execute(IMAGES.insert(), image_row(results_path_stub=OTHER_STUB))
+        with engine.connect() as connection:
+            stubs = connection.execute(
+                sqlalchemy.select(IMAGES.c.results_path_stub).order_by(IMAGES.c.results_path_stub)
+            ).scalars()
+            found = list(stubs)
+    assert found == [STUB, OTHER_STUB]
+
+
+def test_two_roots_hold_the_same_stub_independently(sqlite_url: str) -> None:
+    """A multi-root index serves each consumer only rows from its own root.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    other_root = 'gs://bucket/nav-results'
+    with opened(sqlite_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row(status='success'))
+            connection.execute(IMAGES.insert(), image_row(root_url=other_root, status='error'))
+        with engine.connect() as connection:
+            status = connection.execute(
+                sqlalchemy.select(IMAGES.c.status).where(IMAGES.c.root_url == other_root)
+            ).scalar()
+    assert status == 'error'
+
+
+def test_deleting_an_image_deletes_its_technique_rows(sqlite_url: str) -> None:
+    """Re-ingesting an image must not leave the previous run's children behind.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row())
+            connection.execute(TECHNIQUES.insert(), technique_row())
+            connection.execute(
+                IMAGES.delete().where(IMAGES.c.results_path_stub == STUB),
+            )
+        with engine.connect() as connection:
+            remaining = connection.execute(
+                sqlalchemy.select(sqlalchemy.func.count()).select_from(TECHNIQUES)
+            ).scalar()
+    assert remaining == 0
+
+
+def test_a_child_row_without_its_image_is_rejected(sqlite_url: str) -> None:
+    """The cascade only means anything with foreign keys enforced.
+
+    SQLite leaves them off unless asked, so this is what proves the connect-time
+    pragma reached the connection doing the work.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:  # noqa: SIM117
+        with pytest.raises(sqlalchemy.exc.IntegrityError, match='FOREIGN KEY constraint failed'):
+            with engine.begin() as connection:
+                connection.execute(TECHNIQUES.insert(), technique_row())
+
+
+def test_the_offset_round_trips_at_fifteen_significant_digits(sqlite_url: str) -> None:
+    """The stored offset is the number every consumer applies, unrounded.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row(offset_dv=FIFTEEN_DIGIT_OFFSET))
+        with engine.connect() as connection:
+            stored = connection.execute(sqlalchemy.select(IMAGES.c.offset_dv)).scalar()
+    assert stored == FIFTEEN_DIGIT_OFFSET
+
+
+def test_the_offset_round_trips_bit_for_bit(sqlite_url: str) -> None:
+    """Equality could pass on a value that lost bits below the printed digits.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row(offset_dv=FIFTEEN_DIGIT_OFFSET))
+        with engine.connect() as connection:
+            stored = connection.execute(sqlalchemy.select(IMAGES.c.offset_dv)).scalar()
+    assert repr(stored) == repr(FIFTEEN_DIGIT_OFFSET)
+
+
+def test_a_true_boolean_reads_back_as_true(sqlite_url: str) -> None:
+    """A boolean column reads back as a Python bool, not as 1.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row())
+            connection.execute(TECHNIQUES.insert(), technique_row(spurious=True))
+        with engine.connect() as connection:
+            stored = connection.execute(sqlalchemy.select(TECHNIQUES.c.spurious)).scalar()
+    assert stored is True
+
+
+def test_a_false_boolean_reads_back_as_false(sqlite_url: str) -> None:
+    """And the false case, which an integer column would return as 0.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row())
+            connection.execute(TECHNIQUES.insert(), technique_row(at_edge=False))
+        with engine.connect() as connection:
+            stored = connection.execute(sqlalchemy.select(TECHNIQUES.c.at_edge)).scalar()
+    assert stored is False
+
+
+def test_a_json_column_round_trips_a_list(sqlite_url: str) -> None:
+    """JSON columns hand back parsed values, not the serialized text.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row(excluded_from_consensus=['ring_edge']))
+        with engine.connect() as connection:
+            stored = connection.execute(
+                sqlalchemy.select(IMAGES.c.excluded_from_consensus)
+            ).scalar()
+    assert stored == ['ring_edge']
+
+
+def test_a_nanosecond_mtime_round_trips(sqlite_url: str) -> None:
+    """The incremental skip compares nanosecond epochs, which need 64 bits.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    mtime_ns = 1755000000123456789
+    with opened(sqlite_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(IMAGES.insert(), image_row(mtime_ns=mtime_ns))
+        with engine.connect() as connection:
+            stored = connection.execute(sqlalchemy.select(IMAGES.c.mtime_ns)).scalar()
+    assert stored == mtime_ns
+
+
+def test_a_stub_without_a_separator_stores_a_null_volume(sqlite_url: str) -> None:
+    """The simulated dataset's bare scene basenames are valid stubs.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(
+                IMAGES.insert(), image_row(results_path_stub='sim_scene_0001', volume=None)
+            )
+        with engine.connect() as connection:
+            stored = connection.execute(sqlalchemy.select(IMAGES.c.volume)).scalar()
+    assert stored is None
+
+
+def test_status_error_is_retrievable_verbatim(sqlite_url: str) -> None:
+    """The SPICE-error selection filter matches this value exactly.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(
+                IMAGES.insert(),
+                image_row(
+                    status='error',
+                    status_error='missing_spice_data',
+                    status_reason='no kernel covers the epoch',
+                ),
+            )
+        with engine.connect() as connection:
+            stored = connection.execute(sqlalchemy.select(IMAGES.c.status_error)).scalar()
+    assert stored == 'missing_spice_data'
+
+
+def test_status_reason_is_stored_separately_from_status_error(sqlite_url: str) -> None:
+    """The two are different vocabularies and must not be merged.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(
+                IMAGES.insert(),
+                image_row(
+                    status='error',
+                    status_error='missing_spice_data',
+                    status_reason='no kernel covers the epoch',
+                ),
+            )
+        with engine.connect() as connection:
+            stored = connection.execute(sqlalchemy.select(IMAGES.c.status_reason)).scalar()
+    assert stored == 'no kernel covers the epoch'
+
+
+def test_schema_meta_refuses_a_second_row(sqlite_url: str) -> None:
+    """The table describes the database, so a second row is a contradiction.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:  # noqa: SIM117
+        with pytest.raises(sqlalchemy.exc.IntegrityError):
+            with engine.begin() as connection:
+                connection.execute(
+                    SCHEMA_META.insert().values(
+                        singleton=2,
+                        schema_version=SCHEMA_VERSION,
+                        created_utc='2026-01-01T00:00:00',
+                    )
+                )
+
+
+def test_an_ingest_run_starts_without_a_finish_time(sqlite_url: str) -> None:
+    """A run in flight is exactly a row whose finish time is still NULL.
+
+    Parameters:
+        sqlite_url: URL of an empty database file.
+    """
+    with opened(sqlite_url, create=True) as engine:
+        with engine.begin() as connection:
+            connection.execute(
+                INGEST_RUNS.insert().values(
+                    root_url=ROOT_URL,
+                    started_utc='2026-01-01T00:00:00+00:00',
+                    schema_version=SCHEMA_VERSION,
+                )
+            )
+        with engine.connect() as connection:
+            finished = connection.execute(sqlalchemy.select(INGEST_RUNS.c.finished_utc)).scalar()
+    assert finished is None

--- a/tests/spindoctor/results_index/test_schema.py
+++ b/tests/spindoctor/results_index/test_schema.py
@@ -532,7 +532,7 @@ def test_schema_meta_refuses_a_second_row(sqlite_url: str) -> None:
         sqlite_url: URL of an empty database file.
     """
     with opened(sqlite_url, create=True) as engine:  # noqa: SIM117
-        with pytest.raises(sqlalchemy.exc.IntegrityError):
+        with pytest.raises(sqlalchemy.exc.IntegrityError, match='ck_schema_meta_singleton'):
             with engine.begin() as connection:
                 connection.execute(
                     SCHEMA_META.insert().values(

--- a/tests/spindoctor/results_index/test_source_constructs.py
+++ b/tests/spindoctor/results_index/test_source_constructs.py
@@ -1,0 +1,288 @@
+"""Tests that no SQLite-only construct survives in the results index source.
+
+Four spellings work on SQLite and fail, or silently mean something else, on
+PostgreSQL: a Python function registered on the connection and then called from
+SQL, the ``TOTAL`` aggregate, a script of statements run outside the DDL layer,
+and integer arithmetic on a boolean. None of them announces itself; each is
+found the first time somebody points the code at a server. These read the source
+so that the answer does not depend on which backend a test happened to run
+against.
+
+The scan reads the source rather than importing it, so a module added to the
+package tomorrow is covered without being named here.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+import sqlalchemy
+from filecache import FCPath
+
+from spindoctor.results_index import METADATA
+
+_SOURCE_ROOT = FCPath(Path(__file__).resolve().parents[3]) / 'src' / 'spindoctor' / 'results_index'
+
+# The connect-time events a PRAGMA may legitimately live inside.  A pragma in a
+# query reaches one connection out of however many the pool holds.
+_CONNECT_EVENT = 'connect'
+
+_PRAGMA_RE = re.compile(r'\bpragma\b', re.IGNORECASE)
+
+_TOTAL_RE = re.compile(r'\bTOTAL\s*\(', re.IGNORECASE)
+
+# Registering a Python callable as a SQL function, in either DBAPI's spelling.
+_UDF_REGISTRARS = frozenset({'create_function', 'register_function'})
+
+_SCRIPT_EXECUTORS = frozenset({'executescript'})
+
+
+def _source_files() -> list[FCPath]:
+    """Return every Python module of the package under scan.
+
+    Returns:
+        The modules, sorted by path.
+    """
+    return sorted(_SOURCE_ROOT.rglob('*.py'))
+
+
+def _module_ids() -> list[str]:
+    """Return the module names used as parametrization ids.
+
+    Returns:
+        One base name per module under scan.
+    """
+    return [path.name for path in _source_files()]
+
+
+def _string_constants(tree: ast.AST) -> list[ast.Constant]:
+    """Return every string constant in a parsed module.
+
+    Parameters:
+        tree: The parsed module.
+
+    Returns:
+        The string constant nodes, which carry line numbers.
+    """
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    ]
+
+
+def _connect_handler_names(tree: ast.AST) -> set[str]:
+    """Return the names of functions registered as connect-time events.
+
+    Both spellings are recognized: ``event.listen(target, 'connect', handler)``
+    and the ``@event.listens_for(target, 'connect')`` decorator.
+
+    Parameters:
+        tree: The parsed module.
+
+    Returns:
+        The handler function names.
+    """
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and _called_name(node) == 'listen'
+            and len(node.args) >= 3
+            and _is_string(node.args[1], _CONNECT_EVENT)
+            and isinstance(node.args[2], ast.Name)
+        ):
+            names.add(node.args[2].id)
+        if isinstance(node, ast.FunctionDef):
+            for decorator in node.decorator_list:
+                if (
+                    isinstance(decorator, ast.Call)
+                    and _called_name(decorator) == 'listens_for'
+                    and len(decorator.args) >= 2
+                    and _is_string(decorator.args[1], _CONNECT_EVENT)
+                ):
+                    names.add(node.name)
+    return names
+
+
+def _called_name(node: ast.Call) -> str | None:
+    """Return the final attribute or name a call invokes.
+
+    Parameters:
+        node: The call node.
+
+    Returns:
+        The name, or None when the call target is an expression.
+    """
+    if isinstance(node.func, ast.Attribute):
+        return node.func.attr
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    return None
+
+
+def _is_string(node: ast.expr, value: str) -> bool:
+    """Whether an argument node is exactly the given string literal.
+
+    Parameters:
+        node: The argument node.
+        value: The literal to compare against.
+
+    Returns:
+        True when the node is that literal.
+    """
+    return isinstance(node, ast.Constant) and node.value == value
+
+
+def _connect_handler_line_ranges(tree: ast.AST) -> list[range]:
+    """Return the line ranges of every connect-time event handler.
+
+    Parameters:
+        tree: The parsed module.
+
+    Returns:
+        One range per handler, covering its whole body.
+    """
+    handlers = _connect_handler_names(tree)
+    return [
+        range(node.lineno, (node.end_lineno or node.lineno) + 1)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name in handlers
+    ]
+
+
+def _called_names(tree: ast.AST) -> set[str]:
+    """Return every function or method name the module calls.
+
+    Parameters:
+        tree: The parsed module.
+
+    Returns:
+        The called names.
+    """
+    return {
+        name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        for name in [_called_name(node)]
+        if name is not None
+    }
+
+
+def _boolean_column_names() -> list[str]:
+    """Return every Boolean column name in the schema.
+
+    Returns:
+        The names, sorted and de-duplicated.
+    """
+    return sorted(
+        {
+            column.name
+            for table in METADATA.tables.values()
+            for column in table.columns
+            if isinstance(column.type, sqlalchemy.Boolean)
+        }
+    )
+
+
+@pytest.mark.parametrize('path', _source_files(), ids=_module_ids())
+def test_no_module_registers_a_python_function_as_sql(path: FCPath) -> None:
+    """A UDF exists only on the connection that registered it.
+
+    Parameters:
+        path: The module under scan.
+    """
+    offenders = sorted(_called_names(ast.parse(path.read_text())) & _UDF_REGISTRARS)
+    assert offenders == []
+
+
+@pytest.mark.parametrize('path', _source_files(), ids=_module_ids())
+def test_no_module_uses_the_total_aggregate(path: FCPath) -> None:
+    """``TOTAL`` is a SQLite spelling of ``COALESCE(SUM(...), 0)``.
+
+    Parameters:
+        path: The module under scan.
+    """
+    offenders = [
+        node.value
+        for node in _string_constants(ast.parse(path.read_text()))
+        if _TOTAL_RE.search(str(node.value))
+    ]
+    assert offenders == []
+
+
+@pytest.mark.parametrize('path', _source_files(), ids=_module_ids())
+def test_no_module_runs_a_statement_script(path: FCPath) -> None:
+    """DDL comes from the metadata, so no dialect can be baked into a script.
+
+    Parameters:
+        path: The module under scan.
+    """
+    offenders = sorted(_called_names(ast.parse(path.read_text())) & _SCRIPT_EXECUTORS)
+    assert offenders == []
+
+
+@pytest.mark.parametrize('path', _source_files(), ids=_module_ids())
+def test_every_pragma_lives_inside_a_connect_event(path: FCPath) -> None:
+    """A pragma issued as a query configures one connection out of a pool.
+
+    Parameters:
+        path: The module under scan.
+    """
+    tree = ast.parse(path.read_text())
+    allowed = _connect_handler_line_ranges(tree)
+    offenders = [
+        node.value
+        for node in _string_constants(tree)
+        if _PRAGMA_RE.search(str(node.value))
+        and not any(node.lineno in line_range for line_range in allowed)
+    ]
+    assert offenders == []
+
+
+@pytest.mark.parametrize('path', _source_files(), ids=_module_ids())
+def test_no_module_compares_a_boolean_column_against_an_integer(path: FCPath) -> None:
+    """``spurious = 0`` and ``1 - spurious`` are type errors on PostgreSQL.
+
+    Parameters:
+        path: The module under scan.
+    """
+    patterns = [
+        re.compile(rf'\b{re.escape(name)}\b\s*(=|==|<>|!=|<|>|\+|-|\*)\s*\d')
+        for name in _boolean_column_names()
+    ] + [
+        re.compile(rf'\d\s*(=|==|<>|!=|<|>|\+|-|\*)\s*\b{re.escape(name)}\b')
+        for name in _boolean_column_names()
+    ]
+    offenders = [
+        node.value
+        for node in _string_constants(ast.parse(path.read_text()))
+        if any(pattern.search(str(node.value)) for pattern in patterns)
+    ]
+    assert offenders == []
+
+
+def test_the_scan_actually_reads_some_modules() -> None:
+    """Every assertion above is that a search came back empty.
+
+    A path that names nothing is indistinguishable from a package that is clean,
+    so the scan's own reach is asserted.
+    """
+    assert _module_ids() == ['__init__.py', 'engine.py', 'schema.py']
+
+
+def test_the_boolean_scan_knows_which_columns_are_boolean() -> None:
+    """The boolean check is driven by the schema, so it cannot silently empty."""
+    assert _boolean_column_names() == ['at_edge', 'has_summary_png', 'spurious']
+
+
+def test_the_pragma_scan_finds_the_connect_handler() -> None:
+    """The pragma allowance depends on recognizing the event registration.
+
+    If the recognizer stopped matching, every pragma would read as an offender
+    rather than the check quietly passing -- but the reverse (a handler matched
+    by accident, allowing pragmas anywhere) is what this pins.
+    """
+    tree = ast.parse((_SOURCE_ROOT / 'engine.py').read_text())
+    assert _connect_handler_names(tree) == {'_sqlite_on_connect'}

--- a/tests/spindoctor/results_index/test_source_constructs.py
+++ b/tests/spindoctor/results_index/test_source_constructs.py
@@ -37,6 +37,9 @@ _UDF_REGISTRARS = frozenset({'create_function', 'register_function'})
 
 _SCRIPT_EXECUTORS = frozenset({'executescript'})
 
+_KNOWN_MODULES = frozenset({'__init__.py', 'engine.py', 'schema.py'})
+"""The modules the scan must reach, whatever else the package grows."""
+
 
 def _source_files() -> list[FCPath]:
     """Return every Python module of the package under scan.
@@ -70,6 +73,29 @@ def _string_constants(tree: ast.AST) -> list[ast.Constant]:
         for node in ast.walk(tree)
         if isinstance(node, ast.Constant) and isinstance(node.value, str)
     ]
+
+
+def _call_argument_strings(tree: ast.AST) -> list[ast.Constant]:
+    """Return every string constant a parsed module passes to a call.
+
+    A pragma reaches a database only as the argument of an execute call, and the
+    word itself is ordinary English: scanning every constant would fail on a
+    docstring that merely described one.  Formatted strings are descended into,
+    since that is how a pragma carrying a value is written.
+
+    Parameters:
+        tree: The parsed module.
+
+    Returns:
+        The string constant nodes, which carry line numbers.
+    """
+    arguments = [
+        argument
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        for argument in [*node.args, *(keyword.value for keyword in node.keywords)]
+    ]
+    return [node for argument in arguments for node in _string_constants(argument)]
 
 
 def _connect_handler_names(tree: ast.AST) -> set[str]:
@@ -234,7 +260,7 @@ def test_every_pragma_lives_inside_a_connect_event(path: FCPath) -> None:
     allowed = _connect_handler_line_ranges(tree)
     offenders = [
         node.value
-        for node in _string_constants(tree)
+        for node in _call_argument_strings(tree)
         if _PRAGMA_RE.search(str(node.value))
         and not any(node.lineno in line_range for line_range in allowed)
     ]
@@ -267,9 +293,12 @@ def test_the_scan_actually_reads_some_modules() -> None:
     """Every assertion above is that a search came back empty.
 
     A path that names nothing is indistinguishable from a package that is clean,
-    so the scan's own reach is asserted.
+    so the scan's own reach is asserted.  It is asserted as a floor rather than
+    as an inventory, because the scan finds the package's modules for itself and
+    one added tomorrow is meant to be covered without being named here.
     """
-    assert _module_ids() == ['__init__.py', 'engine.py', 'schema.py']
+    missing = sorted(_KNOWN_MODULES.difference(_module_ids()))
+    assert missing == []
 
 
 def test_the_boolean_scan_knows_which_columns_are_boolean() -> None:


### PR DESCRIPTION
## Purpose

Phase 1 of the results index (issue #430): the core data-access layer that every later phase builds on. Nothing consumes the index yet — this PR introduces the schema, the opener, the version gate, the dependency declarations, the configuration surface, and the `postgres` test tier. Ingest, the report migration, the backplane and reprojection consumers, the selection filters, and the cloud-task driver are Phases 2-6.

No `Closes` keyword: this phase does not close #430. The final pull request to `main` will.

Targets `rf_results_index`, not `main`.

## Changes

- **New library package `spindoctor.results_index`** (deliberately not under `cli`, because library consumers use it):
  - `schema.py` — SQLAlchemy Core metadata for `images`, `techniques`, `feature_sources`, `schema_meta` and `ingest_runs`, with `SCHEMA_VERSION`.
  - `engine.py` — `open_index(url, *, create=False)`, the SQLite dialect connect-time events, the lockability probe, and the missing-driver message.
- **Keying.** `images` is keyed by the composite `(root_url, results_path_stub)`, so two volumes holding an image of the same basename produce two rows instead of silently overwriting each other, and one database can serve several roots. `techniques` and `feature_sources` key on the same pair with a composite foreign key and `ON DELETE CASCADE`, and each declares the tuple that identifies one of its rows unique within an image -- `technique_name` on `techniques`, `(feature_type, source_model, source_name)` on `feature_sources` -- so a retried or duplicated ingest is refused rather than silently doubling every count read from the table. Each constraint's index leads with the image key, so it is also the index a lookup by image uses and no separate one is declared. `results_path_stub` alone carries a **non-unique** index, and `image_date` and `instrument` carry one each, carried over from the indexes `cli/stats/schema.py` already declares so the report does not lose one in the move.
- **Types.** Every pixel, ET, covariance and sigma column is `sqlalchemy.Double`, never bare `Float` (a dialect is free to map `Float` to single precision, and the stored offset has to round-trip bit for bit). Booleans are `sqlalchemy.Boolean`, so a PostgreSQL backend rejects the integer arithmetic SQLite tolerates. `excluded_from_consensus`, `cmatrix`, `cmatrix_original`, `source_names` and `diagnostics` are `sqlalchemy.JSON`, which renders as TEXT on SQLite and `jsonb` on PostgreSQL.
- **The corrected-pointing columns** (`start_et`, `stop_et`, `exposure_s`, the three SCLK strings, the two frame ids, `cmatrix`, `cmatrix_original`) are declared now with the names and shapes their producer specifies, NULL until it lands, because a column-set change costs every operator a rebuild.
- **`open_index` is the only opener.** With `create=False` it refuses a database that does not exist — and does **not** leave an empty SQLite file behind, a deliberate change from `open_stats_db`'s silent-create — refuses one carrying no `schema_meta` row, and refuses one stamped with a different schema version, naming both versions and saying to delete and re-ingest. A PostgreSQL URL whose driver is absent fails with a message naming `rms-spindoctor[postgres]` rather than an import traceback. A SQLite file whose filesystem will not honor a write lock is refused at open (probed with `BEGIN IMMEDIATE` / rollback), naming PostgreSQL as the cross-machine option. The stamped version is read and checked **before anything is written**, so a refused creating open creates no table and writes no row. (Not literally untouched: the connect-time journal-mode selection rewrites a rollback-journal database's header before the gate is reached. What the gate guarantees is the schema and the rows, which is what a rebuild would otherwise have to undo.)
- **Every failure `open_index` reports is a `ValueError` naming the URL**, including the ones a database driver raises: an unparseable URL, a URL scheme no dialect claims, an absent driver for a backend SpinDoctor does not ship, and the ordinary operational failure of a PostgreSQL server that will not accept the connection (down, wrong host, wrong password, wrong database). Each keeps the driver's own exception as its `__cause__`. The translation is a catch-all rather than a list of expected types, because a dialect coerces its own connect arguments and reports a bad one -- a non-numeric port, a non-numeric `timeout` -- as a bare `ValueError` naming nothing. A consumer that reports the cause rather than crashing therefore catches one type, and gets a message naming the URL, which is what identifies which of the three resolution levels supplied it.
- **A read-only SQLite database is not a locking failure and is not reported as one.** A read-only mount honors locking perfectly and a reader cannot corrupt anything, so an archived or read-only copy is opened by a consumer and refused only by a creating open, with a message naming read-only as the cause rather than blaming the filesystem. Whether ingest can write is asked of the filesystem -- `os.access` on the file and on the directory SQLite writes the write-ahead log into -- before the engine is built, because SQLite does not answer that question at open: a write-ahead-logged database, which is the shape this opener always leaves behind, accepts both the journal-mode selection its header already records and the write lock `BEGIN IMMEDIATE` takes, on a file it will never write, and refuses only the first real write, in the middle of an ingest. A rollback-journal database refuses the journal-mode selection instead, so no single SQLite answer covers both shapes; the connect-time selection tolerates that refusal and infers nothing from its absence. A write-ahead-logged copy in a directory that permits no writes cannot be read at all -- SQLite creates an index file beside such a database even to read it -- and says so rather than failing a consumer's first query with a write error. A genuine busy or I/O error still refuses in both modes with the filesystem-and-PostgreSQL message.
- **A failed lock probe is classified by SQLite's own result code before a message is chosen.** One exception type covers a file that is not a database, a path that is a directory, a file this user cannot open, and a results directory nobody has created yet, and prescribing a database server for any of those is a wrong remedy for the most likely first run there is. `SQLITE_NOTADB` and `SQLITE_CANTOPEN` each get a message naming what is actually wrong with the path; only a busy lock, an I/O error, or a code naming no cause at all keeps the filesystem-and-PostgreSQL text. Every other code -- a full disk, a corrupt file -- is reported as what SQLite said, naming the path and prescribing nothing, because inventing a remedy for an unclassified failure is how the wrong one gets prescribed. Codes are matched by prefix, since SQLite refines several of them into extended forms.
- **A `sqlite:` URL carries no query string.** The driver opens a file named after the whole URL, so `.../index.sqlite3?mode=ro` passed the existence check on `index.sqlite3` and then created a stray second file beside it. Such a URL is refused, saying that a SQLite index URL is a plain local path.
- **The URL every message names is rendered with its password masked.** These messages reach run logs and bug reports, and a database password belongs in neither; everything else about the URL survives, since naming it is what identifies the setting that supplied it. A URL the parser rejected cannot render itself, so its password is found **structurally**, by a stated rule rather than by a pattern. A `sqlite:` URL is returned unchanged, since it names a local path with no credentials and is free to carry the colons and at-signs that would otherwise read as some. Otherwise the user name runs from the start of the authority to the first `:` or `/`; only a `:` introduces a password, and that password runs to the first `@` after it, because an `@` is what ends the credentials. A `/` inside that span is part of the password, which is what reaches a password written with an unescaped slash; an `@` inside the user name is kept, which is what reaches the `user@servername` login form of a managed PostgreSQL. `host:5432/path@name` is genuinely ambiguous -- a host with a port and a path, or a user name with a slashed password -- and the digits decide it: a port is digits and a password is not, and mangling a host, a port and half a database name costs the identification these messages exist for. Nothing outside the password is touched.
- **There are no migrations.** Any change to the column set, or to the constraints over it, increments `SCHEMA_VERSION`, which is **2**: the child-table uniqueness constraints are a constraint change, and a database created without them is refused and rebuilt rather than carrying rows the constraints would have prevented.
- **SQLite settings are dialect connect-time events**, never `executescript` and never a bare `PRAGMA` in a query: `PRAGMA foreign_keys = ON`, `busy_timeout`, and write-ahead logging are applied to every connection the pool hands out.
- **A `sqlite:` URL names a local filesystem path** and is the one path in the system that does not go through `FCPath`; the module says so and uses `pathlib`.
- **Nothing in `spindoctor.results_index` calls `logging.getLogger` or enables engine echo.** SQLAlchemy's own stdlib-logging use is left untouched and unconfigured. Enforced by a source-scanning test in `test_logging_static_invariants.py`.
- **Dependencies.** `sqlalchemy>=2.0` joins `[project] dependencies`; a `postgres` extra declaring `psycopg[binary]>=3.1` joins `[project.optional-dependencies]`.
- **Configuration.** `get_results_db_url(arguments, config) -> str | None` beside the existing getters, resolving the command line, then `config.environment.results_db`, then `NAV_RESULTS_DB`, with the literal `none` meaning "no index". Absence is not an error — it is the default mode of every program. Phase 2 wires the `--results-db` argument to it.
- **`environment` joins `HASH_EXCLUDED_SECTIONS`** alongside `logging`, with its rationale on the constant: it holds deployment locations, none of which can change a navigation result.
- **The `postgres` test tier.** Registered in `[tool.pytest.ini_options].markers`; `addopts` becomes `-m "not integration and not postgres"`; `scripts/run-all-checks.sh` gains `-P` / `--postgres` alongside `-i`. The tests read `SPINDOCTOR_TEST_POSTGRES_URL` and skip when it is unset, and each creates and drops a PostgreSQL schema of its own so repeat runs and xdist workers do not collide; a test that reads the server's catalog filters on that schema, since the catalog spans every schema on the server. CI's own `-m` flag restates both exclusions, because a `-m` flag replaces the expression `addopts` carries rather than adding to it.
- **Documentation** for the surfaces this phase changes: the three-tier description and run recipes in `dev_guide_testing.rst`, the `environment.results_db` key and the whole-section hash exclusion in `dev_guide_config_and_static_data.rst`, and the now-two excluded sections in `introduction_configuration.rst`. The dedicated user-guide and API-reference pages are Phase 6.

## Type of Change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that alters existing behavior or public API)
- [ ] Refactor (no functional or API changes)
- [ ] Documentation
- [ ] Tests only (no production code change)
- [x] CI / Build / Dependencies

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable) — this phase adds none; nothing here reaches holdings or SPICE
- [ ] End-to-end tests pass (if applicable)
- [x] New or updated tests for changed code
- [x] Tested manually (described below)

Commands and results, all from the worktree venv:

```text
ruff check src tests                       All checks passed!
ruff format --check src tests              564 files already formatted
MYPYPATH=src mypy src tests                Success: no issues found in 564 source files
pytest -n 4 --dist=loadfile                5214 passed, 7 xfailed
pytest -m postgres                         19 passed
sphinx-build -W -b html docs <out>         build succeeded
pymarkdown scan docs/ .cursor/ *.md        clean
```

The branch point (`rf_results_index` at `7c99913`) runs 5025 passed, 7 xfailed, 0 failed. This branch runs 5214 passed, 7 xfailed, 0 failed: 189 tests added, none broken.

The postgres tier was additionally run under `-n 4 --dist=loadfile` and twice in succession, to confirm the per-test schema isolation holds for parallel workers and repeat runs, and once with `SPINDOCTOR_TEST_POSTGRES_URL` unset, to confirm all 19 skip rather than fail. `/tmp/pytest-of-*` was scanned afterwards for anything left unwritable or world-writable: nothing.

**Every guarantee below was verified by breaking the source and confirming a test fails, then restoring.** All 59 cases were caught, the last six of them for the fourth-round review fixes in the final commit:

| Break | Caught by |
|---|---|
| `results_path_stub` dropped from the primary key | `test_schema.py` (7 failures) |
| `Double` demoted to bare `Float` | `test_schema.py` |
| `Boolean` demoted to `Integer` | `test_schema.py`, `test_postgres.py` |
| `ON DELETE CASCADE` removed | `test_schema.py`, `test_postgres.py` |
| stub index made unique | `test_schema.py` |
| child foreign-key column order swapped | `test_schema.py` |
| `PRAGMA foreign_keys` dropped from the connect event | `test_schema.py` |
| `PRAGMA busy_timeout` dropped | `test_engine.py` |
| write-ahead logging dropped | `test_engine.py` (4 failures) |
| `create=False` allowed to create the database | `test_engine.py` |
| version gate removed | `test_engine.py`, `test_postgres.py` |
| `schema_meta` gate removed | `test_engine.py`, `test_postgres.py` |
| missing-driver message removed | `test_engine.py` |
| lockability probe removed | `test_engine.py` |
| a `PRAGMA` issued outside a connect event | `test_source_constructs.py` |
| `executescript` reintroduced | `test_source_constructs.py` |
| `TOTAL(` reintroduced | `test_source_constructs.py` |
| a boolean column compared to an integer | `test_source_constructs.py` |
| a UDF registration reintroduced | `test_source_constructs.py` |
| stdlib `logging` imported by the index layer | `test_logging_static_invariants.py` |
| engine echo turned on | `test_engine.py` |
| `environment` removed from the hash exclusion | `test_config_hash.py` |
| the `none` sentinel dropped | `test_config_helper.py` |
| results-db resolution order inverted | `test_config_helper.py` |
| a driver exception left untranslated (server refused, malformed URL) | `test_engine.py` (5 failures) |
| the unknown-URL-scheme translation removed | `test_engine.py` |
| a missing driver for an unsupported backend re-raised as `ModuleNotFoundError` | `test_engine.py` |
| the refused open's engine left undisposed | `test_engine.py` |
| tables created before the stamped version is checked | `test_engine.py` |
| a read-only database raised at connect instead of recorded | `test_engine.py` (4 failures) |
| a read-only database refused in both modes | `test_engine.py` (4 failures) |
| the `schema_meta` singleton constraint renamed | `test_schema.py` |
| the URL echoed unmasked by the builder | `test_engine.py`, `test_postgres.py` (4 failures) |
| the URL echoed unmasked by the translation handlers | `test_engine.py` (3 failures) |
| the read-only answer inferred from the journal-mode pragma again | `test_engine.py` (4 failures, every one write-ahead-logged) |
| the filesystem writability check dropped | `test_engine.py` (7 failures) |
| the directory writability check dropped | `test_engine.py` |
| the probe's result-code classification dropped | `test_engine.py` (6 failures) |
| the translation narrowed from a catch-all to SQLAlchemy's own exceptions | `test_engine.py` (5 failures) |
| the query-string refusal dropped | `test_engine.py` (3 failures) |
| a driver exception's `__cause__` dropped | `test_engine.py` (5 failures) |
| the connect-time settings applied once instead of per connection | `test_engine.py` (3 failures) |
| the missing-driver tests' import hook removed (a `psycopg` that is present) | `test_engine.py` |
| a password carrying a `/` left unmasked (the pattern this round replaced) | `test_engine.py` (5 failures, one of them the unparseable-URL route) |
| the masking pattern unanchored, so it mangles a local path | `test_engine.py` |
| the probe's unclassified result codes given the filesystem-and-PostgreSQL message again | `test_engine.py` (4 failures) |
| the read-only backstop inside the probe removed | `test_engine.py` |
| the in-memory branch of the cannot-open message skipped | `test_engine.py` |
| the postgres catalog lookup left unscoped, against a decoy `public.images` carrying a `json` column | `test_postgres.py` |
| the read-only fixture restoring only the database it made read-only | leftover `0444` `-wal` and `-shm` files under `/tmp/pytest-of-*` |
| the structural masking rule reverted to the anchored pattern this round replaced | `test_engine_masking.py` (13 failures: 8 masking-table rows and 5 driven through `open_index` itself) |
| `SQLITE_IOERR` dropped from the lock-refusal prefixes | `test_engine_sqlite.py` |
| `SQLITE_CANTOPEN` matched by equality rather than by prefix | `test_engine_sqlite.py` |
| the non-string guard on the result-code name dropped | `test_engine_sqlite.py` |
| the connect handler's narrow re-raise widened to swallow every driver error | `test_engine_sqlite.py` |
| the child-table uniqueness constraints removed | `test_schema.py` (4 failures), `test_postgres.py` (2) |

## Potential Impacts

**The stamped `config_hash` changes once, for operators who set `environment` keys in configuration files.** Adding `environment` to `HASH_EXCLUDED_SECTIONS` removes those keys from the digest, so results produced before and after this change compare as differently configured if such a key was set. **The change is provenance-only**: no navigation result moves by a pixel. It is the point of the exclusion — a digest that shifted because someone moved a results directory was answering "was this produced by the same configuration" wrongly, and would keep doing so every time a deployment moved.

**`sqlalchemy` becomes a runtime dependency.** It is imported by `spindoctor.results_index` and by nothing on the navigation critical path; `import spindoctor.dataset` still does not import it, and Phase 5 adds the test that pins that.

**The default `pytest` invocation now also excludes the `postgres` marker.** CI's own `-m` flag is updated to `-m "not integration and not postgres"` in the same change, because a `-m` flag replaces the expression `addopts` carries rather than adding to it. Either way the tier would have skipped in CI, which exports no `SPINDOCTOR_TEST_POSTGRES_URL`; naming it keeps the workflow honest about which tiers it covers.

**`scripts/run-all-checks.sh` now passes `--dist=loadfile` to pytest, and `-P` with no server named now fails.** The missing `--dist=loadfile` is **pre-existing on `main`** -- `git show origin/main:scripts/run-all-checks.sh` has the same bare `-n auto` -- and is fixed here because it is one line and CLAUDE.md, the dev guide and CI all require it (default scheduling has crashed PyQt6 workers when tests from one file split across processes). The `-P` change turns an explicit opt-in that would have skipped every test into an error naming the variable to export.

Nothing else changes behavior. No program consumes the index in this phase, and no existing code path was modified: `spindoctor/cli/stats/*` still works exactly as it did, and Phase 2 replaces it.

## Checklist

- [x] Code follows project style (`ruff check`, `ruff format`)
- [x] Type annotations present and `mypy` passes
- [x] Docstrings and Sphinx docs updated (if applicable)
- [ ] CHANGES.md updated (if user-facing change) — no user-facing surface yet; the flags and the user guide arrive in Phases 2 and 6
- [x] No temporary or debug code left in
- [x] Breaking changes flagged in Type of Change above

## Notes

**Decisions taken while implementing, all reconciled into `plans/RESULTS_DB_PLAN.md` in the same commit** so the next reviewer's copy of the plan is not stale:

- `mtime_ns`, `size_bytes` and `image_number` are `BigInteger`. The plan does not specify them; a nanosecond epoch is around `1.75e18`, which overflows the 32-bit `INTEGER` a dialect is free to give a plain `Integer`, and an image-numbering scheme is free to run past it too. A round-trip test on both backends pins it.
- `schema_meta` enforces its single row with a constant primary key `singleton` and `CHECK (singleton = 1)`, so a second row is a database error rather than an ambiguity the version gate has to resolve.
- `ingest_runs` has a surrogate `run_id` primary key (a root legitimately has many runs, and a consumer reads the newest) and the concrete column names `files_seen` / `files_ingested` / `files_skipped` / `files_failed`, which Phases 2 and 3 will write.
- The `none` sentinel is honored at whichever level supplied the value, not only on the command line, so a configuration file or an exported variable can opt out the same way. It is matched as the exact string, so a URL that merely contains the word is still a URL.
- **The codebase convention for an argument of this kind is that each program defines its own**, as it does for the results roots: `add_common_env_args` in `spindoctor/cli/reproj/args.py` groups only the reprojection family, and nothing groups the roots. Recorded as the convention that exists, not as a decision binding a later phase.
- **`images` carries two indexes section 2.2 does not name**, `ix_images_image_date` and `ix_images_instrument`. They are carried over from the `idx_images_date` / `idx_images_instrument` indexes `cli/stats/schema.py` already declares, because the report groups and filters on both across a whole root; without them the migration would lose an index the report has today. Reconciled into section 2.2.
- **The child tables' by-image indexes are dropped**, not merely unchanged. Each uniqueness constraint's index leads with `(root_url, results_path_stub)`, so a separate index on that pair buys nothing and costs write time on every ingested image.
- **The engine tests are three files.** `test_engine.py` had reached 1409 lines, past the 1000-line module cap, so it is split along its own seams: the opener's contract (`test_engine.py`), what it does with a SQLite file (`test_engine_sqlite.py`), and how it names a URL without naming its password (`test_engine_masking.py`). Shared helpers moved to `conftest.py`; each file keeps its own fixtures.
- **A consumer's open takes a SQLite write lock it never needs.** `_probe_sqlite_access` issues `BEGIN IMMEDIATE` for `create=False` too, so once Phase 2 and Phase 3 have something writing the index, a reader opening it during an ingest waits out the 30-second busy timeout and can then fail with the filesystem-and-PostgreSQL message though nothing is wrong. Section 2.5 mandates refusing in both modes, so **this phase implements it as written and changes nothing**; whether the consumer path should probe with a read instead is filed as #462 against Phase 3, which is what makes the collision likely, and recorded in the plan's follow-ups.
- The acceptance-criterion-10 source scan (`tests/spindoctor/results_index/test_source_constructs.py`) is **scoped to `src/spindoctor/results_index/`** in this phase, because `spindoctor/cli/stats/` still holds the old `executescript`, `TOTAL(`, UDF and integer-boolean constructs that Phase 2 removes. **Phase 2 must widen `_SOURCE_ROOT` to cover the statistics package**, and the scan's own reach is asserted (`test_the_scan_actually_reads_some_modules`) so widening it cannot silently find nothing.

**`rf_results_index` had not been pushed**; it was created on the remote from the local branch tip (`7c99913`) so this pull request has a base to target.

**Closed in the second commit, from an adversarial review of the first:** the three routes by which a SQLAlchemy exception escaped the `ValueError` guarantee, and the missing-driver test that asserted one of them escaping; the over-refusal of a read-only index and its misdiagnosis as a locking failure; a creating open that wrote this version's tables into a database stamped with another version before refusing it; a disposal test that proved nothing (it deleted the file and asserted it was gone, which POSIX permits with the descriptor still open, so it passed against an opener that never disposed its engine); missing-driver tests naming `psycopg2`, which the `postgres` extra does not ship, and which passed only because that very common transitive dependency happens to be absent from this environment; and a `pytest.raises` with no message assertion. The plan is reconciled to each of them in the same commit.

**Closed in the final commit, from a fourth adversarial review and every CodeRabbit comment on this pull request:** a masking pattern that typed the user name as `[^/@]*` and so returned unmasked, in full, any URL whose user name carried an `@` -- the `user@servername` login form of a managed PostgreSQL, which SQLAlchemy's own parser accepts -- proven leaking through the real `open_index` on four shapes (a bad port, a space in the scheme, a leading space, a hyphenated scheme), together with the mirror failure in which a URL carrying no credentials at all had its port and half its database name rewritten into an invented password; the two branches of the probe classification that stayed green against a deliberately broken implementation at 100% branch coverage, because the empty-code test covered one side of a short circuit and `SQLITE_FULL` the other, so `startswith` was never the deciding factor; three more covered-but-unasserted spots; the child tables' missing uniqueness; the overclaimed "leaves the database untouched"; a masking table that tested the private helper in isolation, which is precisely where the leak lived; a test file past the 1000-line cap; and the CodeRabbit findings listed in the replies on this pull request, three of which are declined with evidence (a flag on `connection_record.info` the code no longer holds and which is the same dict as `connection.info` in any case; `__all__` in a test package, against a convention of eleven bare `__init__.py` files; and `FCPath` on a `sqlite:` URL, which section 2.5 deliberately exempts). The plan is reconciled to every behavior change in the same commit.

**Closed in the four commits before that, from a third adversarial review:** a password masking that could not span a `/` and so leaked one whole into any message naming a URL the parser rejected, together with the two refusal routes whose absence from the route table let that survive three rounds (a genuinely unparseable URL, and a failure inside the engine factory, the latter now asserting the `__cause__` it never checked); a probe classification whose fall-through prescribed PostgreSQL for a full disk and a corrupt file; a `journal_mode` case in the per-connection pragma test that a persistent database property answered whether or not the connect event ran; four `pytest.raises` asserting only what a message must not say; a PostgreSQL catalog lookup scoped by table and column alone, which under parallel workers reads another schema's column; a read-only fixture that left the write-ahead log and shared-memory index at mode `0444` and skipped before its restore could run; the two branches coverage could not reach, taking `spindoctor.results_index` to 100% statement and branch coverage; and the stale second copy of the `addopts` value in the dev guide alongside a CI marker expression that re-selected the tier `addopts` excludes. The plan is reconciled to the two behavior changes in the same commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a rebuildable navigation-results index supporting SQLite and PostgreSQL.
  * Added results-database URL configuration, environment-variable overrides, and opt-out behavior.
  * Added schema tracking, image metadata, techniques, feature sources, and ingest-run records.
  * Added clear database validation and password-safe error messages.

* **Documentation**
  * Expanded configuration, testing, and API documentation for results indexes and PostgreSQL support.

* **Tests**
  * Added comprehensive SQLite and PostgreSQL coverage, including schema validation, data integrity, error handling, and optional test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


