### PR TITLE
Keep an in-memory sim scene off storage

### DIFF
--- a/docs/dev_guide/dev_guide_simulator.rst
+++ b/docs/dev_guide/dev_guide_simulator.rst
@@ -2808,10 +2808,15 @@ obs to the simulated NavModels -- ``NavModelBodySimulated``,
 feature set per body / ring / star field from that filtered view, while the
 SPICE-backed models decline a simulated obs. From there the same techniques run
 and produce the same ``NavResult``. In tests the scene is usually driven
-directly: ``ObsSim.from_file(path, sim_params=load_sim_scene(path))``. When
-``sim_params`` is supplied the scene file is never read, so ``path`` is only
-the name the observation carries: it may name a file that does not exist, and
-no storage is touched to resolve it. A harness holding a scene it built in
+directly:
+
+.. code-block:: python
+
+    ObsSim.from_file(path, sim_params=load_sim_scene(path))
+
+When ``sim_params`` is supplied the scene file is never read, so ``path`` is
+only the name the observation carries: it may name a file that does not exist,
+and no storage is touched to resolve it. A harness holding a scene it built in
 memory can therefore pass a pure label such as ``sim://limb_bias``.
 
 .. _sim-png-export:

--- a/docs/dev_guide/dev_guide_simulator.rst
+++ b/docs/dev_guide/dev_guide_simulator.rst
@@ -2808,7 +2808,11 @@ obs to the simulated NavModels -- ``NavModelBodySimulated``,
 feature set per body / ring / star field from that filtered view, while the
 SPICE-backed models decline a simulated obs. From there the same techniques run
 and produce the same ``NavResult``. In tests the scene is usually driven
-directly: ``ObsSim.from_file(path, sim_params=load_sim_scene(path))``.
+directly: ``ObsSim.from_file(path, sim_params=load_sim_scene(path))``. When
+``sim_params`` is supplied the scene file is never read, so ``path`` is only
+the name the observation carries: it may name a file that does not exist, and
+no storage is touched to resolve it. A harness holding a scene it built in
+memory can therefore pass a pure label such as ``sim://limb_bias``.
 
 .. _sim-png-export:
 

--- a/src/spindoctor/obs/obs_inst_sim.py
+++ b/src/spindoctor/obs/obs_inst_sim.py
@@ -42,7 +42,9 @@ class ObsSim(ObsSnapshotInst):
         """Creates an ObsSim from a YAML scene file.
 
         Parameters:
-            path: Path to the YAML scene file.
+            path: Path or URL of the YAML scene file.  When ``sim_params`` is
+                supplied no file is read and this is only the name the
+                observation carries, so it may name nothing that exists.
             config: Navigation configuration. If None, uses defaults.
             extfov_margin_vu: Optional extended FOV margins (v,u) to add around the image.
             **kwargs: Additional keyword arguments.
@@ -53,6 +55,9 @@ class ObsSim(ObsSnapshotInst):
             The :class:`ObsSim` wrapping the rendered scene: the rendered
             image as ``data``, the full scene and renderer truth metadata on
             the snapshot, and the filtered idealized view as ``nav_params``.
+            Its ``abspath`` is the local file the scene was read from, or,
+            for a scene supplied in memory, ``path`` rendered absolute
+            without any storage being touched.
         """
 
         config = config or DEFAULT_CONFIG
@@ -60,11 +65,20 @@ class ObsSim(ObsSnapshotInst):
 
         provided_sim_params = kwargs.get('sim_params')
         scene_path = FCPath(path)
-        abspath = cast(Path, scene_path.get_local_path()).absolute()
+        abspath: Path | FCPath
         if provided_sim_params is None:
             logger.debug(f'Reading simulated image scene {scene_path}')
+            # Parsing the scene needs it as a file on local storage, which is
+            # what get_local_path provides: it fetches a remote scene into the
+            # cache and creates the local directories that hold it.
+            abspath = cast(Path, scene_path.get_local_path()).absolute()
             sim_params = load_sim_scene(abspath)
         else:
+            # A scene supplied in memory is never read back, so its path is only
+            # a label carried into the logs and the metadata.  absolute()
+            # renders it without reaching storage, where get_local_path would
+            # create the directories of a file that is never opened.
+            abspath = scene_path.absolute()
             sim_params = provided_sim_params
             logger.debug('Using provided sim_params')
 

--- a/tests/spindoctor/obs/test_obs_inst_sim.py
+++ b/tests/spindoctor/obs/test_obs_inst_sim.py
@@ -94,5 +94,8 @@ def test_scene_url_is_fetched_before_it_is_parsed(
     monkeypatch.chdir(tmp_path)
     scene_path = tmp_path / 'pebble_url.yaml'
     save_sim_scene(_body_scene(), scene_path)
-    obs = ObsSim.from_file(f'file://{scene_path}')
+    # as_uri() rather than an f-string: it escapes the characters a URL has to
+    # escape and spells a drive letter the way a URL spells one, neither of
+    # which an interpolated POSIX path does.
+    obs = ObsSim.from_file(scene_path.as_uri())
     assert obs.sim_params['scene_name'] == 'pebble_url'

--- a/tests/spindoctor/obs/test_obs_inst_sim.py
+++ b/tests/spindoctor/obs/test_obs_inst_sim.py
@@ -1,17 +1,24 @@
-"""ObsSim construction publishes the renderer's output metadata.
+"""ObsSim construction: renderer output metadata and scene-path handling.
 
 ``ObsSim.from_file`` renders the scene and stores the renderer's truth-side
 output on the snapshot for the image-side consumers (recovery scoring, the
 backplane writer).  These tests guard the per-body mask map: a renderer
 change that stops populating ``body_mask_map`` degrades those consumers
 silently, because nothing on the navigation path reads it.
+
+They also guard how the scene path is resolved.  A scene handed over in
+memory names no file, so resolving it must not reach storage; a scene named
+by a file or a URL must be fetched before it can be parsed.
 """
 
+from pathlib import Path
 from typing import Any
 
 import numpy as np
+import pytest
 
 from spindoctor.obs.obs_inst_sim import ObsSim
+from spindoctor.sim.scene import save_sim_scene
 
 _SIZE = 96
 
@@ -49,3 +56,43 @@ def test_body_mask_shape_matches_the_render() -> None:
     assert mask.dtype == np.bool_
     assert mask.shape == np.asarray(obs.data).shape
     assert mask.any()
+
+
+def test_in_memory_scene_creates_nothing_beside_the_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A scene supplied in memory leaves the working directory untouched.
+
+    The scene exists only as a mapping, so its name is a label rather than a
+    file: resolving it against storage would materialize a directory in
+    whatever directory the process happens to be running in.
+    """
+    monkeypatch.chdir(tmp_path)
+    obs = ObsSim.from_file('sim://in_memory', sim_params=_body_scene())
+    assert list(tmp_path.iterdir()) == []
+    assert obs.abspath.name == 'in_memory'
+
+
+def test_scene_file_supplies_the_sim_params(tmp_path: Path) -> None:
+    """With no sim_params supplied the scene is read from the named file."""
+    scene_path = tmp_path / 'pebble.yaml'
+    save_sim_scene(_body_scene(), scene_path)
+    obs = ObsSim.from_file(scene_path)
+    assert obs.sim_params['scene_name'] == 'pebble'
+    assert np.asarray(obs.data).shape == (_SIZE, _SIZE)
+
+
+def test_scene_url_is_fetched_before_it_is_parsed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A scene named by URL is brought to local storage before it is read.
+
+    A ``file://`` URL is not a path any reader can open as it stands; only the
+    file cache turns it into one.  Merely rendering the URL absolute leaves a
+    path that does not exist, so the scene must be fetched.
+    """
+    monkeypatch.chdir(tmp_path)
+    scene_path = tmp_path / 'pebble_url.yaml'
+    save_sim_scene(_body_scene(), scene_path)
+    obs = ObsSim.from_file(f'file://{scene_path}')
+    assert obs.sim_params['scene_name'] == 'pebble_url'


### PR DESCRIPTION
## Purpose

A sim scene that exists only as a mapping in memory still resolved its path through the file cache, so constructing the observation created a directory beside the process for a file nobody ever opens. `tests/integration/limb_bias.py` names its in-memory scene `sim://limb_bias`, and running the suite from a checkout therefore left a directory literally named `sim:` at the repo root; four checkouts on this machine had one. Beyond the litter, it is a library writing into the working directory of whatever invoked it, which is the behavior the suite's own working-directory hygiene refuses.

Closes #490

## Changes

- `ObsSim.from_file` resolved `abspath` through `FCPath.get_local_path()` before it knew whether a scene file would be read. `get_local_path()` creates the parent directories of the path it returns, which is correct when a scene is about to be fetched and parsed and pure litter when the caller already supplied `sim_params`. The download now happens only in the branch that parses a scene file; the in-memory branch uses `FCPath.absolute()`, which renders the path without reaching storage.
- The two branches produce different things because they mean different things. A scene read from a file has a real local file behind it, and `abspath` is that file: a remote scene must be fetched before it can be parsed, and `get_local_path()` is what fetches it. A scene supplied in memory has no file at all, so its path is only the label carried into the logs and into `get_public_metadata`'s `image_name` (which reads `self.abspath.name`); `absolute()` renders that label without asserting anything about storage. `abspath` is annotated `Path | FCPath` accordingly, and every consumer of it uses only `.name`, `.stem`, or `str()`, which both types provide.
- The `from_file` docstring now states that `path` may name nothing that exists when `sim_params` is supplied, and what `abspath` is in each case. The simulator dev guide gains the same note where it documents the in-memory construction pattern.

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that alters existing behavior or public API)
- [ ] Refactor (no functional or API changes)
- [x] Documentation
- [ ] Tests only (no production code change)
- [ ] CI / Build / Dependencies

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] End-to-end tests pass (if applicable)
- [x] New or updated tests for changed code
- [x] Tested manually (describe below if applicable)

Three tests were added to `tests/spindoctor/obs/test_obs_inst_sim.py`, and each one was checked to fail against the code it guards.

`test_in_memory_scene_creates_nothing_beside_the_process` runs in a temporary working directory, builds the observation from `sim://in_memory` with `sim_params` supplied, and asserts the working directory is still empty afterwards. Against the unfixed code it fails with `Left contains one more item: .../sim:` — the defect itself, not a proxy for it.

`test_scene_url_is_fetched_before_it_is_parsed` saves a scene and loads it by `file://` URL, which is not a path any reader can open as it stands. Replacing `get_local_path()` with an absolute rendering in that branch makes it fail with `No such file or directory: '<cwd>/file:/<tmp>/pebble_url.yaml'`, so it genuinely pins the fetch rather than merely passing through the branch. `test_scene_file_supplies_the_sim_params` covers the ordinary file-backed load, asserting the scene name and image shape come from the file.

End to end on the reproducer the issue names: with the fix stashed, `pytest tests/integration/test_limb_bias.py::test_zero_offset_scene_has_finite_bias` from the worktree root creates `sim:` there; with the fix applied it creates nothing.

Full check set, all green: `ruff check src tests` and `ruff format --check src tests` (609 files), `mypy src tests` (609 source files, no issues), unit suite at `-n 4 --dist=loadfile` (5898 passed, 7 xfailed, 50.8s), 105 sim integration tests across the limb-bias, navigation, mutual-event, regression, invariant, artifact-sweep, and irregular-pose files, `sphinx -W -b html docs docs/_build`, and `pymarkdown scan docs/ .cursor/ README.md CONTRIBUTING.md`.

## Potential Impacts

`ObsSim.abspath` is an `FCPath` rather than a `Path` for a scene supplied in memory. Nothing reads more than `.name`, `.stem`, or `str()` from it (`navigate_image_files`, `ui/library_entry`, `ui/manual_nav_dialog`, `ObsSim.get_public_metadata`), and `FCPath` provides all three with the same values, so no consumer changes. A scene read from a file is unaffected: `abspath` is still the local downloaded file. No public API, performance, or downstream effect otherwise.

## Checklist

- [x] Code follows project style (`ruff check`, `ruff format`)
- [x] Type annotations present and `mypy` passes
- [x] Docstrings and Sphinx docs updated (if applicable)
- [ ] CHANGES.md updated (if user-facing change)
- [x] No temporary or debug code left in
- [x] Breaking changes flagged in Type of Change above

## Notes

The stray `sim:` directories already sitting in other checkouts on this machine are not removed here; they are empty and outside this branch, and each belongs to a checkout in use.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * In-memory simulation scenes can now use synthetic or nonexistent path labels without creating local files.
  * Simulation parameters can be supplied directly, avoiding unnecessary scene-path resolution.

* **Bug Fixes**
  * File-backed scenes continue to load correctly from disk.
  * Scene URLs are fetched before being parsed, improving support for remote scene files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->