### PR TITLE
Drop a results index and start from scratch

### DIFF
--- a/docs/api_reference/api_results_index.rst
+++ b/docs/api_reference/api_results_index.rst
@@ -11,7 +11,17 @@ spindoctor.results_index
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: spindoctor.results_index.masking
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: spindoctor.results_index.engine
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: spindoctor.results_index.drop
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api_reference/api_results_index.rst
+++ b/docs/api_reference/api_results_index.rst
@@ -21,6 +21,11 @@ spindoctor.results_index
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: spindoctor.results_index.scope
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: spindoctor.results_index.drop
    :members:
    :undoc-members:

--- a/docs/dev_guide/dev_guide_introduction.rst
+++ b/docs/dev_guide/dev_guide_introduction.rst
@@ -147,8 +147,8 @@ Every CLI listed in ``[project.scripts]`` is installed onto ``$PATH`` by
        See :doc:`/user_guide/user_guide_ck_kernels`.
    * - ``sd_stats_ingest`` / ``sd_stats_ingest_cloud_tasks``
      - Read a navigation-results tree into the results index, in one process or
-       over a queue of workers; ``--drop-index`` empties the index instead. See
-       :doc:`/user_guide/user_guide_statistics`.
+       over a queue of workers. ``sd_stats_ingest --drop-index`` empties the
+       index instead. See :doc:`/user_guide/user_guide_statistics`.
    * - ``sd_stats_report``
      - Write the navigation statistics report and its charts from the index.
        See :doc:`/user_guide/user_guide_statistics`.

--- a/docs/dev_guide/dev_guide_introduction.rst
+++ b/docs/dev_guide/dev_guide_introduction.rst
@@ -147,7 +147,8 @@ Every CLI listed in ``[project.scripts]`` is installed onto ``$PATH`` by
        See :doc:`/user_guide/user_guide_ck_kernels`.
    * - ``sd_stats_ingest`` / ``sd_stats_ingest_cloud_tasks``
      - Read a navigation-results tree into the results index, in one process or
-       over a queue of workers. See :doc:`/user_guide/user_guide_statistics`.
+       over a queue of workers; ``--drop-index`` empties the index instead. See
+       :doc:`/user_guide/user_guide_statistics`.
    * - ``sd_stats_report``
      - Write the navigation statistics report and its charts from the index.
        See :doc:`/user_guide/user_guide_statistics`.

--- a/docs/dev_guide/dev_guide_testing.rst
+++ b/docs/dev_guide/dev_guide_testing.rst
@@ -125,15 +125,25 @@ tests need none of the archive environment above.
        technique, orchestrator, reproj, support).
    * - Results index on a server
        (``tests/spindoctor/results_index/test_postgres.py``,
-       ``test_drop_postgres.py``, ``tests/spindoctor/cli/stats/test_postgres.py``)
+       ``tests/spindoctor/results_index/test_drop_postgres.py``)
      - postgres
      - PostgreSQL
      - The schema, the version gate, and the type discipline against a backend
        that enforces them, rather than against SQLite's permissive typing; and
-       what a drop can only be asked of a server -- that it leaves another
-       owner's tables standing, that an emptied database is the same database as
-       one nothing was built in, and that a lock somebody else holds ends it
-       rather than hanging it.
+       the questions only a server can be asked of a drop -- that it leaves
+       another owner's tables standing, including one named as the index names
+       its own; that a search path crossing schemas cannot make one drop span
+       two of them; that an emptied database is the same database as one nothing
+       was built in; and that a lock somebody else holds ends it rather than
+       hanging it.
+   * - Statistics programs on a server
+       (``tests/spindoctor/cli/stats/test_postgres.py``, and the
+       ``postgres``-marked tests of ``tests/spindoctor/cli/stats/**``)
+     - postgres
+     - PostgreSQL
+     - That the command lines behave the same way against a server as against a
+       file: the same exit statuses for a database holding no index and for one
+       that is not there, and a failure named as what the server said it was.
    * - Simulator unit tests (``tests/spindoctor/sim/**``)
      - default
      - nothing

--- a/docs/dev_guide/dev_guide_testing.rst
+++ b/docs/dev_guide/dev_guide_testing.rst
@@ -125,17 +125,23 @@ tests need none of the archive environment above.
        technique, orchestrator, reproj, support).
    * - Results index on a server
        (``tests/spindoctor/results_index/test_postgres.py``,
-       ``tests/spindoctor/results_index/test_drop_postgres.py``)
+       ``tests/spindoctor/results_index/test_drop_postgres.py``,
+       ``tests/spindoctor/results_index/test_creating_open_postgres.py``)
      - postgres
      - PostgreSQL
      - The schema, the version gate, and the type discipline against a backend
-       that enforces them, rather than against SQLite's permissive typing; and
-       the questions only a server can be asked of a drop -- that it leaves
-       another owner's tables standing, including one named as the index names
-       its own; that a search path crossing schemas cannot make one drop span
-       two of them; that an emptied database is the same database as one nothing
-       was built in; and that a lock somebody else holds ends it rather than
-       hanging it.
+       that enforces them, rather than against SQLite's permissive typing; the
+       questions only a server can be asked of a drop -- that it leaves another
+       owner's tables standing, including one named as the index names its own;
+       that a search path crossing schemas cannot make one drop span two of
+       them; that an emptied database is the same database as one nothing was
+       built in; that a stamp column this account may not read costs the version
+       and not the drop; and that a lock somebody else holds ends it rather than
+       hanging it. And the questions only a server can be asked of a creating
+       open: that the schema it examines is the one the index resolves to rather
+       than the database around it, and that a table of one of the index's own
+       names in another schema of the search path is neither adopted nor built
+       around.
    * - Statistics programs on a server
        (``tests/spindoctor/cli/stats/test_postgres.py``, and the
        ``postgres``-marked tests of ``tests/spindoctor/cli/stats/**``)

--- a/docs/dev_guide/dev_guide_testing.rst
+++ b/docs/dev_guide/dev_guide_testing.rst
@@ -124,11 +124,16 @@ tests need none of the archive environment above.
      - One component in isolation (config, feature, dataset, obs, model,
        technique, orchestrator, reproj, support).
    * - Results index on a server
-       (``tests/spindoctor/results_index/test_postgres.py``)
+       (``tests/spindoctor/results_index/test_postgres.py``,
+       ``test_drop_postgres.py``, ``tests/spindoctor/cli/stats/test_postgres.py``)
      - postgres
      - PostgreSQL
      - The schema, the version gate, and the type discipline against a backend
-       that enforces them, rather than against SQLite's permissive typing.
+       that enforces them, rather than against SQLite's permissive typing; and
+       what a drop can only be asked of a server -- that it leaves another
+       owner's tables standing, that an emptied database is the same database as
+       one nothing was built in, and that a lock somebody else holds ends it
+       rather than hanging it.
    * - Simulator unit tests (``tests/spindoctor/sim/**``)
      - default
      - nothing

--- a/docs/user_guide/user_guide_statistics.rst
+++ b/docs/user_guide/user_guide_statistics.rst
@@ -63,6 +63,34 @@ refused before anything is walked, and an empty one is such a root: with
 ``--nav-results-root "$ROOT"`` and ``ROOT`` unset the program stops rather than
 ingesting whatever directory it was started from under a name nobody chose.
 
+**An ingest builds the index in one schema, and only in a schema of its own.**
+The tables go into the schema the index resolves to: the one holding a
+``schema_meta`` stamp SpinDoctor wrote, or, where the database carries no such
+stamp, the one an unqualified ``CREATE TABLE`` lands in (``main`` on SQLite, the
+first schema of the search path on PostgreSQL). That schema is built in when it
+holds nothing at all, and gone on with when it already carries SpinDoctor's
+stamp, whatever schema version that stamp names. Anything else is **refused**,
+before a table is created or a stamp is written:
+
+- A schema holding a table of one of the index's own names -- ``images``,
+  ``techniques``, ``feature_sources``, ``failed_files``, ``schema_meta`` or
+  ``ingest_runs`` -- that no stamp of SpinDoctor's stands over. Those are among
+  the commonest table names there are, so a table called ``images`` is not
+  evidence of anything, and a stamp written beside somebody else's table would
+  make it SpinDoctor's for every later reading, including the drop's.
+- A schema holding any table SpinDoctor does not own, stamped or not. A results
+  index owns the schema it lives in, so a table nobody here created in it means
+  the URL, or the search path behind it, names a database or a schema other than
+  the one intended.
+
+The refusal names the schema, the tables it stopped on and the index URL with
+its password hidden, and exits 1; nothing is created, nothing is stamped, and
+that schema is exactly as it was. The remedy is to check the URL, or to name a
+schema of the index's own -- on PostgreSQL, by appending
+``?options=-csearch_path=schemaname`` to the URL. Other schemas of the same
+database are neither read nor named, so one server holds an index beside
+whatever else it holds.
+
 **Ingestion is incremental.** One recursive listing per root collects the
 metadata documents and carries each file's size and modification time along
 with it. Every other file under the root -- the summary PNG beside a document,
@@ -201,10 +229,13 @@ tree.
 
 **It removes SpinDoctor's own tables and nothing else** -- ``images``,
 ``techniques``, ``feature_sources``, ``failed_files``, ``schema_meta`` and
-``ingest_runs``, named one at a time. No schema is dropped, nothing is matched
-by pattern, and anything else in that database is left exactly as it was, which
-is what makes the command safe to point at an index sharing a PostgreSQL
-database with somebody else's tables.
+``ingest_runs``, named one at a time. No schema is dropped and nothing is
+matched by pattern. What makes those six SpinDoctor's own rather than six names
+is the rule the ingest follows: it refuses to build an index in a schema holding
+any table it did not create, so a schema carrying SpinDoctor's stamp holds this
+index and nothing else. No other table of that schema, and no other schema of
+that database, is read or written, so an index shares a PostgreSQL server, and a
+database, with whatever else lives in the other schemas.
 
 **It drops only from a database that proves it holds an index.** Those six are
 among the commonest table names there are, so a table called ``images`` is not
@@ -233,7 +264,9 @@ space, so ``y``, ``Y``, ``yes`` and ``YES`` all mean yes; anything else, Ctrl-C
 included, leaves the index alone and exits 1. ``--yes`` drops without asking,
 for a run with nobody at the terminal -- and is required for one, because a
 standard input with nothing to read is treated as a refusal rather than as
-consent. Every message names the index URL with its password hidden.
+consent. Every refusal, the question itself, and the first line of the account
+name the index URL with its password hidden; the lines that continue that
+account carry the schema and the counts rather than repeating the URL.
 
 **It does one thing, so it refuses to be asked for two.** ``--drop-index``
 together with ``--force``, ``--nav-results-root``, ``--output-cloud-tasks-file``
@@ -248,10 +281,19 @@ side: it answers a question only the drop asks.
 **It works on the databases nothing else will open**, which is the point: an
 index stamped with a schema version this build does not read, or one whose stamp
 holds something no version number could, is exactly what the drop is pointed at.
+It also works on one whose columns are not this build's, since a stamp says which
+version wrote a database rather than that nothing has happened to it since: the
+account then leaves out whatever could not be read -- the schema version, the
+count of unfinished ingest runs -- and drops the tables all the same. The drop
+never refuses a database the other programs open.
 
 **Dropping twice is not an error.** A database holding none of these tables is
 not written at all, and says so; an index that is already gone is the state the
-command was asked for, so it exits 0. A database that is not there at all is a
+command was asked for, so it exits 0. What that answer was established over is
+what the connection reaches: an index in a schema outside this URL's search
+path, or in one this account may not look into, reads the same way as one that
+is not there, and the message says so rather than claiming the database holds
+none. A database that is not there at all is a
 different answer: the server refuses a PostgreSQL database it does not have, and
 a SQLite path that is not there gets the same refusal rather than being created,
 so both exit 1 and neither leaves an empty database behind.
@@ -272,7 +314,10 @@ driver would otherwise commit each ``DROP TABLE`` on its own -- the drop opens
 its transaction itself, which SQLite's own transactional DDL then honors. Ctrl-C
 partway through, a table that will not drop, a lost connection: each leaves the
 database exactly as it was, still readable by every consumer, and the drop is
-run again when the cause is dealt with.
+run again when the cause is dealt with. Ctrl-C is reported as the refusal it is
+wherever it lands -- while the database is being opened, while what it holds is
+being read, or during the drop -- naming which step stopped and exiting 1,
+rather than printing a traceback.
 
 Two things it does **not** refuse:
 

--- a/docs/user_guide/user_guide_statistics.rst
+++ b/docs/user_guide/user_guide_statistics.rst
@@ -169,6 +169,13 @@ at all. A scheduled invocation therefore reads the same status from the same
 tree every time, and a status of 1 always means something needs fixing rather
 than that a tree happens to hold no results.
 
+Under ``--drop-index`` the status says whether the index is gone: 0 when the
+tables went, and 0 again when the database held none of them, since an index
+that is already absent is the state the command was asked for. It is 1 when the
+database could not be opened or read, when the database holds tables of those
+names that nothing proves are the index's, when a table would not drop, and when
+whoever was asked answered anything but yes.
+
 The index is disposable, and there is no schema migration. It carries the column
 set version that wrote it, and opening one stamped with a different version
 fails naming both versions. The remedy is always the same -- empty the database
@@ -199,31 +206,73 @@ by pattern, and anything else in that database is left exactly as it was, which
 is what makes the command safe to point at an index sharing a PostgreSQL
 database with somebody else's tables.
 
+**It drops only from a database that proves it holds an index.** Those six are
+among the commonest table names there are, so a table called ``images`` is not
+evidence of anything and is never removed for its name alone. What is evidence
+is the index's own stamp: a ``schema_meta`` table carrying the columns
+SpinDoctor's stamp carries. A database with no such stamp is refused, exits 1,
+and has the tables that stopped it named -- because nothing distinguishes
+somebody else's ``images`` from what is left of an index whose stamp has gone,
+and a destructive command may not decide that on your behalf. Such tables are
+removed by hand, or with the SQLite file that holds them.
+
+**It drops from one schema: the one that stamp was found in.** A server resolves
+an unqualified table name through a search path that may cross several schemas,
+so the stamp is looked for once and every statement of the drop then names the
+schema it was found in. A table of one of these names in any other schema
+belongs to whoever put it there and is not touched. The schema is named in the
+confirmation and in the run log. On SQLite it is always ``main``, the one
+namespace a database file has.
+
 **It confirms first.** The run log lists the tables with their row counts and
-names the schema version, and the question -- which names the index, how many
-tables and rows go with it, and any ingest run that has not finished -- is put
-to the terminal. Anything but ``y`` or ``yes`` leaves the index alone and exits
-1. ``--yes`` drops without asking, for a run with nobody at the terminal -- and
-is required for one, because a standard input with nothing to read is treated as
-a refusal rather than as consent. Every message names the index URL with its
-password hidden.
+names the schema and the schema version, and the question -- which names the
+index, its schema, how many tables and rows go with it, and any ingest run that
+has not finished -- is written to standard output, which is where ``input``
+writes a prompt. The answer is read without regard to case or surrounding
+space, so ``y``, ``Y``, ``yes`` and ``YES`` all mean yes; anything else, Ctrl-C
+included, leaves the index alone and exits 1. ``--yes`` drops without asking,
+for a run with nobody at the terminal -- and is required for one, because a
+standard input with nothing to read is treated as a refusal rather than as
+consent. Every message names the index URL with its password hidden.
+
+**It does one thing, so it refuses to be asked for two.** ``--drop-index``
+together with ``--force``, ``--nav-results-root``, ``--output-cloud-tasks-file``
+or ``--complete-cloud-tasks-file`` is refused before anything is opened and
+exits 1, naming the option it will not combine with: a drop reads no document
+and walks no tree, so each of those was meant for a different command. A results
+root reaching the program from ``NAV_RESULTS_ROOT`` or from the configuration is
+a machine's standing setting rather than a request, and is simply unused.
+``--yes`` without ``--drop-index`` is refused for the same reason from the other
+side: it answers a question only the drop asks.
 
 **It works on the databases nothing else will open**, which is the point: an
-index stamped with a schema version this build does not read, or one an
-interrupted creation left holding part of a schema, is exactly what the drop is
-pointed at.
+index stamped with a schema version this build does not read, or one whose stamp
+holds something no version number could, is exactly what the drop is pointed at.
 
 **Dropping twice is not an error.** A database holding none of these tables is
 not written at all, and says so; an index that is already gone is the state the
-command was asked for, so it exits 0.
+command was asked for, so it exits 0. A database that is not there at all is a
+different answer: the server refuses a PostgreSQL database it does not have, and
+a SQLite path that is not there gets the same refusal rather than being created,
+so both exit 1 and neither leaves an empty database behind.
 
 **What is left behind is a database, not a hole.** Every consumer reads a
 dropped index exactly as it reads one nobody has ever ingested into -- "not
 ingested", with a message naming ``sd_stats_ingest`` -- and the next
 ``sd_stats_ingest`` builds it again from the metadata documents. On PostgreSQL
 the two states are literally the same database. On SQLite the file itself
-remains, empty; deleting the file is equivalent and is the one thing the drop
-deliberately does not do for you.
+remains, empty, and the drop deliberately does not delete it, so that one flag
+means one thing on both backends. Deleting the file instead removes the database
+rather than the index, which every consumer reads the same way but which a later
+``--drop-index`` refuses rather than reporting as nothing to do.
+
+**An interruption costs nothing.** The whole drop is one transaction on both
+backends: PostgreSQL rolls DDL back with everything else, and on SQLite -- whose
+driver would otherwise commit each ``DROP TABLE`` on its own -- the drop opens
+its transaction itself, which SQLite's own transactional DDL then honors. Ctrl-C
+partway through, a table that will not drop, a lost connection: each leaves the
+database exactly as it was, still readable by every consumer, and the drop is
+run again when the cause is dealt with.
 
 Two things it does **not** refuse:
 
@@ -235,13 +284,14 @@ Two things it does **not** refuse:
   gone; no reader is affected, because an unfinished run already reads as "not
   ingested" both before and after.
 * **Another process holding the database.** Neither backend can be asked that
-  question honestly, so the attempt is what answers it. On PostgreSQL the drop
-  waits a bounded time for each table's lock and then gives up, and its
-  transaction puts every table back; on SQLite the same bound is the busy
-  timeout, and the tables are dropped in an order whose every interruption
-  leaves a database with no version stamp -- which reads as "not ingested" and
-  which the next ingest rebuilds -- rather than a stamp standing over tables
-  that have gone.
+  question honestly, so the attempt is what answers it. Both the reading that
+  precedes the question and the drop itself wait a bounded time for each table
+  -- ``lock_timeout`` on PostgreSQL, the busy timeout on SQLite -- and then give
+  up, and what they give up on is put back whole by the transaction around it.
+  A failure names what the database said the cause was: a lock somebody holds, a
+  view or another object depending on one of these tables, an account that does
+  not own one of them, or, where the database gave no code this recognizes, its
+  own words with no cause invented for them.
 
 Ingesting over a queue of workers
 ---------------------------------

--- a/docs/user_guide/user_guide_statistics.rst
+++ b/docs/user_guide/user_guide_statistics.rst
@@ -171,9 +171,77 @@ than that a tree happens to hold no results.
 
 The index is disposable, and there is no schema migration. It carries the column
 set version that wrote it, and opening one stamped with a different version
-fails naming both versions. The remedy is always the same -- delete the database
-and re-run ``sd_stats_ingest`` (the source of truth is the metadata documents,
-so nothing is lost).
+fails naming both versions. The remedy is always the same -- empty the database
+with ``sd_stats_ingest --drop-index`` and re-run ``sd_stats_ingest`` (the source
+of truth is the metadata documents, so nothing is lost).
+
+Dropping an index and starting over
+-----------------------------------
+
+Starting a results tree over -- delete the results, navigate again, ingest
+again -- has a counterpart on the index, and it is a flag on the same command:
+
+.. code-block:: bash
+
+    sd_stats_ingest --results-db postgresql+psycopg://user@dbhost/spindoctor \
+        --drop-index
+
+**It drops and stops.** No results root is read and no document is ingested, so
+dropping is a deliberate act rather than the opening move of a long pass, and a
+mistyped URL costs one command. It needs no ``--nav-results-root``: a drop is
+about the database alone, and works on a machine that has the index and not the
+tree.
+
+**It removes SpinDoctor's own tables and nothing else** -- ``images``,
+``techniques``, ``feature_sources``, ``failed_files``, ``schema_meta`` and
+``ingest_runs``, named one at a time. No schema is dropped, nothing is matched
+by pattern, and anything else in that database is left exactly as it was, which
+is what makes the command safe to point at an index sharing a PostgreSQL
+database with somebody else's tables.
+
+**It confirms first.** The run log lists the tables with their row counts and
+names the schema version, and the question -- which names the index, how many
+tables and rows go with it, and any ingest run that has not finished -- is put
+to the terminal. Anything but ``y`` or ``yes`` leaves the index alone and exits
+1. ``--yes`` drops without asking, for a run with nobody at the terminal -- and
+is required for one, because a standard input with nothing to read is treated as
+a refusal rather than as consent. Every message names the index URL with its
+password hidden.
+
+**It works on the databases nothing else will open**, which is the point: an
+index stamped with a schema version this build does not read, or one an
+interrupted creation left holding part of a schema, is exactly what the drop is
+pointed at.
+
+**Dropping twice is not an error.** A database holding none of these tables is
+not written at all, and says so; an index that is already gone is the state the
+command was asked for, so it exits 0.
+
+**What is left behind is a database, not a hole.** Every consumer reads a
+dropped index exactly as it reads one nobody has ever ingested into -- "not
+ingested", with a message naming ``sd_stats_ingest`` -- and the next
+``sd_stats_ingest`` builds it again from the metadata documents. On PostgreSQL
+the two states are literally the same database. On SQLite the file itself
+remains, empty; deleting the file is equivalent and is the one thing the drop
+deliberately does not do for you.
+
+Two things it does **not** refuse:
+
+* **An ingest run that has not finished.** Such a run is either a pass writing
+  the index at this moment or one that died, and nothing recorded in the index
+  tells the two apart. A pass that died is also the commonest reason to want a
+  drop, so the count is reported in the confirmation rather than acted on.
+  Dropping under a live pass ends that pass, which fails on a table that has
+  gone; no reader is affected, because an unfinished run already reads as "not
+  ingested" both before and after.
+* **Another process holding the database.** Neither backend can be asked that
+  question honestly, so the attempt is what answers it. On PostgreSQL the drop
+  waits a bounded time for each table's lock and then gives up, and its
+  transaction puts every table back; on SQLite the same bound is the busy
+  timeout, and the tables are dropped in an order whose every interruption
+  leaves a database with no version stamp -- which reads as "not ingested" and
+  which the next ingest rebuilds -- rather than a stamp standing over tables
+  that have gone.
 
 Ingesting over a queue of workers
 ---------------------------------

--- a/plans/RESULTS_DB_PLAN.md
+++ b/plans/RESULTS_DB_PLAN.md
@@ -261,6 +261,12 @@ password belongs in neither. Everything else about the URL survives, because
 naming the URL is what tells a reader which of the three resolution levels
 supplied the value.
 
+The rule lives in `spindoctor/results_index/masking.py`, beside the opener
+rather than inside it, because it has a second caller: a run log records the
+command line it was given, and one of those words may be an index URL, so
+`support/command_line.py` masks the arguments through the same rule the opener
+masks its messages through.
+
 One structural rule does this for every URL, not only for the ones the parser
 rejects. A parsed URL renders itself with its password hidden but renders a
 `?password=` query parameter verbatim, and that parameter authenticates exactly
@@ -1127,9 +1133,10 @@ oversight.
 Emptying an index is the counterpart to starting a results tree over, and the
 version gate in section 2.4 makes it structural rather than convenient: a
 version bump is deliberately not migrated, and the remedy that gate prescribes
-is delete-and-re-ingest. On SQLite that remedy is `rm`; on PostgreSQL it is
-`psql`, the right connection string, and knowing which tables SpinDoctor owns
-in a database that may hold somebody else's.
+is delete-and-re-ingest. With no command behind it that remedy would be `rm` on
+SQLite and, on PostgreSQL, `psql` with the right connection string and a
+knowledge of which tables SpinDoctor owns in a database that may hold somebody
+else's; `--drop-index` is one flag for it on either backend.
 
 `sd_stats_ingest --drop-index` removes the index's tables from whatever backend
 the URL names and **stops** -- it reads no results root and ingests no
@@ -1140,68 +1147,132 @@ resolves no results root at all, so a machine holding the index and not the tree
 can still drop.
 
 `--yes` drops without asking. Without it the tables are listed with their row
-counts and the schema version, the question is put to standard output, and
-anything but `y` or `yes` leaves the index alone and exits 1. A standard input
+counts, the schema and the schema version, the question is put to standard
+output by `input`, and anything but `y` or `yes` -- compared after the line is
+stripped and lower-cased -- leaves the index alone and exits 1. A standard input
 that has nothing to read -- at its end, closed, or absent, which is what a
 scheduled run has -- is a refusal rather than consent, and the refusal names
-`--yes`. Every message names the index URL through `masked_url`.
+`--yes`. Ctrl-C at the question is a refusal too, and prints the line every
+other refusal prints rather than a traceback. Every message names the index URL
+through `masked_url`.
 
 The Core layer holds the operation, in `spindoctor/results_index/drop.py`:
-`index_contents(engine)` reads what of the index a database holds, and
-`drop_index_tables(engine)` removes it. The confirmation, the messages and the
-exit status are the CLI's, in `spindoctor/cli/stats/drop.py`.
+`index_contents(engine)` reads what of the index a database holds and where, and
+`drop_index_tables(engine, contents)` removes exactly that. The confirmation,
+the messages and the exit status are the CLI's, in `spindoctor/cli/stats/drop.py`.
 
+- **A name is not evidence.** The six names are `images`, `techniques`,
+  `feature_sources`, `failed_files`, `schema_meta` and `ingest_runs`, which are
+  among the commonest table names there are, and a shared PostgreSQL server
+  holds databases SpinDoctor did not create. So nothing is dropped from a
+  database until that database has proved it holds an index of ours, and the
+  proof is the index's own stamp: a `schema_meta` carrying the columns
+  `singleton` and `schema_version`. Two columns rather than the whole set,
+  because a stamp left by a schema whose columns differed is one of the states
+  the drop exists for; two rather than one, because a version column alone is
+  what any migration table carries. A database with tables of these names and no
+  such stamp is **refused** and its tables are named -- #487's "refuses
+  rather than half-completes when the URL names something that is not a
+  SpinDoctor index" -- since nothing distinguishes somebody else's `images` from
+  the remains of an index whose stamp has gone. The cost is named rather than
+  hidden: a creation interrupted before it wrote `schema_meta` is a database the
+  drop declines, and its tables go by hand or with the file.
+- **The evidence names the schema, and the schema is named in every
+  statement.** A server resolves a bare table name through a search path, and
+  six bare names resolved one at a time is how a drop comes to span two schemas
+  -- destroying a table in the first while leaving the index's own standing in
+  the second, committing, and exiting 0. So the stamp is located once (through
+  `pg_table_is_visible`, which is the server's own resolution rule) and every
+  statement afterwards -- the presence checks, the row counts, the `DROP TABLE`
+  -- names that schema explicitly. A table of one of these names in any other
+  schema is never reached. On SQLite the schema is `main`, the one namespace a
+  database file has, and naming it is what keeps the two backends on one code
+  path.
 - **The tables come from `METADATA` by name**, one `DROP TABLE` each. Never
-  `DROP SCHEMA`, never a wildcard, nothing discovered by pattern. A shared
-  PostgreSQL server may hold objects SpinDoctor did not create, and a hand-
-  written list would be right on the day it was written; a test reads the
-  statements the drop issues and asserts they are exactly those names.
-- **`open_database`** is the opener, beside `open_index` in
-  `engine.py`. It applies every URL diagnosis, SQLite probe and masking rule
-  `open_index` does and stops before the version gate, because a database the
-  gate refuses is precisely what a drop is pointed at. Nothing is read from the
-  database through it, so no column the gate protects is ever touched. The
-  three openers differ along four axes -- creating, writing, must-exist, gated
-  -- and an `_Access` record spells each combination out rather than inferring
-  one from another; it carries the read-only and absent-path remedies too,
-  since what to do about an unwritable file differs by operation.
+  `DROP SCHEMA`, never a wildcard, nothing discovered by pattern. A hand-written
+  list would be right on the day it was written; a test reads the statements the
+  drop issues and asserts they are exactly those names, each qualified by the
+  one schema.
+- **The reading is what is dropped.** `drop_index_tables` takes the
+  `IndexContents` the operator was shown rather than reading the database again,
+  so the tables that go are the tables that were named in the question. Between
+  two readings the answer is free to change, and a destructive command must not
+  act on a list nobody saw.
+- **`open_database`** is the opener, beside `open_index` in `engine.py`. It
+  applies every URL diagnosis, SQLite probe and masking rule `open_index` does
+  and stops before the version gate, because a database the gate refuses is
+  precisely what a drop is pointed at. It connects all the same: reading the
+  stamp is what reaches the server for the other opener, and an engine handed
+  back unconnected would turn an absent database or a refused password into
+  whatever statement ran first. Nothing is read from the database through it, so
+  no column the gate protects is ever touched. The three accesses differ along
+  four axes -- creating, writing, must-exist, gated -- and an `_Access` record
+  spells each combination out rather than inferring one from another; it carries
+  the read-only and absent-path remedies too, and what a failure calls the thing
+  it could not open, since a drop is pointed at databases that are not indexes.
 - **A database that is not there is refused**, on both backends alike: a
   PostgreSQL database that does not exist is refused by the server, and a
   SQLite path that does not exist gets the same answer rather than being
   created. A database that *is* there and holds none of these tables is not
   written at all and says so, and exits 0: an index already gone is the state
-  asked for, and an idempotent drop has to be visibly idempotent.
-- **`schema_meta` is dropped first**, before the tables it stamps. The drop runs
-  in one transaction, but that transaction is not equally strong on both
-  backends -- PostgreSQL rolls DDL back with everything else, while the SQLite
-  driver commits each `DROP TABLE` outside it -- so the order is what carries
-  the guarantee. Every state an interruption can leave is then one with no
-  stamp, which the gate reads as "this is not a results index" and which the
-  next `create=True` open rebuilds. The state that must never be left is the
-  opposite one: a stamp standing over tables that have gone, which the gate
-  reads as healthy and every consumer then fails inside its first query.
+  asked for, and an idempotent drop has to be visibly idempotent. The two
+  backends give the same status for the same state of the database, which is
+  what "works on both backends from the same flag" means for a teardown script.
+- **The transaction carries the guarantee, on both backends.** PostgreSQL rolls
+  DDL back with everything else. SQLite's own DDL is transactional as well; what
+  is not is its Python driver, which opens a transaction when it sees an INSERT,
+  UPDATE or DELETE and for nothing else, so a run of `DROP TABLE` statements
+  would otherwise be issued in autocommit and stand one at a time. The drop
+  therefore issues `BEGIN IMMEDIATE` itself as its first statement, which also
+  takes the write lock before anything has been dropped. Ctrl-C, a table that
+  will not drop and a lost connection each leave the database exactly as it was.
+- **`schema_meta` is dropped first**, before the tables it stamps. With the
+  transaction covering both backends this is the second line rather than the
+  first: what it forbids is the one state that must never be reached, a stamp
+  standing over tables that have gone, which the gate reads as healthy and
+  inside which every consumer's first query fails. The opposite state -- tables
+  standing with no stamp -- is not a safe resting place either, since a creating
+  open adopts it and the incremental skip then never re-reads the documents
+  whose rows survived; that it cannot arise is a property of the transaction,
+  not of the order.
 - **A dropped index and one that never existed are the same thing to every
-  consumer.** Both are "not ingested": `open_index` refuses both naming
-  `sd_stats_ingest`, `read_result_stubs` refuses both, and `sd_stats_report`
-  exits 1 on both. On PostgreSQL they are literally the same database, and a
-  test compares the two refusals character for character over one URL. On
-  SQLite the emptied file remains; deleting it is equivalent, and the drop
-  deliberately does not do it, so that one flag means one thing on both
-  backends.
+  consumer.** Both are "not ingested". There are five opener call sites:
+  `cli/stats/report.py`, `sd_stats_ingest.py`, `sd_stats_ingest_cloud_tasks.py`
+  and `selection.py` through `open_index`, and `cli/stats/drop.py` through
+  `open_database`. `open_index` refuses both naming `sd_stats_ingest`, so the
+  report exits 1 on both, the cloud-task worker returns `index_unopenable` on
+  both, a completion exits 1 on both, and `read_result_stubs` -- which only
+  `selection.py` goes through -- refuses both; a creating ingest builds one over
+  either. On PostgreSQL they are literally the same database, and a test
+  compares the two refusals character for character over one URL. On SQLite the
+  emptied file remains and the drop deliberately does not delete it, so that one
+  flag means one thing on both backends; deleting the file removes the database
+  rather than the index, which reads the same to every consumer but which a
+  later `--drop-index` refuses rather than reporting as nothing to do.
+- **A failure is named as what it was.** A drop can fail for a lock somebody
+  holds, a view or another object depending on one of these tables, an account
+  that does not own one of them, or a table that went between the reading and
+  the drop, and the remedies are different in every case. The CLI reads the
+  database's own code -- SQLSTATE from PostgreSQL, the result-code name from
+  SQLite -- and answers it from a table; a code not in that table is reported as
+  the database worded it, with no cause invented for it. Naming the wrong cause
+  in a destructive command's failure sends whoever reads it to grant a privilege
+  over a lock.
 
 Two questions the drop answers by reporting rather than by refusing.
 
 **An unfinished ingest run does not stop a drop.** Such a run is either a pass
-writing the index now or one that died, and nothing recorded in the index tells
-the two apart: there is no heartbeat and no process to ask. A pass that died is
-also the commonest reason to want a drop, so refusing on that evidence would
-withhold the command from the case that needs it most, to guard a case the
-confirmation already guards. The count is therefore named in the summary, before
-the question, so the person about to end a live pass is told while there is
-still an answer to give. What a drop under a live pass costs is that pass, which
-fails on a table that has gone; no reader is affected, since an unfinished run
-already reads as "not ingested" before and after. The count is asked only of a
-database stamped with this version, because the question is phrased in a column.
+writing the index at this moment or one that died, and nothing recorded in the
+index tells the two apart: there is no heartbeat and no process to ask. A pass
+that died is also the commonest reason to want a drop, so refusing on that
+evidence would withhold the command from the case that needs it most, to guard a
+case the confirmation already guards. The count is therefore named in the
+summary, before the question, so the person about to end a live pass is told
+while there is still an answer to give. What a drop under a live pass costs is
+that pass, which fails on a table that has gone; no reader is affected, since an
+unfinished run already reads as "not ingested" before and after. The count is
+asked only of a database stamped with this version, because the question is
+phrased in a column.
 
 **Another process holding the database does not stop it either.** Neither
 backend can be asked honestly: SQLite's readers take no lock to observe under
@@ -1209,11 +1280,23 @@ write-ahead logging, and a PostgreSQL role need not be allowed to read the
 server's activity view, so a "nobody is using it" answer would be a guess. What
 can be done is to make the attempt fail rather than hang, and to leave nothing
 half-finished when it does. `DROP_LOCK_TIMEOUT_MS` (30 s, matching
-`SQLITE_BUSY_TIMEOUT_MS`) is issued as `SET LOCAL lock_timeout` inside the drop
-transaction, so a table another session holds ends the drop promptly and
-PostgreSQL's transaction puts every table back; on SQLite the busy timeout
-already bounds the same wait, and the drop order covers the rest. The database
-itself decides, per table, instead of a guess deciding beforehand.
+`SQLITE_BUSY_TIMEOUT_MS`) is issued as `SET LOCAL lock_timeout` -- local, so the
+bound belongs to that transaction and does not ride a pooled connection into
+whatever runs on it next -- inside the drop's transaction **and inside the
+reading that precedes the question**, because counting a table's rows takes a
+lock too and an unbounded reading hangs the command before anybody has been
+asked anything. On SQLite the busy timeout already bounds the same wait, and
+`BEGIN IMMEDIATE` is where it is met. The database itself decides, per table,
+instead of a guess deciding beforehand.
+
+**Known limit, tracked as #501.** `open_index(create=True)` resolves its
+table names through the search path as `MetaData.create_all` does, so a database
+whose search path reaches a schema holding a table of one of these names has
+that table adopted rather than a fresh one created. The drop does not produce such a
+state and does not act on one, but the creating open can still walk into one a
+person built. Binding every statement of the index -- the ingest's
+writes, the report's reads, the selection queries -- to one named schema is the
+fix, and it is a change to every query rather than to the drop.
 
 ---
 

--- a/plans/RESULTS_DB_PLAN.md
+++ b/plans/RESULTS_DB_PLAN.md
@@ -370,7 +370,8 @@ open_index(url: str, *, create: bool = False) -> Engine
   from the current opener's silent-create behavior.
 - Either way, a `schema_version` that does not match the version the code
   was built for raises, naming both versions and instructing the reader to
-  delete the database and re-ingest. The stamped version is read and checked
+  empty the database with `sd_stats_ingest --drop-index` and re-ingest
+  (section 2.11). The stamped version is read and checked
   before anything is written, so a refused `create=True` open creates no table
   and writes no row; creating this version's tables inside a database
   stamped with another version would leave a mixture no single version number
@@ -1120,6 +1121,100 @@ reading a report; a logger would wrap that in machinery it does not need.
 The docstring says so, so the split reads as a decision rather than an
 oversight.
 
+
+### 2.11 Dropping an index
+
+Emptying an index is the counterpart to starting a results tree over, and the
+version gate in section 2.4 makes it structural rather than convenient: a
+version bump is deliberately not migrated, and the remedy that gate prescribes
+is delete-and-re-ingest. On SQLite that remedy is `rm`; on PostgreSQL it is
+`psql`, the right connection string, and knowing which tables SpinDoctor owns
+in a database that may hold somebody else's.
+
+`sd_stats_ingest --drop-index` removes the index's tables from whatever backend
+the URL names and **stops** -- it reads no results root and ingests no
+document. Dropping is a deliberate act rather than the first step of a long
+pass, and a command that did both would make a mistyped URL expensive twice
+over; dropping and re-ingesting in one command is available as two commands. It
+resolves no results root at all, so a machine holding the index and not the tree
+can still drop.
+
+`--yes` drops without asking. Without it the tables are listed with their row
+counts and the schema version, the question is put to standard output, and
+anything but `y` or `yes` leaves the index alone and exits 1. A standard input
+that has nothing to read -- at its end, closed, or absent, which is what a
+scheduled run has -- is a refusal rather than consent, and the refusal names
+`--yes`. Every message names the index URL through `masked_url`.
+
+The Core layer holds the operation, in `spindoctor/results_index/drop.py`:
+`index_contents(engine)` reads what of the index a database holds, and
+`drop_index_tables(engine)` removes it. The confirmation, the messages and the
+exit status are the CLI's, in `spindoctor/cli/stats/drop.py`.
+
+- **The tables come from `METADATA` by name**, one `DROP TABLE` each. Never
+  `DROP SCHEMA`, never a wildcard, nothing discovered by pattern. A shared
+  PostgreSQL server may hold objects SpinDoctor did not create, and a hand-
+  written list would be right on the day it was written; a test reads the
+  statements the drop issues and asserts they are exactly those names.
+- **`open_database`** is the opener, beside `open_index` in
+  `engine.py`. It applies every URL diagnosis, SQLite probe and masking rule
+  `open_index` does and stops before the version gate, because a database the
+  gate refuses is precisely what a drop is pointed at. Nothing is read from the
+  database through it, so no column the gate protects is ever touched. The
+  three openers differ along four axes -- creating, writing, must-exist, gated
+  -- and an `_Access` record spells each combination out rather than inferring
+  one from another; it carries the read-only and absent-path remedies too,
+  since what to do about an unwritable file differs by operation.
+- **A database that is not there is refused**, on both backends alike: a
+  PostgreSQL database that does not exist is refused by the server, and a
+  SQLite path that does not exist gets the same answer rather than being
+  created. A database that *is* there and holds none of these tables is not
+  written at all and says so, and exits 0: an index already gone is the state
+  asked for, and an idempotent drop has to be visibly idempotent.
+- **`schema_meta` is dropped first**, before the tables it stamps. The drop runs
+  in one transaction, but that transaction is not equally strong on both
+  backends -- PostgreSQL rolls DDL back with everything else, while the SQLite
+  driver commits each `DROP TABLE` outside it -- so the order is what carries
+  the guarantee. Every state an interruption can leave is then one with no
+  stamp, which the gate reads as "this is not a results index" and which the
+  next `create=True` open rebuilds. The state that must never be left is the
+  opposite one: a stamp standing over tables that have gone, which the gate
+  reads as healthy and every consumer then fails inside its first query.
+- **A dropped index and one that never existed are the same thing to every
+  consumer.** Both are "not ingested": `open_index` refuses both naming
+  `sd_stats_ingest`, `read_result_stubs` refuses both, and `sd_stats_report`
+  exits 1 on both. On PostgreSQL they are literally the same database, and a
+  test compares the two refusals character for character over one URL. On
+  SQLite the emptied file remains; deleting it is equivalent, and the drop
+  deliberately does not do it, so that one flag means one thing on both
+  backends.
+
+Two questions the drop answers by reporting rather than by refusing.
+
+**An unfinished ingest run does not stop a drop.** Such a run is either a pass
+writing the index now or one that died, and nothing recorded in the index tells
+the two apart: there is no heartbeat and no process to ask. A pass that died is
+also the commonest reason to want a drop, so refusing on that evidence would
+withhold the command from the case that needs it most, to guard a case the
+confirmation already guards. The count is therefore named in the summary, before
+the question, so the person about to end a live pass is told while there is
+still an answer to give. What a drop under a live pass costs is that pass, which
+fails on a table that has gone; no reader is affected, since an unfinished run
+already reads as "not ingested" before and after. The count is asked only of a
+database stamped with this version, because the question is phrased in a column.
+
+**Another process holding the database does not stop it either.** Neither
+backend can be asked honestly: SQLite's readers take no lock to observe under
+write-ahead logging, and a PostgreSQL role need not be allowed to read the
+server's activity view, so a "nobody is using it" answer would be a guess. What
+can be done is to make the attempt fail rather than hang, and to leave nothing
+half-finished when it does. `DROP_LOCK_TIMEOUT_MS` (30 s, matching
+`SQLITE_BUSY_TIMEOUT_MS`) is issued as `SET LOCAL lock_timeout` inside the drop
+transaction, so a table another session holds ends the drop promptly and
+PostgreSQL's transaction puts every table back; on SQLite the busy timeout
+already bounds the same wait, and the drop order covers the rest. The database
+itself decides, per table, instead of a guess deciding beforehand.
+
 ---
 
 ## 3. Current state
@@ -1237,7 +1332,7 @@ exclusion.
 The engine tests are three files, because one would run past the 1000-line
 module cap: the opener's contract (`test_engine.py`), what it does with a
 SQLite file (`test_engine_sqlite.py`), and how it names a URL without naming
-its password (`test_engine_masking.py`).
+its password (`test_masking.py`).
 
 ### Phase 2 — Ingest and reporting onto the index
 

--- a/plans/RESULTS_DB_PLAN.md
+++ b/plans/RESULTS_DB_PLAN.md
@@ -1193,6 +1193,11 @@ the messages and the exit status are the CLI's, in `spindoctor/cli/stats/drop.py
   list would be right on the day it was written; a test reads the statements the
   drop issues and asserts they are exactly those names, each qualified by the
   one schema.
+- **The six names in a stamped schema are six tables SpinDoctor created**,
+  because an ingest refuses to build an index in a schema holding anything it
+  did not create (below). That is what turns "the tables the drop removes" from
+  a claim about names into a claim about provenance, and it is what the user
+  guide's "nothing else in that schema is touched" rests on.
 - **The reading is what is dropped.** `drop_index_tables` takes the
   `IndexContents` the operator was shown rather than reading the database again,
   so the tables that go are the tables that were named in the question. Between
@@ -1289,14 +1294,47 @@ asked anything. On SQLite the busy timeout already bounds the same wait, and
 `BEGIN IMMEDIATE` is where it is met. The database itself decides, per table,
 instead of a guess deciding beforehand.
 
-**Known limit, tracked as #501.** `open_index(create=True)` resolves its
-table names through the search path as `MetaData.create_all` does, so a database
-whose search path reaches a schema holding a table of one of these names has
-that table adopted rather than a fresh one created. The drop does not produce such a
-state and does not act on one, but the creating open can still walk into one a
-person built. Binding every statement of the index -- the ingest's
-writes, the report's reads, the selection queries -- to one named schema is the
-fix, and it is a change to every query rather than to the drop.
+**What makes the drop's promise true is a rule on the creating open.** A drop
+that will not destroy a table on the strength of its name must not become
+willing because a stamp was found beside it, and `MetaData.create_all` defaults
+to `checkfirst=True`, so without a rule an ordinary ingest adopts an existing
+table of one of these names and stamps the schema over it. From then on nothing
+distinguishes that table from one SpinDoctor created. So an ingest never stamps
+a schema that already holds tables SpinDoctor did not create. The creating open
+resolves one schema -- the one a `schema_meta` of ours was found in, or, where
+there is none, the one an unqualified `CREATE TABLE` lands in -- and answers
+four ways:
+
+- The schema holds nothing: create the tables and stamp it.
+- The schema carries a stamp of SpinDoctor's: it is the index's own whatever
+  version that stamp names, and the version gate decides. This is the case
+  `--drop-index` exists for, so it must keep working for a stamp of any version;
+  the evidence is deliberately the two marks rather than the column set, since a
+  stamp of an older version has our tables with other columns.
+- The schema holds a table of one of the index's own names with no such stamp:
+  refuse. A name is not evidence, and a stamp written beside a stranger's table
+  would make it the index's for every later reading.
+- The schema holds any table the index does not own, stamped or not: refuse. The
+  index and its consumers own the schema they live in, so a foreign table means
+  the URL, or the search path behind it, names somewhere it should not.
+
+A refusal names the schema, the tables it found and the URL with its password
+hidden, creates nothing, stamps nothing and leaves the schema exactly as it was;
+the exit status is 1. The DDL is issued against that one schema by name, so a
+table of one of these names in another schema the search path reaches is neither
+adopted nor built around: the index is created whole in one schema, which is the
+schema the drop later removes it from. Only that schema is examined -- the rest
+of the database belongs to whoever made it and is neither read nor named.
+
+**What is left for #501.** The DDL names its schema; the queries beside it --
+the ingest's writes, `selection.py`, `roots.py` and the report's raw SQL -- still
+name their tables bare and let the server resolve them through the search path.
+Nothing can be adopted or destroyed through that any more, since the index is
+built whole in one schema and the drop removes it from that same one; what
+remains is that a table of one of these names created in an earlier schema of
+the path *after* the index was built would shadow the index's own for those
+queries. Binding `METADATA` to the resolved schema for every statement closes
+it, and it is a change to every query rather than to one command.
 
 ---
 
@@ -1368,10 +1406,11 @@ results-db URL.
 
 Introduce `spindoctor/results_index/` as a library package (not under
 `cli`; library consumers use it). Define the SQLAlchemy Core metadata for
-`images`, `techniques`, `feature_sources`, `schema_meta` and `ingest_runs`
-per sections 2.2-2.4; `open_index` with the `create` flag and version gate;
-the SQLite dialect events (WAL, `busy_timeout`, foreign keys, the
-lockability probe); and the missing-driver message for PostgreSQL URLs.
+`images`, `techniques`, `feature_sources`, `failed_files`, `schema_meta` and
+`ingest_runs` per sections 2.2-2.4; `open_index` with the `create` flag and
+the version gate; the SQLite dialect events (WAL, `busy_timeout`, foreign
+keys, the lockability probe); and the missing-driver message for PostgreSQL
+URLs.
 
 Declare `sqlalchemy` in `[project] dependencies` and the `postgres` extra in
 `[project.optional-dependencies]`. Add `environment` to

--- a/src/spindoctor/cli/sd_stats_ingest.py
+++ b/src/spindoctor/cli/sd_stats_ingest.py
@@ -13,6 +13,14 @@ consumer's lookup can match.
 Ingest is never automatic: no batch driver runs it as a side effect, and the
 index it writes is a snapshot of the tree as of this run.
 
+``--drop-index`` is the opposite operation and shares only the URL with the
+rest: it removes the index's own tables from the database that URL names and
+stops there, walking no tree.  It is what makes emptying an index and starting
+over something an operator can reach without hand-written SQL, on a shared
+PostgreSQL server as well as on a file -- which the schema version gate depends
+on, since a version bump is deliberately not migrated and rebuilding is the
+whole of the remedy.
+
 One pass may also be spread over a queue of workers.  ``--output-cloud-tasks-file``
 lists each root once, removes the rows whose documents have left the tree, and
 writes out the shares for ``sd_stats_ingest_cloud_tasks`` to read; when those
@@ -35,6 +43,7 @@ package_source_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, package_source_path)
 
 from spindoctor.cli.logging_args import add_logging_arguments, reporting_logging_errors
+from spindoctor.cli.stats.drop import drop_results_index
 from spindoctor.cli.stats.ingest import (
     IngestCounts,
     TaskCompletion,
@@ -113,6 +122,27 @@ def parse_args(command_list: list[str]) -> argparse.Namespace:
         help="""Read every document, including ones whose recorded size and
         modification time still match the tree. Refused with
         --complete-cloud-tasks-file, which reads no document.""",
+    )
+
+    drop_group = cmdparser.add_argument_group('Drop')
+    drop_group.add_argument(
+        '--drop-index',
+        action='store_true',
+        default=False,
+        help="""Remove the results index's own tables from the database
+        --results-db names, and stop: no results root is read and no document is
+        ingested. Nothing else in that database is touched, and a database
+        holding none of those tables is left alone and said to be. Refused
+        together with --force and with either cloud-tasks mode, none of which
+        this does.""",
+    )
+    drop_group.add_argument(
+        '--yes',
+        action='store_true',
+        default=False,
+        help="""Drop without asking for confirmation, for a run with nobody at
+        the terminal. Meaningful only with --drop-index, which is the only thing
+        this program asks about.""",
     )
 
     cloud_group = cmdparser.add_argument_group('Cloud tasks')
@@ -359,13 +389,55 @@ def _complete_cloud_tasks(engine: sqlalchemy.Engine, roots: list[str], *, path: 
     return 1 if unfinished else 0
 
 
+def _mode_refusal(arguments: argparse.Namespace) -> str | None:
+    """Return why a command line cannot be run as it stands, or None.
+
+    Refused rather than ignored, on the same grounds as ``--force`` under a
+    completion below: an operator who typed an option meant something by it, and
+    a program that silently does one of the two things asked of it has decided
+    which one on their behalf.  ``--drop-index`` removes the index and stops, so
+    every option describing an ingest is at odds with it rather than modifying
+    it; and ``--yes`` answers a question only the drop asks.
+
+    Parameters:
+        arguments: The parsed command line.
+
+    Returns:
+        The refusal to report, or None when the arguments agree with each other.
+    """
+    if not arguments.drop_index:
+        if arguments.yes:
+            return (
+                '--yes says not to ask before dropping the results index, and this command '
+                'line asks for no drop. Add --drop-index, or leave --yes off.'
+            )
+        return None
+    conflicting = [
+        name
+        for name, given in (
+            ('--force', arguments.force),
+            ('--output-cloud-tasks-file', arguments.output_cloud_tasks_file is not None),
+            ('--complete-cloud-tasks-file', arguments.complete_cloud_tasks_file is not None),
+        )
+        if given
+    ]
+    if conflicting:
+        return (
+            f'--drop-index removes the index and stops, reading no document, so it has '
+            f'nothing to do with {", ".join(conflicting)}. Drop first, then run the ingest '
+            f'you want against what it left behind.'
+        )
+    return None
+
+
 def main() -> None:
     """Console entry point for ``sd_stats_ingest``.
 
-    Resolves the index URL and the results roots and, according to the mode
-    named on the command line, reads every document under those roots, divides
-    them into cloud tasks, or adds up what those tasks did.  The outcome goes to
-    the main log either way.
+    Resolves the index URL and, unless the command line asks for a drop, the
+    results roots as well; then, according to the mode named on the command
+    line, removes the index's tables, reads every document under those roots,
+    divides them into cloud tasks, or adds up what those tasks did.  The outcome
+    goes to the main log whichever mode ran.
 
     Raises:
         SystemExit: Always, since this is a console entry point.  The status
@@ -380,7 +452,10 @@ def main() -> None:
             is read.  Completing a fan-out exits 1 when the event log cannot be
             read, when a named root has no unfinished run, when its run never
             recorded what its listing found, or when its tasks did not account
-            for exactly the files that listing found.
+            for exactly the files that listing found.  A drop exits 0 when the
+            tables went and 0 again when there were none to go, and 1 when the
+            database could not be opened or read, when a table would not drop,
+            or when whoever was asked said anything but yes.
     """
     command_list = sys.argv[1:]
     arguments = parse_args(command_list)
@@ -397,6 +472,11 @@ def main() -> None:
     with reporting_logging_errors():
         build_run_logging(PROGRAM_NAME, arguments, DEFAULT_CONFIG)
 
+    refusal = _mode_refusal(arguments)
+    if refusal is not None:
+        MAIN_LOGGER.fatal('%s', refusal)
+        sys.exit(1)
+
     url = get_results_db_url(arguments, DEFAULT_CONFIG)
     if url is None:
         MAIN_LOGGER.fatal(
@@ -404,6 +484,14 @@ def main() -> None:
             'environment.results_db configuration variable, or NAV_RESULTS_DB.'
         )
         sys.exit(1)
+
+    if arguments.drop_index:
+        # Before the roots are resolved, and instead of them: a drop is about
+        # the database alone, and requiring a results root for it would refuse
+        # the command on a machine that has the index and not the tree.
+        MAIN_LOGGER.info('Starting results index drop')
+        MAIN_LOGGER.info('Arguments: %s', masked_command_line(command_list))
+        sys.exit(drop_results_index(url, assume_yes=arguments.yes, logger=MAIN_LOGGER))
 
     try:
         named = arguments.nav_results_roots or [get_nav_results_root(arguments, DEFAULT_CONFIG)]

--- a/src/spindoctor/cli/sd_stats_ingest.py
+++ b/src/spindoctor/cli/sd_stats_ingest.py
@@ -23,6 +23,12 @@ whole of the remedy.  It drops from one schema, the one this database's own
 stamp table was found in, and only after finding that stamp: a table called
 ``images`` is not evidence of anything.
 
+The two halves rest on one rule.  An ingest builds an index only in a schema
+that holds nothing, or one already carrying a stamp of SpinDoctor's, and refuses
+a schema holding a table it did not create -- so a stamp never comes to stand
+over somebody else's table, and the six names the drop removes from a stamped
+schema are six tables SpinDoctor created.
+
 One pass may also be spread over a queue of workers.  ``--output-cloud-tasks-file``
 lists each root once, removes the rows whose documents have left the tree, and
 writes out the shares for ``sd_stats_ingest_cloud_tasks`` to read; when those
@@ -113,7 +119,12 @@ def parse_args(command_list: list[str]) -> argparse.Namespace:
         help="""Connection URL of the results index to write (a sqlite: URL
         naming a local path, or a postgresql+psycopg: URL naming a server);
         overrides NAV_RESULTS_DB and the environment.results_db configuration
-        variable. The tables are created if they are absent.""",
+        variable. The tables are created if they are absent, in the schema this
+        database's own schema_meta stamp was found in or, where there is no such
+        stamp, the one a table created without a schema name lands in. That
+        schema is refused, and nothing is created or stamped in it, when it
+        already holds any table the index does not own or any table of the
+        index's own names that no stamp of ours stands over.""",
     )
 
     ingest_group = cmdparser.add_argument_group('Ingest')
@@ -133,21 +144,24 @@ def parse_args(command_list: list[str]) -> argparse.Namespace:
         default=False,
         help="""Remove the results index's own tables from the database
         --results-db names, and stop: no results root is read and no document is
-        ingested. The tables go from the one schema this database's own
-        schema_meta stamp was found in, and nothing else in that schema, and no
-        other schema, is touched; a database holding none of those tables is
-        left alone and said to be, and one holding tables of those names that no
-        stamp of ours stands over is refused. Refused together with --force,
-        --nav-results-root and either cloud-tasks mode, none of which this
-        does.""",
+        ingested. The tables that go are the index's own six names, from the one
+        schema this database's own schema_meta stamp was found in; no other
+        table of that schema, and no other schema, is touched. What makes those
+        six SpinDoctor's own is that an ingest refuses to build an index in a
+        schema holding anything it did not create, so a schema carrying that
+        stamp holds this index and nothing else. A database holding none of
+        those tables is left alone and said to be, and one holding tables of
+        those names that no stamp of ours stands over is refused. Refused
+        together with --force, --nav-results-root and either cloud-tasks mode,
+        none of which this does.""",
     )
     drop_group.add_argument(
         '--yes',
         action='store_true',
         default=False,
         help="""Drop without asking for confirmation, for a run with nobody at
-        the terminal. Meaningful only with --drop-index, which is the only thing
-        this program asks about.""",
+        the terminal. Refused without --drop-index, which is the only thing this
+        program asks about.""",
     )
 
     cloud_group = cmdparser.add_argument_group('Cloud tasks')

--- a/src/spindoctor/cli/sd_stats_ingest.py
+++ b/src/spindoctor/cli/sd_stats_ingest.py
@@ -19,7 +19,9 @@ stops there, walking no tree.  It is what makes emptying an index and starting
 over something an operator can reach without hand-written SQL, on a shared
 PostgreSQL server as well as on a file -- which the schema version gate depends
 on, since a version bump is deliberately not migrated and rebuilding is the
-whole of the remedy.
+whole of the remedy.  It drops from one schema, the one this database's own
+stamp table was found in, and only after finding that stamp: a table called
+``images`` is not evidence of anything.
 
 One pass may also be spread over a queue of workers.  ``--output-cloud-tasks-file``
 lists each root once, removes the rows whose documents have left the tree, and
@@ -131,10 +133,13 @@ def parse_args(command_list: list[str]) -> argparse.Namespace:
         default=False,
         help="""Remove the results index's own tables from the database
         --results-db names, and stop: no results root is read and no document is
-        ingested. Nothing else in that database is touched, and a database
-        holding none of those tables is left alone and said to be. Refused
-        together with --force and with either cloud-tasks mode, none of which
-        this does.""",
+        ingested. The tables go from the one schema this database's own
+        schema_meta stamp was found in, and nothing else in that schema, and no
+        other schema, is touched; a database holding none of those tables is
+        left alone and said to be, and one holding tables of those names that no
+        stamp of ours stands over is refused. Refused together with --force,
+        --nav-results-root and either cloud-tasks mode, none of which this
+        does.""",
     )
     drop_group.add_argument(
         '--yes',
@@ -399,6 +404,12 @@ def _mode_refusal(arguments: argparse.Namespace) -> str | None:
     every option describing an ingest is at odds with it rather than modifying
     it; and ``--yes`` answers a question only the drop asks.
 
+    ``--nav-results-root`` is refused only when it was typed.  The same root
+    reaches this program from the configuration and from the environment, where
+    it is a machine's standing setting rather than a request, and refusing a
+    drop because the machine has a results tree would refuse it nearly
+    everywhere.
+
     Parameters:
         arguments: The parsed command line.
 
@@ -416,6 +427,7 @@ def _mode_refusal(arguments: argparse.Namespace) -> str | None:
         name
         for name, given in (
             ('--force', arguments.force),
+            ('--nav-results-root', arguments.nav_results_roots is not None),
             ('--output-cloud-tasks-file', arguments.output_cloud_tasks_file is not None),
             ('--complete-cloud-tasks-file', arguments.complete_cloud_tasks_file is not None),
         )
@@ -453,9 +465,10 @@ def main() -> None:
             read, when a named root has no unfinished run, when its run never
             recorded what its listing found, or when its tasks did not account
             for exactly the files that listing found.  A drop exits 0 when the
-            tables went and 0 again when there were none to go, and 1 when the
-            database could not be opened or read, when a table would not drop,
-            or when whoever was asked said anything but yes.
+            tables went and 0 again when the database held none of them, and 1
+            when the database could not be opened or read, when it holds tables
+            of those names that nothing proves are the index's, when a table
+            would not drop, or when whoever was asked said anything but yes.
     """
     command_list = sys.argv[1:]
     arguments = parse_args(command_list)

--- a/src/spindoctor/cli/stats/drop.py
+++ b/src/spindoctor/cli/stats/drop.py
@@ -1,0 +1,224 @@
+"""Dropping a results index from the command line.
+
+The destructive half of the statistics system.  It opens the database the URL
+names, says what of the index is in it, asks whoever typed the command whether
+that is what they meant, removes those tables and stops.  It never walks a
+results tree: dropping is a deliberate act, not the opening move of a long
+ingest, and a command that did both would make a mistyped URL expensive twice
+over.
+
+The account of what is about to go is written to the log, which is where
+everything else ``sd_stats_ingest`` does is written.  The one thing this module
+puts on the terminal itself is the question, which ``input`` writes: a prompt is
+a dialogue rather than a report, and carrying it in the log alone would leave a
+run whose log was routed to a file waiting silently for an answer.
+
+Two questions this answers by reporting rather than by refusing:
+
+**An ingest run that has not finished does not stop a drop.**  Such a run is
+either a pass writing the index at this moment or one that died, and nothing in
+the index tells the two apart -- there is no heartbeat and no process to ask.
+A pass that died is also the commonest reason to want a drop, so refusing on
+that evidence would withhold the command from the case that needs it most, in
+order to guard a case the confirmation already guards.  It is therefore counted
+and said out loud, before the question is asked, so that the person who is about
+to shoot a live ingest is told so while there is still an answer to give.  What
+a drop under a live pass costs is that pass, which fails on a table that has
+gone and leaves nothing behind: an unfinished run already reads as "not
+ingested" to every consumer, so no reader is told anything different before and
+after.
+
+**Another process holding the database does not stop a drop either.**  Neither
+backend can be asked the question honestly: SQLite's readers take no lock to
+observe under write-ahead logging, and a PostgreSQL role need not be allowed to
+read the server's activity view.  What can be done is to make the attempt fail
+rather than hang, which
+:data:`~spindoctor.results_index.drop.DROP_LOCK_TIMEOUT_MS` does, and to leave
+nothing half-finished when it does, which the drop order does.  So the database
+itself decides, promptly and per table, instead of a guess deciding beforehand.
+"""
+
+from pdslogger import PdsLogger
+from sqlalchemy.exc import SQLAlchemyError
+
+from spindoctor.results_index import (
+    IndexContents,
+    drop_index_tables,
+    index_contents,
+    masked_url,
+    open_database,
+)
+
+__all__ = ['AGREEMENT', 'drop_results_index']
+
+AGREEMENT = ('y', 'yes')
+"""The answers that mean yes.  Anything else, including nothing, means no."""
+
+_PROMPT = 'Drop {tables} table(s) and {rows} row(s) from {url}?{unfinished} [y/N] '
+"""What the operator is asked.
+
+The question carries the facts an answer turns on rather than only the verb.
+The account above it goes to the log, which is where the whole of what this run
+did belongs and which is on the terminal in an ordinary run -- but a run whose
+log has been routed to a file still puts this line in front of the person
+typing, and a question that read only "are you sure?" would be one they had to
+answer out of memory.
+
+``sd_stats_ingest`` carries a main logger and reports through it; this is a
+dialogue rather than a report, and the prompt is written by ``input`` itself.
+"""
+
+_UNFINISHED = ' {count} ingest run(s) have not finished.'
+"""The one fact from the account that is repeated into the question.
+
+A pass may be writing the index at this moment, and the drop would end it.  It
+is the only thing here that a person answering could not have known from the
+command they typed.
+"""
+
+
+def _summary(safe_url: str, contents: IndexContents) -> list[str]:
+    """Return the account of what a drop is about to remove.
+
+    Written for a person deciding whether to answer yes, so it leads with what
+    is lost rather than with what is done: the tables by name, how many rows are
+    in each of them, and the two facts that change the answer -- a schema
+    version that is not the one this code reads, which is the case the drop
+    exists for, and an ingest run that nothing has finished.
+
+    Parameters:
+        safe_url: The index URL with its credentials already masked.
+        contents: What the database holds of the index.
+
+    Returns:
+        The lines, in the order they are said.
+    """
+    lines = [f'About to drop the SpinDoctor results index tables from {safe_url}']
+    lines.extend(f'    {table.name}: {table.rows} row(s)' for table in contents.tables)
+    lines.append(f'    {len(contents.tables)} table(s), {contents.rows} row(s) in all')
+    if contents.schema_version is None:
+        lines.append('This database carries no readable schema version stamp.')
+    else:
+        lines.append(f'This database is stamped with schema version {contents.schema_version}.')
+    if contents.unfinished_runs:
+        lines.append(
+            f'{contents.unfinished_runs} ingest run(s) have begun and not finished. Either a '
+            f'pass is writing this index now, which the drop would end, or one died; nothing '
+            f'recorded here tells the two apart.'
+        )
+    lines.append(
+        'Nothing else in this database is touched. The metadata documents are the source of '
+        'truth, so a dropped index is rebuilt by running sd_stats_ingest again.'
+    )
+    return lines
+
+
+def _answer(safe_url: str, contents: IndexContents) -> str | None:
+    """Put the question to whoever typed the command.
+
+    Parameters:
+        safe_url: The index URL with its credentials already masked.
+        contents: What the database holds of the index.
+
+    Returns:
+        The line that was typed, or None when there was nobody to type one.
+        Three ways of having no standard input are read the same way, because
+        the drop's answer to all of them is the same: one at its end, which is
+        what a scheduled run redirected from nowhere has; one whose file has
+        been closed under it; and none at all, which is what a service manager
+        that hands its children no input leaves behind.
+    """
+    unfinished = (
+        _UNFINISHED.format(count=contents.unfinished_runs) if contents.unfinished_runs else ''
+    )
+    question = _PROMPT.format(
+        tables=len(contents.tables), rows=contents.rows, url=safe_url, unfinished=unfinished
+    )
+    try:
+        return input(question)
+    except (EOFError, OSError, RuntimeError):
+        return None
+
+
+def drop_results_index(url: str, *, assume_yes: bool, logger: PdsLogger) -> int:
+    """Remove every table of a results index, having said what that costs.
+
+    Which index is being dropped is recorded before it is opened, since a run
+    log that says only that a database could not be opened leaves out the one
+    thing a reader has to check: which of the three resolution levels supplied
+    the URL, and which URL it was.
+
+    Parameters:
+        url: Connection URL of the index to drop.
+        assume_yes: Whether to drop without asking.  A run with nobody at the
+            terminal needs this; without it, a standard input that is at its end
+            is treated as a refusal rather than as consent.
+        logger: Logger the whole account is written to, whether or not anybody
+            was asked.
+
+    Returns:
+        The exit status: 0 when the tables were dropped and 0 again when there
+        were none to drop, since an index that is already gone is the state
+        asked for; 1 when the database could not be opened or read, when a
+        table would not drop, and when the operator answered anything but yes.
+    """
+    safe_url = masked_url(url)
+    logger.info('Results index to drop the tables of: %s', safe_url)
+    try:
+        engine = open_database(url)
+    except ValueError as exc:
+        logger.fatal('Cannot open the database to drop the results index from: %s', exc)
+        return 1
+    try:
+        try:
+            contents = index_contents(engine)
+        except SQLAlchemyError as exc:
+            logger.fatal(
+                'Nothing was dropped: %s holds tables of the results index that could not be '
+                'read (%s: %s). Check that the account this URL opens may read every table '
+                'it is being asked to drop.',
+                safe_url,
+                type(exc).__name__,
+                exc,
+            )
+            return 1
+        if not contents.tables:
+            logger.info(
+                '%s holds none of the results index tables, so nothing was dropped. An index '
+                'that is not there and one that has been dropped are the same thing to every '
+                'program that reads one.',
+                safe_url,
+            )
+            return 0
+        for line in _summary(safe_url, contents):
+            logger.info('%s', line)
+        if not assume_yes:
+            answer = _answer(safe_url, contents)
+            if answer is None:
+                logger.fatal(
+                    'Nothing was dropped: there is nobody to confirm with, since standard '
+                    'input is at its end. Pass --yes to drop without being asked.'
+                )
+                return 1
+            if answer.strip().lower() not in AGREEMENT:
+                logger.info('Nothing was dropped: the answer was %r rather than yes.', answer)
+                return 1
+        try:
+            dropped = drop_index_tables(engine)
+        except SQLAlchemyError as exc:
+            logger.fatal(
+                'The drop of %s did not complete (%s: %s). Another session may be holding one '
+                'of these tables; nothing else in the database was touched.',
+                safe_url,
+                type(exc).__name__,
+                exc,
+            )
+            return 1
+        logger.info('Dropped from %s: %s', safe_url, ', '.join(dropped))
+        logger.info(
+            'That index is now what one nobody has ingested into looks like. Run '
+            'sd_stats_ingest to build it again.'
+        )
+    finally:
+        engine.dispose()
+    return 0

--- a/src/spindoctor/cli/stats/drop.py
+++ b/src/spindoctor/cli/stats/drop.py
@@ -1,17 +1,24 @@
 """Dropping a results index from the command line.
 
 The destructive half of the statistics system.  It opens the database the URL
-names, says what of the index is in it, asks whoever typed the command whether
-that is what they meant, removes those tables and stops.  It never walks a
-results tree: dropping is a deliberate act, not the opening move of a long
-ingest, and a command that did both would make a mistyped URL expensive twice
-over.
+names, finds out whether that database holds a SpinDoctor index at all, says
+what of one is in it, asks whoever typed the command whether that is what they
+meant, removes those tables and stops.  It never walks a results tree: dropping
+is a deliberate act, not the opening move of a long ingest, and a command that
+did both would make a mistyped URL expensive twice over.
 
 The account of what is about to go is written to the log, which is where
 everything else ``sd_stats_ingest`` does is written.  The one thing this module
-puts on the terminal itself is the question, which ``input`` writes: a prompt is
-a dialogue rather than a report, and carrying it in the log alone would leave a
-run whose log was routed to a file waiting silently for an answer.
+puts on standard output itself is the question, which ``input`` writes there: a
+prompt is a dialogue rather than a report, and carrying it in the log alone
+would leave a run whose log was routed to a file waiting silently for an answer.
+
+**A database has to prove it holds an index before anything is dropped from
+it.**  The proof is the index's own stamp table, and the schema that stamp was
+found in is the only schema anything is dropped from.  A database holding tables
+that merely share these names -- ``images`` above all -- is refused and named,
+because nothing can tell somebody else's table from the remains of an index of
+ours, and a destructive command must not decide such a thing on its own.
 
 Two questions this answers by reporting rather than by refusing:
 
@@ -33,9 +40,10 @@ backend can be asked the question honestly: SQLite's readers take no lock to
 observe under write-ahead logging, and a PostgreSQL role need not be allowed to
 read the server's activity view.  What can be done is to make the attempt fail
 rather than hang, which
-:data:`~spindoctor.results_index.drop.DROP_LOCK_TIMEOUT_MS` does, and to leave
-nothing half-finished when it does, which the drop order does.  So the database
-itself decides, promptly and per table, instead of a guess deciding beforehand.
+:data:`~spindoctor.results_index.drop.DROP_LOCK_TIMEOUT_MS` does for the reading
+and for the drop alike, and to leave nothing half-finished when it does, which
+the transaction around the drop does on both backends.  So the database itself
+decides, promptly and per table, instead of a guess deciding beforehand.
 """
 
 from pdslogger import PdsLogger
@@ -52,9 +60,13 @@ from spindoctor.results_index import (
 __all__ = ['AGREEMENT', 'drop_results_index']
 
 AGREEMENT = ('y', 'yes')
-"""The answers that mean yes.  Anything else, including nothing, means no."""
+"""The answers that mean yes.  Anything else, including nothing, means no.
 
-_PROMPT = 'Drop {tables} table(s) and {rows} row(s) from {url}?{unfinished} [y/N] '
+Compared after the line is stripped and lower-cased, so ``Y``, ``YES`` and a
+line with spaces around it are the same answer as ``yes``.
+"""
+
+_PROMPT = 'Drop {tables} table(s) and {rows} row(s) from {url}, schema {schema}?{unfinished} [y/N] '
 """What the operator is asked.
 
 The question carries the facts an answer turns on rather than only the verb.
@@ -62,10 +74,13 @@ The account above it goes to the log, which is where the whole of what this run
 did belongs and which is on the terminal in an ordinary run -- but a run whose
 log has been routed to a file still puts this line in front of the person
 typing, and a question that read only "are you sure?" would be one they had to
-answer out of memory.
+answer out of memory.  The schema is one of those facts: on a server the same
+URL reaches several, and which one holds the index is not something the command
+line said.
 
 ``sd_stats_ingest`` carries a main logger and reports through it; this is a
-dialogue rather than a report, and the prompt is written by ``input`` itself.
+dialogue rather than a report, and the prompt is written to standard output by
+``input`` itself.
 """
 
 _UNFINISHED = ' {count} ingest run(s) have not finished.'
@@ -75,6 +90,80 @@ A pass may be writing the index at this moment, and the drop would end it.  It
 is the only thing here that a person answering could not have known from the
 command they typed.
 """
+
+_FAILURE_CAUSES = (
+    ('55P03', 'Another session is holding a lock on one of these tables.'),
+    (
+        '2BP01',
+        'Another object of this database depends on one of these tables, and has to be '
+        'removed, or stop depending on it, first.',
+    ),
+    (
+        '42501',
+        'This account does not own one of these tables, and a table is dropped by its owner.',
+    ),
+    (
+        '42P01',
+        'One of these tables went between the reading of what this database held and the '
+        'drop of it.',
+    ),
+    ('SQLITE_BUSY', 'Another process is holding the write lock on this SQLite database.'),
+    ('SQLITE_READONLY', 'This SQLite database is read-only.'),
+    (
+        'SQLITE_CONSTRAINT_FOREIGNKEY',
+        'A table outside the index carries a reference into one of these tables.',
+    ),
+)
+"""What a database's own failure code says the cause was.
+
+A destructive command that names the wrong cause is worse than one that names
+none: it sends whoever reads it to grant a privilege over a lock, or to hunt a
+session over a view.  So each code is answered with what it means and nothing
+is answered with a guess -- a code not in this table is reported as the database
+worded it, with no cause invented for it.
+
+PostgreSQL codes are the five-character SQLSTATE the server returns; SQLite
+codes are the result-code names its driver carries, matched by prefix because
+SQLite refines several of them into extended forms.
+"""
+
+
+def _failure_code(exc: BaseException) -> str:
+    """Return the code a database driver's own exception carries.
+
+    Parameters:
+        exc: The exception to read, either a driver exception or the wrapper
+            SQLAlchemy raised around one.
+
+    Returns:
+        The SQLSTATE or SQLite result-code name, or an empty string for a
+        failure that carries neither -- a connection that dropped, or an
+        exception SQLAlchemy raised on its own behalf.
+    """
+    original = getattr(exc, 'orig', exc)
+    for attribute in ('sqlstate', 'sqlite_errorname'):
+        code = getattr(original, attribute, None)
+        if isinstance(code, str) and code:
+            return code
+    return ''
+
+
+def _because(exc: SQLAlchemyError) -> str:
+    """Return what the database said the cause was, ready to append to a message.
+
+    Parameters:
+        exc: The failure to diagnose.
+
+    Returns:
+        One sentence with a leading space, or an empty string when the database
+        gave no code this recognizes and there is therefore nothing to say
+        beyond what it said itself.
+    """
+    code = _failure_code(exc)
+    for prefix, cause in _FAILURE_CAUSES:
+        if code.startswith(prefix):
+            return f' {cause}'
+    return ''
 
 
 def _summary(safe_url: str, contents: IndexContents) -> list[str]:
@@ -93,7 +182,10 @@ def _summary(safe_url: str, contents: IndexContents) -> list[str]:
     Returns:
         The lines, in the order they are said.
     """
-    lines = [f'About to drop the SpinDoctor results index tables from {safe_url}']
+    lines = [
+        f'About to drop the SpinDoctor results index tables from {safe_url}, '
+        f'schema {contents.schema}'
+    ]
     lines.extend(f'    {table.name}: {table.rows} row(s)' for table in contents.tables)
     lines.append(f'    {len(contents.tables)} table(s), {contents.rows} row(s) in all')
     if contents.schema_version is None:
@@ -107,8 +199,9 @@ def _summary(safe_url: str, contents: IndexContents) -> list[str]:
             f'recorded here tells the two apart.'
         )
     lines.append(
-        'Nothing else in this database is touched. The metadata documents are the source of '
-        'truth, so a dropped index is rebuilt by running sd_stats_ingest again.'
+        f'Nothing else in schema {contents.schema} is touched, and no other schema of this '
+        f'database is looked at. The metadata documents are the source of truth, so a dropped '
+        f'index is rebuilt by running sd_stats_ingest again.'
     )
     return lines
 
@@ -132,12 +225,57 @@ def _answer(safe_url: str, contents: IndexContents) -> str | None:
         _UNFINISHED.format(count=contents.unfinished_runs) if contents.unfinished_runs else ''
     )
     question = _PROMPT.format(
-        tables=len(contents.tables), rows=contents.rows, url=safe_url, unfinished=unfinished
+        tables=len(contents.tables),
+        rows=contents.rows,
+        url=safe_url,
+        schema=contents.schema,
+        unfinished=unfinished,
     )
     try:
         return input(question)
     except (EOFError, OSError, RuntimeError):
         return None
+
+
+def _nothing_of_ours(safe_url: str, contents: IndexContents, logger: PdsLogger) -> int:
+    """Report a database that proved it holds no index of SpinDoctor's, and drop nothing.
+
+    Two states reach this, and they are not the same answer.  A database with no
+    table of these names in it is the state a drop was asked for and exits 0.
+    One holding tables of these names with no stamp of ours over them is a URL
+    naming something that is not a SpinDoctor index, which is refused: the
+    tables are either somebody else's -- ``images`` is not a name anyone owns --
+    or what is left of an index whose stamp has gone, and nothing in the
+    database says which.
+
+    Parameters:
+        safe_url: The index URL with its credentials already masked.
+        contents: What the database holds of the index, proving nothing.
+        logger: Logger the account is written to.
+
+    Returns:
+        The exit status: 0 when there was nothing of these names, 1 when there
+        was and none of it could be shown to be the index's.
+    """
+    if not contents.unproven:
+        logger.info(
+            '%s holds none of the results index tables, so nothing was dropped. An index '
+            'that is not there and one that has been dropped are the same thing to every '
+            'program that reads one.',
+            safe_url,
+        )
+        return 0
+    logger.fatal(
+        'Nothing was dropped: %s holds table(s) the results index also uses (%s), but no '
+        "schema_meta of SpinDoctor's stands over them, so nothing here says this database "
+        'holds a results index. They are either tables somebody else created under names '
+        'this index also uses, or what an index whose stamp has gone left behind, and the '
+        'database does not say which. Check the URL; remove them by hand if they are an '
+        'index of yours.',
+        safe_url,
+        ', '.join(contents.unproven),
+    )
+    return 1
 
 
 def drop_results_index(url: str, *, assume_yes: bool, logger: PdsLogger) -> int:
@@ -157,10 +295,11 @@ def drop_results_index(url: str, *, assume_yes: bool, logger: PdsLogger) -> int:
             was asked.
 
     Returns:
-        The exit status: 0 when the tables were dropped and 0 again when there
-        were none to drop, since an index that is already gone is the state
-        asked for; 1 when the database could not be opened or read, when a
-        table would not drop, and when the operator answered anything but yes.
+        The exit status: 0 when the tables were dropped and 0 again when the
+        database held none of them, since an index that is already gone is the
+        state asked for; 1 when the database could not be opened or read, when
+        it holds tables of these names that nothing proves are the index's, when
+        a table would not drop, and when the operator answered anything but yes.
     """
     safe_url = masked_url(url)
     logger.info('Results index to drop the tables of: %s', safe_url)
@@ -170,51 +309,64 @@ def drop_results_index(url: str, *, assume_yes: bool, logger: PdsLogger) -> int:
         logger.fatal('Cannot open the database to drop the results index from: %s', exc)
         return 1
     try:
+        # Said before rather than after, because reading it counts the rows of
+        # every table, which on a production-sized index is a scan apiece: a
+        # confirmation that appears minutes after the command was typed is
+        # otherwise a command that looks hung.
+        logger.info('Reading what %s holds of the results index', safe_url)
         try:
             contents = index_contents(engine)
         except SQLAlchemyError as exc:
             logger.fatal(
-                'Nothing was dropped: %s holds tables of the results index that could not be '
-                'read (%s: %s). Check that the account this URL opens may read every table '
-                'it is being asked to drop.',
+                'Nothing was dropped: what %s holds of the results index could not be read '
+                '(%s: %s).%s',
                 safe_url,
                 type(exc).__name__,
                 exc,
+                _because(exc),
             )
             return 1
-        if not contents.tables:
-            logger.info(
-                '%s holds none of the results index tables, so nothing was dropped. An index '
-                'that is not there and one that has been dropped are the same thing to every '
-                'program that reads one.',
-                safe_url,
-            )
-            return 0
+        if contents.schema is None:
+            return _nothing_of_ours(safe_url, contents, logger)
         for line in _summary(safe_url, contents):
             logger.info('%s', line)
         if not assume_yes:
-            answer = _answer(safe_url, contents)
+            try:
+                answer = _answer(safe_url, contents)
+            except KeyboardInterrupt:
+                # The one refusal a person makes with a key rather than a word.
+                # It reaches here as an exception rather than as an answer, and
+                # a destructive command owes it the same line every other
+                # refusal gets rather than a traceback.
+                logger.fatal('Nothing was dropped from %s: the question was interrupted.', safe_url)
+                return 1
             if answer is None:
                 logger.fatal(
-                    'Nothing was dropped: there is nobody to confirm with, since standard '
-                    'input is at its end. Pass --yes to drop without being asked.'
+                    'Nothing was dropped from %s: there is nobody to confirm with, since '
+                    'standard input is at its end. Pass --yes to drop without being asked.',
+                    safe_url,
                 )
                 return 1
             if answer.strip().lower() not in AGREEMENT:
-                logger.info('Nothing was dropped: the answer was %r rather than yes.', answer)
+                logger.info(
+                    'Nothing was dropped from %s: the answer was %r rather than yes.',
+                    safe_url,
+                    answer,
+                )
                 return 1
         try:
-            dropped = drop_index_tables(engine)
+            dropped = drop_index_tables(engine, contents)
         except SQLAlchemyError as exc:
             logger.fatal(
-                'The drop of %s did not complete (%s: %s). Another session may be holding one '
-                'of these tables; nothing else in the database was touched.',
+                'The drop of %s did not complete (%s: %s).%s The transaction was taken back, '
+                'so that database is exactly as it was.',
                 safe_url,
                 type(exc).__name__,
                 exc,
+                _because(exc),
             )
             return 1
-        logger.info('Dropped from %s: %s', safe_url, ', '.join(dropped))
+        logger.info('Dropped from %s, schema %s: %s', safe_url, contents.schema, ', '.join(dropped))
         logger.info(
             'That index is now what one nobody has ingested into looks like. Run '
             'sd_stats_ingest to build it again.'

--- a/src/spindoctor/cli/stats/drop.py
+++ b/src/spindoctor/cli/stats/drop.py
@@ -248,6 +248,13 @@ def _nothing_of_ours(safe_url: str, contents: IndexContents, logger: PdsLogger) 
     or what is left of an index whose stamp has gone, and nothing in the
     database says which.
 
+    The first of the two is reported as a fact about this connection rather than
+    about the database.  What was asked is what an unqualified name on this
+    connection reaches, so an index in a schema outside its search path, or in
+    one this account may not look into, answers the same way as one that is not
+    there.  The status is 0 all the same, because the state asked for -- no
+    index reachable through this URL -- is the state found.
+
     Parameters:
         safe_url: The index URL with its credentials already masked.
         contents: What the database holds of the index, proving nothing.
@@ -259,9 +266,11 @@ def _nothing_of_ours(safe_url: str, contents: IndexContents, logger: PdsLogger) 
     """
     if not contents.unproven:
         logger.info(
-            '%s holds none of the results index tables, so nothing was dropped. An index '
-            'that is not there and one that has been dropped are the same thing to every '
-            'program that reads one.',
+            'This connection to %s reaches none of the results index tables, so nothing was '
+            'dropped. What was looked at is what the connection reaches: an index in a schema '
+            'outside its search path, or one this account may not look into, is not reported '
+            'here and is not what was dropped. An index that is not there and one that has '
+            'been dropped are the same thing to every program that reads one.',
             safe_url,
         )
         return 0
@@ -286,6 +295,12 @@ def drop_results_index(url: str, *, assume_yes: bool, logger: PdsLogger) -> int:
     thing a reader has to check: which of the three resolution levels supplied
     the URL, and which URL it was.
 
+    No step of this answers an interrupt with a traceback.  Opening the
+    database, reading what it holds and dropping the tables can each wait on
+    something -- a server, a lock, a scan of a large table -- and Ctrl-C during
+    any of them is reported as the refusal it is, naming which step stopped and
+    saying that nothing went.
+
     Parameters:
         url: Connection URL of the index to drop.
         assume_yes: Whether to drop without asking.  A run with nobody at the
@@ -299,7 +314,8 @@ def drop_results_index(url: str, *, assume_yes: bool, logger: PdsLogger) -> int:
         database held none of them, since an index that is already gone is the
         state asked for; 1 when the database could not be opened or read, when
         it holds tables of these names that nothing proves are the index's, when
-        a table would not drop, and when the operator answered anything but yes.
+        a table would not drop, when the operator answered anything but yes, and
+        when any step of it was interrupted.
     """
     safe_url = masked_url(url)
     logger.info('Results index to drop the tables of: %s', safe_url)
@@ -307,6 +323,9 @@ def drop_results_index(url: str, *, assume_yes: bool, logger: PdsLogger) -> int:
         engine = open_database(url)
     except ValueError as exc:
         logger.fatal('Cannot open the database to drop the results index from: %s', exc)
+        return 1
+    except KeyboardInterrupt:
+        logger.fatal('Nothing was dropped from %s: opening it was interrupted.', safe_url)
         return 1
     try:
         # Said before rather than after, because reading it counts the rows of
@@ -324,6 +343,17 @@ def drop_results_index(url: str, *, assume_yes: bool, logger: PdsLogger) -> int:
                 type(exc).__name__,
                 exc,
                 _because(exc),
+            )
+            return 1
+        except KeyboardInterrupt:
+            # The reading is the step that can run for minutes, so it is the
+            # step most likely to be interrupted, and a destructive command owes
+            # an interrupt the same line every other refusal gets rather than a
+            # traceback.  Nothing had been dropped yet, which is what the line
+            # says.
+            logger.fatal(
+                'Nothing was dropped from %s: the reading of what it holds was interrupted.',
+                safe_url,
             )
             return 1
         if contents.schema is None:
@@ -364,6 +394,17 @@ def drop_results_index(url: str, *, assume_yes: bool, logger: PdsLogger) -> int:
                 type(exc).__name__,
                 exc,
                 _because(exc),
+            )
+            return 1
+        except KeyboardInterrupt:
+            # An interrupt while the drop waits on a lock is the one way this
+            # step ends without a database error, and it is the moment at which
+            # the reassurance matters most: the transaction is taken back on
+            # both backends, so nothing of the index has gone.
+            logger.fatal(
+                'The drop of %s was interrupted. The transaction was taken back, so that '
+                'database is exactly as it was.',
+                safe_url,
             )
             return 1
         logger.info('Dropped from %s, schema %s: %s', safe_url, contents.schema, ', '.join(dropped))

--- a/src/spindoctor/results_index/__init__.py
+++ b/src/spindoctor/results_index/__init__.py
@@ -22,8 +22,15 @@ Public API:
     SCHEMA_META      -- the single row stamping the schema version
     INGEST_RUNS      -- one row per ingest pass over one root
     UNKNOWN_STATUS   -- the status a document that named no outcome is recorded with
-    open_index       -- the only opener, with the version gate
+    open_index       -- the opener every reader and writer goes through
+    open_database    -- the opener the drop uses, which stops before the gate
+    stamped_version  -- the schema version a database is stamped with
     masked_url       -- a connection URL with any password in it hidden
+    TableContents    -- one table of the index, and how many rows it holds
+    IndexContents    -- what of the index a database holds, before a drop
+    index_contents   -- read that, so a drop can say what it is about to remove
+    index_table_names -- every table the index owns, in drop order
+    drop_index_tables -- remove those tables, and nothing else
     normalize_root_url    -- the one spelling of a results root
     ingested_roots        -- the roots a completed ingest covered
     require_ingested_roots -- refuse to read absence from a root nobody ingested
@@ -36,7 +43,15 @@ Public API:
     reporting_a_failed_read -- the one translation of a database failure into a refusal
 """
 
-from spindoctor.results_index.engine import masked_url, open_index
+from spindoctor.results_index.drop import (
+    IndexContents,
+    TableContents,
+    drop_index_tables,
+    index_contents,
+    index_table_names,
+)
+from spindoctor.results_index.engine import open_database, open_index, stamped_version
+from spindoctor.results_index.masking import masked_url
 from spindoctor.results_index.roots import (
     NewestPass,
     ingested_roots,
@@ -75,14 +90,21 @@ __all__ = [
     'SPICE_STATUS_ERROR',
     'TECHNIQUES',
     'UNKNOWN_STATUS',
+    'IndexContents',
     'NewestPass',
     'ResultStubs',
+    'TableContents',
+    'drop_index_tables',
+    'index_contents',
+    'index_table_names',
     'ingested_roots',
     'masked_url',
     'newest_pass',
     'normalize_root_url',
+    'open_database',
     'open_index',
     'read_result_stubs',
     'reporting_a_failed_read',
     'require_ingested_roots',
+    'stamped_version',
 ]

--- a/src/spindoctor/results_index/__init__.py
+++ b/src/spindoctor/results_index/__init__.py
@@ -24,7 +24,6 @@ Public API:
     UNKNOWN_STATUS   -- the status a document that named no outcome is recorded with
     open_index       -- the opener every reader and writer goes through
     open_database    -- the opener the drop uses, which stops before the gate
-    stamped_version  -- the schema version a database is stamped with
     masked_url       -- a connection URL with any password in it hidden
     TableContents    -- one table of the index, and how many rows it holds
     IndexContents    -- what of the index a database holds, before a drop
@@ -50,7 +49,7 @@ from spindoctor.results_index.drop import (
     index_contents,
     index_table_names,
 )
-from spindoctor.results_index.engine import open_database, open_index, stamped_version
+from spindoctor.results_index.engine import open_database, open_index
 from spindoctor.results_index.masking import masked_url
 from spindoctor.results_index.roots import (
     NewestPass,
@@ -106,5 +105,4 @@ __all__ = [
     'read_result_stubs',
     'reporting_a_failed_read',
     'require_ingested_roots',
-    'stamped_version',
 ]

--- a/src/spindoctor/results_index/drop.py
+++ b/src/spindoctor/results_index/drop.py
@@ -1,0 +1,311 @@
+"""Removing the results index's own tables, and nothing else.
+
+Starting a results tree over is an ordinary operation -- delete the results,
+navigate again, ingest again -- and the index needs a counterpart to it.  The
+schema version gate makes that need sharper rather than softer: a version bump
+is deliberately not migrated, so emptying the database and ingesting again is
+the whole of what the gate leaves an operator to do, and it is what the gate's
+own refusal sends them here for.
+
+**Only the tables named here are touched.**  They are the tables of
+:data:`~spindoctor.results_index.schema.METADATA`, taken by name.  No schema is
+dropped, no pattern is matched and nothing is discovered by looking at what the
+database holds: a PostgreSQL server is routinely shared, and an index living in
+a database beside somebody else's tables must be removable without a thought
+about theirs.
+
+**What is left behind is a database, not a hole.**  Dropping every table of an
+index leaves what a database that was never ingested into looks like -- on
+PostgreSQL literally so -- which every consumer already reads as "not
+ingested", and which the next opener with ``create`` rebuilds.
+
+**The order is the guarantee.**  ``schema_meta`` goes first, before the tables
+it stamps.  Every state an interrupted drop can leave is then one with no stamp,
+which the version gate reads as "this is not a results index"; the state that
+must never be left is the opposite one, a stamp still standing over tables that
+have gone, because the gate reads that as a healthy index and every consumer
+then fails inside its first query.  The order matters because the transaction
+around the drop is not equally strong on both backends: PostgreSQL rolls DDL
+back with everything else, while the SQLite driver commits each ``DROP TABLE``
+outside the surrounding transaction.
+"""
+
+from dataclasses import dataclass
+
+import sqlalchemy
+from sqlalchemy.engine import Engine
+
+from spindoctor.results_index.engine import stamped_version
+from spindoctor.results_index.schema import INGEST_RUNS, METADATA, SCHEMA_META, SCHEMA_VERSION
+
+__all__ = [
+    'DROP_LOCK_TIMEOUT_MS',
+    'IndexContents',
+    'TableContents',
+    'drop_index_tables',
+    'index_contents',
+    'index_table_names',
+]
+
+DROP_LOCK_TIMEOUT_MS = 30000
+"""How long the drop waits for a PostgreSQL lock before giving the table up.
+
+``DROP TABLE`` takes a lock no other statement shares, so a transaction that has
+so much as read the table holds the drop off for as long as it stays open -- an
+ingest in flight, or a session somebody left sitting in ``psql``.  Without a
+bound the drop waits for that silently and forever, which reads as a hung
+command rather than as a table somebody else is using.
+
+Matched to :data:`~spindoctor.results_index.engine.SQLITE_BUSY_TIMEOUT_MS`, so
+that a contended drop gives up after the same wait on either backend.  SQLite
+needs nothing more: the busy timeout applies to every connection already.
+"""
+
+_POSTGRES_DIALECT = 'postgresql'
+"""Dialect name of every PostgreSQL driver, whichever one the URL asked for."""
+
+
+@dataclass(frozen=True)
+class TableContents:
+    """One table of the index, and how much of it there is to lose.
+
+    Parameters:
+        name: The table's name, as the database holds it.
+        rows: How many rows it holds.
+    """
+
+    name: str
+    rows: int
+
+
+@dataclass(frozen=True)
+class IndexContents:
+    """What of SpinDoctor's own index a database holds.
+
+    Read before the drop, so that a destructive command can say what it is about
+    to destroy, and so that a database holding none of it is answered without
+    being touched.
+
+    Parameters:
+        tables: The index's tables that are present, in the order they would be
+            dropped, each with its row count.  Empty when the database holds
+            none of them.
+        schema_version: The version the database is stamped with, or None when
+            it carries no readable stamp.  It is reported rather than required:
+            a database this command is pointed at is quite likely to be one no
+            opener would accept.
+        unfinished_runs: How many ingest runs have begun and not finished, or
+            None when the question cannot be put to this database -- there is no
+            run table, or its stamp is not the version whose columns this code
+            knows.
+    """
+
+    tables: tuple[TableContents, ...]
+    schema_version: int | None
+    unfinished_runs: int | None
+
+    @property
+    def rows(self) -> int:
+        """Total rows across every table of the index that is present.
+
+        Returns:
+            The sum of the per-table counts.
+        """
+        return sum(table.rows for table in self.tables)
+
+
+def _drop_order() -> tuple[sqlalchemy.Table, ...]:
+    """Return every table of the index, in the order the drop removes them.
+
+    Dependents come before what they depend on, because a table another one
+    references cannot be dropped while that reference stands.  ``schema_meta``
+    is lifted to the front of that order: it references nothing and nothing
+    references it, so it is free to go first, and going first is what makes
+    every interruption leave a database with no stamp rather than a stamp with
+    no tables.
+
+    Returns:
+        The tables, in drop order.
+    """
+    dependents_first = reversed(METADATA.sorted_tables)
+    return (SCHEMA_META, *(table for table in dependents_first if table is not SCHEMA_META))
+
+
+def index_table_names() -> tuple[str, ...]:
+    """Return the name of every table the index owns.
+
+    The whole of what a drop removes, and the only names it ever utters.
+
+    Returns:
+        The table names, in the order the drop removes them.
+    """
+    return tuple(table.name for table in _drop_order())
+
+
+def _present_tables(engine: Engine) -> tuple[sqlalchemy.Table, ...]:
+    """Return the index's tables that this database actually holds.
+
+    Parameters:
+        engine: The open database.
+
+    Returns:
+        The tables that are there, in drop order.
+    """
+    inspector = sqlalchemy.inspect(engine)
+    return tuple(table for table in _drop_order() if inspector.has_table(table.name))
+
+
+def _row_count(connection: sqlalchemy.Connection, table: sqlalchemy.Table) -> int:
+    """Return how many rows a table holds.
+
+    Counted through the table's name alone and none of its columns, so that a
+    table belonging to a schema version this code does not read is still counted
+    rather than refused.
+
+    Parameters:
+        connection: An open connection to the database.
+        table: The table to count.
+
+    Returns:
+        The row count.
+    """
+    counted = connection.execute(
+        sqlalchemy.select(sqlalchemy.func.count()).select_from(table)
+    ).scalar()
+    return 0 if counted is None else int(counted)
+
+
+def _stamp(engine: Engine) -> int | None:
+    """Return the schema version a database is stamped with, if it can be read.
+
+    The stamp is a fact this reports rather than one it requires.  A database
+    the drop is pointed at may be malformed in ways no opener would accept --
+    a ``schema_meta`` left over from a schema whose columns were different -- and
+    refusing to say what a database holds because the stamp would not come out
+    of it would withhold the drop from one of the cases it exists for.
+
+    Parameters:
+        engine: The open database.
+
+    Returns:
+        The stamped version, or None when there is none or it will not be read.
+    """
+    try:
+        return stamped_version(engine)
+    except sqlalchemy.exc.SQLAlchemyError:
+        return None
+
+
+def _unfinished_runs(
+    connection: sqlalchemy.Connection, present: tuple[sqlalchemy.Table, ...], version: int | None
+) -> int | None:
+    """Return how many ingest runs have begun and not finished.
+
+    An unfinished run is either a pass writing this index at this moment or one
+    that died, and nothing in the index tells the two apart.  It is therefore
+    reported rather than acted on: it is what a person about to drop an index
+    someone else may be filling needs to see, and what nothing can conclude from
+    on its own.
+
+    Asked only of a database stamped with the version this code reads, because
+    the question is phrased in a column, and a column is exactly what a version
+    is free to have changed.
+
+    Parameters:
+        connection: An open connection to the database.
+        present: The index's tables that this database holds.
+        version: The version the database is stamped with, if any.
+
+    Returns:
+        The count, or None when the question cannot be put to this database.
+    """
+    if version != SCHEMA_VERSION or INGEST_RUNS not in present:
+        return None
+    counted = connection.execute(
+        sqlalchemy.select(sqlalchemy.func.count())
+        .select_from(INGEST_RUNS)
+        .where(INGEST_RUNS.c.finished_utc.is_(None))
+    ).scalar()
+    return 0 if counted is None else int(counted)
+
+
+def index_contents(engine: Engine) -> IndexContents:
+    """Return what of SpinDoctor's own index a database holds.
+
+    Parameters:
+        engine: An open database, from
+            :func:`~spindoctor.results_index.engine.open_database`, since one
+            holding a version no opener accepts is a database this is asked
+            about rather than one it is not.
+
+    Returns:
+        The tables that are present with their row counts, the stamp, and how
+        many ingest runs are outstanding.
+
+    Raises:
+        sqlalchemy.exc.SQLAlchemyError: If a table that is there cannot be
+            counted.  A table this account may not read is one it is unlikely to
+            be able to drop, and finding that out before anything is dropped is
+            what keeps a refusal from becoming a half-finished drop.
+    """
+    present = _present_tables(engine)
+    version = _stamp(engine)
+    with engine.connect() as connection:
+        tables = tuple(
+            TableContents(name=table.name, rows=_row_count(connection, table)) for table in present
+        )
+        unfinished = _unfinished_runs(connection, present, version)
+    return IndexContents(tables=tables, schema_version=version, unfinished_runs=unfinished)
+
+
+def _bound_the_lock_wait(connection: sqlalchemy.Connection) -> None:
+    """Stop the drop from waiting forever on a lock somebody else holds.
+
+    ``SET LOCAL`` lasts exactly as long as the transaction it is issued in, so
+    the bound applies to this drop and to no other statement the connection
+    later carries.
+
+    SQLite is left alone: its busy timeout is applied to every connection when
+    the engine is built, and it bounds the same wait for the same reason.
+
+    Parameters:
+        connection: The connection the drop runs on, inside its transaction.
+    """
+    if connection.dialect.name != _POSTGRES_DIALECT:
+        return
+    # Rendered rather than bound: a session setting takes a literal, and no
+    # dialect accepts a parameter here.  The value is an integer of this
+    # module's own, forced to one so that nothing else can be spelled into it.
+    connection.exec_driver_sql(f"SET LOCAL lock_timeout = '{int(DROP_LOCK_TIMEOUT_MS)}ms'")
+
+
+def drop_index_tables(engine: Engine) -> tuple[str, ...]:
+    """Remove every table of the results index from a database, and nothing else.
+
+    Idempotent: a database holding none of these tables is not written at all,
+    and the empty answer is what says so.
+
+    Parameters:
+        engine: An open database, from
+            :func:`~spindoctor.results_index.engine.open_database`.
+
+    Returns:
+        The names of the tables that were dropped, in the order they went, and
+        an empty tuple when there was nothing of the index there.
+
+    Raises:
+        sqlalchemy.exc.SQLAlchemyError: If a table cannot be dropped, including
+            because another session holds a lock on it for longer than
+            :data:`DROP_LOCK_TIMEOUT_MS`.  On PostgreSQL the transaction rolls
+            back and the database is left exactly as it was; on SQLite the drops
+            already committed stand, which the order they are issued in is what
+            makes safe.
+    """
+    present = _present_tables(engine)
+    if not present:
+        return ()
+    with engine.begin() as connection:
+        _bound_the_lock_wait(connection)
+        for table in present:
+            connection.execute(sqlalchemy.schema.DropTable(table))
+    return tuple(table.name for table in present)

--- a/src/spindoctor/results_index/drop.py
+++ b/src/spindoctor/results_index/drop.py
@@ -45,6 +45,11 @@ import sqlalchemy
 from sqlalchemy.engine import Engine
 
 from spindoctor.results_index.schema import INGEST_RUNS, METADATA, SCHEMA_META, SCHEMA_VERSION
+from spindoctor.results_index.scope import (
+    carries_the_stamp_marks,
+    index_tables_in,
+    resolved_schema,
+)
 
 __all__ = [
     'DROP_LOCK_TIMEOUT_MS',
@@ -79,33 +84,6 @@ _POSTGRES_DIALECT = 'postgresql'
 
 _SQLITE_DIALECT = 'sqlite'
 """Dialect name of the SQLite driver."""
-
-_STAMP_MARKS = ('singleton', 'schema_version')
-"""Columns whose presence in a ``schema_meta`` says SpinDoctor wrote it.
-
-Two rather than the whole column set, because a stamp left by a schema whose
-columns differed from this one's is exactly the database a drop is pointed at,
-and requiring today's columns would withhold the drop from it.  Two rather than
-one, because the pair is idiosyncratic: a version column is what any migration
-table carries, and a constant-keyed ``singleton`` beside it is what this one
-does.
-"""
-
-_VISIBLE_SCHEMA_SQL = """
-SELECT n.nspname
-  FROM pg_catalog.pg_class c
-  JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
- WHERE c.relname = :name
-   AND c.relkind IN ('r', 'p', 'f')
-   AND pg_catalog.pg_table_is_visible(c.oid)
-"""
-"""Which schema an unqualified table name resolves to on this connection.
-
-PostgreSQL resolves a bare name through the search path, and the catalog is the
-only thing that can say where it landed.  ``pg_table_is_visible`` is that rule
-itself, so at most one row comes back: the table the server would have reached,
-in the schema it lives in.
-"""
 
 
 @dataclass(frozen=True)
@@ -196,51 +174,6 @@ def index_table_names() -> tuple[str, ...]:
     return tuple(table.name for table in _drop_order())
 
 
-def _tables_of(schema: str) -> dict[str, sqlalchemy.Table]:
-    """Return every table the index owns, named in one schema explicitly.
-
-    The schema is rendered into every statement built from these, so nothing the
-    drop issues can resolve through a search path onto a table in another one.
-
-    Parameters:
-        schema: The schema the index's own stamp was found in.
-
-    Returns:
-        The tables, keyed by name.
-    """
-    metadata = sqlalchemy.MetaData(schema=schema)
-    return {table.name: table.to_metadata(metadata) for table in METADATA.sorted_tables}
-
-
-def _resolved_schema(connection: sqlalchemy.Connection) -> str | None:
-    """Return the schema an unqualified ``schema_meta`` resolves to.
-
-    The same resolution the rest of the system's statements get, asked once and
-    then written down, rather than repeated per table where two tables of these
-    names in two schemas would answer differently.
-
-    Parameters:
-        connection: An open connection to the database.
-
-    Returns:
-        The schema name, or None when this connection reaches no ``schema_meta``
-        at all.
-    """
-    if connection.dialect.name == _POSTGRES_DIALECT:
-        found = connection.execute(
-            sqlalchemy.text(_VISIBLE_SCHEMA_SQL), {'name': SCHEMA_META.name}
-        ).scalar()
-        return None if found is None else str(found)
-    # Every other backend this supports has one namespace per database, which
-    # the inspector names: "main" for SQLite.  Naming it rather than leaving it
-    # implicit is what keeps the two backends on one code path.
-    inspector = sqlalchemy.inspect(connection)
-    schema = inspector.default_schema_name
-    if schema is None or not inspector.has_table(SCHEMA_META.name, schema=schema):
-        return None
-    return schema
-
-
 def _index_schema(connection: sqlalchemy.Connection) -> str | None:
     """Return the schema this database's own results index lives in, if it has one.
 
@@ -252,18 +185,19 @@ def _index_schema(connection: sqlalchemy.Connection) -> str | None:
         marks, or None when this database offers no evidence of holding an
         index of ours.
     """
-    schema = _resolved_schema(connection)
+    schema = resolved_schema(connection)
     if schema is None:
         return None
-    columns = {
-        column['name']
-        for column in sqlalchemy.inspect(connection).get_columns(SCHEMA_META.name, schema=schema)
-    }
-    return schema if columns.issuperset(_STAMP_MARKS) else None
+    return schema if carries_the_stamp_marks(connection, schema) else None
 
 
 def _present_tables(connection: sqlalchemy.Connection, schema: str) -> tuple[sqlalchemy.Table, ...]:
     """Return the index's tables that this schema actually holds.
+
+    Tables only.  A view of one of these names is not a table this drops -- a
+    ``DROP TABLE`` refuses one, and refusing it in the middle of the drop would
+    take back the whole of it -- so it is left out of the account rather than
+    counted into a drop that could not then finish.
 
     Parameters:
         connection: An open connection to the database.
@@ -272,11 +206,9 @@ def _present_tables(connection: sqlalchemy.Connection, schema: str) -> tuple[sql
     Returns:
         The tables that are there, in drop order.
     """
-    inspector = sqlalchemy.inspect(connection)
-    bound = _tables_of(schema)
-    return tuple(
-        bound[name] for name in index_table_names() if inspector.has_table(name, schema=schema)
-    )
+    held = set(sqlalchemy.inspect(connection).get_table_names(schema=schema))
+    bound = index_tables_in(schema)
+    return tuple(bound[name] for name in index_table_names() if name in held)
 
 
 def _unproven_tables(connection: sqlalchemy.Connection) -> tuple[str, ...]:
@@ -365,6 +297,15 @@ def _unfinished_runs(
     the question is phrased in a column, and a column is exactly what a version
     is free to have changed.
 
+    The stamp is not proof of the column all the same, so the count is taken
+    inside a savepoint and every failure of it is answered as "the question
+    cannot be put to this database".  A stamp says which version wrote the
+    database, not that nothing has happened to it since, and a drop that
+    refused a database because one column of ``ingest_runs`` was not where the
+    stamp implied would refuse the database every other program opens without
+    complaint.  The savepoint is what keeps such a failure from ending the
+    transaction the rest of this account is read in.
+
     Parameters:
         connection: An open connection to the database.
         present: The index's tables that this database holds.
@@ -376,11 +317,15 @@ def _unfinished_runs(
     """
     if version != SCHEMA_VERSION or not any(table.name == INGEST_RUNS.name for table in present):
         return None
-    counted = connection.execute(
-        sqlalchemy.select(sqlalchemy.func.count())
-        .select_from(runs_table)
-        .where(runs_table.c.finished_utc.is_(None))
-    ).scalar()
+    try:
+        with connection.begin_nested():
+            counted = connection.execute(
+                sqlalchemy.select(sqlalchemy.func.count())
+                .select_from(runs_table)
+                .where(runs_table.c.finished_utc.is_(None))
+            ).scalar()
+    except (sqlalchemy.exc.SQLAlchemyError, TypeError, ValueError):
+        return None
     return 0 if counted is None else int(counted)
 
 
@@ -450,7 +395,11 @@ def index_contents(engine: Engine) -> IndexContents:
             be able to drop, and finding that out before anything is dropped is
             what keeps a refusal from becoming a half-finished drop.
     """
-    with engine.begin() as connection:
+    # A connection rather than a transaction that commits: this reads and writes
+    # nothing, and what it leaves behind on the server is a transaction rolled
+    # back rather than one committed.  The lock bound still applies, since the
+    # first statement opens the transaction ``SET LOCAL`` is scoped to.
+    with engine.connect() as connection:
         _bound_the_lock_wait(connection)
         schema = _index_schema(connection)
         if schema is None:
@@ -461,7 +410,7 @@ def index_contents(engine: Engine) -> IndexContents:
                 unfinished_runs=None,
                 unproven=_unproven_tables(connection),
             )
-        bound = _tables_of(schema)
+        bound = index_tables_in(schema)
         present = _present_tables(connection, schema)
         version = _stamp(connection, bound[SCHEMA_META.name])
         tables = tuple(
@@ -507,7 +456,7 @@ def drop_index_tables(engine: Engine, contents: IndexContents) -> tuple[str, ...
     """
     if contents.schema is None or not contents.tables:
         return ()
-    bound = _tables_of(contents.schema)
+    bound = index_tables_in(contents.schema)
     going = tuple(bound[table.name] for table in contents.tables)
     with engine.begin() as connection:
         _open_one_transaction(connection)

--- a/src/spindoctor/results_index/drop.py
+++ b/src/spindoctor/results_index/drop.py
@@ -7,27 +7,36 @@ is deliberately not migrated, so emptying the database and ingesting again is
 the whole of what the gate leaves an operator to do, and it is what the gate's
 own refusal sends them here for.
 
-**Only the tables named here are touched.**  They are the tables of
-:data:`~spindoctor.results_index.schema.METADATA`, taken by name.  No schema is
-dropped, no pattern is matched and nothing is discovered by looking at what the
-database holds: a PostgreSQL server is routinely shared, and an index living in
-a database beside somebody else's tables must be removable without a thought
-about theirs.
+**A name is not evidence.**  The tables this removes are called ``images``,
+``techniques``, ``feature_sources``, ``failed_files``, ``schema_meta`` and
+``ingest_runs``, which are among the commonest table names there are, so a
+database is never taken to hold a SpinDoctor index because a table of one of
+those names is in it.  What proves the index is its own stamp table: a
+``schema_meta`` carrying the marks SpinDoctor's stamp carries.  Without that
+this reports what it found and removes nothing, which is the same answer the
+drop owes a URL naming something that is not an index at all.
 
-**What is left behind is a database, not a hole.**  Dropping every table of an
-index leaves what a database that was never ingested into looks like -- on
-PostgreSQL literally so -- which every consumer already reads as "not
-ingested", and which the next opener with ``create`` rebuilds.
+**The evidence names the schema too.**  A server resolves an unqualified table
+name through a search path that may cross several schemas, and resolving six
+names independently is how one drop comes to span two of them -- destroying a
+stranger's table in the first while leaving the index's own in the second.  So
+the stamp is looked for once, the schema it was found in is the schema every
+later statement names explicitly, and a table of one of these names in any other
+schema is not this index's and is never touched.
 
-**The order is the guarantee.**  ``schema_meta`` goes first, before the tables
-it stamps.  Every state an interrupted drop can leave is then one with no stamp,
-which the version gate reads as "this is not a results index"; the state that
-must never be left is the opposite one, a stamp still standing over tables that
-have gone, because the gate reads that as a healthy index and every consumer
-then fails inside its first query.  The order matters because the transaction
-around the drop is not equally strong on both backends: PostgreSQL rolls DDL
-back with everything else, while the SQLite driver commits each ``DROP TABLE``
-outside the surrounding transaction.
+**The transaction is the guarantee, on both backends.**  PostgreSQL rolls DDL
+back with everything else.  The SQLite driver opens no transaction of its own
+for ``DROP TABLE``, which would leave each drop committed on its own -- so this
+opens one itself, with ``BEGIN IMMEDIATE``, and SQLite's own DDL is
+transactional inside it.  An interrupted drop therefore leaves the database
+exactly as it was on either backend, rather than a state something else has to
+be able to read.
+
+**The order is the second line.**  ``schema_meta`` goes first, before the tables
+it stamps, so that the one state which must never be reached is the one the
+statement order cannot produce: a stamp still standing over tables that have
+gone, which the version gate reads as a healthy index and inside which every
+consumer's first query fails.
 """
 
 from dataclasses import dataclass
@@ -35,7 +44,6 @@ from dataclasses import dataclass
 import sqlalchemy
 from sqlalchemy.engine import Engine
 
-from spindoctor.results_index.engine import stamped_version
 from spindoctor.results_index.schema import INGEST_RUNS, METADATA, SCHEMA_META, SCHEMA_VERSION
 
 __all__ = [
@@ -56,6 +64,11 @@ ingest in flight, or a session somebody left sitting in ``psql``.  Without a
 bound the drop waits for that silently and forever, which reads as a hung
 command rather than as a table somebody else is using.
 
+Applied to the reading that precedes the drop as well as to the drop itself.
+Counting the rows of a table takes a lock too, and a bound that began only after
+the confirmation would leave the command hanging before anybody was asked
+anything -- which is the one place a hang is hardest to account for.
+
 Matched to :data:`~spindoctor.results_index.engine.SQLITE_BUSY_TIMEOUT_MS`, so
 that a contended drop gives up after the same wait on either backend.  SQLite
 needs nothing more: the busy timeout applies to every connection already.
@@ -63,6 +76,36 @@ needs nothing more: the busy timeout applies to every connection already.
 
 _POSTGRES_DIALECT = 'postgresql'
 """Dialect name of every PostgreSQL driver, whichever one the URL asked for."""
+
+_SQLITE_DIALECT = 'sqlite'
+"""Dialect name of the SQLite driver."""
+
+_STAMP_MARKS = ('singleton', 'schema_version')
+"""Columns whose presence in a ``schema_meta`` says SpinDoctor wrote it.
+
+Two rather than the whole column set, because a stamp left by a schema whose
+columns differed from this one's is exactly the database a drop is pointed at,
+and requiring today's columns would withhold the drop from it.  Two rather than
+one, because the pair is idiosyncratic: a version column is what any migration
+table carries, and a constant-keyed ``singleton`` beside it is what this one
+does.
+"""
+
+_VISIBLE_SCHEMA_SQL = """
+SELECT n.nspname
+  FROM pg_catalog.pg_class c
+  JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+ WHERE c.relname = :name
+   AND c.relkind IN ('r', 'p', 'f')
+   AND pg_catalog.pg_table_is_visible(c.oid)
+"""
+"""Which schema an unqualified table name resolves to on this connection.
+
+PostgreSQL resolves a bare name through the search path, and the catalog is the
+only thing that can say where it landed.  ``pg_table_is_visible`` is that rule
+itself, so at most one row comes back: the table the server would have reached,
+in the schema it lives in.
+"""
 
 
 @dataclass(frozen=True)
@@ -80,16 +123,21 @@ class TableContents:
 
 @dataclass(frozen=True)
 class IndexContents:
-    """What of SpinDoctor's own index a database holds.
+    """What of SpinDoctor's own index a database holds, and where.
 
     Read before the drop, so that a destructive command can say what it is about
-    to destroy, and so that a database holding none of it is answered without
-    being touched.
+    to destroy, so that a database holding none of it is answered without being
+    touched, and so that one holding tables that merely share these names is
+    refused rather than emptied.
 
     Parameters:
-        tables: The index's tables that are present, in the order they would be
-            dropped, each with its row count.  Empty when the database holds
-            none of them.
+        schema: The schema SpinDoctor's own stamp table was found in, which is
+            the schema every statement of the drop then names.  None when
+            nothing in this database proves it holds a SpinDoctor index, in
+            which case nothing is to be dropped from it whatever it is called.
+        tables: The index's tables that are present in that schema, in the order
+            they would be dropped, each with its row count.  Empty when the
+            database holds none of them, and empty whenever ``schema`` is None.
         schema_version: The version the database is stamped with, or None when
             it carries no readable stamp.  It is reported rather than required:
             a database this command is pointed at is quite likely to be one no
@@ -98,11 +146,18 @@ class IndexContents:
             None when the question cannot be put to this database -- there is no
             run table, or its stamp is not the version whose columns this code
             knows.
+        unproven: Names of tables the database holds that the index also uses,
+            reported only when ``schema`` is None.  They are what a refusal
+            names: either somebody else's tables that happen to be called this,
+            or the remains of an index whose stamp has gone, and nothing here
+            can tell those apart.
     """
 
+    schema: str | None
     tables: tuple[TableContents, ...]
     schema_version: int | None
     unfinished_runs: int | None
+    unproven: tuple[str, ...]
 
     @property
     def rows(self) -> int:
@@ -120,9 +175,8 @@ def _drop_order() -> tuple[sqlalchemy.Table, ...]:
     Dependents come before what they depend on, because a table another one
     references cannot be dropped while that reference stands.  ``schema_meta``
     is lifted to the front of that order: it references nothing and nothing
-    references it, so it is free to go first, and going first is what makes
-    every interruption leave a database with no stamp rather than a stamp with
-    no tables.
+    references it, so it is free to go first, and going first is what keeps a
+    stamp from ever standing over tables that have gone.
 
     Returns:
         The tables, in drop order.
@@ -142,17 +196,105 @@ def index_table_names() -> tuple[str, ...]:
     return tuple(table.name for table in _drop_order())
 
 
-def _present_tables(engine: Engine) -> tuple[sqlalchemy.Table, ...]:
-    """Return the index's tables that this database actually holds.
+def _tables_of(schema: str) -> dict[str, sqlalchemy.Table]:
+    """Return every table the index owns, named in one schema explicitly.
+
+    The schema is rendered into every statement built from these, so nothing the
+    drop issues can resolve through a search path onto a table in another one.
 
     Parameters:
-        engine: The open database.
+        schema: The schema the index's own stamp was found in.
+
+    Returns:
+        The tables, keyed by name.
+    """
+    metadata = sqlalchemy.MetaData(schema=schema)
+    return {table.name: table.to_metadata(metadata) for table in METADATA.sorted_tables}
+
+
+def _resolved_schema(connection: sqlalchemy.Connection) -> str | None:
+    """Return the schema an unqualified ``schema_meta`` resolves to.
+
+    The same resolution the rest of the system's statements get, asked once and
+    then written down, rather than repeated per table where two tables of these
+    names in two schemas would answer differently.
+
+    Parameters:
+        connection: An open connection to the database.
+
+    Returns:
+        The schema name, or None when this connection reaches no ``schema_meta``
+        at all.
+    """
+    if connection.dialect.name == _POSTGRES_DIALECT:
+        found = connection.execute(
+            sqlalchemy.text(_VISIBLE_SCHEMA_SQL), {'name': SCHEMA_META.name}
+        ).scalar()
+        return None if found is None else str(found)
+    # Every other backend this supports has one namespace per database, which
+    # the inspector names: "main" for SQLite.  Naming it rather than leaving it
+    # implicit is what keeps the two backends on one code path.
+    inspector = sqlalchemy.inspect(connection)
+    schema = inspector.default_schema_name
+    if schema is None or not inspector.has_table(SCHEMA_META.name, schema=schema):
+        return None
+    return schema
+
+
+def _index_schema(connection: sqlalchemy.Connection) -> str | None:
+    """Return the schema this database's own results index lives in, if it has one.
+
+    Parameters:
+        connection: An open connection to the database.
+
+    Returns:
+        The schema holding a ``schema_meta`` that carries SpinDoctor's own
+        marks, or None when this database offers no evidence of holding an
+        index of ours.
+    """
+    schema = _resolved_schema(connection)
+    if schema is None:
+        return None
+    columns = {
+        column['name']
+        for column in sqlalchemy.inspect(connection).get_columns(SCHEMA_META.name, schema=schema)
+    }
+    return schema if columns.issuperset(_STAMP_MARKS) else None
+
+
+def _present_tables(connection: sqlalchemy.Connection, schema: str) -> tuple[sqlalchemy.Table, ...]:
+    """Return the index's tables that this schema actually holds.
+
+    Parameters:
+        connection: An open connection to the database.
+        schema: The schema the index's own stamp was found in.
 
     Returns:
         The tables that are there, in drop order.
     """
-    inspector = sqlalchemy.inspect(engine)
-    return tuple(table for table in _drop_order() if inspector.has_table(table.name))
+    inspector = sqlalchemy.inspect(connection)
+    bound = _tables_of(schema)
+    return tuple(
+        bound[name] for name in index_table_names() if inspector.has_table(name, schema=schema)
+    )
+
+
+def _unproven_tables(connection: sqlalchemy.Connection) -> tuple[str, ...]:
+    """Return the index's table names that this database holds somewhere reachable.
+
+    Asked only of a database that proved nothing, and only so that the refusal
+    can say what it saw.  The names are resolved the way the server resolves
+    them, because those are the tables a drop deciding from names alone would
+    have destroyed.
+
+    Parameters:
+        connection: An open connection to the database.
+
+    Returns:
+        The names, in drop order.
+    """
+    inspector = sqlalchemy.inspect(connection)
+    return tuple(name for name in index_table_names() if inspector.has_table(name))
 
 
 def _row_count(connection: sqlalchemy.Connection, table: sqlalchemy.Table) -> int:
@@ -164,7 +306,7 @@ def _row_count(connection: sqlalchemy.Connection, table: sqlalchemy.Table) -> in
 
     Parameters:
         connection: An open connection to the database.
-        table: The table to count.
+        table: The table to count, named in its schema.
 
     Returns:
         The row count.
@@ -175,29 +317,41 @@ def _row_count(connection: sqlalchemy.Connection, table: sqlalchemy.Table) -> in
     return 0 if counted is None else int(counted)
 
 
-def _stamp(engine: Engine) -> int | None:
+def _stamp(connection: sqlalchemy.Connection, stamp_table: sqlalchemy.Table) -> int | None:
     """Return the schema version a database is stamped with, if it can be read.
 
     The stamp is a fact this reports rather than one it requires.  A database
     the drop is pointed at may be malformed in ways no opener would accept --
-    a ``schema_meta`` left over from a schema whose columns were different -- and
+    a ``schema_meta`` whose version column holds text, or nothing at all -- and
     refusing to say what a database holds because the stamp would not come out
-    of it would withhold the drop from one of the cases it exists for.
+    of it would withhold the drop from one of the cases it exists for.  So every
+    way of not being a version is answered the same way, including the ones that
+    are not database errors at all.
+
+    The read is taken inside a savepoint, because a statement PostgreSQL refuses
+    ends the transaction around it, and everything else this reads would then
+    fail with the first failure's shadow rather than with its own answer.
 
     Parameters:
-        engine: The open database.
+        connection: An open connection to the database.
+        stamp_table: The index's stamp table, named in its schema.
 
     Returns:
         The stamped version, or None when there is none or it will not be read.
     """
     try:
-        return stamped_version(engine)
-    except sqlalchemy.exc.SQLAlchemyError:
+        with connection.begin_nested():
+            row = connection.execute(sqlalchemy.select(stamp_table.c.schema_version)).first()
+            return None if row is None else int(row.schema_version)
+    except (sqlalchemy.exc.SQLAlchemyError, TypeError, ValueError):
         return None
 
 
 def _unfinished_runs(
-    connection: sqlalchemy.Connection, present: tuple[sqlalchemy.Table, ...], version: int | None
+    connection: sqlalchemy.Connection,
+    present: tuple[sqlalchemy.Table, ...],
+    version: int | None,
+    runs_table: sqlalchemy.Table,
 ) -> int | None:
     """Return how many ingest runs have begun and not finished.
 
@@ -215,61 +369,33 @@ def _unfinished_runs(
         connection: An open connection to the database.
         present: The index's tables that this database holds.
         version: The version the database is stamped with, if any.
+        runs_table: The index's run table, named in its schema.
 
     Returns:
         The count, or None when the question cannot be put to this database.
     """
-    if version != SCHEMA_VERSION or INGEST_RUNS not in present:
+    if version != SCHEMA_VERSION or not any(table.name == INGEST_RUNS.name for table in present):
         return None
     counted = connection.execute(
         sqlalchemy.select(sqlalchemy.func.count())
-        .select_from(INGEST_RUNS)
-        .where(INGEST_RUNS.c.finished_utc.is_(None))
+        .select_from(runs_table)
+        .where(runs_table.c.finished_utc.is_(None))
     ).scalar()
     return 0 if counted is None else int(counted)
 
 
-def index_contents(engine: Engine) -> IndexContents:
-    """Return what of SpinDoctor's own index a database holds.
-
-    Parameters:
-        engine: An open database, from
-            :func:`~spindoctor.results_index.engine.open_database`, since one
-            holding a version no opener accepts is a database this is asked
-            about rather than one it is not.
-
-    Returns:
-        The tables that are present with their row counts, the stamp, and how
-        many ingest runs are outstanding.
-
-    Raises:
-        sqlalchemy.exc.SQLAlchemyError: If a table that is there cannot be
-            counted.  A table this account may not read is one it is unlikely to
-            be able to drop, and finding that out before anything is dropped is
-            what keeps a refusal from becoming a half-finished drop.
-    """
-    present = _present_tables(engine)
-    version = _stamp(engine)
-    with engine.connect() as connection:
-        tables = tuple(
-            TableContents(name=table.name, rows=_row_count(connection, table)) for table in present
-        )
-        unfinished = _unfinished_runs(connection, present, version)
-    return IndexContents(tables=tables, schema_version=version, unfinished_runs=unfinished)
-
-
 def _bound_the_lock_wait(connection: sqlalchemy.Connection) -> None:
-    """Stop the drop from waiting forever on a lock somebody else holds.
+    """Stop a statement from waiting forever on a lock somebody else holds.
 
     ``SET LOCAL`` lasts exactly as long as the transaction it is issued in, so
-    the bound applies to this drop and to no other statement the connection
-    later carries.
+    the bound applies to the work this transaction carries and to no other
+    statement the connection is later handed.
 
     SQLite is left alone: its busy timeout is applied to every connection when
     the engine is built, and it bounds the same wait for the same reason.
 
     Parameters:
-        connection: The connection the drop runs on, inside its transaction.
+        connection: The connection the work runs on, inside its transaction.
     """
     if connection.dialect.name != _POSTGRES_DIALECT:
         return
@@ -279,33 +405,113 @@ def _bound_the_lock_wait(connection: sqlalchemy.Connection) -> None:
     connection.exec_driver_sql(f"SET LOCAL lock_timeout = '{int(DROP_LOCK_TIMEOUT_MS)}ms'")
 
 
-def drop_index_tables(engine: Engine) -> tuple[str, ...]:
-    """Remove every table of the results index from a database, and nothing else.
+def _open_one_transaction(connection: sqlalchemy.Connection) -> None:
+    """Make everything that follows one transaction, on the SQLite driver too.
 
-    Idempotent: a database holding none of these tables is not written at all,
+    SQLite's own DDL is transactional; its Python driver is what is not.  The
+    driver opens a transaction when it sees an INSERT, UPDATE or DELETE and for
+    nothing else, so a run of ``DROP TABLE`` statements is issued in autocommit
+    and each one stands on its own the moment it returns.  Issuing ``BEGIN``
+    here is what puts them inside a transaction that a failure or an interrupt
+    takes back whole.
+
+    ``IMMEDIATE`` rather than a plain begin, so the write lock is taken at the
+    start: a drop that would have to give way to another writer gives way before
+    it has dropped anything, and the busy timeout bounds that wait exactly as
+    the lock timeout bounds PostgreSQL's.
+
+    Parameters:
+        connection: The connection the drop runs on, at the start of its
+            transaction and before any statement of its own.
+    """
+    if connection.dialect.name != _SQLITE_DIALECT:
+        return
+    connection.exec_driver_sql('BEGIN IMMEDIATE')
+
+
+def index_contents(engine: Engine) -> IndexContents:
+    """Return what of SpinDoctor's own index a database holds, and where.
+
+    Parameters:
+        engine: An open database, from
+            :func:`~spindoctor.results_index.engine.open_database`, since one
+            holding a version no opener accepts is a database this is asked
+            about rather than one it is not.
+
+    Returns:
+        The schema the index's own stamp proves it lives in, the tables of that
+        schema that are present with their row counts, the stamp, and how many
+        ingest runs are outstanding -- or, for a database that proves nothing,
+        a report naming whatever tables of these names it does hold.
+
+    Raises:
+        sqlalchemy.exc.SQLAlchemyError: If a table that is there cannot be
+            counted.  A table this account may not read is one it is unlikely to
+            be able to drop, and finding that out before anything is dropped is
+            what keeps a refusal from becoming a half-finished drop.
+    """
+    with engine.begin() as connection:
+        _bound_the_lock_wait(connection)
+        schema = _index_schema(connection)
+        if schema is None:
+            return IndexContents(
+                schema=None,
+                tables=(),
+                schema_version=None,
+                unfinished_runs=None,
+                unproven=_unproven_tables(connection),
+            )
+        bound = _tables_of(schema)
+        present = _present_tables(connection, schema)
+        version = _stamp(connection, bound[SCHEMA_META.name])
+        tables = tuple(
+            TableContents(name=table.name, rows=_row_count(connection, table)) for table in present
+        )
+        unfinished = _unfinished_runs(connection, present, version, bound[INGEST_RUNS.name])
+    return IndexContents(
+        schema=schema,
+        tables=tables,
+        schema_version=version,
+        unfinished_runs=unfinished,
+        unproven=(),
+    )
+
+
+def drop_index_tables(engine: Engine, contents: IndexContents) -> tuple[str, ...]:
+    """Remove the tables a reading of this database found, and nothing else.
+
+    The reading is passed in rather than taken again, so that the tables which
+    go are the tables somebody was shown and agreed to.  Between one reading and
+    another the answer is free to change -- a creating open in another process
+    puts them back -- and a destructive command must not act on a list nobody
+    saw.
+
+    Idempotent: contents holding no table of the index are not written at all,
     and the empty answer is what says so.
 
     Parameters:
         engine: An open database, from
             :func:`~spindoctor.results_index.engine.open_database`.
+        contents: What :func:`index_contents` read from that database, naming
+            the schema to drop from and the tables to drop.
 
     Returns:
         The names of the tables that were dropped, in the order they went, and
-        an empty tuple when there was nothing of the index there.
+        an empty tuple when there was nothing of the index to drop.
 
     Raises:
         sqlalchemy.exc.SQLAlchemyError: If a table cannot be dropped, including
             because another session holds a lock on it for longer than
-            :data:`DROP_LOCK_TIMEOUT_MS`.  On PostgreSQL the transaction rolls
-            back and the database is left exactly as it was; on SQLite the drops
-            already committed stand, which the order they are issued in is what
-            makes safe.
+            :data:`DROP_LOCK_TIMEOUT_MS`.  The transaction rolls back on both
+            backends and the database is left exactly as it was.
     """
-    present = _present_tables(engine)
-    if not present:
+    if contents.schema is None or not contents.tables:
         return ()
+    bound = _tables_of(contents.schema)
+    going = tuple(bound[table.name] for table in contents.tables)
     with engine.begin() as connection:
+        _open_one_transaction(connection)
         _bound_the_lock_wait(connection)
-        for table in present:
+        for table in going:
             connection.execute(sqlalchemy.schema.DropTable(table))
-    return tuple(table.name for table in present)
+    return tuple(table.name for table in going)

--- a/src/spindoctor/results_index/engine.py
+++ b/src/spindoctor/results_index/engine.py
@@ -1,14 +1,20 @@
 """Engine factory and version gate for the navigation results index.
 
-:func:`open_index` is the only opener.  It selects the backend from the
-connection URL, applies the SQLite settings the concurrency model depends on,
-and refuses a database whose schema version is not the one this code reads.
-Every refusal is a ``ValueError`` naming the URL, including the ones a database
-driver raises, so a caller that reports failures catches one type.  The URL is
-named with its credentials masked, and so is anything the failure underneath it
-quoted back: these messages are written to run logs, returned in cloud task
-results and handed to operators, and a database password belongs in none of
-them.
+:func:`open_index` is the opener every program that reads or writes the index
+goes through.  It selects the backend from the connection URL, applies the
+SQLite settings the concurrency model depends on, and refuses a database whose
+schema version is not the one this code reads.  Every refusal is a
+``ValueError`` naming the URL, including the ones a database driver raises, so a
+caller that reports failures catches one type.  The URL is named with its
+credentials masked, and so is anything the failure underneath it quoted back:
+these messages are written to run logs, returned in cloud task results and
+handed to operators, and a database password belongs in none of them.  The
+masking rule itself lives in :mod:`spindoctor.results_index.masking`, because a
+run log records a command line whose words may include one of these URLs.
+
+:func:`open_database` is the one opener that stops before the version gate, and
+it exists for the one operation that has to work on a database the gate refuses:
+dropping the tables, which is the remedy the gate's own message prescribes.
 
 Two URL forms are supported::
 
@@ -26,17 +32,18 @@ ships as an optional extra.
 
 import datetime
 import os
-import re
 import sqlite3
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import sqlalchemy
 from sqlalchemy.engine import URL, Engine
 
+from spindoctor.results_index.masking import masked_url, without_credentials
 from spindoctor.results_index.schema import METADATA, SCHEMA_META, SCHEMA_VERSION
 
-__all__ = ['SQLITE_BUSY_TIMEOUT_MS', 'masked_url', 'open_index']
+__all__ = ['SQLITE_BUSY_TIMEOUT_MS', 'open_database', 'open_index', 'stamped_version']
 
 SQLITE_BUSY_TIMEOUT_MS = 30000
 """How long a SQLite connection waits for a competing writer before failing.
@@ -68,49 +75,97 @@ These are the codes a filesystem that cannot honor SQLite locking produces, and
 the only ones for which moving the index to a server is the remedy.
 """
 
-_HIDDEN_PASSWORD = '***'
-"""What a password is replaced by, matching what a parsed URL renders itself as."""
-
-_CREDENTIAL_QUERY_MARKERS = ('password', 'passwd', 'pwd', 'secret', 'token', 'credential')
-"""Text that makes a query parameter's value a credential rather than a setting.
-
-A connection URL may carry its password as a query parameter instead of in the
-authority -- ``postgresql+psycopg://user@host/db?password=...`` authenticates
-exactly as the authority form does -- and a driver accepts any parameter its
-library knows, so the name is matched by what it contains rather than against a
-fixed list.  Over-hiding a setting whose name says credential costs a word of a
-message; under-hiding one puts a working password in a run log.
-"""
-
-_QUERY_SEPARATOR = re.compile(r'([;&])')
-"""What separates one query parameter from the next, kept by the split.
-
-A connection URL's query is separated by ``&`` or by ``;``: libpq accepts
-either, and so does every driver built on it.  The separator is captured so
-that a masked query is rebuilt with the separators it was written with.
-"""
-
 _SUPPORTED_URL_FORMS = (
     'A results index is either a sqlite: URL naming a local path, or a '
     'postgresql+psycopg: URL naming a server.'
 )
 
-_SHORTEST_HIDDEN_RUN = 3
-"""Shortest run of a credential that is hidden where something quotes one back.
 
-A message quoting a URL back rarely quotes the whole of it.  A driver that could
-not read a URL reports the fragment it stopped on, and that fragment is a slice
-of the string rather than a field of it: SQLAlchemy reads
-``user:se@cr:etpassword@host`` as a host and a port, and says it could not read
-``etpassword@host`` as a number.  Only the credential itself says which slices
-are its own, so every run of one that appears in a quoted message is replaced.
+@dataclass(frozen=True)
+class _Access:
+    """What a caller means to do with the database it is opening.
 
-Three characters is where that stops being worth doing.  Shorter runs collide
-with ordinary words often enough to turn a diagnosis into a row of markers, and
-a secret disclosed three characters at a time, with neither the order of the
-runs nor the gaps between them, is not disclosed.  A credential shorter than
-that is hidden whole, since there is nothing to be lost by mangling a message
-about a two-character password.
+    The three openers differ in four independent ways, and spelling each one out
+    is what keeps them from being inferred from one another.  A drop, in
+    particular, writes a database it does not create and reads a version it does
+    not require, which no combination of "create" and "read" describes.
+
+    Parameters:
+        creating: Whether missing tables and the version row are to be created.
+        writing: Whether the database is going to be written, which is what a
+            SQLite database on a read-only file or directory is refused for.
+        must_exist: Whether a SQLite path that is not there is a refusal.  A
+            caller that creates is the only one for which it is not.
+        gated: Whether the stamped schema version must be the one this code
+            reads.
+        writer: What has to write the database, named in the refusal a
+            read-only one raises.  Empty for an access that does not write,
+            which never reaches that refusal.
+        write_remedy: What to do about a read-only database file.  The three
+            remedies below are a message table keyed by operation, because the
+            same filesystem fact calls for different advice: working on a copy
+            answers it for a pass that only wants the rows, and answers nothing
+            for one whose whole purpose is to change this database.
+        directory_remedy: What to do about a read-only directory, separately,
+            because the file itself may be perfectly writable.
+        absent_remedy: What to do about a SQLite path that is not there.  Empty
+            for an access that creates one, which is never refused for it.
+    """
+
+    creating: bool
+    writing: bool
+    must_exist: bool
+    gated: bool
+    writer: str = ''
+    write_remedy: str = ''
+    directory_remedy: str = ''
+    absent_remedy: str = ''
+
+
+_READING = _Access(
+    creating=False,
+    writing=False,
+    must_exist=True,
+    gated=True,
+    absent_remedy='Run sd_stats_ingest to build one.',
+)
+"""Every consumer: the database must already be an index of this version."""
+
+_INGESTING = _Access(
+    creating=True,
+    writing=True,
+    must_exist=False,
+    gated=True,
+    writer='ingest',
+    write_remedy='Ingest a writable copy; a consumer reads this one as it is.',
+    directory_remedy='Ingest into a writable directory; a consumer reads this one as it is.',
+)
+"""The ingest programs: missing tables are created and the version row written."""
+
+_DROPPING = _Access(
+    creating=False,
+    writing=True,
+    must_exist=True,
+    gated=False,
+    writer='dropping the index',
+    write_remedy=(
+        'Make the file writable, or delete it: a SQLite index is one file, and removing '
+        'it removes the index.'
+    ),
+    directory_remedy=(
+        'Make the directory writable, or delete the database file: a SQLite index is one '
+        'file, and removing it removes the index.'
+    ),
+    absent_remedy='Nothing was dropped.',
+)
+"""The drop: a database that is there is opened whatever it holds.
+
+Ungated on purpose.  A database stamped with another version, or carrying no
+stamp at all, is exactly what the drop is pointed at -- the gate's own message
+prescribes deleting such a database -- so requiring the gate to pass first would
+withhold the remedy from the case that needs it.  Nothing is read from the
+database through this access, so the columns the gate protects are never
+touched: only the table names are, and those come from the schema metadata.
 """
 
 
@@ -124,327 +179,6 @@ class _IndexOpenError(ValueError):
     being wrapped in a second one, while a caller still catches the
     ``ValueError`` the contract promises.
     """
-
-
-def _scheme_base(url: str) -> str:
-    """Return the backend a URL's scheme names, whatever driver it asks for.
-
-    Parameters:
-        url: The URL as the caller wrote it.
-
-    Returns:
-        The scheme with any ``+driver`` suffix and surrounding space removed and
-        lower cased, or an empty string when the string carries no scheme.
-    """
-    scheme, separator, _remainder = url.partition(':')
-    if not separator:
-        return ''
-    return scheme.strip().split('+', 1)[0].lower()
-
-
-def _authority_start(url: str) -> int:
-    """Return the index at which a URL's authority section begins.
-
-    A scheme is only recognized as one when a ``/`` follows its ``:``.  Without
-    that slash the text before the colon reads equally as a scheme and as a user
-    name -- ``postgresql:svc:pw@host/db`` and ``svc:pw@host/db`` are the same
-    shape -- and reading it as a scheme is what leaves the password of the
-    second one visible.  It is therefore read as a user name in both, which
-    hides the first one's user name along with its password.  That is one word
-    of a message about a URL no driver would have accepted anyway; the other
-    reading loses a working password.
-
-    Every slash of the run is consumed, however many there are.  Two is the
-    spelling a URL is defined with and one is what a hand-edited setting
-    arrives as, but three is an ordinary spelling too -- ``postgresql:///db``
-    omits the host to name a local socket, and ``sqlite:///path`` habituates
-    the form -- and a rule that stopped counting at two would leave the
-    authority start on a slash, which reads as a path beginning before any
-    password and returns the URL whole.
-
-    Parameters:
-        url: The URL as the caller wrote it.
-
-    Returns:
-        The index just past the scheme and the slashes that open the authority.
-    """
-    colon = url.find(':')
-    start = 0
-    if colon >= 0 and url[colon + 1 : colon + 2] == '/':
-        prefix = url[:colon]
-        # A '/' or an '@' before the colon puts the colon inside the authority
-        # rather than after a scheme, whatever follows it.
-        if '/' not in prefix and '@' not in prefix:
-            start = colon + 1
-    end = start
-    while url[end : end + 1] == '/':
-        end += 1
-    return end
-
-
-def _password_span(url: str) -> tuple[int, int] | None:
-    """Return the half-open range of characters holding a URL's password.
-
-    The rule is the one a URL's own grammar states.  The user name runs from the
-    start of the authority to the first ``:``; only a ``:`` introduces a
-    password, and that password runs to the ``@`` that ends the credentials.
-
-    Which ``@`` ends them is the whole question.  It is the **last** one in the
-    string.  A user name is free to carry one -- ``user@servername`` is the
-    login form of a managed server -- and so is a password: ``p@ssword``,
-    ``p@ss/word`` and ``pw:with@both`` are all things an operator types.  Every
-    narrower choice stops inside a password that carries the character it stops
-    at.  Ending at the ``@`` before the first ``/`` leaves the tail of
-    ``p@ss/word`` in the message; ending at the last ``@`` before a ``#``
-    leaves the tail of ``pw@part#rest``.  The last ``@`` is the only bound that
-    cannot stop early, because the span it produces contains every other
-    candidate span.
-
-    What that costs is over-masking a URL whose real credentials end sooner and
-    whose tail happens to carry an ``@`` -- a fragment such as
-    ``...?password=x#note@host`` is masked to its last character.  A connection
-    URL has no use for a fragment, so that is a mangled message about a URL no
-    driver would have accepted, against a working password in a run log.
-
-    One shape is genuinely ambiguous: ``host:5432/path@name`` reads equally as a
-    host with a port and a path, or as a user name with a password that carries
-    a slash.  It is read as credentials, which is how the URL parser itself
-    reads it -- for the spelling of that shape a parser accepts, this rule and
-    ``render_as_string()`` hide the same characters.  Reading it as a port
-    instead would leave a password beginning with digits, ``123/secret``, in
-    every message; the cost of the reading taken is a mangled host and database
-    name in a message about a URL that was already unusable.
-
-    Parameters:
-        url: The URL as the caller wrote it.
-
-    Returns:
-        The first and last-plus-one index of the password, or None when the URL
-        carries no password to hide.
-    """
-    start = _authority_start(url)
-    colon = url.find(':', start)
-    if colon < 0:
-        return None
-    slash = url.find('/', start)
-    if 0 <= slash < colon:
-        # The authority ended before any colon, so what follows is a path.
-        return None
-    at = url.rfind('@', colon)
-    if at < 0:
-        return None
-    return colon + 1, at
-
-
-def _names_a_credential(name: str) -> bool:
-    """Whether a query parameter's name says its value is a credential.
-
-    Parameters:
-        name: The parameter's name, as written.
-
-    Returns:
-        True when the name carries one of :data:`_CREDENTIAL_QUERY_MARKERS`.
-    """
-    return any(marker in name.strip().lower() for marker in _CREDENTIAL_QUERY_MARKERS)
-
-
-def _masked_parameter(parameter: str) -> str:
-    """Return one query parameter with its value replaced if it is a credential.
-
-    Parameters:
-        parameter: The parameter as written, ``name=value`` or a bare name.
-
-    Returns:
-        The parameter, with its value replaced when its name says credential.
-    """
-    name, separator, _value = parameter.partition('=')
-    if not separator:
-        return parameter
-    if not _names_a_credential(name):
-        return parameter
-    return f'{name}={_HIDDEN_PASSWORD}'
-
-
-def _query_span(url: str) -> tuple[int, int] | None:
-    """Return the half-open range of characters holding a URL's query string.
-
-    Parameters:
-        url: The URL as the caller wrote it.
-
-    Returns:
-        The first and last-plus-one index of the query, without its leading
-        ``?`` and without any fragment after it, or None when the URL carries no
-        query at all.
-    """
-    start = url.find('?')
-    if start < 0:
-        return None
-    end = url.find('#', start)
-    return start + 1, len(url) if end < 0 else end
-
-
-def _query_pieces(url: str) -> list[str]:
-    """Split a URL's query into its parameters and the separators between them.
-
-    Parameters:
-        url: The URL as the caller wrote it, which must carry a query.
-
-    Returns:
-        The parameters at even positions and the separators at odd ones.  A
-        query is separated by ``&`` or by ``;``, both of which libpq and the
-        drivers accept, and splitting on one alone leaves a parameter written
-        with the other unexamined; the separators are kept so that a masked
-        query is rebuilt with the ones it was written with.
-    """
-    span = _query_span(url)
-    if span is None:
-        return []
-    first, past_last = span
-    return _QUERY_SEPARATOR.split(url[first:past_last])
-
-
-def _masked_query(url: str) -> str:
-    """Return a URL with the value of every credential query parameter replaced.
-
-    Run after the authority has been masked, so that a ``?`` inside a password
-    has already gone with the password and cannot be mistaken for the start of a
-    query.
-
-    Parameters:
-        url: The URL, with its authority already masked.
-
-    Returns:
-        The URL with any credential-bearing parameter hidden.
-    """
-    span = _query_span(url)
-    if span is None:
-        return url
-    first, past_last = span
-    pieces = _query_pieces(url)
-    masked = [
-        piece if index % 2 else _masked_parameter(piece) for index, piece in enumerate(pieces)
-    ]
-    if masked == pieces:
-        return url
-    return f'{url[:first]}{"".join(masked)}{url[past_last:]}'
-
-
-def masked_url(url: str) -> str:
-    """Return a URL string with every credential in it replaced.
-
-    Anything that puts a connection URL in front of a person -- a refusal whose
-    parsing is what failed, a run log recording the command line it was given --
-    calls this, so that one structural rule decides what a credential is.  It is
-    the only rule: a parsed URL renders itself with its password hidden, but it
-    renders a ``?password=`` query parameter verbatim, so adopting the parser
-    for the URLs it accepts would adopt its blind spot with it.
-
-    Everything outside a credential survives, because naming the URL is what
-    tells a reader which of the resolution levels supplied the value.
-
-    A ``sqlite:`` URL is returned exactly as it came.  It names a local
-    filesystem path, which has no credentials at all, and a path is free to carry
-    the colons, at-signs and question marks that would otherwise read as some.
-
-    A results root is not a connection URL and is never passed here.  It has no
-    credentials to hide, and a root is the one string an operator reads a run
-    log to correct, so mangling one costs more than it protects.
-
-    Parameters:
-        url: The URL as the caller wrote it.
-
-    Returns:
-        The URL with its credentials, if any, masked.
-    """
-    if _scheme_base(url) == _SQLITE_BACKEND:
-        return url
-    span = _password_span(url)
-    if span is not None:
-        first, past_last = span
-        url = f'{url[:first]}{_HIDDEN_PASSWORD}{url[past_last:]}'
-    return _masked_query(url)
-
-
-def _credentials(url: str) -> list[str]:
-    """Return every credential a URL carries, exactly as it is written.
-
-    The same structural rule :func:`masked_url` masks by, read as values rather
-    than as spans, so that what a message quotes back is measured against the
-    same idea of a credential the URL itself is.
-
-    Parameters:
-        url: The URL as the caller wrote it.
-
-    Returns:
-        The password from the authority and the value of every credential-
-        bearing query parameter, skipping the empty ones.  A ``sqlite:`` URL is
-        a local filesystem path and carries none.
-    """
-    if _scheme_base(url) == _SQLITE_BACKEND:
-        return []
-    found: list[str] = []
-    span = _password_span(url)
-    if span is not None:
-        first, past_last = span
-        found.append(url[first:past_last])
-    for index, piece in enumerate(_query_pieces(url)):
-        name, separator, value = piece.partition('=')
-        if not index % 2 and separator and _names_a_credential(name):
-            found.append(value)
-    return [secret for secret in found if secret]
-
-
-def _without_runs_of(text: str, secret: str) -> str:
-    """Return text with every run of one secret in it replaced.
-
-    Parameters:
-        text: The text to clean, which is not a URL and cannot be masked as one.
-        secret: The credential whose runs are to go.
-
-    Returns:
-        The text, with every run of :data:`_SHORTEST_HIDDEN_RUN` or more
-        characters that also appears in the secret replaced, and a secret
-        shorter than that replaced wherever it appears whole.  Scanned from the
-        left, taking the longest run at each position: a run left over when a
-        shorter one has been replaced is examined again at the position it
-        resumes from, so no run of the secret survives in part.
-    """
-    kept: list[str] = []
-    index = 0
-    while index < len(text):
-        length = 0
-        while index + length < len(text) and text[index : index + length + 1] in secret:
-            length += 1
-        if length and length >= min(_SHORTEST_HIDDEN_RUN, len(secret)):
-            kept.append(_HIDDEN_PASSWORD)
-            index += length
-        else:
-            kept.append(text[index])
-            index += 1
-    return ''.join(kept)
-
-
-def _without_credentials(text: str, url: str) -> str:
-    """Return a message quoting a URL back with the credentials of that URL gone.
-
-    Masking the URL a refusal names is not enough on its own.  A refusal also
-    quotes what the failure underneath it said, and a driver that could not read
-    a URL says so by quoting the piece of it that stopped it -- which, for a
-    password carrying an ``@`` and a ``:``, is a run of the password in
-    cleartext.  Such a message travels: it is written to run logs, returned in a
-    cloud task's result, and collected into event logs an operator concatenates
-    and hands on.
-
-    Parameters:
-        text: What the underlying failure said.
-        url: The URL it was raised about, as the caller wrote it.
-
-    Returns:
-        The text with every run of every credential of that URL replaced.
-    """
-    for secret in _credentials(url):
-        text = _without_runs_of(text, secret)
-    return text
 
 
 def _sqlite_error_name(exc: BaseException) -> str:
@@ -565,23 +299,25 @@ def _make_engine(parsed: URL, url: str) -> Engine:
         ) from exc
 
 
-def _read_only_refusal(url: str) -> _IndexOpenError:
-    """Return the refusal for a database ingest is never going to be able to write.
+def _read_only_refusal(url: str, access: _Access) -> _IndexOpenError:
+    """Return the refusal for a database the caller is never going to be able to write.
 
     Parameters:
         url: The URL as messages name it.
+        access: What the caller means to do with the database, which names the
+            writer and says what to do instead.
 
     Returns:
         The refusal to raise.
     """
     return _IndexOpenError(
-        f'{url}: this SQLite database is read-only, and ingest has to write it. '
-        f'Ingest a writable copy; a consumer reads this one as it is.'
+        f'{url}: this SQLite database is read-only, and {access.writer} has to write it. '
+        f'{access.write_remedy}'
     )
 
 
-def _require_writable_sqlite_database(path: Path, url: str) -> None:
-    """Verify that ingest can write the SQLite database a URL names.
+def _require_writable_sqlite_database(path: Path, url: str, access: _Access) -> None:
+    """Verify that the caller can write the SQLite database a URL names.
 
     The question is put to the filesystem rather than to SQLite, because SQLite
     does not answer it at open.  A write-ahead-logged database -- the shape this
@@ -597,19 +333,20 @@ def _require_writable_sqlite_database(path: Path, url: str) -> None:
     Parameters:
         path: The database file's path.
         url: The URL as messages name it.
+        access: What the caller means to do with the database, which names the
+            writer and says what to do instead.
 
     Raises:
         ValueError: If the file exists and cannot be written, or if its
             directory exists and cannot be written.
     """
     if path.exists() and not os.access(path, os.W_OK):
-        raise _read_only_refusal(url)
+        raise _read_only_refusal(url, access)
     directory = path.parent
     if directory.is_dir() and not os.access(directory, os.W_OK):
         raise _IndexOpenError(
-            f'{url}: the directory {directory} is read-only, and ingest has to write the '
-            f'write-ahead log beside the database. Ingest into a writable directory; a '
-            f'consumer reads this one as it is.'
+            f'{url}: the directory {directory} is read-only, and {access.writer} has to '
+            f'write the write-ahead log beside the database. {access.directory_remedy}'
         )
 
 
@@ -695,7 +432,7 @@ def _sqlite_probe_failure(
     )
 
 
-def _probe_sqlite_access(engine: Engine, url: str, path: Path | None, *, create: bool) -> None:
+def _probe_sqlite_access(engine: Engine, url: str, path: Path | None, access: _Access) -> None:
     """Verify that a SQLite database can be locked, and read when that is all it is.
 
     Taking and releasing a write lock is the cheapest question that distinguishes
@@ -717,7 +454,7 @@ def _probe_sqlite_access(engine: Engine, url: str, path: Path | None, *, create:
         engine: The engine to probe.
         url: The URL as messages name it.
         path: The database file's path, or None for an in-memory database.
-        create: Whether the caller intends to write the database.
+        access: What the caller means to do with the database.
 
     Raises:
         ValueError: If the write lock cannot be taken, if the path is not a
@@ -732,8 +469,8 @@ def _probe_sqlite_access(engine: Engine, url: str, path: Path | None, *, create:
     except sqlalchemy.exc.DBAPIError as exc:
         if not _is_read_only_error(_sqlite_error_name(exc)):
             raise _sqlite_probe_failure(exc, url, path) from exc
-        if create:
-            raise _read_only_refusal(url) from exc
+        if access.writing:
+            raise _read_only_refusal(url, access) from exc
         _require_sqlite_readable(engine, url)
 
 
@@ -782,8 +519,11 @@ def _create_schema(engine: Engine) -> None:
             )
 
 
-def _stamped_version(engine: Engine) -> int | None:
+def stamped_version(engine: Engine) -> int | None:
     """Return the schema version the database is stamped with.
+
+    Read by the version gate, and reported by the drop, which names the version
+    it is about to remove precisely because that version may not be this one.
 
     Parameters:
         engine: The engine to inspect.
@@ -821,18 +561,18 @@ def _verify_schema_version(stamped: int | None, url: str) -> None:
     if stamped != SCHEMA_VERSION:
         raise _IndexOpenError(
             f'{url}: results index schema version {stamped} is not the '
-            f'version {SCHEMA_VERSION} this code reads. There are no migrations: delete '
-            f'the database and re-run sd_stats_ingest.'
+            f'version {SCHEMA_VERSION} this code reads. There are no migrations: empty '
+            f'the database with sd_stats_ingest --drop-index and re-run sd_stats_ingest.'
         )
 
 
-def _sqlite_target(parsed: URL, url: str, *, create: bool) -> Path | None:
+def _sqlite_target(parsed: URL, url: str, access: _Access) -> Path | None:
     """Return the local path a SQLite URL names, refusing one it cannot serve.
 
     Parameters:
         parsed: The parsed connection URL, whose backend is SQLite.
         url: The URL as messages name it.
-        create: Whether the caller intends to write the database.
+        access: What the caller means to do with the database.
 
     Returns:
         The database file's path, or None for an in-memory database.
@@ -840,7 +580,7 @@ def _sqlite_target(parsed: URL, url: str, *, create: bool) -> Path | None:
     Raises:
         ValueError: If the URL carries a query string; if the caller means to
             write a database the filesystem will not let it write; or if the
-            caller means to read one that is not there.
+            caller requires one that is not there.
     """
     if parsed.query:
         carried = ', '.join(sorted(parsed.query))
@@ -852,25 +592,23 @@ def _sqlite_target(parsed: URL, url: str, *, create: bool) -> Path | None:
     path = _sqlite_path(parsed)
     if path is None:
         return None
-    if create:
-        _require_writable_sqlite_database(path, url)
-    elif not path.exists():
-        raise _IndexOpenError(
-            f'{url}: there is no results index at {path}. Run sd_stats_ingest to build one.'
-        )
+    if access.must_exist and not path.exists():
+        raise _IndexOpenError(f'{url}: there is no results index at {path}. {access.absent_remedy}')
+    if access.writing:
+        _require_writable_sqlite_database(path, url, access)
     return path
 
 
-def _build_engine(url: str, *, create: bool) -> Engine:
-    """Open the index, letting a driver's own exceptions escape untranslated.
+def _build_engine(url: str, access: _Access) -> Engine:
+    """Open the database, letting a driver's own exceptions escape untranslated.
 
-    :func:`open_index` wraps this so that every escape becomes a ``ValueError``.
+    :func:`_translated` wraps this so that every escape becomes a ``ValueError``.
     The separation keeps the translation in one place rather than repeated around
     each call a driver can fail inside.
 
     Parameters:
         url: The connection URL.
-        create: Whether to create missing tables and the version row.
+        access: What the caller means to do with the database.
 
     Returns:
         An open engine.
@@ -881,21 +619,23 @@ def _build_engine(url: str, *, create: bool) -> Engine:
     parsed = sqlalchemy.engine.make_url(url)
     safe_url = masked_url(url)
     backend = parsed.get_backend_name()
-    path = _sqlite_target(parsed, safe_url, create=create) if backend == _SQLITE_BACKEND else None
+    path = _sqlite_target(parsed, safe_url, access) if backend == _SQLITE_BACKEND else None
     engine = _make_engine(parsed, safe_url)
     try:
         if backend == _SQLITE_BACKEND:
             sqlalchemy.event.listen(engine, 'connect', _sqlite_on_connect)
-            _probe_sqlite_access(engine, safe_url, path, create=create)
+            _probe_sqlite_access(engine, safe_url, path, access)
+        if not access.gated:
+            return engine
         # The stamped version is checked before anything is written: creating
         # this version's tables inside a database stamped with another version
         # would leave a mixture no single version number describes.
-        stamped = _stamped_version(engine)
+        stamped = stamped_version(engine)
         if stamped is not None:
             _verify_schema_version(stamped, safe_url)
-        if create:
+        if access.creating:
             _create_schema(engine)
-            stamped = _stamped_version(engine)
+            stamped = stamped_version(engine)
         # The gate a non-creating open is refused by.  Reached after the create
         # branch too, where it re-reads the row that branch has just written and
         # so cannot fail; no test can observe that call refusing anything.
@@ -906,11 +646,49 @@ def _build_engine(url: str, *, create: bool) -> Engine:
     return engine
 
 
+def _translated(url: str, access: _Access) -> Engine:
+    """Open a database, turning every way of failing into one exception type.
+
+    Parameters:
+        url: The connection URL.
+        access: What the caller means to do with the database.
+
+    Returns:
+        An open engine.
+
+    Raises:
+        ValueError: For every failure, with the driver's own exception kept as
+            the ``__cause__`` and every credential of the URL replaced, both in
+            the URL the message names and in whatever the failure quoted back.
+    """
+    try:
+        return _build_engine(url, access)
+    except _IndexOpenError:
+        raise
+    except sqlalchemy.exc.NoSuchModuleError as exc:
+        raise ValueError(
+            f'{masked_url(url)}: there is no database driver for this URL scheme '
+            f'({without_credentials(str(exc), url)}). {_SUPPORTED_URL_FORMS}'
+        ) from exc
+    except Exception as exc:
+        # Everything else, not only SQLAlchemy's own exceptions: a dialect
+        # reports a malformed port or an uncoercible connect argument as a bare
+        # ValueError naming neither the URL nor the setting that supplied it.
+        # What it does name is the piece of the URL it stopped on, which is why
+        # the quoted message is cleaned as well as the URL beside it.
+        raise ValueError(
+            f'{masked_url(url)}: could not open the results index '
+            f'({type(exc).__name__}: {without_credentials(str(exc), url)}).'
+        ) from exc
+
+
 def open_index(url: str, *, create: bool = False) -> Engine:
     """Open the results index named by a connection URL.
 
-    This is the only opener.  Every program that reads or writes the index goes
-    through it, so the version gate cannot be bypassed.
+    Every program that reads or writes the index goes through this, so the
+    version gate cannot be bypassed by one.  :func:`open_database` is the one
+    other opener, and it reads and writes nothing: it exists so that the tables
+    the gate refused can be dropped.
 
     With ``create`` false -- every consumer -- a database that does not exist, or
     that carries no ``schema_meta`` row, is an error naming ``sd_stats_ingest``.
@@ -951,22 +729,44 @@ def open_index(url: str, *, create: bool = False) -> Engine:
             database or its ``schema_meta`` row does not exist; or if the
             stamped schema version is not the one this code reads.
     """
-    try:
-        return _build_engine(url, create=create)
-    except _IndexOpenError:
-        raise
-    except sqlalchemy.exc.NoSuchModuleError as exc:
-        raise ValueError(
-            f'{masked_url(url)}: there is no database driver for this URL scheme '
-            f'({_without_credentials(str(exc), url)}). {_SUPPORTED_URL_FORMS}'
-        ) from exc
-    except Exception as exc:
-        # Everything else, not only SQLAlchemy's own exceptions: a dialect
-        # reports a malformed port or an uncoercible connect argument as a bare
-        # ValueError naming neither the URL nor the setting that supplied it.
-        # What it does name is the piece of the URL it stopped on, which is why
-        # the quoted message is cleaned as well as the URL beside it.
-        raise ValueError(
-            f'{masked_url(url)}: could not open the results index '
-            f'({type(exc).__name__}: {_without_credentials(str(exc), url)}).'
-        ) from exc
+    return _translated(url, _INGESTING if create else _READING)
+
+
+def open_database(url: str) -> Engine:
+    """Open the database a URL names, without requiring it to hold an index.
+
+    The opener for the one operation that has to work on a database
+    :func:`open_index` refuses: dropping the tables, which is the remedy the
+    version gate's own message prescribes.  Requiring the gate to pass first
+    would withhold that remedy from every database that needs it -- one stamped
+    with a version this code does not read, and one left holding part of a
+    schema by an interrupted creation.
+
+    Everything else :func:`open_index` does is done here.  The URL is parsed,
+    diagnosed and named the same way, a SQLite database is probed the same way
+    and refused for the same causes, and every failure is the same ``ValueError``
+    naming the same masked URL.  The database must already be there, on both
+    backends alike: a SQLite path that is not there is refused rather than
+    created, exactly as a PostgreSQL database that is not there is refused by
+    the server.
+
+    Nothing is read out of the database through this, so no column the version
+    gate protects is ever touched.  What the caller may do with it is name
+    tables, and the only names it has come from the schema metadata.
+
+    Parameters:
+        url: A ``sqlite:`` URL naming an existing local path, or a
+            ``postgresql+psycopg:`` URL naming a server.
+
+    Returns:
+        An open engine.  SQLite engines have foreign keys, write-ahead logging
+        and a busy timeout applied to every connection.
+
+    Raises:
+        ValueError: If the URL cannot be parsed, carries a query string a SQLite
+            index may not have, names a backend with no driver installed, or
+            names a server that will not accept the connection; or if SQLite
+            refuses the file, including one that is not there and one the
+            filesystem will not let this user write.
+    """
+    return _translated(url, _DROPPING)

--- a/src/spindoctor/results_index/engine.py
+++ b/src/spindoctor/results_index/engine.py
@@ -41,7 +41,15 @@ import sqlalchemy
 from sqlalchemy.engine import URL, Engine
 
 from spindoctor.results_index.masking import masked_url, without_credentials
-from spindoctor.results_index.schema import METADATA, SCHEMA_META, SCHEMA_VERSION
+from spindoctor.results_index.schema import SCHEMA_META, SCHEMA_VERSION
+from spindoctor.results_index.scope import (
+    INDEX_TABLE_NAMES,
+    carries_the_stamp_marks,
+    creation_schema,
+    index_tables_in,
+    relations_in,
+    resolved_schema,
+)
 
 __all__ = ['SQLITE_BUSY_TIMEOUT_MS', 'open_database', 'open_index']
 
@@ -122,7 +130,8 @@ class _Access:
             because the file itself may be perfectly writable.
         absent_remedy: What to do about a SQLite path that is not there.  Empty
             for an access that creates one, which is never refused for it.
-        opening: What this access is opening, as a failure names it.  A drop is
+        opening: What this access is opening, as a failure names it, without an
+            article so that a message is free to supply its own.  A drop is
             pointed at databases that are not indexes, which is the whole of why
             it exists, so reporting that one of those "could not be opened as
             the results index" would name a fault of its own making.
@@ -136,7 +145,7 @@ class _Access:
     write_remedy: str = ''
     directory_remedy: str = ''
     absent_remedy: str = ''
-    opening: str = 'the results index'
+    opening: str = 'results index'
 
 
 _READING = _Access(
@@ -174,7 +183,7 @@ _DROPPING = _Access(
         'file, and removing it removes the index.'
     ),
     absent_remedy='Nothing was dropped.',
-    opening='the database',
+    opening='database',
 )
 """The drop: a database that is there is opened whatever it holds.
 
@@ -527,18 +536,130 @@ def _require_sqlite_readable(engine: Engine, url: str) -> None:
         ) from exc
 
 
-def _create_schema(engine: Engine) -> None:
+def _index_schema_refusal(url: str, schema: str, held: tuple[str, ...]) -> _IndexOpenError:
+    """Return the refusal for a schema an index may not be created in.
+
+    Two shapes reach this, and each is named for what it is.  A schema holding a
+    relation the index does not own is one that belongs to something else: the
+    index and its consumers own the schema they live in, so anything else in it
+    says the URL, or the search path behind it, names somewhere it should not.
+    A schema holding only relations of the index's own names, with no stamp of
+    SpinDoctor's over them, says nothing about whose they are: those names are
+    among the commonest there are, and a stamp written beside a stranger's table
+    would make it this index's for every later reading.
+
+    Parameters:
+        url: The URL as messages name it.
+        schema: The schema the index would have been created in.
+        held: Every relation that schema holds, sorted.
+
+    Returns:
+        The refusal to raise.
+    """
+    foreign = tuple(name for name in held if name not in INDEX_TABLE_NAMES)
+    if foreign:
+        return _IndexOpenError(
+            f'{url}: schema {schema} of this database holds table(s) the results index does '
+            f'not own ({", ".join(foreign)}), so no index was created in it and nothing was '
+            f'stamped. A results index owns the schema it lives in -- its own tables are the '
+            f'whole of what belongs there -- so a table SpinDoctor did not create in that '
+            f'schema means this URL, or the search path behind it, names a database or a '
+            f"schema other than the index's. Check the URL, or name an empty schema with "
+            f'options=-csearch_path=schemaname.'
+        )
+    return _IndexOpenError(
+        f'{url}: schema {schema} of this database holds table(s) the results index also uses '
+        f"({', '.join(held)}), but no schema_meta of SpinDoctor's stands over them, so "
+        f'nothing there says they are an index of ours. They are either tables somebody else '
+        f'created under names this index also uses, what an index whose stamp has gone left '
+        f'behind, or an index another ingest is building at this moment, and the database '
+        f'does not say which. No index was created and nothing was stamped, so they are '
+        f'exactly as they were. Check the URL; run this again if another ingest was building '
+        f'one; remove them by hand if they are an index of yours.'
+    )
+
+
+def _schema_to_create_in(engine: Engine, url: str) -> str:
+    """Return the schema an index may be created in, refusing one that is not ours.
+
+    An ingest never stamps a schema that already holds tables SpinDoctor did not
+    create.  The stamp is what every later reading takes as proof that the tables
+    beside it are the index's -- it is what the drop destroys on the strength of
+    -- so writing one over tables of unknown provenance is what makes a
+    stranger's table indistinguishable from ours.  The four answers:
+
+    - A schema holding nothing is created in and stamped.
+    - A schema carrying a stamp of SpinDoctor's is the index's own, whatever
+      version it is stamped with, and is left to the version gate to accept or
+      refuse.
+    - A schema holding relations of the index's own names with no such stamp is
+      refused, since a name is not evidence.  An index another ingest is part
+      way through building looks like this for as long as that takes, and is
+      answered the same way: running again once it has finished is what the
+      refusal says to do.
+    - A schema holding any relation the index does not own is refused, stamp or
+      no stamp.
+
+    The question is asked of one schema, not of the database: the one the index
+    resolves to, which is where a stamp of ours was found, or, for a database
+    that reaches no stamp at all, the one a table created without a schema name
+    lands in.  Every other schema of the database belongs to whoever made it and
+    is neither read nor named.
+
+    Parameters:
+        engine: The open engine.
+        url: The URL as messages name it.
+
+    Returns:
+        The schema to create the index in.
+
+    Raises:
+        ValueError: If that schema holds anything this did not create, or if the
+            connection reaches no schema a table could be created in.
+    """
+    with engine.connect() as connection:
+        schema = resolved_schema(connection)
+        if schema is None:
+            schema = creation_schema(connection)
+        if schema is None:
+            raise _IndexOpenError(
+                f'{url}: this connection reaches no schema a table can be created in, so '
+                f'there is nowhere to build a results index. Name a schema that exists with '
+                f'options=-csearch_path=schemaname, or create one on the server first.'
+            )
+        held = relations_in(connection, schema)
+        if not held:
+            return schema
+        if not carries_the_stamp_marks(connection, schema) or any(
+            name not in INDEX_TABLE_NAMES for name in held
+        ):
+            raise _index_schema_refusal(url, schema, held)
+    return schema
+
+
+def _create_schema(engine: Engine, schema: str) -> None:
     """Create every missing table and stamp the database with its version.
+
+    Every table is named with its schema, so a name this creates cannot resolve
+    through a search path onto a table of that name in another schema and be
+    built over it.  The whole of the index therefore lands in one schema, which
+    is the schema the drop later removes it from.
 
     Parameters:
         engine: The engine to create the schema in.
+        schema: The schema to create the tables in, from
+            :func:`_schema_to_create_in`.
     """
-    METADATA.create_all(engine)
+    bound = index_tables_in(schema)
+    stamp_table = bound[SCHEMA_META.name]
+    # Every table of that mapping shares one metadata container, which is what
+    # creates them together and in dependency order.
+    stamp_table.metadata.create_all(engine)
     with engine.begin() as connection:
-        stamped = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).first()
+        stamped = connection.execute(sqlalchemy.select(stamp_table.c.schema_version)).first()
         if stamped is None:
             connection.execute(
-                SCHEMA_META.insert().values(
+                stamp_table.insert().values(
                     singleton=1,
                     schema_version=SCHEMA_VERSION,
                     created_utc=datetime.datetime.now(datetime.UTC).isoformat(),
@@ -619,9 +740,17 @@ def _sqlite_target(parsed: URL, url: str, access: _Access) -> Path | None:
         )
     path = _sqlite_path(parsed)
     if path is None:
+        if access.must_exist:
+            raise _IndexOpenError(
+                f'{url}: this URL names an in-memory SQLite database, which holds nothing '
+                f'when it is opened and is gone when it is closed, so nothing else can ever '
+                f'have written one. Name the database file itself. {access.absent_remedy}'
+            )
         return None
     if access.must_exist and not path.exists():
-        raise _IndexOpenError(f'{url}: there is no results index at {path}. {access.absent_remedy}')
+        raise _IndexOpenError(
+            f'{url}: there is no {access.opening} at {path}. {access.absent_remedy}'
+        )
     if access.writing:
         _require_writable_sqlite_database(path, url, access)
     return path
@@ -665,14 +794,20 @@ def _build_engine(url: str, access: _Access) -> Engine:
                 with engine.connect():
                     pass
             return engine
+        # Which schema to build in is settled before a column of the database is
+        # read, because a schema that is not this index's own is one whose
+        # columns are nobody's business here: reading a stamp out of a stranger's
+        # schema_meta first would answer a wrong URL with whatever that statement
+        # fell over rather than with the diagnosis.
+        schema = _schema_to_create_in(engine, safe_url) if access.creating else None
         # The stamped version is checked before anything is written: creating
         # this version's tables inside a database stamped with another version
         # would leave a mixture no single version number describes.
         stamped = _stamped_version(engine)
         if stamped is not None:
             _verify_schema_version(stamped, safe_url)
-        if access.creating:
-            _create_schema(engine)
+        if schema is not None:
+            _create_schema(engine, schema)
             stamped = _stamped_version(engine)
         # The gate a non-creating open is refused by.  Reached after the create
         # branch too, where it re-reads the row that branch has just written and
@@ -715,7 +850,7 @@ def _translated(url: str, access: _Access) -> Engine:
         # What it does name is the piece of the URL it stopped on, which is why
         # the quoted message is cleaned as well as the URL beside it.
         raise ValueError(
-            f'{masked_url(url)}: could not open {access.opening} '
+            f'{masked_url(url)}: could not open the {access.opening} '
             f'({type(exc).__name__}: {without_credentials(str(exc), url)}).'
         ) from exc
 
@@ -735,6 +870,20 @@ def open_index(url: str, *, create: bool = False) -> Engine:
     -- missing tables are created and the version row is written, and a database
     the filesystem will not let this user write is refused before anything is
     opened.
+
+    **A creating open never stamps a schema that already holds tables SpinDoctor
+    did not create.**  The tables go into one schema: the one a stamp of
+    SpinDoctor's was found in, or, for a database carrying no such stamp, the one
+    a table created without a schema name lands in.  That schema is created in
+    when it holds nothing, and gone on with when it carries a stamp of
+    SpinDoctor's, whatever version that stamp names.  It is refused when it holds
+    a table of one of the index's own names with no such stamp over it -- a name
+    is not evidence, and a stamp written beside a stranger's table would make it
+    this index's for every later reading -- and refused when it holds any table
+    the index does not own, stamp or no stamp, since a results index owns the
+    schema it lives in.  A refusal names the schema and the tables it found and
+    creates nothing, stamps nothing and leaves that schema exactly as it was.
+    Every other schema of the database is neither read nor named.
 
     Either way a database stamped with a different schema version is refused,
     naming both versions, because the index carries no migrations and rebuilding
@@ -764,8 +913,10 @@ def open_index(url: str, *, create: bool = False) -> Engine:
             refuses the file -- because its filesystem cannot honor write
             locking, or for any other cause it reports -- or the file cannot be
             written and ``create`` is true; if ``create`` is false and the
-            database or its ``schema_meta`` row does not exist; or if the
-            stamped schema version is not the one this code reads.
+            database or its ``schema_meta`` row does not exist; if ``create`` is
+            true and the schema the index resolves to holds tables no stamp of
+            SpinDoctor's stands over, or any table the index does not own; or if
+            the stamped schema version is not the one this code reads.
     """
     return _translated(url, _INGESTING if create else _READING)
 

--- a/src/spindoctor/results_index/engine.py
+++ b/src/spindoctor/results_index/engine.py
@@ -43,7 +43,7 @@ from sqlalchemy.engine import URL, Engine
 from spindoctor.results_index.masking import masked_url, without_credentials
 from spindoctor.results_index.schema import METADATA, SCHEMA_META, SCHEMA_VERSION
 
-__all__ = ['SQLITE_BUSY_TIMEOUT_MS', 'open_database', 'open_index', 'stamped_version']
+__all__ = ['SQLITE_BUSY_TIMEOUT_MS', 'open_database', 'open_index']
 
 SQLITE_BUSY_TIMEOUT_MS = 30000
 """How long a SQLite connection waits for a competing writer before failing.
@@ -68,11 +68,23 @@ _SQLITE_NOT_A_DATABASE = 'SQLITE_NOTADB'
 _SQLITE_CANNOT_OPEN = 'SQLITE_CANTOPEN'
 """Result code SQLite gives for a path it cannot open, whatever the reason."""
 
-_SQLITE_LOCK_REFUSED_PREFIXES = ('SQLITE_BUSY', 'SQLITE_IOERR')
-"""Prefixes of the result codes that say the write lock itself was not granted.
+_SQLITE_BUSY_PREFIX = 'SQLITE_BUSY'
+"""Prefix of the result codes that say somebody else holds the write lock.
 
-These are the codes a filesystem that cannot honor SQLite locking produces, and
-the only ones for which moving the index to a server is the remedy.
+A lock another process is holding is the ordinary reason: an ingest of this
+index is running, or a session was left open on it.  A filesystem that cannot
+honor SQLite locking produces this code too, which is why the remedy for that is
+offered second rather than asserted first -- the common cause is a live writer,
+and telling an operator to rebuild their deployment over one is telling them to
+solve the wrong problem.
+"""
+
+_SQLITE_LOCK_REFUSED_PREFIXES = ('SQLITE_IOERR',)
+"""Prefixes of the result codes a filesystem that cannot lock produces.
+
+Distinct from a busy lock: this is the layer under SQLite failing to carry the
+locking operation at all, which no waiting fixes and which moving the index to a
+server does.
 """
 
 _SUPPORTED_URL_FORMS = (
@@ -85,8 +97,8 @@ _SUPPORTED_URL_FORMS = (
 class _Access:
     """What a caller means to do with the database it is opening.
 
-    The three openers differ in four independent ways, and spelling each one out
-    is what keeps them from being inferred from one another.  A drop, in
+    The three accesses differ in four independent ways, and spelling each one
+    out is what keeps them from being inferred from one another.  A drop, in
     particular, writes a database it does not create and reads a version it does
     not require, which no combination of "create" and "read" describes.
 
@@ -110,6 +122,10 @@ class _Access:
             because the file itself may be perfectly writable.
         absent_remedy: What to do about a SQLite path that is not there.  Empty
             for an access that creates one, which is never refused for it.
+        opening: What this access is opening, as a failure names it.  A drop is
+            pointed at databases that are not indexes, which is the whole of why
+            it exists, so reporting that one of those "could not be opened as
+            the results index" would name a fault of its own making.
     """
 
     creating: bool
@@ -120,6 +136,7 @@ class _Access:
     write_remedy: str = ''
     directory_remedy: str = ''
     absent_remedy: str = ''
+    opening: str = 'the results index'
 
 
 _READING = _Access(
@@ -157,6 +174,7 @@ _DROPPING = _Access(
         'file, and removing it removes the index.'
     ),
     absent_remedy='Nothing was dropped.',
+    opening='the database',
 )
 """The drop: a database that is there is opened whatever it holds.
 
@@ -420,6 +438,15 @@ def _sqlite_probe_failure(
         )
     if error_name.startswith(_SQLITE_CANNOT_OPEN):
         return _IndexOpenError(_cannot_open_message(exc, url, path))
+    if error_name.startswith(_SQLITE_BUSY_PREFIX):
+        return _IndexOpenError(
+            f'{url}: could not take a SQLite write lock within {SQLITE_BUSY_TIMEOUT_MS} ms '
+            f'({exc.orig}). Another process is holding it: an ingest of this index, or a '
+            f'session left open on it. Wait for that to finish and run this again. If '
+            f'nothing else is using this file, then its filesystem is not honoring SQLite '
+            f'locking, and a postgresql+psycopg: URL is how one index is shared across '
+            f'machines.'
+        )
     if error_name.startswith(_SQLITE_LOCK_REFUSED_PREFIXES):
         return _IndexOpenError(
             f'{url}: could not take a SQLite write lock ({exc.orig}). A SQLite index '
@@ -519,11 +546,12 @@ def _create_schema(engine: Engine) -> None:
             )
 
 
-def stamped_version(engine: Engine) -> int | None:
+def _stamped_version(engine: Engine) -> int | None:
     """Return the schema version the database is stamped with.
 
-    Read by the version gate, and reported by the drop, which names the version
-    it is about to remove precisely because that version may not be this one.
+    Read by the version gate, and by nothing else: the drop reads its own,
+    because it reads one out of a named schema and tolerates a value that is not
+    a version, neither of which the gate does.
 
     Parameters:
         engine: The engine to inspect.
@@ -626,16 +654,26 @@ def _build_engine(url: str, access: _Access) -> Engine:
             sqlalchemy.event.listen(engine, 'connect', _sqlite_on_connect)
             _probe_sqlite_access(engine, safe_url, path, access)
         if not access.gated:
+            if backend != _SQLITE_BACKEND:
+                # Reading the stamp is what reaches the server for every other
+                # access.  An ungated open that returned here would hand back an
+                # engine that has never connected to anything, and a URL naming
+                # a database the server does not have, a password it refuses or
+                # a host nothing answers on would surface later as some
+                # statement failing rather than as this URL not opening -- which
+                # is the difference between a diagnosis and a symptom.
+                with engine.connect():
+                    pass
             return engine
         # The stamped version is checked before anything is written: creating
         # this version's tables inside a database stamped with another version
         # would leave a mixture no single version number describes.
-        stamped = stamped_version(engine)
+        stamped = _stamped_version(engine)
         if stamped is not None:
             _verify_schema_version(stamped, safe_url)
         if access.creating:
             _create_schema(engine)
-            stamped = stamped_version(engine)
+            stamped = _stamped_version(engine)
         # The gate a non-creating open is refused by.  Reached after the create
         # branch too, where it re-reads the row that branch has just written and
         # so cannot fail; no test can observe that call refusing anything.
@@ -677,7 +715,7 @@ def _translated(url: str, access: _Access) -> Engine:
         # What it does name is the piece of the URL it stopped on, which is why
         # the quoted message is cleaned as well as the URL beside it.
         raise ValueError(
-            f'{masked_url(url)}: could not open the results index '
+            f'{masked_url(url)}: could not open {access.opening} '
             f'({type(exc).__name__}: {without_credentials(str(exc), url)}).'
         ) from exc
 
@@ -752,7 +790,11 @@ def open_database(url: str) -> Engine:
 
     Nothing is read out of the database through this, so no column the version
     gate protects is ever touched.  What the caller may do with it is name
-    tables, and the only names it has come from the schema metadata.
+    tables, and the only names it has come from the schema metadata.  The
+    connection is taken all the same, and taken here: reading the stamp is what
+    reaches the server for the other opener, and an engine handed back without
+    it would turn a database that is not there, or a password the server
+    refuses, into whatever statement the caller ran first.
 
     Parameters:
         url: A ``sqlite:`` URL naming an existing local path, or a

--- a/src/spindoctor/results_index/masking.py
+++ b/src/spindoctor/results_index/masking.py
@@ -1,0 +1,397 @@
+"""The rule that decides which part of a connection URL is a credential.
+
+A connection URL reaches a person in several places -- a refusal naming the
+index that could not be opened, a run log recording the command line a program
+was given -- and one part of it is a password.  The rule that hides it is stated
+here, once, so that everything putting a URL in front of a person hides the same
+characters: the opener in :mod:`spindoctor.results_index.engine`, the refusals
+of :mod:`spindoctor.results_index.roots` and
+:mod:`spindoctor.results_index.selection`, and
+:func:`spindoctor.support.command_line.masked_command_line`, which decides which
+words of a command line are URLs and applies this rule to each of them.
+
+It is a structural rule over the string rather than a parse.  A parsed URL
+renders itself with its password hidden but renders a ``?password=`` query
+parameter verbatim, and that parameter authenticates exactly as the authority
+form does, so adopting the parser for the URLs it accepts would adopt its blind
+spot with it.  The URLs a parser refuses are also the ones a refusal quotes back
+most often, since being unreadable is what the refusal is about.
+
+Two questions are asked of a URL here.  :func:`masked_url` renders the URL
+itself with its credentials replaced.  :func:`without_credentials` cleans a
+message that quoted a piece of that URL back, which is a different problem: a
+driver reports the fragment it stopped on rather than a field of the URL, so
+what has to go is every run of the credential rather than a span of the string.
+"""
+
+import re
+
+__all__ = ['masked_url', 'without_credentials']
+
+_HIDDEN_PASSWORD = '***'
+"""What a password is replaced by, matching what a parsed URL renders itself as."""
+
+_SQLITE_SCHEME = 'sqlite'
+"""Scheme of the one URL form that names a local path instead of a server.
+
+Such a URL has no credentials at all, and a path is free to carry the colons,
+at-signs and question marks that would otherwise read as some.
+"""
+
+_CREDENTIAL_QUERY_MARKERS = ('password', 'passwd', 'pwd', 'secret', 'token', 'credential')
+"""Text that makes a query parameter's value a credential rather than a setting.
+
+A connection URL may carry its password as a query parameter instead of in the
+authority -- ``postgresql+psycopg://user@host/db?password=...`` authenticates
+exactly as the authority form does -- and a driver accepts any parameter its
+library knows, so the name is matched by what it contains rather than against a
+fixed list.  Over-hiding a setting whose name says credential costs a word of a
+message; under-hiding one puts a working password in a run log.
+"""
+
+_QUERY_SEPARATOR = re.compile(r'([;&])')
+"""What separates one query parameter from the next, kept by the split.
+
+A connection URL's query is separated by ``&`` or by ``;``: libpq accepts
+either, and so does every driver built on it.  The separator is captured so
+that a masked query is rebuilt with the separators it was written with.
+"""
+
+_SHORTEST_HIDDEN_RUN = 3
+"""Shortest run of a credential that is hidden where something quotes one back.
+
+A message quoting a URL back rarely quotes the whole of it.  A driver that could
+not read a URL reports the fragment it stopped on, and that fragment is a slice
+of the string rather than a field of it: SQLAlchemy reads
+``user:se@cr:etpassword@host`` as a host and a port, and says it could not read
+``etpassword@host`` as a number.  Only the credential itself says which slices
+are its own, so every run of one that appears in a quoted message is replaced.
+
+Three characters is where that stops being worth doing.  Shorter runs collide
+with ordinary words often enough to turn a diagnosis into a row of markers, and
+a secret disclosed three characters at a time, with neither the order of the
+runs nor the gaps between them, is not disclosed.  A credential shorter than
+that is hidden whole, since there is nothing to be lost by mangling a message
+about a two-character password.
+"""
+
+
+def _scheme_base(url: str) -> str:
+    """Return the backend a URL's scheme names, whatever driver it asks for.
+
+    Parameters:
+        url: The URL as the caller wrote it.
+
+    Returns:
+        The scheme with any ``+driver`` suffix and surrounding space removed and
+        lower cased, or an empty string when the string carries no scheme.
+    """
+    scheme, separator, _remainder = url.partition(':')
+    if not separator:
+        return ''
+    return scheme.strip().split('+', 1)[0].lower()
+
+
+def _authority_start(url: str) -> int:
+    """Return the index at which a URL's authority section begins.
+
+    A scheme is only recognized as one when a ``/`` follows its ``:``.  Without
+    that slash the text before the colon reads equally as a scheme and as a user
+    name -- ``postgresql:svc:pw@host/db`` and ``svc:pw@host/db`` are the same
+    shape -- and reading it as a scheme is what leaves the password of the
+    second one visible.  It is therefore read as a user name in both, which
+    hides the first one's user name along with its password.  That is one word
+    of a message about a URL no driver would have accepted anyway; the other
+    reading loses a working password.
+
+    Every slash of the run is consumed, however many there are.  Two is the
+    spelling a URL is defined with and one is what a hand-edited setting
+    arrives as, but three is an ordinary spelling too -- ``postgresql:///db``
+    omits the host to name a local socket, and ``sqlite:///path`` habituates
+    the form -- and a rule that stopped counting at two would leave the
+    authority start on a slash, which reads as a path beginning before any
+    password and returns the URL whole.
+
+    Parameters:
+        url: The URL as the caller wrote it.
+
+    Returns:
+        The index just past the scheme and the slashes that open the authority.
+    """
+    colon = url.find(':')
+    start = 0
+    if colon >= 0 and url[colon + 1 : colon + 2] == '/':
+        prefix = url[:colon]
+        # A '/' or an '@' before the colon puts the colon inside the authority
+        # rather than after a scheme, whatever follows it.
+        if '/' not in prefix and '@' not in prefix:
+            start = colon + 1
+    end = start
+    while url[end : end + 1] == '/':
+        end += 1
+    return end
+
+
+def _password_span(url: str) -> tuple[int, int] | None:
+    """Return the half-open range of characters holding a URL's password.
+
+    The rule is the one a URL's own grammar states.  The user name runs from the
+    start of the authority to the first ``:``; only a ``:`` introduces a
+    password, and that password runs to the ``@`` that ends the credentials.
+
+    Which ``@`` ends them is the whole question.  It is the **last** one in the
+    string.  A user name is free to carry one -- ``user@servername`` is the
+    login form of a managed server -- and so is a password: ``p@ssword``,
+    ``p@ss/word`` and ``pw:with@both`` are all things an operator types.  Every
+    narrower choice stops inside a password that carries the character it stops
+    at.  Ending at the ``@`` before the first ``/`` leaves the tail of
+    ``p@ss/word`` in the message; ending at the last ``@`` before a ``#``
+    leaves the tail of ``pw@part#rest``.  The last ``@`` is the only bound that
+    cannot stop early, because the span it produces contains every other
+    candidate span.
+
+    What that costs is over-masking a URL whose real credentials end sooner and
+    whose tail happens to carry an ``@`` -- a fragment such as
+    ``...?password=x#note@host`` is masked to its last character.  A connection
+    URL has no use for a fragment, so that is a mangled message about a URL no
+    driver would have accepted, against a working password in a run log.
+
+    One shape is genuinely ambiguous: ``host:5432/path@name`` reads equally as a
+    host with a port and a path, or as a user name with a password that carries
+    a slash.  It is read as credentials, which is how the URL parser itself
+    reads it -- for the spelling of that shape a parser accepts, this rule and
+    ``render_as_string()`` hide the same characters.  Reading it as a port
+    instead would leave a password beginning with digits, ``123/secret``, in
+    every message; the cost of the reading taken is a mangled host and database
+    name in a message about a URL that was already unusable.
+
+    Parameters:
+        url: The URL as the caller wrote it.
+
+    Returns:
+        The first and last-plus-one index of the password, or None when the URL
+        carries no password to hide.
+    """
+    start = _authority_start(url)
+    colon = url.find(':', start)
+    if colon < 0:
+        return None
+    slash = url.find('/', start)
+    if 0 <= slash < colon:
+        # The authority ended before any colon, so what follows is a path.
+        return None
+    at = url.rfind('@', colon)
+    if at < 0:
+        return None
+    return colon + 1, at
+
+
+def _names_a_credential(name: str) -> bool:
+    """Whether a query parameter's name says its value is a credential.
+
+    Parameters:
+        name: The parameter's name, as written.
+
+    Returns:
+        True when the name carries one of :data:`_CREDENTIAL_QUERY_MARKERS`.
+    """
+    return any(marker in name.strip().lower() for marker in _CREDENTIAL_QUERY_MARKERS)
+
+
+def _masked_parameter(parameter: str) -> str:
+    """Return one query parameter with its value replaced if it is a credential.
+
+    Parameters:
+        parameter: The parameter as written, ``name=value`` or a bare name.
+
+    Returns:
+        The parameter, with its value replaced when its name says credential.
+    """
+    name, separator, _value = parameter.partition('=')
+    if not separator:
+        return parameter
+    if not _names_a_credential(name):
+        return parameter
+    return f'{name}={_HIDDEN_PASSWORD}'
+
+
+def _query_span(url: str) -> tuple[int, int] | None:
+    """Return the half-open range of characters holding a URL's query string.
+
+    Parameters:
+        url: The URL as the caller wrote it.
+
+    Returns:
+        The first and last-plus-one index of the query, without its leading
+        ``?`` and without any fragment after it, or None when the URL carries no
+        query at all.
+    """
+    start = url.find('?')
+    if start < 0:
+        return None
+    end = url.find('#', start)
+    return start + 1, len(url) if end < 0 else end
+
+
+def _query_pieces(url: str) -> list[str]:
+    """Split a URL's query into its parameters and the separators between them.
+
+    Parameters:
+        url: The URL as the caller wrote it, which must carry a query.
+
+    Returns:
+        The parameters at even positions and the separators at odd ones.  A
+        query is separated by ``&`` or by ``;``, both of which libpq and the
+        drivers accept, and splitting on one alone leaves a parameter written
+        with the other unexamined; the separators are kept so that a masked
+        query is rebuilt with the ones it was written with.
+    """
+    span = _query_span(url)
+    if span is None:
+        return []
+    first, past_last = span
+    return _QUERY_SEPARATOR.split(url[first:past_last])
+
+
+def _masked_query(url: str) -> str:
+    """Return a URL with the value of every credential query parameter replaced.
+
+    Run after the authority has been masked, so that a ``?`` inside a password
+    has already gone with the password and cannot be mistaken for the start of a
+    query.
+
+    Parameters:
+        url: The URL, with its authority already masked.
+
+    Returns:
+        The URL with any credential-bearing parameter hidden.
+    """
+    span = _query_span(url)
+    if span is None:
+        return url
+    first, past_last = span
+    pieces = _query_pieces(url)
+    masked = [
+        piece if index % 2 else _masked_parameter(piece) for index, piece in enumerate(pieces)
+    ]
+    if masked == pieces:
+        return url
+    return f'{url[:first]}{"".join(masked)}{url[past_last:]}'
+
+
+def masked_url(url: str) -> str:
+    """Return a URL string with every credential in it replaced.
+
+    Anything that puts a connection URL in front of a person -- a refusal whose
+    parsing is what failed, a run log recording the command line it was given --
+    calls this, so that one structural rule decides what a credential is.  It is
+    the only rule: a parsed URL renders itself with its password hidden, but it
+    renders a ``?password=`` query parameter verbatim, so adopting the parser
+    for the URLs it accepts would adopt its blind spot with it.
+
+    Everything outside a credential survives, because naming the URL is what
+    tells a reader which of the resolution levels supplied the value.
+
+    A ``sqlite:`` URL is returned exactly as it came.  It names a local
+    filesystem path, which has no credentials at all, and a path is free to carry
+    the colons, at-signs and question marks that would otherwise read as some.
+
+    A results root is not a connection URL and is never passed here.  It has no
+    credentials to hide, and a root is the one string an operator reads a run
+    log to correct, so mangling one costs more than it protects.
+
+    Parameters:
+        url: The URL as the caller wrote it.
+
+    Returns:
+        The URL with its credentials, if any, masked.
+    """
+    if _scheme_base(url) == _SQLITE_SCHEME:
+        return url
+    span = _password_span(url)
+    if span is not None:
+        first, past_last = span
+        url = f'{url[:first]}{_HIDDEN_PASSWORD}{url[past_last:]}'
+    return _masked_query(url)
+
+
+def _credentials(url: str) -> list[str]:
+    """Return every credential a URL carries, exactly as it is written.
+
+    The same structural rule :func:`masked_url` masks by, read as values rather
+    than as spans, so that what a message quotes back is measured against the
+    same idea of a credential the URL itself is.
+
+    Parameters:
+        url: The URL as the caller wrote it.
+
+    Returns:
+        The password from the authority and the value of every credential-
+        bearing query parameter, skipping the empty ones.  A ``sqlite:`` URL is
+        a local filesystem path and carries none.
+    """
+    if _scheme_base(url) == _SQLITE_SCHEME:
+        return []
+    found: list[str] = []
+    span = _password_span(url)
+    if span is not None:
+        first, past_last = span
+        found.append(url[first:past_last])
+    for index, piece in enumerate(_query_pieces(url)):
+        name, separator, value = piece.partition('=')
+        if not index % 2 and separator and _names_a_credential(name):
+            found.append(value)
+    return [secret for secret in found if secret]
+
+
+def _without_runs_of(text: str, secret: str) -> str:
+    """Return text with every run of one secret in it replaced.
+
+    Parameters:
+        text: The text to clean, which is not a URL and cannot be masked as one.
+        secret: The credential whose runs are to go.
+
+    Returns:
+        The text, with every run of :data:`_SHORTEST_HIDDEN_RUN` or more
+        characters that also appears in the secret replaced, and a secret
+        shorter than that replaced wherever it appears whole.  Scanned from the
+        left, taking the longest run at each position: a run left over when a
+        shorter one has been replaced is examined again at the position it
+        resumes from, so no run of the secret survives in part.
+    """
+    kept: list[str] = []
+    index = 0
+    while index < len(text):
+        length = 0
+        while index + length < len(text) and text[index : index + length + 1] in secret:
+            length += 1
+        if length and length >= min(_SHORTEST_HIDDEN_RUN, len(secret)):
+            kept.append(_HIDDEN_PASSWORD)
+            index += length
+        else:
+            kept.append(text[index])
+            index += 1
+    return ''.join(kept)
+
+
+def without_credentials(text: str, url: str) -> str:
+    """Return a message quoting a URL back with the credentials of that URL gone.
+
+    Masking the URL a refusal names is not enough on its own.  A refusal also
+    quotes what the failure underneath it said, and a driver that could not read
+    a URL says so by quoting the piece of it that stopped it -- which, for a
+    password carrying an ``@`` and a ``:``, is a run of the password in
+    cleartext.  Such a message travels: it is written to run logs, returned in a
+    cloud task's result, and collected into event logs an operator concatenates
+    and hands on.
+
+    Parameters:
+        text: What the underlying failure said.
+        url: The URL it was raised about, as the caller wrote it.
+
+    Returns:
+        The text with every run of every credential of that URL replaced.
+    """
+    for secret in _credentials(url):
+        text = _without_runs_of(text, secret)
+    return text

--- a/src/spindoctor/results_index/roots.py
+++ b/src/spindoctor/results_index/roots.py
@@ -29,7 +29,7 @@ from pathlib import Path
 import sqlalchemy
 from filecache import FCPath
 
-from spindoctor.results_index.engine import masked_url
+from spindoctor.results_index.masking import masked_url
 from spindoctor.results_index.schema import INGEST_RUNS
 
 __all__ = [

--- a/src/spindoctor/results_index/scope.py
+++ b/src/spindoctor/results_index/scope.py
@@ -1,0 +1,202 @@
+"""Which schema of a database the results index's own tables live in.
+
+A server resolves an unqualified table name through a search path that may reach
+several schemas, so "where the index is" is a question about a schema rather
+than about a database.  The creating open and the drop both have to answer it,
+and they have to answer it the same way: what one builds is what the other
+removes, and a disagreement between them is a drop aimed at tables nobody
+created.
+
+**The stamp names the schema.**  ``schema_meta`` is the one table of the index
+whose shape says something.  Two of its columns are the marks: a version column
+is what any migration table carries, and a constant-keyed ``singleton`` beside
+it is what this one does, so the pair together is idiosyncratic where either
+alone is not.  The schema a bare ``schema_meta`` resolves to is therefore the
+schema the index lives in, and a database that reaches no such table holds no
+index of ours at all.
+
+**Two marks, not the whole column set.**  A database stamped by a schema version
+whose columns differ from this one's is exactly what a drop is pointed at, and
+requiring today's columns as evidence would withhold the drop from the case it
+exists for.  The marks are what a stamp of any version carries.
+
+**A schema a fresh table lands in is a different question**, and only a creating
+open asks it: a database with no stamp anywhere has no schema resolved for it,
+and the index is then built in the schema an unqualified ``CREATE TABLE`` would
+write to.
+"""
+
+import sqlalchemy
+
+from spindoctor.results_index.schema import METADATA, SCHEMA_META
+
+__all__ = [
+    'INDEX_TABLE_NAMES',
+    'STAMP_MARKS',
+    'carries_the_stamp_marks',
+    'creation_schema',
+    'index_tables_in',
+    'relations_in',
+    'resolved_schema',
+]
+
+INDEX_TABLE_NAMES = frozenset(table.name for table in METADATA.sorted_tables)
+"""Every table name the index owns, and the whole of what belongs to it.
+
+A schema holding a relation not named here holds something SpinDoctor did not
+create, whoever else created it and whatever it is for.
+"""
+
+STAMP_MARKS = ('singleton', 'schema_version')
+"""Columns whose presence in a ``schema_meta`` say SpinDoctor wrote it.
+
+Two rather than the whole column set, because a stamp left by a schema whose
+columns differed from this one's is exactly the database a drop is pointed at,
+and requiring today's columns would withhold the drop from it.  Two rather than
+one, because the pair is idiosyncratic: a version column is what any migration
+table carries, and a constant-keyed ``singleton`` beside it is what this one
+does.
+"""
+
+_POSTGRES_DIALECT = 'postgresql'
+"""Dialect name of every PostgreSQL driver, whichever one the URL asked for."""
+
+_VISIBLE_SCHEMA_SQL = """
+SELECT n.nspname
+  FROM pg_catalog.pg_class c
+  JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+ WHERE c.relname = :name
+   AND c.relkind IN ('r', 'p', 'f')
+   AND pg_catalog.pg_table_is_visible(c.oid)
+"""
+"""Which schema an unqualified table name resolves to on this connection.
+
+PostgreSQL resolves a bare name through the search path, and the catalog is the
+only thing that can say where it landed.  ``pg_table_is_visible`` is that rule
+itself, so at most one row comes back: the table the server would have reached,
+in the schema it lives in.
+"""
+
+_CREATION_SCHEMA_SQL = 'SELECT current_schema()'
+"""Which schema an unqualified ``CREATE TABLE`` writes to on this connection.
+
+The first schema of the search path that exists.  A path naming none that exist
+answers with nothing, which is a connection no table can be created through.
+"""
+
+
+def resolved_schema(connection: sqlalchemy.Connection) -> str | None:
+    """Return the schema an unqualified ``schema_meta`` resolves to.
+
+    The same resolution the rest of the system's statements get, asked once and
+    then written down, rather than repeated per table where two tables of these
+    names in two schemas would answer differently.
+
+    Only a table answers, never a view of that name: what is being looked for is
+    the object a ``CREATE TABLE`` of the index's would have found already there.
+
+    Parameters:
+        connection: An open connection to the database.
+
+    Returns:
+        The schema name, or None when this connection reaches no ``schema_meta``
+        at all.
+    """
+    if connection.dialect.name == _POSTGRES_DIALECT:
+        found = connection.execute(
+            sqlalchemy.text(_VISIBLE_SCHEMA_SQL), {'name': SCHEMA_META.name}
+        ).scalar()
+        return None if found is None else str(found)
+    # Every other backend this supports has one namespace per database, which
+    # the inspector names: "main" for SQLite.  Naming it rather than leaving it
+    # implicit is what keeps the two backends on one code path.
+    inspector = sqlalchemy.inspect(connection)
+    schema = inspector.default_schema_name
+    if schema is None or SCHEMA_META.name not in inspector.get_table_names(schema=schema):
+        return None
+    return schema
+
+
+def creation_schema(connection: sqlalchemy.Connection) -> str | None:
+    """Return the schema a table created without a schema name lands in.
+
+    Asked of a database that reaches no stamp of ours, which is the database an
+    index is about to be built in.  Naming that schema is what keeps the six
+    tables together in one of them: a name resolved through the search path is
+    free to find a table of that name somewhere else and be built over it, and a
+    name qualified with the schema a fresh table lands in is not.
+
+    Parameters:
+        connection: An open connection to the database.
+
+    Returns:
+        The schema name, or None when the connection's search path names no
+        schema that exists, which is a connection nothing can be created
+        through.
+    """
+    if connection.dialect.name == _POSTGRES_DIALECT:
+        found = connection.execute(sqlalchemy.text(_CREATION_SCHEMA_SQL)).scalar()
+        return None if found is None else str(found)
+    schema = sqlalchemy.inspect(connection).default_schema_name
+    return None if schema is None else str(schema)
+
+
+def carries_the_stamp_marks(connection: sqlalchemy.Connection, schema: str) -> bool:
+    """Report whether a schema's ``schema_meta`` carries SpinDoctor's own marks.
+
+    Parameters:
+        connection: An open connection to the database.
+        schema: The schema whose ``schema_meta`` is to be examined.
+
+    Returns:
+        True when that schema holds a ``schema_meta`` carrying every column of
+        :data:`STAMP_MARKS`, whatever else it carries and whatever version it
+        is stamped with.  False when it holds no such table, or one carrying
+        only some of the marks, which is what any table of that name is free to
+        carry.
+    """
+    inspector = sqlalchemy.inspect(connection)
+    if SCHEMA_META.name not in inspector.get_table_names(schema=schema):
+        return False
+    columns = {column['name'] for column in inspector.get_columns(SCHEMA_META.name, schema=schema)}
+    return columns.issuperset(STAMP_MARKS)
+
+
+def index_tables_in(schema: str) -> dict[str, sqlalchemy.Table]:
+    """Return every table the index owns, named in one schema explicitly.
+
+    The schema is rendered into every statement built from these, so nothing
+    built from them can resolve through a search path onto a table in another
+    schema.  Every table of the answer belongs to one metadata container, which
+    is what creates them together and in dependency order.
+
+    Parameters:
+        schema: The schema the tables are to be named in.
+
+    Returns:
+        The tables, keyed by name.
+    """
+    metadata = sqlalchemy.MetaData(schema=schema)
+    return {table.name: table.to_metadata(metadata) for table in METADATA.sorted_tables}
+
+
+def relations_in(connection: sqlalchemy.Connection, schema: str) -> tuple[str, ...]:
+    """Return the name of every table and view one schema holds.
+
+    Tables and views together, because both are what an unqualified name
+    resolves to and what a ``CREATE TABLE`` of that name finds already there.
+    The indexes, sequences and constraints the index's own tables bring with
+    them are not relations of this kind and are never named here, so a schema
+    holding exactly one index answers with exactly its six tables.
+
+    Parameters:
+        connection: An open connection to the database.
+        schema: The schema to enumerate.
+
+    Returns:
+        The names, sorted, and empty for a schema holding neither.
+    """
+    inspector = sqlalchemy.inspect(connection)
+    tables = inspector.get_table_names(schema=schema)
+    views = inspector.get_view_names(schema=schema)
+    return tuple(sorted(set(tables) | set(views)))

--- a/src/spindoctor/results_index/selection.py
+++ b/src/spindoctor/results_index/selection.py
@@ -85,7 +85,8 @@ from pathlib import Path
 import sqlalchemy
 from filecache import FCPath
 
-from spindoctor.results_index.engine import masked_url, open_index
+from spindoctor.results_index.engine import open_index
+from spindoctor.results_index.masking import masked_url
 from spindoctor.results_index.roots import (
     newest_pass,
     normalize_root_url,

--- a/src/spindoctor/support/command_line.py
+++ b/src/spindoctor/support/command_line.py
@@ -98,7 +98,7 @@ def masked_command_line(command_list: Sequence[str]) -> list[str]:
     # the GUI imports elsewhere in the package: this module is reached by the
     # run banner of every program, including the ones that never open a
     # database, and the masking rule lives beside the URL parsing it mirrors.
-    from spindoctor.results_index.engine import masked_url
+    from spindoctor.results_index.masking import masked_url
 
     masked = list(command_list)
     for index, start in starts.items():

--- a/tests/spindoctor/cli/reproj/conftest.py
+++ b/tests/spindoctor/cli/reproj/conftest.py
@@ -24,6 +24,7 @@ from filecache import FCPath
 from sqlalchemy.engine import Engine
 from tests.spindoctor.cli.stats.conftest import metadata_document, write_metadata
 from tests.spindoctor.results_index.conftest import (
+    postgres_decoy_schema,
     postgres_schema,
     postgres_server_url,
     postgres_url,
@@ -41,7 +42,12 @@ from spindoctor.results_index import normalize_root_url, open_index
 # The pointing postgres tier runs against a schema of its own, exactly as the
 # results-index tier does; re-exporting rather than restating keeps one
 # definition of how that schema is created and dropped.
-__all__ = ['postgres_schema', 'postgres_server_url', 'postgres_url']
+__all__ = [
+    'postgres_decoy_schema',
+    'postgres_schema',
+    'postgres_server_url',
+    'postgres_url',
+]
 
 CMATRIX_ORIGINAL = [
     0.963676611721357,

--- a/tests/spindoctor/cli/stats/conftest.py
+++ b/tests/spindoctor/cli/stats/conftest.py
@@ -22,6 +22,7 @@ import pdslogger
 import pytest
 import sqlalchemy
 from tests.spindoctor.results_index.conftest import (
+    postgres_decoy_schema,
     postgres_schema,
     postgres_server_url,
     postgres_url,
@@ -42,7 +43,7 @@ from spindoctor.results_index import INGEST_RUNS, normalize_root_url, open_index
 # The statistics postgres tier runs against a schema of its own, exactly as the
 # results-index tier does; re-exporting rather than restating keeps one
 # definition of how that schema is created and dropped.
-__all__ = ['postgres_schema', 'postgres_server_url', 'postgres_url']
+__all__ = ['postgres_decoy_schema', 'postgres_schema', 'postgres_server_url', 'postgres_url']
 
 DATA_DIR = Path(__file__).resolve().parent / 'data'
 """Directory holding the fixture results tree and the frozen report output."""

--- a/tests/spindoctor/cli/stats/test_drop_cli.py
+++ b/tests/spindoctor/cli/stats/test_drop_cli.py
@@ -11,6 +11,7 @@ statement about them.
 """
 
 import io
+import sqlite3
 from pathlib import Path
 from typing import Any
 
@@ -18,11 +19,13 @@ import pdslogger
 import pytest
 import sqlalchemy
 
+from spindoctor.cli.stats.drop import _because
 from spindoctor.cli.stats.report import main_report
 from spindoctor.results_index import IMAGES, SCHEMA_VERSION, index_table_names, read_result_stubs
+from spindoctor.results_index import engine as engine_module
 
 from .conftest import index_url, ingest_tree, metadata_document, rows_of, write_metadata
-from .ingest_driver_helpers import run_driver
+from .ingest_driver_helpers import process, run_driver
 
 STUB = 'VOL/N1454725799_1_CALIB'
 """The stub of the document the trees below hold."""
@@ -41,6 +44,34 @@ CREDENTIALED_URL = f'postgresql+psycopg://ad@min:{SECRET}@127.0.0.1:1/spindoctor
 Port 1 refuses at once, so the refusal this drives is the connection failing
 rather than a name lookup waiting.
 """
+
+
+class _CodedError(Exception):
+    """A driver exception carrying the code a server would have returned.
+
+    Parameters:
+        sqlstate: The five-character code.
+    """
+
+    def __init__(self, sqlstate: str) -> None:
+        super().__init__(f'the server said {sqlstate}')
+        self.sqlstate = sqlstate
+
+
+def _failure_with(sqlstate: str) -> sqlalchemy.exc.SQLAlchemyError:
+    """Return the failure SQLAlchemy raises around a driver exception of one code.
+
+    Every one of these is reachable from a real server, and two of them are
+    reached in the postgres tier; asking each of them here is what keeps the
+    table of causes from losing a row unnoticed.
+
+    Parameters:
+        sqlstate: The five-character code the server returns.
+
+    Returns:
+        The wrapper, carrying the driver exception as its ``orig``.
+    """
+    return sqlalchemy.exc.OperationalError('DROP TABLE images', {}, _CodedError(sqlstate))
 
 
 def _tree_with_an_index(tmp_path: Path, logger: pdslogger.PdsLogger) -> str:
@@ -262,7 +293,7 @@ def test_the_question_names_the_index_it_is_about(
     url = _tree_with_an_index(tmp_path, quiet_logger)
     _answering(monkeypatch, 'n\n')
     _drop(url, monkeypatch, tmp_path)
-    assert f'from {url}?' in capsys.readouterr().out
+    assert f'from {url}, schema ' in capsys.readouterr().out
 
 
 def test_the_account_of_each_table_is_logged(
@@ -819,3 +850,719 @@ def test_a_rebuilt_index_carries_this_schema_version(
     finally:
         engine.dispose()
     assert stamped == SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# A database that does not prove it holds an index of ours
+# ---------------------------------------------------------------------------
+
+
+def _database_holding(tmp_path: Path, *statements: str) -> str:
+    """Build a database that SpinDoctor did not create, and return its URL.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+        statements: The statements that create what is in it.
+
+    Returns:
+        The database URL.
+    """
+    url = index_url(tmp_path / 'theirs.sqlite3')
+    engine = sqlalchemy.create_engine(url)
+    try:
+        with engine.begin() as connection:
+            for statement in statements:
+                connection.exec_driver_sql(statement)
+    finally:
+        engine.dispose()
+    return url
+
+
+def test_a_stranger_s_table_of_one_of_our_names_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A URL naming something that is not a SpinDoctor index is refused.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _database_holding(
+        tmp_path,
+        'CREATE TABLE images (id INTEGER PRIMARY KEY, caption TEXT)',
+        "INSERT INTO images (caption) VALUES ('somebody elses cat'), ('their dog')",
+        'CREATE TABLE customers (id INTEGER PRIMARY KEY, name TEXT)',
+    )
+    status, _written = _drop(url, monkeypatch, tmp_path, '--yes')
+    assert status == 1
+
+
+def test_such_a_refusal_names_the_tables_it_would_not_account_for(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An operator needs to know which tables stopped it, to decide about them.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _database_holding(tmp_path, 'CREATE TABLE images (id INTEGER PRIMARY KEY)')
+    _status, written = _drop(url, monkeypatch, tmp_path, '--yes')
+    assert any('images' in line and 'schema_meta' in line for line in written)
+
+
+def test_such_a_database_keeps_every_table(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The finding itself: two rows of somebody else's data, destroyed at exit 0.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _database_holding(
+        tmp_path,
+        'CREATE TABLE images (id INTEGER PRIMARY KEY, caption TEXT)',
+        "INSERT INTO images (caption) VALUES ('somebody elses cat'), ('their dog')",
+        'CREATE TABLE customers (id INTEGER PRIMARY KEY, name TEXT)',
+    )
+    _drop(url, monkeypatch, tmp_path, '--yes')
+    assert _tables(url) == ['customers', 'images']
+
+
+def test_such_a_database_keeps_the_rows_of_that_table(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Counted, because a table recreated empty passes a test that counts tables.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _database_holding(
+        tmp_path,
+        'CREATE TABLE images (id INTEGER PRIMARY KEY, caption TEXT)',
+        "INSERT INTO images (caption) VALUES ('somebody elses cat'), ('their dog')",
+    )
+    _drop(url, monkeypatch, tmp_path, '--yes')
+    engine = sqlalchemy.create_engine(url)
+    try:
+        with engine.connect() as connection:
+            remaining: Any = connection.exec_driver_sql('SELECT count(*) FROM images').scalar()
+    finally:
+        engine.dispose()
+    assert remaining == 2
+
+
+def test_such_a_database_is_never_called_the_results_index(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The account said "the SpinDoctor results index tables" over a stranger's rows.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _database_holding(tmp_path, 'CREATE TABLE images (id INTEGER PRIMARY KEY)')
+    _status, written = _drop(url, monkeypatch, tmp_path, '--yes')
+    assert not any(
+        line.startswith('About to drop the SpinDoctor results index') for line in written
+    )
+
+
+def test_nobody_is_asked_about_a_database_that_proves_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """There is no question to ask: the answer does not turn on consent.
+
+    Standard input holds a yes, which would drop an index that was there.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+        monkeypatch: Fixture the driver and standard input are run through.
+    """
+    url = _database_holding(tmp_path, 'CREATE TABLE images (id INTEGER PRIMARY KEY)')
+    _answering(monkeypatch, 'yes\n')
+    _drop(url, monkeypatch, tmp_path)
+    assert _tables(url) == ['images']
+
+
+# ---------------------------------------------------------------------------
+# What the messages name
+# ---------------------------------------------------------------------------
+
+
+def test_the_refusal_for_want_of_an_answer_names_the_index(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every message of a destructive command says which database it is about.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _answering(monkeypatch, '')
+    _status, written = _drop(url, monkeypatch, tmp_path)
+    assert any('Nothing was dropped from ' in line and url in line for line in written)
+
+
+def test_the_refusal_of_an_answer_that_is_not_yes_names_the_index(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same, for the refusal a person makes by typing one.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _answering(monkeypatch, 'n\n')
+    _status, written = _drop(url, monkeypatch, tmp_path)
+    assert any('rather than yes' in line and url in line for line in written)
+
+
+def test_the_reading_is_announced_before_it_is_done(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Counting the rows of a large index is a scan per table, and looks like a hang.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _status, written = _drop(url, monkeypatch, tmp_path, '--yes')
+    assert any(line.startswith('Reading what ') for line in written)
+
+
+def test_the_summary_names_the_schema_the_tables_are_in(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One URL reaches several schemas of a server, and only one holds the index.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _status, written = _drop(url, monkeypatch, tmp_path, '--yes')
+    about = [line for line in written if line.startswith('About to drop ')]
+    assert about[0].endswith(', schema main')
+
+
+# ---------------------------------------------------------------------------
+# Ctrl-C at the question
+# ---------------------------------------------------------------------------
+
+
+def _interrupting(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the confirmation raise ``KeyboardInterrupt``, as Ctrl-C does.
+
+    Parameters:
+        monkeypatch: Fixture the built-in reader is replaced through.
+    """
+
+    def interrupted(prompt: str = '') -> str:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr('builtins.input', interrupted)
+
+
+def test_ctrl_c_at_the_question_leaves_the_index_alone(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The refusal a person makes with a key rather than a word.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and the reader are replaced through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _interrupting(monkeypatch)
+    _drop(url, monkeypatch, tmp_path)
+    assert _tables(url) == sorted(index_table_names())
+
+
+def test_ctrl_c_at_the_question_exits_nonzero(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A script must not read success from a drop nobody agreed to.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and the reader are replaced through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _interrupting(monkeypatch)
+    status, _written = _drop(url, monkeypatch, tmp_path)
+    assert status == 1
+
+
+def test_ctrl_c_at_the_question_says_so_rather_than_raising(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every other refusal prints a line, and this one is not a traceback either.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and the reader are replaced through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _interrupting(monkeypatch)
+    _status, written = _drop(url, monkeypatch, tmp_path)
+    assert any('the question was interrupted' in line for line in written)
+
+
+# ---------------------------------------------------------------------------
+# The option a drop has nothing to do with
+# ---------------------------------------------------------------------------
+
+
+def test_a_drop_refuses_a_results_root_that_was_typed(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A drop reads no tree, so a root named on the command line meant something else.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _status, written = _drop(
+        url, monkeypatch, tmp_path, '--nav-results-root', str(tmp_path / 'results')
+    )
+    assert any('--nav-results-root' in line for line in written)
+
+
+def test_such_a_command_line_leaves_the_index_alone(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Refused before the open, so nothing is opened and nothing goes.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _drop(url, monkeypatch, tmp_path, '--yes', '--nav-results-root', str(tmp_path / 'results'))
+    assert _tables(url) == sorted(index_table_names())
+
+
+def test_a_results_root_from_the_environment_does_not_refuse_a_drop(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A machine's standing setting is not a request, so it is not a conflict.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and the environment are set through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    monkeypatch.setenv('NAV_RESULTS_ROOT', str(tmp_path / 'results'))
+    status, _written = _drop(url, monkeypatch, tmp_path, '--yes')
+    assert status == 0
+
+
+# ---------------------------------------------------------------------------
+# What a failure is blamed on
+# ---------------------------------------------------------------------------
+
+
+def test_a_live_writer_is_not_reported_as_a_filesystem_that_cannot_lock(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A running ingest is the ordinary cause, and rebuilding a deployment is not the fix.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and the busy timeout are set through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    monkeypatch.setattr(engine_module, 'SQLITE_BUSY_TIMEOUT_MS', 50)
+    holder = sqlite3.connect(tmp_path / 'index.sqlite3')
+    try:
+        holder.execute('BEGIN IMMEDIATE')
+        _status, written = _drop(url, monkeypatch, tmp_path, '--yes')
+    finally:
+        holder.rollback()
+        holder.close()
+    assert any('Another process is holding it' in line for line in written)
+
+
+def test_a_live_writer_leaves_the_index_alone(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The bound is what makes it a refusal rather than a wait.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and the busy timeout are set through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    monkeypatch.setattr(engine_module, 'SQLITE_BUSY_TIMEOUT_MS', 50)
+    holder = sqlite3.connect(tmp_path / 'index.sqlite3')
+    try:
+        holder.execute('BEGIN IMMEDIATE')
+        _drop(url, monkeypatch, tmp_path, '--yes')
+    finally:
+        holder.rollback()
+        holder.close()
+    assert _tables(url) == sorted(index_table_names())
+
+
+def test_an_unrecognized_failure_gets_no_cause_invented_for_it() -> None:
+    """A code this does not know is reported as the database worded it, and no more.
+
+    Parameters:
+        None.
+    """
+    assert _because(sqlalchemy.exc.SQLAlchemyError('something nobody enumerated')) == ''
+
+
+@pytest.mark.parametrize(
+    ('sqlstate', 'names'),
+    [
+        ('55P03', 'lock'),
+        ('2BP01', 'depends on'),
+        ('42501', 'does not own'),
+    ],
+    ids=['a-lock', 'a-dependent-object', 'a-privilege'],
+)
+def test_each_failure_a_server_reports_is_named_as_itself(sqlstate: str, names: str) -> None:
+    """Blaming a lock for a dependent view sends an operator hunting a session.
+
+    Parameters:
+        sqlstate: The five-character code the server returns.
+        names: What the message for it has to say.
+    """
+    assert names in _because(_failure_with(sqlstate))
+
+
+@pytest.mark.parametrize(
+    'sqlstate',
+    ['2BP01', '42501'],
+    ids=['a-dependent-object', 'a-privilege'],
+)
+def test_a_failure_that_is_not_a_lock_is_not_blamed_on_one(sqlstate: str) -> None:
+    """Which is what every drop failure was blamed on.
+
+    Parameters:
+        sqlstate: The five-character code the server returns.
+    """
+    assert 'Another session' not in _because(_failure_with(sqlstate))
+
+
+# ---------------------------------------------------------------------------
+# The five programs that open an index
+# ---------------------------------------------------------------------------
+
+
+def test_neither_state_lets_a_cloud_task_worker_ingest_a_share(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The worker opens without creating, so both states are the same refusal.
+
+    Parameters:
+        tmp_path: Directory the trees and the indexes live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    monkeypatch.delenv('NAV_RESULTS_DB', raising=False)
+    outcomes = []
+    for url in _dropped_and_never_built(tmp_path, quiet_logger, monkeypatch):
+        _retry, result = process(
+            {'root_url': str(tmp_path / 'results'), 'files': [], 'run_id': 1}, url
+        )
+        outcomes.append(result['status_error'])
+    assert outcomes == ['index_unopenable', 'index_unopenable']
+
+
+def test_neither_state_lets_a_fan_out_be_completed(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Completion opens without creating too, so a wrong URL is not a first run.
+
+    Parameters:
+        tmp_path: Directory the trees and the indexes live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    events = tmp_path / 'events.log'
+    events.write_text('', encoding='utf-8')
+    statuses = [
+        run_driver(
+            [
+                '--results-db',
+                url,
+                '--nav-results-root',
+                str(tmp_path / 'results'),
+                '--complete-cloud-tasks-file',
+                str(events),
+            ],
+            monkeypatch,
+            tmp_path,
+        )[0]
+        for url in _dropped_and_never_built(tmp_path, quiet_logger, monkeypatch)
+    ]
+    assert statuses == [1, 1]
+
+
+def test_both_states_are_rebuilt_by_the_ingest_that_creates(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The one opener that creates treats them alike as well: it builds one.
+
+    Parameters:
+        tmp_path: Directory the trees and the indexes live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    root = tmp_path / 'results'
+    statuses = [
+        run_driver(
+            ['--results-db', url, '--nav-results-root', root.as_posix()], monkeypatch, tmp_path
+        )[0]
+        for url in _dropped_and_never_built(tmp_path, quiet_logger, monkeypatch)
+    ]
+    assert statuses == [0, 0]
+
+
+def test_neither_state_lets_a_drop_find_anything_to_drop(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fifth opener is the drop's own, and it answers the two the same way.
+
+    An index that was dropped is a database holding none of these tables; one
+    that was never built is a SQLite path that is not there, which is refused on
+    both backends alike.  Both leave nothing behind and neither creates one.
+
+    Parameters:
+        tmp_path: Directory the trees and the indexes live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    dropped, never_built = _dropped_and_never_built(tmp_path, quiet_logger, monkeypatch)
+    assert _drop(dropped, monkeypatch, tmp_path, '--yes')[0] == 0
+    assert not Path(never_built.removeprefix('sqlite:///')).exists()
+
+
+# ---------------------------------------------------------------------------
+# The same command line against a server
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.postgres
+def test_a_server_database_holding_no_index_exits_zero(
+    postgres_url: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same status a SQLite database holding none of them exits with.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        tmp_path: Directory the run's log files are written under.
+        monkeypatch: Fixture the driver is run through.
+    """
+    status, _written = _drop(postgres_url, monkeypatch, tmp_path, '--yes')
+    assert status == 0
+
+
+@pytest.mark.postgres
+def test_a_server_database_that_is_not_there_is_refused(
+    postgres_server_url: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """As a SQLite path that is not there is: one flag, one answer, two backends.
+
+    Parameters:
+        postgres_server_url: URL of the server, unscoped.
+        tmp_path: Directory the run's log files are written under.
+        monkeypatch: Fixture the driver is run through.
+    """
+    absent = sqlalchemy.engine.make_url(postgres_server_url).set(database='ri_no_such_database')
+    status, _written = _drop(
+        absent.render_as_string(hide_password=False), monkeypatch, tmp_path, '--yes'
+    )
+    assert status == 1
+
+
+@pytest.mark.postgres
+def test_a_server_database_that_is_not_there_is_not_called_a_permissions_problem(
+    postgres_server_url: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """It was reported as tables that could not be read, over a database never reached.
+
+    Parameters:
+        postgres_server_url: URL of the server, unscoped.
+        tmp_path: Directory the run's log files are written under.
+        monkeypatch: Fixture the driver is run through.
+    """
+    absent = sqlalchemy.engine.make_url(postgres_server_url).set(database='ri_no_such_database')
+    _status, written = _drop(
+        absent.render_as_string(hide_password=False), monkeypatch, tmp_path, '--yes'
+    )
+    said = '\n'.join(written)
+    assert 'may read every table' not in said
+
+
+@pytest.mark.postgres
+def test_a_server_database_that_is_not_there_says_it_could_not_be_opened(
+    postgres_server_url: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Which is what happened, and what names the thing to fix.
+
+    Parameters:
+        postgres_server_url: URL of the server, unscoped.
+        tmp_path: Directory the run's log files are written under.
+        monkeypatch: Fixture the driver is run through.
+    """
+    absent = sqlalchemy.engine.make_url(postgres_server_url).set(database='ri_no_such_database')
+    _status, written = _drop(
+        absent.render_as_string(hide_password=False), monkeypatch, tmp_path, '--yes'
+    )
+    assert any('Cannot open the database' in line for line in written)
+
+
+@pytest.mark.postgres
+def test_a_dependent_view_is_not_reported_as_a_lock(
+    postgres_url: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, quiet_logger: Any
+) -> None:
+    """A view over ``images`` is a drop failure nobody's session is holding.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        tmp_path: Directory the run's log files are written under.
+        monkeypatch: Fixture the driver is run through.
+        quiet_logger: Logger the ingest reports through, unused here.
+    """
+    engine = sqlalchemy.create_engine(postgres_url)
+    try:
+        with engine.begin() as connection:
+            connection.exec_driver_sql(
+                'CREATE TABLE schema_meta (singleton int primary key, schema_version int, '
+                'created_utc text)'
+            )
+            connection.exec_driver_sql('INSERT INTO schema_meta VALUES (1, 6, now()::text)')
+            connection.exec_driver_sql('CREATE TABLE images (root_url text)')
+            connection.exec_driver_sql('CREATE VIEW their_view AS SELECT * FROM images')
+    finally:
+        engine.dispose()
+    _status, written = _drop(postgres_url, monkeypatch, tmp_path, '--yes')
+    said = '\n'.join(written)
+    assert 'Another session' not in said
+
+
+@pytest.mark.postgres
+def test_a_dependent_view_is_reported_as_what_it_is(
+    postgres_url: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """So that the next step is to look at the view rather than at pg_stat_activity.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        tmp_path: Directory the run's log files are written under.
+        monkeypatch: Fixture the driver is run through.
+    """
+    engine = sqlalchemy.create_engine(postgres_url)
+    try:
+        with engine.begin() as connection:
+            connection.exec_driver_sql(
+                'CREATE TABLE schema_meta (singleton int primary key, schema_version int, '
+                'created_utc text)'
+            )
+            connection.exec_driver_sql('INSERT INTO schema_meta VALUES (1, 6, now()::text)')
+            connection.exec_driver_sql('CREATE TABLE images (root_url text)')
+            connection.exec_driver_sql('CREATE VIEW their_view AS SELECT * FROM images')
+    finally:
+        engine.dispose()
+    _status, written = _drop(postgres_url, monkeypatch, tmp_path, '--yes')
+    assert any('depends on one of these tables' in line for line in written)
+
+
+@pytest.mark.postgres
+def test_a_drop_a_dependent_view_refused_leaves_every_table(
+    postgres_url: str,
+    postgres_server_url: str,
+    postgres_schema: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The transaction takes them back, so a refused drop costs nothing.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+        tmp_path: Directory the run's log files are written under.
+        monkeypatch: Fixture the driver is run through.
+    """
+    engine = sqlalchemy.create_engine(postgres_url)
+    try:
+        with engine.begin() as connection:
+            connection.exec_driver_sql(
+                'CREATE TABLE schema_meta (singleton int primary key, schema_version int, '
+                'created_utc text)'
+            )
+            connection.exec_driver_sql('INSERT INTO schema_meta VALUES (1, 6, now()::text)')
+            connection.exec_driver_sql('CREATE TABLE images (root_url text)')
+            connection.exec_driver_sql('CREATE VIEW their_view AS SELECT * FROM images')
+    finally:
+        engine.dispose()
+    _drop(postgres_url, monkeypatch, tmp_path, '--yes')
+    remaining = sqlalchemy.create_engine(postgres_server_url)
+    try:
+        held = sorted(sqlalchemy.inspect(remaining).get_table_names(schema=postgres_schema))
+    finally:
+        remaining.dispose()
+    assert held == ['images', 'schema_meta']
+
+
+def test_the_tables_dropped_are_the_tables_the_question_named(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second reading between the question and the drop is a different list.
+
+    The index here is missing one of its tables when the question is put, and
+    that table is put back while the answer is being typed.  What goes is what
+    the person was shown.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and the reader are replaced through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _run_sql(url, 'DROP TABLE ingest_runs')
+
+    def answering_and_meddling(prompt: str = '') -> str:
+        _run_sql(url, 'CREATE TABLE ingest_runs (run_id INTEGER PRIMARY KEY)')
+        return 'yes'
+
+    monkeypatch.setattr('builtins.input', answering_and_meddling)
+    _drop(url, monkeypatch, tmp_path)
+    assert _tables(url) == ['ingest_runs']
+
+
+def _run_sql(url: str, *statements: str) -> None:
+    """Run statements against a database from outside the command under test.
+
+    Parameters:
+        url: The database URL.
+        statements: The statements to run, in order.
+    """
+    engine = sqlalchemy.create_engine(url)
+    try:
+        with engine.begin() as connection:
+            for statement in statements:
+                connection.exec_driver_sql(statement)
+    finally:
+        engine.dispose()

--- a/tests/spindoctor/cli/stats/test_drop_cli.py
+++ b/tests/spindoctor/cli/stats/test_drop_cli.py
@@ -1,0 +1,821 @@
+"""Tests for ``sd_stats_ingest --drop-index``.
+
+The destructive command, so what is asked of it is mostly what it does *not* do:
+it does not drop without an answer, it does not treat a closed standard input as
+consent, it does not walk a tree, it does not print a password, and it does not
+leave behind a database anything reads differently from one nobody ever built.
+
+The last of those is asked of the real consumer entry points rather than
+asserted about the schema, because "indistinguishable to every consumer" is a
+statement about them.
+"""
+
+import io
+from pathlib import Path
+from typing import Any
+
+import pdslogger
+import pytest
+import sqlalchemy
+
+from spindoctor.cli.stats.report import main_report
+from spindoctor.results_index import IMAGES, SCHEMA_VERSION, index_table_names, read_result_stubs
+
+from .conftest import index_url, ingest_tree, metadata_document, rows_of, write_metadata
+from .ingest_driver_helpers import run_driver
+
+STUB = 'VOL/N1454725799_1_CALIB'
+"""The stub of the document the trees below hold."""
+
+SECRET = 'p@ss:w/rd?x#y'
+"""A password carrying every character that means something to a URL.
+
+Each of them is a place a rule reading the URL by eye stops early, and the
+at-sign in the user name beside it is the other one.  A message that carries
+this string carries a working password.
+"""
+
+CREDENTIALED_URL = f'postgresql+psycopg://ad@min:{SECRET}@127.0.0.1:1/spindoctor'
+"""A server URL nothing answers on, carrying credentials worth hiding.
+
+Port 1 refuses at once, so the refusal this drives is the connection failing
+rather than a name lookup waiting.
+"""
+
+
+def _tree_with_an_index(tmp_path: Path, logger: pdslogger.PdsLogger) -> str:
+    """Write a one-document results tree, ingest it, and return the index URL.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        logger: Logger the ingest reports through.
+
+    Returns:
+        The index URL.
+    """
+    root = tmp_path / 'results'
+    write_metadata(root, STUB, metadata_document())
+    url = index_url(tmp_path / 'index.sqlite3')
+    ingest_tree(url, [root], logger=logger)
+    return url
+
+
+def _answering(monkeypatch: pytest.MonkeyPatch, answer: str) -> None:
+    """Put an answer where the confirmation will read one.
+
+    Parameters:
+        monkeypatch: Fixture standard input is replaced through.
+        answer: What is typed, including any newline.  An empty string is a
+            standard input at its end, which is what a scheduled run has.
+    """
+    monkeypatch.setattr('sys.stdin', io.StringIO(answer))
+
+
+def _drop(
+    url: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *extra: str
+) -> tuple[int | None, list[str]]:
+    """Run a drop of one index and return its status and main log.
+
+    Parameters:
+        url: The index URL to drop.
+        monkeypatch: Fixture the driver is run through.
+        tmp_path: Directory the run's log files are written under.
+        extra: Further arguments, such as ``--yes``.
+
+    Returns:
+        The exit status, and one entry per line written to the main log.
+    """
+    return run_driver(['--results-db', url, '--drop-index', *extra], monkeypatch, tmp_path)
+
+
+def _tables(url: str) -> list[str]:
+    """Return every table a database holds.
+
+    Parameters:
+        url: The database URL.
+
+    Returns:
+        The table names, sorted.
+    """
+    engine = sqlalchemy.create_engine(url)
+    try:
+        return sorted(sqlalchemy.inspect(engine).get_table_names())
+    finally:
+        engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# The confirmation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('answer', ['y\n', 'yes\n', 'Y\n', ' yes \n'])
+def test_an_answer_of_yes_drops_the_tables(
+    answer: str, tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Case and surrounding space are not part of the answer.
+
+    Parameters:
+        answer: What is typed at the prompt.
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _answering(monkeypatch, answer)
+    _drop(url, monkeypatch, tmp_path)
+    assert _tables(url) == []
+
+
+@pytest.mark.parametrize('answer', ['n\n', '\n', 'yes please\n', 'drop\n'])
+def test_any_other_answer_leaves_the_index_alone(
+    answer: str, tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Anything that is not yes is no, including nothing at all.
+
+    Parameters:
+        answer: What is typed at the prompt.
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _answering(monkeypatch, answer)
+    _drop(url, monkeypatch, tmp_path)
+    assert _tables(url) == sorted(index_table_names())
+
+
+def test_an_answer_that_is_not_yes_exits_nonzero(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A script must not read success from a drop that did not happen.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _answering(monkeypatch, 'n\n')
+    status, _written = _drop(url, monkeypatch, tmp_path)
+    assert status == 1
+
+
+def test_a_declined_drop_says_what_the_answer_was(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A run log has to distinguish an answer of no from a failure to ask.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _answering(monkeypatch, 'n\n')
+    _status, written = _drop(url, monkeypatch, tmp_path)
+    assert any('rather than yes' in line for line in written)
+
+
+def test_a_drop_with_nobody_to_ask_leaves_the_index_alone(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A standard input at its end is not consent.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _answering(monkeypatch, '')
+    _drop(url, monkeypatch, tmp_path)
+    assert _tables(url) == sorted(index_table_names())
+
+
+def test_a_drop_with_nobody_to_ask_names_the_flag_that_would_have_worked(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A scheduled run's operator reads the log to find out what to add.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _answering(monkeypatch, '')
+    _status, written = _drop(url, monkeypatch, tmp_path)
+    assert any('--yes' in line for line in written)
+
+
+def test_yes_drops_without_reading_an_answer(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Told not to ask, it does not ask, and does not obey what was typed anyway.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _answering(monkeypatch, 'n\n')
+    _drop(url, monkeypatch, tmp_path, '--yes')
+    assert _tables(url) == []
+
+
+def test_the_question_is_put_to_the_terminal(
+    tmp_path: Path,
+    quiet_logger: pdslogger.PdsLogger,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The summary is read in the second before an answer is typed.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+        capsys: Fixture the terminal output is captured through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _answering(monkeypatch, 'n\n')
+    _drop(url, monkeypatch, tmp_path)
+    assert 'Drop 6 table(s) and ' in capsys.readouterr().out
+
+
+def test_the_question_names_the_index_it_is_about(
+    tmp_path: Path,
+    quiet_logger: pdslogger.PdsLogger,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The question has to stand on its own, for a run whose log went to a file.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+        capsys: Fixture the terminal output is captured through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _answering(monkeypatch, 'n\n')
+    _drop(url, monkeypatch, tmp_path)
+    assert f'from {url}?' in capsys.readouterr().out
+
+
+def test_the_account_of_each_table_is_logged(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """What is at stake is rows, and the tree above holds exactly one image.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _answering(monkeypatch, 'n\n')
+    _status, written = _drop(url, monkeypatch, tmp_path)
+    assert any('images: 1 row(s)' in line for line in written)
+
+
+def test_a_run_told_not_to_ask_still_records_what_it_removed(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The summary goes to the log whether or not anybody was shown it.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _answering(monkeypatch, '')
+    _status, written = _drop(url, monkeypatch, tmp_path, '--yes')
+    assert any('images: 1 row(s)' in line for line in written)
+
+
+def test_the_drop_names_the_tables_it_removed(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ "Says what it removed" is a list of names, not a count.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _status, written = _drop(url, monkeypatch, tmp_path, '--yes')
+    dropped = [line for line in written if line.startswith('Dropped from ')]
+    assert dropped[0].endswith(', '.join(index_table_names()))
+
+
+def test_an_unfinished_ingest_run_is_reported_before_the_question(
+    tmp_path: Path,
+    quiet_logger: pdslogger.PdsLogger,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A drop under a live pass is allowed, so the person answering is told.
+
+    The run is left unfinished the way a real one is: a fan-out records what its
+    listing found and waits for workers that have not run.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+        capsys: Fixture the terminal output is captured through.
+    """
+    root = tmp_path / 'results'
+    write_metadata(root, STUB, metadata_document())
+    url = index_url(tmp_path / 'index.sqlite3')
+    run_driver(
+        [
+            '--results-db',
+            url,
+            '--nav-results-root',
+            root.as_posix(),
+            '--output-cloud-tasks-file',
+            str(tmp_path / 'tasks.json'),
+        ],
+        monkeypatch,
+        tmp_path,
+    )
+    _answering(monkeypatch, 'n\n')
+    _status, written = _drop(url, monkeypatch, tmp_path)
+    assert any('1 ingest run(s) have begun and not finished' in line for line in written)
+
+
+def test_an_unfinished_ingest_run_is_named_in_the_question_itself(
+    tmp_path: Path,
+    quiet_logger: pdslogger.PdsLogger,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The one fact a person answering could not have known from what they typed.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+        capsys: Fixture the terminal output is captured through.
+    """
+    root = tmp_path / 'results'
+    write_metadata(root, STUB, metadata_document())
+    url = index_url(tmp_path / 'index.sqlite3')
+    run_driver(
+        [
+            '--results-db',
+            url,
+            '--nav-results-root',
+            root.as_posix(),
+            '--output-cloud-tasks-file',
+            str(tmp_path / 'tasks.json'),
+        ],
+        monkeypatch,
+        tmp_path,
+    )
+    _answering(monkeypatch, 'n\n')
+    _drop(url, monkeypatch, tmp_path)
+    assert '1 ingest run(s) have not finished.' in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Dropping nothing
+# ---------------------------------------------------------------------------
+
+
+def test_a_database_holding_no_index_exits_zero(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The state asked for is the state arrived at, so it is not a failure.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _drop(url, monkeypatch, tmp_path, '--yes')
+    status, _written = _drop(url, monkeypatch, tmp_path, '--yes')
+    assert status == 0
+
+
+def test_a_database_holding_no_index_says_it_removed_nothing(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An idempotent drop has to be visibly idempotent rather than silent.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _drop(url, monkeypatch, tmp_path, '--yes')
+    _status, written = _drop(url, monkeypatch, tmp_path, '--yes')
+    assert any('holds none of the results index tables' in line for line in written)
+
+
+def test_nobody_is_asked_when_there_is_nothing_to_drop(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A question about nothing is noise, so it is not asked at all.
+
+    Standard input is at its end, which would refuse a drop that had something
+    to remove.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _drop(url, monkeypatch, tmp_path, '--yes')
+    _answering(monkeypatch, '')
+    status, _written = _drop(url, monkeypatch, tmp_path)
+    assert status == 0
+
+
+# ---------------------------------------------------------------------------
+# What a drop refuses to be combined with
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ('extra', 'named'),
+    [
+        (['--force'], '--force'),
+        (['--output-cloud-tasks-file', 'tasks.json'], '--output-cloud-tasks-file'),
+        (['--complete-cloud-tasks-file', 'events.log'], '--complete-cloud-tasks-file'),
+    ],
+)
+def test_a_drop_refuses_the_ingest_options(
+    extra: list[str],
+    named: str,
+    tmp_path: Path,
+    quiet_logger: pdslogger.PdsLogger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Refused rather than ignored: a program may not choose which half to do.
+
+    Parameters:
+        extra: The ingest option the command line also carries.
+        named: What the refusal has to name.
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _status, written = _drop(url, monkeypatch, tmp_path, *extra)
+    assert any(named in line for line in written)
+
+
+def test_a_refused_combination_leaves_the_index_alone(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The refusal is before the open, so nothing is opened and nothing goes.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _drop(url, monkeypatch, tmp_path, '--force', '--yes')
+    assert _tables(url) == sorted(index_table_names())
+
+
+def test_a_refused_combination_exits_nonzero(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The status has to say the command did not run, not that it ran.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    status, _written = _drop(url, monkeypatch, tmp_path, '--force', '--yes')
+    assert status == 1
+
+
+def test_yes_without_a_drop_is_refused(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """It answers a question only the drop asks, so on its own it means nothing.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    status, _written = run_driver(['--results-db', url, '--yes'], monkeypatch, tmp_path)
+    assert status == 1
+
+
+def test_the_refusal_of_yes_alone_says_what_to_add(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An operator who typed it meant something, so the refusal says what.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _status, written = run_driver(['--results-db', url, '--yes'], monkeypatch, tmp_path)
+    assert any('--drop-index' in line for line in written)
+
+
+# ---------------------------------------------------------------------------
+# What a drop does not need, and what it will not do
+# ---------------------------------------------------------------------------
+
+
+def test_a_drop_needs_no_results_root(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A drop is about the database alone, on a machine that may not hold the tree.
+
+    Neither the option nor the environment variable names one here, which is
+    what stops every other mode of this program.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    monkeypatch.delenv('NAV_RESULTS_ROOT', raising=False)
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    status, _written = _drop(url, monkeypatch, tmp_path, '--yes')
+    assert status == 0
+
+
+def test_a_drop_ingests_nothing(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """It stops where it stops: a mistyped URL costs one command, not a walk.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _status, written = _drop(url, monkeypatch, tmp_path, '--yes')
+    assert not any(line.startswith('Metadata files seen') for line in written)
+
+
+def test_a_database_that_is_not_there_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A typed path gets the answer a server gives for a database that is absent.
+
+    Parameters:
+        tmp_path: Directory the path names a file in.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = index_url(tmp_path / 'absent.sqlite3')
+    status, _written = _drop(url, monkeypatch, tmp_path, '--yes')
+    assert status == 1
+
+
+def test_the_index_being_dropped_is_recorded_before_it_is_opened(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A log saying only that a database would not open leaves out which one.
+
+    The database here is one that cannot be opened, so a line naming it is a
+    line written before the attempt.
+
+    Parameters:
+        tmp_path: Directory the path names a file in.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = index_url(tmp_path / 'absent.sqlite3')
+    _status, written = _drop(url, monkeypatch, tmp_path, '--yes')
+    assert f'Results index to drop the tables of: {url}' in written
+
+
+def test_a_database_that_is_not_there_is_not_created(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A mistyped URL must not leave an empty database where it pointed.
+
+    Parameters:
+        tmp_path: Directory the path names a file in.
+        monkeypatch: Fixture the driver is run through.
+    """
+    path = tmp_path / 'absent.sqlite3'
+    _drop(index_url(path), monkeypatch, tmp_path, '--yes')
+    assert not path.exists()
+
+
+# ---------------------------------------------------------------------------
+# The password
+# ---------------------------------------------------------------------------
+
+
+def _credentialed_drop(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> str:
+    """Run a drop of an unreachable server URL and return everything it said.
+
+    Parameters:
+        monkeypatch: Fixture the driver is run through.
+        tmp_path: Directory the run's log files are written under.
+        capsys: Fixture the terminal output is captured through.
+
+    Returns:
+        The main log and the terminal output, joined.
+    """
+    _status, written = _drop(CREDENTIALED_URL, monkeypatch, tmp_path, '--yes')
+    captured = capsys.readouterr()
+    return '\n'.join([*written, captured.out, captured.err])
+
+
+def test_the_password_survives_nowhere_a_drop_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Asserted on the bytes, over a password carrying every character that ends one.
+
+    Parameters:
+        tmp_path: Directory the run's log files are written under.
+        monkeypatch: Fixture the driver is run through.
+        capsys: Fixture the terminal output is captured through.
+    """
+    assert SECRET not in _credentialed_drop(monkeypatch, tmp_path, capsys)
+
+
+def test_no_run_of_the_password_survives_either(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A driver quotes back the fragment it stopped on, not the field it read.
+
+    Parameters:
+        tmp_path: Directory the run's log files are written under.
+        monkeypatch: Fixture the driver is run through.
+        capsys: Fixture the terminal output is captured through.
+    """
+    said = _credentialed_drop(monkeypatch, tmp_path, capsys)
+    assert not any(SECRET[start : start + 4] in said for start in range(len(SECRET) - 3))
+
+
+def test_the_masked_url_still_names_the_server(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Masking must not cost the identification the message exists for.
+
+    Parameters:
+        tmp_path: Directory the run's log files are written under.
+        monkeypatch: Fixture the driver is run through.
+        capsys: Fixture the terminal output is captured through.
+    """
+    assert '127.0.0.1' in _credentialed_drop(monkeypatch, tmp_path, capsys)
+
+
+def test_the_command_line_the_drop_logs_is_masked_too(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The run banner records the arguments, and one of those words is the URL.
+
+    Parameters:
+        tmp_path: Directory the run's log files are written under.
+        monkeypatch: Fixture the driver is run through.
+        capsys: Fixture the terminal output is captured through.
+    """
+    said = _credentialed_drop(monkeypatch, tmp_path, capsys)
+    assert 'ad@min:***@127.0.0.1' in said
+
+
+# ---------------------------------------------------------------------------
+# A dropped index and an index that never existed
+# ---------------------------------------------------------------------------
+
+
+def _dropped_and_never_built(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> tuple[str, str]:
+    """Return the URL of an index that was dropped and of one never built.
+
+    Parameters:
+        tmp_path: Directory the trees and the indexes live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+
+    Returns:
+        The dropped index's URL and the never-built one's.
+    """
+    dropped = _tree_with_an_index(tmp_path, quiet_logger)
+    _drop(dropped, monkeypatch, tmp_path, '--yes')
+    return dropped, index_url(tmp_path / 'never-built.sqlite3')
+
+
+def test_neither_a_dropped_index_nor_an_absent_one_answers_a_selection(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The filters read absence of a row as "never navigated", so both must refuse.
+
+    Parameters:
+        tmp_path: Directory the trees and the indexes live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    for url in _dropped_and_never_built(tmp_path, quiet_logger, monkeypatch):
+        with pytest.raises(ValueError):
+            read_result_stubs(url, tmp_path / 'results', ['VOL'])
+
+
+def test_both_send_the_reader_to_the_ingest(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two states, one remedy, so the two refusals prescribe the same thing.
+
+    Parameters:
+        tmp_path: Directory the trees and the indexes live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    said = []
+    for url in _dropped_and_never_built(tmp_path, quiet_logger, monkeypatch):
+        with pytest.raises(ValueError) as excinfo:
+            read_result_stubs(url, tmp_path / 'results', ['VOL'])
+        said.append('sd_stats_ingest' in str(excinfo.value))
+    assert said == [True, True]
+
+
+def test_the_report_refuses_both(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The one consumer that requires an index treats the two the same way.
+
+    Parameters:
+        tmp_path: Directory the trees and the indexes live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    monkeypatch.delenv('NAV_RESULTS_DB', raising=False)
+    statuses = [
+        main_report(['--results-db', url, '--output-dir', str(tmp_path / 'report')])
+        for url in _dropped_and_never_built(tmp_path, quiet_logger, monkeypatch)
+    ]
+    assert statuses == [1, 1]
+
+
+def test_an_ingest_over_a_dropped_index_writes_the_rows_again(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Starting from scratch, which is the operation the whole command is for.
+
+    The rows are compared against the ones the first ingest wrote, so a drop
+    that had left something behind, or one an ingest could only half-rebuild
+    over, shows up as a difference rather than as a count.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    root = tmp_path / 'results'
+    write_metadata(root, STUB, metadata_document())
+    url = index_url(tmp_path / 'index.sqlite3')
+    ingest_tree(url, [root], logger=quiet_logger)
+    before = rows_of(url, IMAGES)
+    _drop(url, monkeypatch, tmp_path, '--yes')
+    ingest_tree(url, [root], logger=quiet_logger)
+    assert rows_of(url, IMAGES) == before
+
+
+def test_a_rebuilt_index_carries_this_schema_version(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stamp goes with the tables and comes back with them.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    root = tmp_path / 'results'
+    write_metadata(root, STUB, metadata_document())
+    url = index_url(tmp_path / 'index.sqlite3')
+    ingest_tree(url, [root], logger=quiet_logger)
+    _drop(url, monkeypatch, tmp_path, '--yes')
+    ingest_tree(url, [root], logger=quiet_logger)
+    engine = sqlalchemy.create_engine(url)
+    try:
+        with engine.connect() as connection:
+            stamped: Any = connection.exec_driver_sql(
+                'SELECT schema_version FROM schema_meta'
+            ).scalar()
+    finally:
+        engine.dispose()
+    assert stamped == SCHEMA_VERSION

--- a/tests/spindoctor/cli/stats/test_drop_cli.py
+++ b/tests/spindoctor/cli/stats/test_drop_cli.py
@@ -74,6 +74,20 @@ def _failure_with(sqlstate: str) -> sqlalchemy.exc.SQLAlchemyError:
     return sqlalchemy.exc.OperationalError('DROP TABLE images', {}, _CodedError(sqlstate))
 
 
+def _sqlite_failure_with(error_name: str) -> sqlalchemy.exc.SQLAlchemyError:
+    """Return the failure SQLAlchemy raises around a SQLite result code.
+
+    Parameters:
+        error_name: The result-code name the driver carries.
+
+    Returns:
+        The wrapper, carrying the driver exception as its ``orig``.
+    """
+    original = sqlite3.OperationalError(f'the driver said {error_name}')
+    original.sqlite_errorname = error_name
+    return sqlalchemy.exc.OperationalError('DROP TABLE images', {}, original)
+
+
 def _tree_with_an_index(tmp_path: Path, logger: pdslogger.PdsLogger) -> str:
     """Write a one-document results tree, ingest it, and return the index URL.
 
@@ -449,7 +463,27 @@ def test_a_database_holding_no_index_says_it_removed_nothing(
     url = _tree_with_an_index(tmp_path, quiet_logger)
     _drop(url, monkeypatch, tmp_path, '--yes')
     _status, written = _drop(url, monkeypatch, tmp_path, '--yes')
-    assert any('holds none of the results index tables' in line for line in written)
+    assert any('reaches none of the results index tables' in line for line in written)
+
+
+def test_the_empty_answer_is_about_this_connection_rather_than_the_database(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """What was looked at is what an unqualified name on this connection reaches.
+
+    An index in a schema this connection's search path does not name, or in one
+    this account may not look into, answers exactly as one that is not there
+    does, so the sentence says which of the two was established.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and standard input are run through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _drop(url, monkeypatch, tmp_path, '--yes')
+    _status, written = _drop(url, monkeypatch, tmp_path, '--yes')
+    assert any('outside its search path' in line for line in written)
 
 
 def test_nobody_is_asked_when_there_is_nothing_to_drop(
@@ -1119,6 +1153,93 @@ def test_ctrl_c_at_the_question_says_so_rather_than_raising(
     assert any('the question was interrupted' in line for line in written)
 
 
+def _interrupting_the_step(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
+    """Make one step of the drop raise ``KeyboardInterrupt``, as Ctrl-C does.
+
+    The three steps this stands in for all wait on something outside the
+    process -- a server accepting a connection, a scan of every table, a lock
+    another session holds -- so each of them is a real place for Ctrl-C to land.
+
+    Parameters:
+        monkeypatch: Fixture the step is replaced through.
+        name: The name the drop module calls that step by.
+    """
+
+    def interrupted(*args: Any, **kwargs: Any) -> Any:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(f'spindoctor.cli.stats.drop.{name}', interrupted)
+
+
+@pytest.mark.parametrize(
+    ('step', 'says'),
+    [
+        ('open_database', 'opening it was interrupted'),
+        ('index_contents', 'the reading of what it holds was interrupted'),
+        ('drop_index_tables', 'The drop of'),
+    ],
+    ids=['the-open', 'the-reading', 'the-drop'],
+)
+def test_ctrl_c_during_a_step_says_so_rather_than_raising(
+    step: str,
+    says: str,
+    tmp_path: Path,
+    quiet_logger: pdslogger.PdsLogger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A destructive command owes an interrupt a line wherever it lands.
+
+    Parameters:
+        step: The step of the drop that is interrupted.
+        says: What the line for that step has to say.
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and the step are replaced through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _interrupting_the_step(monkeypatch, step)
+    _status, written = _drop(url, monkeypatch, tmp_path, '--yes')
+    assert any(says in line for line in written)
+
+
+@pytest.mark.parametrize(
+    'step',
+    ['open_database', 'index_contents', 'drop_index_tables'],
+    ids=['the-open', 'the-reading', 'the-drop'],
+)
+def test_ctrl_c_during_a_step_exits_nonzero(
+    step: str, tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A script must not read success from a drop that was cut short.
+
+    Parameters:
+        step: The step of the drop that is interrupted.
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and the step are replaced through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _interrupting_the_step(monkeypatch, step)
+    status, _written = _drop(url, monkeypatch, tmp_path, '--yes')
+    assert status == 1
+
+
+def test_ctrl_c_during_the_drop_leaves_every_table(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reassurance the line gives is the one the transaction makes true.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver and the step are replaced through.
+    """
+    url = _tree_with_an_index(tmp_path, quiet_logger)
+    _interrupting_the_step(monkeypatch, 'drop_index_tables')
+    _drop(url, monkeypatch, tmp_path, '--yes')
+    assert _tables(url) == sorted(index_table_names())
+
+
 # ---------------------------------------------------------------------------
 # The option a drop has nothing to do with
 # ---------------------------------------------------------------------------
@@ -1247,6 +1368,30 @@ def test_each_failure_a_server_reports_is_named_as_itself(sqlstate: str, names: 
         names: What the message for it has to say.
     """
     assert names in _because(_failure_with(sqlstate))
+
+
+@pytest.mark.parametrize(
+    ('error_name', 'names'),
+    [
+        ('SQLITE_BUSY_SNAPSHOT', 'holding the write lock'),
+        ('SQLITE_READONLY_DBMOVED', 'read-only'),
+    ],
+    ids=['a-busy-snapshot', 'a-moved-database'],
+)
+def test_an_extended_sqlite_code_is_named_as_the_cause_it_refines(
+    error_name: str, names: str
+) -> None:
+    """SQLite refines its codes into extended forms that name the same cause.
+
+    ``SQLITE_BUSY`` arrives as ``SQLITE_BUSY_SNAPSHOT`` from a connection whose
+    snapshot has moved on, and matching those by equality would answer the
+    precise code with no cause at all.
+
+    Parameters:
+        error_name: The extended result-code name the driver carries.
+        names: What the message for the code it refines has to say.
+    """
+    assert names in _because(_sqlite_failure_with(error_name))
 
 
 @pytest.mark.parametrize(
@@ -1432,6 +1577,28 @@ def test_a_server_database_that_is_not_there_says_it_could_not_be_opened(
     assert any('Cannot open the database' in line for line in written)
 
 
+def _index_under_a_dependent_view(url: str) -> None:
+    """Build a stamped index table with a view of somebody's standing over it.
+
+    Parameters:
+        url: The scoped server URL the tables are created through.
+    """
+    engine = sqlalchemy.create_engine(url)
+    try:
+        with engine.begin() as connection:
+            connection.exec_driver_sql(
+                'CREATE TABLE schema_meta (singleton int primary key, schema_version int, '
+                'created_utc text)'
+            )
+            connection.exec_driver_sql(
+                f'INSERT INTO schema_meta VALUES (1, {SCHEMA_VERSION}, now()::text)'
+            )
+            connection.exec_driver_sql('CREATE TABLE images (root_url text)')
+            connection.exec_driver_sql('CREATE VIEW their_view AS SELECT * FROM images')
+    finally:
+        engine.dispose()
+
+
 @pytest.mark.postgres
 def test_a_dependent_view_is_not_reported_as_a_lock(
     postgres_url: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, quiet_logger: Any
@@ -1444,18 +1611,7 @@ def test_a_dependent_view_is_not_reported_as_a_lock(
         monkeypatch: Fixture the driver is run through.
         quiet_logger: Logger the ingest reports through, unused here.
     """
-    engine = sqlalchemy.create_engine(postgres_url)
-    try:
-        with engine.begin() as connection:
-            connection.exec_driver_sql(
-                'CREATE TABLE schema_meta (singleton int primary key, schema_version int, '
-                'created_utc text)'
-            )
-            connection.exec_driver_sql('INSERT INTO schema_meta VALUES (1, 6, now()::text)')
-            connection.exec_driver_sql('CREATE TABLE images (root_url text)')
-            connection.exec_driver_sql('CREATE VIEW their_view AS SELECT * FROM images')
-    finally:
-        engine.dispose()
+    _index_under_a_dependent_view(postgres_url)
     _status, written = _drop(postgres_url, monkeypatch, tmp_path, '--yes')
     said = '\n'.join(written)
     assert 'Another session' not in said
@@ -1472,18 +1628,7 @@ def test_a_dependent_view_is_reported_as_what_it_is(
         tmp_path: Directory the run's log files are written under.
         monkeypatch: Fixture the driver is run through.
     """
-    engine = sqlalchemy.create_engine(postgres_url)
-    try:
-        with engine.begin() as connection:
-            connection.exec_driver_sql(
-                'CREATE TABLE schema_meta (singleton int primary key, schema_version int, '
-                'created_utc text)'
-            )
-            connection.exec_driver_sql('INSERT INTO schema_meta VALUES (1, 6, now()::text)')
-            connection.exec_driver_sql('CREATE TABLE images (root_url text)')
-            connection.exec_driver_sql('CREATE VIEW their_view AS SELECT * FROM images')
-    finally:
-        engine.dispose()
+    _index_under_a_dependent_view(postgres_url)
     _status, written = _drop(postgres_url, monkeypatch, tmp_path, '--yes')
     assert any('depends on one of these tables' in line for line in written)
 
@@ -1505,18 +1650,7 @@ def test_a_drop_a_dependent_view_refused_leaves_every_table(
         tmp_path: Directory the run's log files are written under.
         monkeypatch: Fixture the driver is run through.
     """
-    engine = sqlalchemy.create_engine(postgres_url)
-    try:
-        with engine.begin() as connection:
-            connection.exec_driver_sql(
-                'CREATE TABLE schema_meta (singleton int primary key, schema_version int, '
-                'created_utc text)'
-            )
-            connection.exec_driver_sql('INSERT INTO schema_meta VALUES (1, 6, now()::text)')
-            connection.exec_driver_sql('CREATE TABLE images (root_url text)')
-            connection.exec_driver_sql('CREATE VIEW their_view AS SELECT * FROM images')
-    finally:
-        engine.dispose()
+    _index_under_a_dependent_view(postgres_url)
     _drop(postgres_url, monkeypatch, tmp_path, '--yes')
     remaining = sqlalchemy.create_engine(postgres_server_url)
     try:

--- a/tests/spindoctor/results_index/conftest.py
+++ b/tests/spindoctor/results_index/conftest.py
@@ -204,31 +204,82 @@ def postgres_schema() -> str:
 
 
 @pytest.fixture
-def postgres_url(postgres_server_url: str, postgres_schema: str) -> Iterator[str]:
+def postgres_decoy_schema() -> str:
+    """Return the name of a second schema, behind this test's own on the path.
+
+    A search path of one entry is the one shape in which every unqualified table
+    name resolves to the same schema whatever the code does with it, so a
+    fixture that pins one cannot see a query that resolves two names into two
+    schemas.  Every postgres test therefore runs with a schema behind its own.
+
+    Returns:
+        A schema name no other test uses.
+    """
+    return f'ri_decoy_{uuid.uuid4().hex}'
+
+
+DECOY_TABLE = 'customers'
+"""What the decoy schema holds: a table of a name the index never uses.
+
+Deliberately not one of the index's names.  A table called ``images`` in a
+schema the search path reaches is one ``MetaData.create_all`` finds and does not
+create, so an index built over such a path is built across two schemas -- which
+is a defect of the creating open rather than of these tests, and is tracked
+separately.  The tests that need that collision build it after the index exists.
+"""
+
+
+@pytest.fixture
+def postgres_url(
+    postgres_server_url: str, postgres_schema: str, postgres_decoy_schema: str
+) -> Iterator[str]:
     """Yield a PostgreSQL URL scoped to a schema of this test's own.
 
-    The schema is created before the test and dropped after it, so repeated runs
-    and parallel workers never see one another's tables.
+    The schemas are created before the test and dropped after it, so repeated
+    runs and parallel workers never see one another's tables.  The index's own
+    schema leads the search path, so that is where a creating open builds it;
+    the decoy behind it is what makes the path more than one entry long.
 
     Parameters:
-        postgres_server_url: The server URL the schema is created on.
-        postgres_schema: Name of the schema to create.
+        postgres_server_url: The server URL the schemas are created on.
+        postgres_schema: Name of the schema to create for the index.
+        postgres_decoy_schema: Name of the schema to create behind it.
 
     Yields:
-        A URL whose search path names the private schema.
+        A URL whose search path names the private schema and then the decoy.
     """
     schema = postgres_schema
+    decoy = postgres_decoy_schema
     scoped = sqlalchemy.engine.make_url(postgres_server_url).update_query_dict(
-        {'options': f'-csearch_path={schema}'}
+        {'options': f'-csearch_path={schema},{decoy}'}
     )
     admin = sqlalchemy.create_engine(postgres_server_url)
     try:
         with admin.begin() as connection:
             connection.exec_driver_sql(f'CREATE SCHEMA "{schema}"')
+            connection.exec_driver_sql(f'CREATE SCHEMA "{decoy}"')
+            connection.exec_driver_sql(f'CREATE TABLE "{decoy}".{DECOY_TABLE} (x INTEGER)')
         try:
             yield scoped.render_as_string(hide_password=False)
         finally:
             with admin.begin() as connection:
                 connection.exec_driver_sql(f'DROP SCHEMA "{schema}" CASCADE')
+                connection.exec_driver_sql(f'DROP SCHEMA "{decoy}" CASCADE')
     finally:
         admin.dispose()
+
+
+def url_scoped_to(server_url: str, *schemas: str) -> str:
+    """Return the server URL with a search path naming these schemas in order.
+
+    Parameters:
+        server_url: The server URL, unscoped.
+        schemas: The schemas to name, first one first.
+
+    Returns:
+        The scoped URL, with its password intact so it can be opened.
+    """
+    scoped = sqlalchemy.engine.make_url(server_url).update_query_dict(
+        {'options': f'-csearch_path={",".join(schemas)}'}
+    )
+    return scoped.render_as_string(hide_password=False)

--- a/tests/spindoctor/results_index/conftest.py
+++ b/tests/spindoctor/results_index/conftest.py
@@ -221,11 +221,12 @@ def postgres_decoy_schema() -> str:
 DECOY_TABLE = 'customers'
 """What the decoy schema holds: a table of a name the index never uses.
 
-Deliberately not one of the index's names.  A table called ``images`` in a
-schema the search path reaches is one ``MetaData.create_all`` finds and does not
-create, so an index built over such a path is built across two schemas -- which
-is a defect of the creating open rather than of these tests, and is tracked
-separately.  The tests that need that collision build it after the index exists.
+Deliberately not one of the index's own names, so that the decoy makes the
+search path longer than one entry without also making a bare ``images``
+resolve into it.  A creating open binds the schema it builds in and does not
+adopt a table of one of its names from anywhere else, and the drop reports
+every table of those names its connection reaches; the tests that need either
+of those build the collision themselves.
 """
 
 

--- a/tests/spindoctor/results_index/test_creating_open.py
+++ b/tests/spindoctor/results_index/test_creating_open.py
@@ -1,0 +1,401 @@
+"""What a creating open will and will not build an index on top of.
+
+One rule is under test: an ingest never stamps a schema that already holds
+tables SpinDoctor did not create.  The stamp is what every later reading treats
+as proof that the tables beside it are the index's -- it is what the drop
+destroys on the strength of -- so a stamp written over a stranger's table is
+what makes somebody else's data indistinguishable from ours.
+
+Four answers make up the rule, and each is asked here: a schema holding nothing
+is built in, one carrying a stamp of SpinDoctor's is gone on with whatever
+version it names, one holding tables of the index's own names with no such stamp
+is refused, and one holding any table the index does not own is refused whether
+it is stamped or not.  A refusal must also leave the schema exactly as it found
+it, which is the half a message cannot assert on its own.
+"""
+
+from pathlib import Path
+
+import pytest
+import sqlalchemy
+from tests.spindoctor.results_index.conftest import opened, sqlite_url_for
+
+from spindoctor.results_index import (
+    IMAGES,
+    INGEST_RUNS,
+    SCHEMA_META,
+    SCHEMA_VERSION,
+    index_table_names,
+    open_index,
+)
+
+FOREIGN_TABLE = 'somebody_elses_table'
+"""A table of the same schema that SpinDoctor did not create.
+
+Named nothing like the index's own tables, so that what refuses it is its
+being there rather than what it is called.
+"""
+
+COLLIDING_TABLE = IMAGES.name
+"""A table SpinDoctor did not create, under a name SpinDoctor also uses.
+
+``images`` is among the commonest table names there are, so a database is free
+to hold one for a reason of its own, and a creating open that built over it
+would write its stamp beside somebody else's rows.
+"""
+
+SQLITE_SCHEMA = 'main'
+"""The one namespace a SQLite database has, which a refusal names."""
+
+
+def _execute(path: Path, *statements: str) -> None:
+    """Run statements against a database as somebody other than the index.
+
+    Parameters:
+        path: The database file's path.
+        statements: The statements to run, in order.
+    """
+    engine = sqlalchemy.create_engine(sqlite_url_for(path))
+    try:
+        with engine.begin() as connection:
+            for statement in statements:
+                connection.exec_driver_sql(statement)
+    finally:
+        engine.dispose()
+
+
+def _tables(path: Path) -> list[str]:
+    """Return every table a database holds, whoever created it.
+
+    Parameters:
+        path: The database file's path.
+
+    Returns:
+        The table names, sorted.
+    """
+    engine = sqlalchemy.create_engine(sqlite_url_for(path))
+    try:
+        return sorted(sqlalchemy.inspect(engine).get_table_names())
+    finally:
+        engine.dispose()
+
+
+def _rows_of(path: Path, table: str) -> int:
+    """Return how many rows a table holds.
+
+    Parameters:
+        path: The database file's path.
+        table: The table to count.
+
+    Returns:
+        The row count.
+    """
+    engine = sqlalchemy.create_engine(sqlite_url_for(path))
+    try:
+        with engine.connect() as connection:
+            counted = connection.exec_driver_sql(f'SELECT count(*) FROM {table}').scalar()
+    finally:
+        engine.dispose()
+    return 0 if counted is None else int(counted)
+
+
+def _refusal_of(path: Path) -> str:
+    """Return the message a creating open of a database is refused with.
+
+    Parameters:
+        path: The database file's path.
+
+    Returns:
+        The refusal message.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        open_index(sqlite_url_for(path), create=True)
+    return str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# A schema holding nothing
+# ---------------------------------------------------------------------------
+
+
+def test_a_database_holding_nothing_is_built_in(tmp_path: Path) -> None:
+    """The ordinary first ingest, which every other answer is measured against.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    assert _tables(path) == sorted(index_table_names())
+
+
+def test_a_database_holding_nothing_is_stamped(tmp_path: Path) -> None:
+    """A schema built in is a schema stamped, in the same open.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True) as engine, engine.connect() as connection:
+        stamped = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).scalar()
+    assert stamped == SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# A schema carrying a stamp of SpinDoctor's
+# ---------------------------------------------------------------------------
+
+
+def test_an_index_of_this_version_is_opened_again(tmp_path: Path) -> None:
+    """Every ingest after the first opens a schema that is already full.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    assert _tables(path) == sorted(index_table_names())
+
+
+def test_a_stamp_of_another_version_reaches_the_version_gate(tmp_path: Path) -> None:
+    """A stamp is evidence of ownership, not of a column set.
+
+    The database a version bump leaves behind carries our marks and our names
+    and neither our version nor our columns.  It is the index's own, and the
+    answer it is owed is the version gate's, which prescribes the drop.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    path = tmp_path / 'index.sqlite3'
+    _execute(
+        path,
+        f'CREATE TABLE {SCHEMA_META.name} '
+        f'(singleton INTEGER PRIMARY KEY, schema_version INTEGER, created_utc TEXT)',
+        f"INSERT INTO {SCHEMA_META.name} VALUES (1, {SCHEMA_VERSION - 1}, 'then')",
+        f'CREATE TABLE {COLLIDING_TABLE} (root_url TEXT, a_column_of_an_older_version TEXT)',
+    )
+    assert f'schema version {SCHEMA_VERSION - 1} is not the version' in _refusal_of(path)
+
+
+def test_a_stamp_of_another_version_is_not_built_over(tmp_path: Path) -> None:
+    """Refused before anything is created, so the drop still has one version to remove.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    path = tmp_path / 'index.sqlite3'
+    _execute(
+        path,
+        f'CREATE TABLE {SCHEMA_META.name} '
+        f'(singleton INTEGER PRIMARY KEY, schema_version INTEGER, created_utc TEXT)',
+        f"INSERT INTO {SCHEMA_META.name} VALUES (1, {SCHEMA_VERSION - 1}, 'then')",
+        f'CREATE TABLE {COLLIDING_TABLE} (root_url TEXT)',
+    )
+    _refusal_of(path)
+    assert _tables(path) == sorted([SCHEMA_META.name, COLLIDING_TABLE])
+
+
+def test_a_stamp_with_no_row_in_it_is_completed(tmp_path: Path) -> None:
+    """An interrupted creation left the marks, so the schema is the index's own.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    path = tmp_path / 'index.sqlite3'
+    _execute(
+        path,
+        f'CREATE TABLE {SCHEMA_META.name} '
+        f'(singleton INTEGER PRIMARY KEY, schema_version INTEGER, created_utc TEXT)',
+    )
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    assert _tables(path) == sorted(index_table_names())
+
+
+# ---------------------------------------------------------------------------
+# A schema holding our names with no stamp of ours
+# ---------------------------------------------------------------------------
+
+
+def test_a_table_of_one_of_our_names_with_no_stamp_is_refused(tmp_path: Path) -> None:
+    """The name is not evidence, so nothing is written beside it that would be.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    path = tmp_path / 'theirs.sqlite3'
+    _execute(path, f'CREATE TABLE {COLLIDING_TABLE} (id INTEGER PRIMARY KEY, caption TEXT)')
+    assert 'no schema_meta of SpinDoctor' in _refusal_of(path)
+
+
+def test_that_refusal_names_the_table_it_stopped_on(tmp_path: Path) -> None:
+    """An operator who has typed the wrong URL has to be able to tell from the message.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    path = tmp_path / 'theirs.sqlite3'
+    _execute(path, f'CREATE TABLE {COLLIDING_TABLE} (id INTEGER PRIMARY KEY)')
+    assert COLLIDING_TABLE in _refusal_of(path)
+
+
+def test_that_refusal_names_the_schema_it_looked_at(tmp_path: Path) -> None:
+    """One schema was examined, and which one is not something the URL said.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    path = tmp_path / 'theirs.sqlite3'
+    _execute(path, f'CREATE TABLE {COLLIDING_TABLE} (id INTEGER PRIMARY KEY)')
+    assert f'schema {SQLITE_SCHEMA}' in _refusal_of(path)
+
+
+def test_that_refusal_names_the_url(tmp_path: Path) -> None:
+    """A run resolves its index URL from three places, so the message says which one.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    path = tmp_path / 'theirs.sqlite3'
+    _execute(path, f'CREATE TABLE {COLLIDING_TABLE} (id INTEGER PRIMARY KEY)')
+    assert sqlite_url_for(path) in _refusal_of(path)
+
+
+def test_a_refused_schema_is_not_stamped(tmp_path: Path) -> None:
+    """The stamp is what a later drop destroys on the strength of.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    path = tmp_path / 'theirs.sqlite3'
+    _execute(path, f'CREATE TABLE {COLLIDING_TABLE} (id INTEGER PRIMARY KEY)')
+    _refusal_of(path)
+    assert _tables(path) == [COLLIDING_TABLE]
+
+
+def test_a_refused_schema_keeps_the_rows_it_had(tmp_path: Path) -> None:
+    """Left exactly as it was found, which is the half the message cannot assert.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    path = tmp_path / 'theirs.sqlite3'
+    _execute(
+        path,
+        f'CREATE TABLE {COLLIDING_TABLE} (id INTEGER PRIMARY KEY, caption TEXT)',
+        f"INSERT INTO {COLLIDING_TABLE} (caption) VALUES ('their cat'), ('their dog')",
+    )
+    _refusal_of(path)
+    assert _rows_of(path, COLLIDING_TABLE) == 2
+
+
+def test_a_stamp_carrying_only_the_version_mark_is_not_evidence(tmp_path: Path) -> None:
+    """One mark is what any migration table carries, and is not enough to build over.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    path = tmp_path / 'theirs.sqlite3'
+    _execute(
+        path,
+        f'CREATE TABLE {SCHEMA_META.name} (schema_version INTEGER)',
+        f'CREATE TABLE {COLLIDING_TABLE} (id INTEGER)',
+    )
+    assert 'no schema_meta of SpinDoctor' in _refusal_of(path)
+
+
+def test_a_stamp_carrying_only_the_singleton_mark_is_not_evidence(tmp_path: Path) -> None:
+    """The other mark alone is no better, so the pair is what is required.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    path = tmp_path / 'theirs.sqlite3'
+    _execute(
+        path,
+        f'CREATE TABLE {SCHEMA_META.name} (singleton INTEGER PRIMARY KEY)',
+        f'CREATE TABLE {COLLIDING_TABLE} (id INTEGER)',
+    )
+    assert 'no schema_meta of SpinDoctor' in _refusal_of(path)
+
+
+def test_a_view_of_one_of_our_names_is_refused(tmp_path: Path) -> None:
+    """A view of that name is what a create finds already there, and is not ours.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    path = tmp_path / 'theirs.sqlite3'
+    _execute(path, f'CREATE VIEW {INGEST_RUNS.name} AS SELECT 1 AS run_id')
+    assert INGEST_RUNS.name in _refusal_of(path)
+
+
+# ---------------------------------------------------------------------------
+# A schema holding a table the index does not own
+# ---------------------------------------------------------------------------
+
+
+def test_a_table_the_index_does_not_own_is_refused(tmp_path: Path) -> None:
+    """A results index owns the schema it lives in, so anything else is a wrong URL.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    path = tmp_path / 'theirs.sqlite3'
+    _execute(path, f'CREATE TABLE {FOREIGN_TABLE} (x INTEGER)')
+    assert 'does not own' in _refusal_of(path)
+
+
+def test_that_refusal_names_the_foreign_table(tmp_path: Path) -> None:
+    """What the schema holds is what says the URL names somewhere else.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    path = tmp_path / 'theirs.sqlite3'
+    _execute(path, f'CREATE TABLE {FOREIGN_TABLE} (x INTEGER)')
+    assert FOREIGN_TABLE in _refusal_of(path)
+
+
+def test_a_foreign_table_is_not_built_around(tmp_path: Path) -> None:
+    """Nothing is created, so a schema that was somebody else's stays only theirs.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    path = tmp_path / 'theirs.sqlite3'
+    _execute(path, f'CREATE TABLE {FOREIGN_TABLE} (x INTEGER)')
+    _refusal_of(path)
+    assert _tables(path) == [FOREIGN_TABLE]
+
+
+def test_a_foreign_table_beside_a_stamped_index_is_refused(tmp_path: Path) -> None:
+    """A stamp says the tables of our names are ours; it says nothing about the rest.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    _execute(path, f'CREATE TABLE {FOREIGN_TABLE} (x INTEGER)')
+    assert FOREIGN_TABLE in _refusal_of(path)
+
+
+def test_a_foreign_table_beside_a_stamped_index_leaves_the_index(tmp_path: Path) -> None:
+    """The refusal creates nothing and removes nothing, on a schema of either kind.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    path = tmp_path / 'index.sqlite3'
+    with opened(sqlite_url_for(path), create=True):
+        pass
+    _execute(path, f'CREATE TABLE {FOREIGN_TABLE} (x INTEGER)')
+    _refusal_of(path)
+    assert _tables(path) == sorted([*index_table_names(), FOREIGN_TABLE])

--- a/tests/spindoctor/results_index/test_creating_open_postgres.py
+++ b/tests/spindoctor/results_index/test_creating_open_postgres.py
@@ -1,0 +1,385 @@
+"""What a creating open builds on a real PostgreSQL server, and where.
+
+Four things about the rule are properties of a server rather than of the schema
+and cannot be asked of SQLite, whose database has one namespace.  That the
+schema examined is the one the index resolves to and not the database around it,
+since a server's other schemas belong to whoever made them.  That a table of one
+of the index's own names in another schema the search path reaches is neither
+built over nor built beside, which is the arrangement that would otherwise
+spread one index across two schemas.  That a refusal names the URL with its
+password hidden, since that URL goes into run logs.  And that a connection whose
+search path names nothing that exists is told so rather than failing inside the
+first ``CREATE TABLE``.
+"""
+
+import uuid
+from collections.abc import Iterator
+
+import pytest
+import sqlalchemy
+from tests.spindoctor.results_index.conftest import opened, url_scoped_to
+
+from spindoctor.results_index import (
+    IMAGES,
+    SCHEMA_META,
+    SCHEMA_VERSION,
+    index_table_names,
+    open_index,
+)
+
+pytestmark = pytest.mark.postgres
+
+FOREIGN_TABLE = 'somebody_elses_table'
+"""A table of the same schema that SpinDoctor did not create."""
+
+COLLIDING_TABLE = IMAGES.name
+"""A table SpinDoctor did not create, under a name SpinDoctor also uses."""
+
+BOGUS_PASSWORD = 'hunter2-not-the-real-one'
+"""A password a refusal must not repeat, distinctive enough to grep for."""
+
+
+def _execute(url: str, *statements: str) -> None:
+    """Run statements against a database as somebody other than the index.
+
+    Parameters:
+        url: The database URL.
+        statements: The statements to run, in order.
+    """
+    engine = sqlalchemy.create_engine(url)
+    try:
+        with engine.begin() as connection:
+            for statement in statements:
+                connection.exec_driver_sql(statement)
+    finally:
+        engine.dispose()
+
+
+def _schema_tables(server_url: str, schema: str) -> list[str]:
+    """Return every table of one schema, whoever created it.
+
+    Parameters:
+        server_url: URL of the server, unscoped.
+        schema: The schema to list.
+
+    Returns:
+        The table names, sorted.
+    """
+    engine = sqlalchemy.create_engine(server_url)
+    try:
+        return sorted(sqlalchemy.inspect(engine).get_table_names(schema=schema))
+    finally:
+        engine.dispose()
+
+
+def _rows_of(url: str, qualified: str) -> int:
+    """Return how many rows a schema-qualified table holds.
+
+    Parameters:
+        url: The database URL.
+        qualified: The table, named with its schema.
+
+    Returns:
+        The row count.
+    """
+    engine = sqlalchemy.create_engine(url)
+    try:
+        with engine.connect() as connection:
+            counted = connection.exec_driver_sql(f'SELECT count(*) FROM {qualified}').scalar()
+    finally:
+        engine.dispose()
+    return 0 if counted is None else int(counted)
+
+
+def _refusal_of(url: str) -> str:
+    """Return the message a creating open of a database is refused with.
+
+    Parameters:
+        url: The database URL.
+
+    Returns:
+        The refusal message.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        open_index(url, create=True)
+    return str(excinfo.value)
+
+
+@pytest.fixture
+def tenant_schema(postgres_server_url: str) -> Iterator[str]:
+    """Yield a schema standing for another tenant's, created empty.
+
+    Parameters:
+        postgres_server_url: The server URL the schema is created on.
+
+    Yields:
+        The schema's name.
+    """
+    schema = f'ri_tenant_{uuid.uuid4().hex}'
+    admin = sqlalchemy.create_engine(postgres_server_url)
+    try:
+        with admin.begin() as connection:
+            connection.exec_driver_sql(f'CREATE SCHEMA "{schema}"')
+        try:
+            yield schema
+        finally:
+            with admin.begin() as connection:
+                connection.exec_driver_sql(f'DROP SCHEMA "{schema}" CASCADE')
+    finally:
+        admin.dispose()
+
+
+# ---------------------------------------------------------------------------
+# The schema examined is the one the index resolves to
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_schema_of_a_populated_database_is_built_in(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str
+) -> None:
+    """A server holds schemas nobody here created, and they are not asked about.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+    """
+    with opened(postgres_url, create=True):
+        pass
+    assert _schema_tables(postgres_server_url, postgres_schema) == sorted(index_table_names())
+
+
+def test_a_foreign_table_in_that_schema_is_refused(postgres_url: str) -> None:
+    """A results index owns the schema it lives in, whatever else the server holds.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    _execute(postgres_url, f'CREATE TABLE {FOREIGN_TABLE} (x INTEGER)')
+    assert 'does not own' in _refusal_of(postgres_url)
+
+
+def test_a_stranger_s_table_of_one_of_our_names_is_refused(postgres_url: str) -> None:
+    """The chain a wrong URL starts: adopt, fail, and be sent to the drop.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    _execute(postgres_url, f'CREATE TABLE {COLLIDING_TABLE} (id int primary key, note text)')
+    assert 'no schema_meta of SpinDoctor' in _refusal_of(postgres_url)
+
+
+def test_a_stranger_s_table_keeps_its_rows(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str
+) -> None:
+    """Nothing is created and nothing is written, so their rows are still theirs.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+    """
+    _execute(
+        postgres_url,
+        f'CREATE TABLE {COLLIDING_TABLE} (id int primary key, note text)',
+        f"INSERT INTO {COLLIDING_TABLE} VALUES (1, 'theirs'), (2, 'also theirs')",
+    )
+    _refusal_of(postgres_url)
+    assert _rows_of(postgres_server_url, f'"{postgres_schema}".{COLLIDING_TABLE}') == 2
+
+
+def test_a_stranger_s_table_is_not_stamped_over(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str
+) -> None:
+    """A stamp beside it would make it this index's for every later reading.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+    """
+    _execute(postgres_url, f'CREATE TABLE {COLLIDING_TABLE} (id int primary key, note text)')
+    _refusal_of(postgres_url)
+    assert _schema_tables(postgres_server_url, postgres_schema) == [COLLIDING_TABLE]
+
+
+# ---------------------------------------------------------------------------
+# A table of one of our names in another schema on the search path
+# ---------------------------------------------------------------------------
+
+
+def _tenant_holding_one_of_our_names(server_url: str, tenant_schema: str) -> None:
+    """Put a table of one of the index's own names in another tenant's schema.
+
+    Parameters:
+        server_url: URL of the server, unscoped.
+        tenant_schema: Schema standing for another tenant's.
+    """
+    _execute(
+        server_url,
+        f'CREATE TABLE "{tenant_schema}".{COLLIDING_TABLE} (id int primary key, payload text)',
+        f'INSERT INTO "{tenant_schema}".{COLLIDING_TABLE} VALUES (1, \'not ours\')',
+    )
+
+
+def test_a_tenant_s_table_of_one_of_our_names_is_not_adopted(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str, tenant_schema: str
+) -> None:
+    """The index is built whole in one schema, not spread across the search path.
+
+    A bare name resolves through the whole path, so a table of one of these
+    names in a schema behind the index's own is one a creating open could find
+    already there and build the rest of the index around.
+
+    Parameters:
+        postgres_url: URL whose fixture creates and removes the schema built in.
+        postgres_server_url: URL of the server, unscoped.
+        postgres_schema: Name of the schema the index is built in.
+        tenant_schema: Schema standing for another tenant's.
+    """
+    _tenant_holding_one_of_our_names(postgres_server_url, tenant_schema)
+    crossed = url_scoped_to(postgres_server_url, postgres_schema, tenant_schema)
+    with opened(crossed, create=True):
+        pass
+    assert _schema_tables(postgres_server_url, postgres_schema) == sorted(index_table_names())
+
+
+def test_a_tenant_s_table_keeps_its_rows_through_a_creating_open(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str, tenant_schema: str
+) -> None:
+    """Their table is not written into, which is what adoption would have done.
+
+    Parameters:
+        postgres_url: URL whose fixture creates and removes the schema built in.
+        postgres_server_url: URL of the server, unscoped.
+        postgres_schema: Name of the schema the index is built in.
+        tenant_schema: Schema standing for another tenant's.
+    """
+    _tenant_holding_one_of_our_names(postgres_server_url, tenant_schema)
+    crossed = url_scoped_to(postgres_server_url, postgres_schema, tenant_schema)
+    with opened(crossed, create=True):
+        pass
+    assert _rows_of(postgres_server_url, f'"{tenant_schema}".{COLLIDING_TABLE}') == 1
+
+
+def test_a_tenant_s_table_keeps_its_columns_through_a_creating_open(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str, tenant_schema: str
+) -> None:
+    """Nor is it altered into the shape the index wanted.
+
+    Parameters:
+        postgres_url: URL whose fixture creates and removes the schema built in.
+        postgres_server_url: URL of the server, unscoped.
+        postgres_schema: Name of the schema the index is built in.
+        tenant_schema: Schema standing for another tenant's.
+    """
+    _tenant_holding_one_of_our_names(postgres_server_url, tenant_schema)
+    crossed = url_scoped_to(postgres_server_url, postgres_schema, tenant_schema)
+    with opened(crossed, create=True):
+        pass
+    engine = sqlalchemy.create_engine(postgres_server_url)
+    try:
+        columns = sqlalchemy.inspect(engine).get_columns(COLLIDING_TABLE, schema=tenant_schema)
+    finally:
+        engine.dispose()
+    assert [column['name'] for column in columns] == ['id', 'payload']
+
+
+def test_an_index_is_completed_in_the_schema_its_stamp_was_found_in(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str, tenant_schema: str
+) -> None:
+    """The stamp names the schema, so an ingest reached through a longer path finds it.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+        tenant_schema: Schema standing for another tenant's, empty and ahead of it.
+    """
+    with opened(postgres_url, create=True):
+        pass
+    reached = url_scoped_to(postgres_server_url, tenant_schema, postgres_schema)
+    with opened(reached, create=True):
+        pass
+    assert _schema_tables(postgres_server_url, tenant_schema) == []
+
+
+# ---------------------------------------------------------------------------
+# What a refusal says
+# ---------------------------------------------------------------------------
+
+
+def test_a_refusal_names_the_schema_it_examined(postgres_url: str, postgres_schema: str) -> None:
+    """Which schema a URL resolves to is not something the URL says.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_schema: Name of that schema.
+    """
+    _execute(postgres_url, f'CREATE TABLE {FOREIGN_TABLE} (x INTEGER)')
+    assert f'schema {postgres_schema}' in _refusal_of(postgres_url)
+
+
+def test_a_refusal_does_not_repeat_the_password(postgres_url: str) -> None:
+    """These messages go to run logs, and a database password belongs in none.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    _execute(postgres_url, f'CREATE TABLE {FOREIGN_TABLE} (x INTEGER)')
+    with_password = sqlalchemy.engine.make_url(postgres_url).set(password=BOGUS_PASSWORD)
+    refused = _refusal_of(with_password.render_as_string(hide_password=False))
+    assert BOGUS_PASSWORD not in refused
+
+
+def test_a_search_path_naming_no_schema_that_exists_is_refused(
+    postgres_server_url: str,
+) -> None:
+    """There is nowhere to build, and saying so beats failing inside the first DDL.
+
+    Parameters:
+        postgres_server_url: URL of the server, unscoped.
+    """
+    nowhere = url_scoped_to(postgres_server_url, f'ri_absent_{uuid.uuid4().hex}')
+    assert 'reaches no schema a table can be created in' in _refusal_of(nowhere)
+
+
+# ---------------------------------------------------------------------------
+# A stamp of another version
+# ---------------------------------------------------------------------------
+
+
+def test_a_stamped_schema_of_another_version_reaches_the_version_gate(
+    postgres_url: str,
+) -> None:
+    """The database a version bump leaves behind is the index's own, and is told so.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    _execute(
+        postgres_url,
+        f'CREATE TABLE {SCHEMA_META.name} '
+        f'(singleton int primary key, schema_version int, created_utc text)',
+        f'INSERT INTO {SCHEMA_META.name} VALUES (1, {SCHEMA_VERSION - 1}, now()::text)',
+        f'CREATE TABLE {COLLIDING_TABLE} (root_url text, a_column_of_an_older_version text)',
+    )
+    assert f'schema version {SCHEMA_VERSION - 1} is not the version' in _refusal_of(postgres_url)
+
+
+def test_a_foreign_table_beside_a_stamped_schema_is_refused_first(
+    postgres_url: str,
+) -> None:
+    """A stamp says the tables of our names are ours, and nothing about the rest.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    _execute(
+        postgres_url,
+        f'CREATE TABLE {SCHEMA_META.name} '
+        f'(singleton int primary key, schema_version int, created_utc text)',
+        f'INSERT INTO {SCHEMA_META.name} VALUES (1, {SCHEMA_VERSION}, now()::text)',
+        f'CREATE TABLE {FOREIGN_TABLE} (x INTEGER)',
+    )
+    assert FOREIGN_TABLE in _refusal_of(postgres_url)

--- a/tests/spindoctor/results_index/test_drop.py
+++ b/tests/spindoctor/results_index/test_drop.py
@@ -1,0 +1,575 @@
+"""Removing the results index's own tables, and nothing else.
+
+Three things are asked here.  That the drop removes exactly the tables the
+schema declares and no other object of the database.  That it works on the
+databases no opener will accept, since a version the gate refuses is the case
+the drop exists for.  And that whatever it leaves behind is a state the version
+gate reads as "not an index" rather than as a broken one, which is what the
+order the tables go in is for.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import sqlalchemy
+from tests.spindoctor.results_index.conftest import image_row, opened, sqlite_url_for
+
+from spindoctor.results_index import (
+    IMAGES,
+    INGEST_RUNS,
+    METADATA,
+    SCHEMA_META,
+    SCHEMA_VERSION,
+    drop_index_tables,
+    index_contents,
+    index_table_names,
+    open_database,
+    open_index,
+)
+
+FOREIGN_TABLE = 'somebody_elses_table'
+"""A table of the same database that SpinDoctor did not create.
+
+A PostgreSQL server is routinely shared, and a SQLite file is free to hold
+anything, so the drop's promise is about the tables it names rather than about
+the database around them.
+"""
+
+
+def _built(path: Path) -> str:
+    """Create an index at a path and return its URL.
+
+    Parameters:
+        path: The database file's path.
+
+    Returns:
+        The URL of the created index.
+    """
+    url = sqlite_url_for(path)
+    with opened(url, create=True):
+        pass
+    return url
+
+
+def _table_names(url: str) -> list[str]:
+    """Return every table a database holds, whoever created it.
+
+    Parameters:
+        url: The database URL.
+
+    Returns:
+        The table names, sorted.
+    """
+    engine = sqlalchemy.create_engine(url)
+    try:
+        return sorted(sqlalchemy.inspect(engine).get_table_names())
+    finally:
+        engine.dispose()
+
+
+def _dropped(url: str) -> tuple[str, ...]:
+    """Open a database, drop the index tables from it, and close it.
+
+    Parameters:
+        url: The database URL.
+
+    Returns:
+        The names of the tables that were dropped.
+    """
+    engine = open_database(url)
+    try:
+        return drop_index_tables(engine)
+    finally:
+        engine.dispose()
+
+
+def _contents(url: str) -> Any:
+    """Open a database and read what of the index it holds.
+
+    Parameters:
+        url: The database URL.
+
+    Returns:
+        The contents.
+    """
+    engine = open_database(url)
+    try:
+        return index_contents(engine)
+    finally:
+        engine.dispose()
+
+
+def _add_foreign_table(url: str) -> None:
+    """Create a table in the database that the index does not own.
+
+    Parameters:
+        url: The database URL.
+    """
+    engine = sqlalchemy.create_engine(url)
+    try:
+        with engine.begin() as connection:
+            connection.exec_driver_sql(f'CREATE TABLE {FOREIGN_TABLE} (x INTEGER)')
+    finally:
+        engine.dispose()
+
+
+# The order the tables go in
+
+
+def test_the_drop_covers_every_table_the_schema_declares() -> None:
+    """The names come from the metadata, so a table added to it is dropped too.
+
+    A hand-written list would be right on the day it was written and wrong on
+    the day the next table was added, and the table it forgot is the one left
+    standing over a database that reads as empty.
+    """
+    assert sorted(index_table_names()) == sorted(METADATA.tables)
+
+
+def test_the_stamp_is_dropped_before_anything_it_stamps() -> None:
+    """Every state an interrupted drop can leave is then one with no stamp.
+
+    A stamp still standing over tables that have gone is the one state that must
+    not be left: the version gate reads it as a healthy index of this version,
+    and every consumer then fails inside its first query instead of being told
+    to ingest.
+    """
+    assert index_table_names()[0] == SCHEMA_META.name
+
+
+@pytest.mark.parametrize('child', ['techniques', 'feature_sources'])
+def test_a_child_table_goes_before_the_table_it_references(child: str) -> None:
+    """A table another one references cannot be dropped while that reference stands.
+
+    Parameters:
+        child: Name of a table carrying a foreign key into ``images``.
+    """
+    order = index_table_names()
+    assert order.index(child) < order.index(IMAGES.name)
+
+
+# What a drop removes
+
+
+def test_the_drop_removes_every_table_of_the_index(tmp_path: Path) -> None:
+    """The whole schema goes, not the part a query happened to name.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    _dropped(url)
+    assert _table_names(url) == []
+
+
+def test_the_drop_names_what_it_removed(tmp_path: Path) -> None:
+    """An operator reads the answer, so the answer is the table names.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    assert _dropped(url) == index_table_names()
+
+
+def test_a_table_the_index_does_not_own_survives_the_drop(tmp_path: Path) -> None:
+    """A shared database is the case this promise is about.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    _add_foreign_table(url)
+    _dropped(url)
+    assert _table_names(url) == [FOREIGN_TABLE]
+
+
+def _statements_of_a_drop(url: str) -> list[str]:
+    """Return every statement a drop issued, in the order it issued them.
+
+    Parameters:
+        url: The database URL.
+
+    Returns:
+        The statements, stripped of surrounding space.
+    """
+    statements: list[str] = []
+    engine = open_database(url)
+    sqlalchemy.event.listen(
+        engine,
+        'before_cursor_execute',
+        lambda conn, cursor, statement, *rest: statements.append(statement.strip()),
+    )
+    try:
+        drop_index_tables(engine)
+    finally:
+        engine.dispose()
+    return statements
+
+
+def test_the_drop_issues_one_drop_table_per_index_table(tmp_path: Path) -> None:
+    """Read off the statements themselves, rather than off what survived.
+
+    A database this test can see the whole of would pass on its contents alone
+    even if the drop had reached for the schema around them; what says it did
+    not is that the only destructive statements it issued were these six, each
+    naming one table by name.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    issued = _statements_of_a_drop(url)
+    destructive = [statement for statement in issued if statement.upper().startswith('DROP')]
+    assert destructive == [f'DROP TABLE {name}' for name in index_table_names()]
+
+
+def test_the_drop_never_utters_a_table_it_does_not_own(tmp_path: Path) -> None:
+    """Including in the statements it issues to find out what is there.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    _add_foreign_table(url)
+    named = [statement for statement in _statements_of_a_drop(url) if FOREIGN_TABLE in statement]
+    assert named == []
+
+
+def test_a_second_drop_removes_nothing(tmp_path: Path) -> None:
+    """An idempotent drop has to be visibly idempotent, not silently so.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    _dropped(url)
+    assert _dropped(url) == ()
+
+
+def test_a_second_drop_leaves_a_foreign_table_alone(tmp_path: Path) -> None:
+    """A database holding none of the index is not written at all.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    _add_foreign_table(url)
+    _dropped(url)
+    _dropped(url)
+    assert _table_names(url) == [FOREIGN_TABLE]
+
+
+# The databases no opener accepts
+
+
+def test_an_index_stamped_with_another_version_can_be_dropped(tmp_path: Path) -> None:
+    """The case the drop exists for: the gate's own remedy, made reachable.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    with opened(url) as engine, engine.begin() as connection:
+        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    _dropped(url)
+    assert _table_names(url) == []
+
+
+def test_the_contents_report_a_version_this_code_does_not_read(tmp_path: Path) -> None:
+    """What is about to go is named by the version it was written under.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    with opened(url) as engine, engine.begin() as connection:
+        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    assert _contents(url).schema_version == SCHEMA_VERSION + 1
+
+
+def test_a_database_holding_part_of_a_schema_can_be_dropped(tmp_path: Path) -> None:
+    """An interrupted creation leaves one, and no opener will touch it.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'index.sqlite3')
+    engine = sqlalchemy.create_engine(url)
+    try:
+        IMAGES.create(engine)
+    finally:
+        engine.dispose()
+    assert _dropped(url) == (IMAGES.name,)
+
+
+def test_a_stamp_whose_columns_are_not_this_version_does_not_stop_the_drop(
+    tmp_path: Path,
+) -> None:
+    """The stamp is a fact reported, not a fact required.
+
+    A ``schema_meta`` left over from a schema whose columns were different is
+    exactly the shape an old index has, and refusing to say what a database
+    holds because its stamp would not come out is withholding the drop from one
+    of the cases it is for.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'index.sqlite3')
+    engine = sqlalchemy.create_engine(url)
+    try:
+        with engine.begin() as connection:
+            connection.exec_driver_sql(f'CREATE TABLE {SCHEMA_META.name} (something_else INTEGER)')
+    finally:
+        engine.dispose()
+    assert _contents(url).schema_version is None
+
+
+# What the drop leaves behind
+
+
+def test_a_database_with_no_stamp_reads_as_one_nobody_ingested(tmp_path: Path) -> None:
+    """The state an interrupted drop leaves, put to the gate that reads it.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    with opened(url) as engine, engine.begin() as connection:
+        connection.execute(sqlalchemy.schema.DropTable(SCHEMA_META))
+    with pytest.raises(ValueError, match='this is not a results index'):
+        open_index(url)
+
+
+def test_a_dropped_index_is_rebuilt_by_the_next_creating_open(tmp_path: Path) -> None:
+    """Left usable, rather than left absent: the next ingest builds it again.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    _dropped(url)
+    with opened(url, create=True):
+        pass
+    assert _table_names(url) == sorted(METADATA.tables)
+
+
+def test_a_rebuilt_index_carries_this_version(tmp_path: Path) -> None:
+    """And is stamped, so the gate lets a consumer in again.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    _dropped(url)
+    with opened(url, create=True) as engine, engine.connect() as connection:
+        stamped = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).scalar()
+    assert stamped == SCHEMA_VERSION
+
+
+def test_a_rebuilt_index_holds_none_of_the_dropped_rows(tmp_path: Path) -> None:
+    """Starting from scratch is the point, so nothing may survive the rebuild.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    with opened(url) as engine, engine.begin() as connection:
+        connection.execute(IMAGES.insert(), image_row())
+    _dropped(url)
+    with opened(url, create=True) as engine, engine.connect() as connection:
+        remaining = connection.execute(
+            sqlalchemy.select(sqlalchemy.func.count()).select_from(IMAGES)
+        ).scalar()
+    assert remaining == 0
+
+
+# What a drop says it is about to remove
+
+
+def test_the_contents_count_the_rows_of_each_table(tmp_path: Path) -> None:
+    """What is at stake is rows, so rows are what the account is in.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    with opened(url) as engine, engine.begin() as connection:
+        connection.execute(IMAGES.insert(), image_row())
+    counted = {table.name: table.rows for table in _contents(url).tables}
+    assert counted[IMAGES.name] == 1
+
+
+def test_the_contents_total_the_rows_across_the_tables(tmp_path: Path) -> None:
+    """One number for a person deciding, beside the per-table breakdown.
+
+    The stamp row is one of them, so a freshly created index holding one image
+    totals two.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    with opened(url) as engine, engine.begin() as connection:
+        connection.execute(IMAGES.insert(), image_row())
+    assert _contents(url).rows == 2
+
+
+def test_the_contents_report_the_stamp(tmp_path: Path) -> None:
+    """A version that is not this one is what makes a drop the right move.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    assert _contents(url).schema_version == SCHEMA_VERSION
+
+
+def test_the_contents_of_a_database_holding_no_index_are_empty(tmp_path: Path) -> None:
+    """Which is what lets a drop answer without writing anything.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'index.sqlite3')
+    _add_foreign_table(url)
+    assert _contents(url).tables == ()
+
+
+def test_the_contents_count_an_unfinished_ingest_run(tmp_path: Path) -> None:
+    """A drop is allowed under one, so the person answering is told about it.
+
+    Nothing in the index tells a pass that is writing it now from one that died,
+    so the count is reported rather than acted on.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    with opened(url) as engine, engine.begin() as connection:
+        connection.execute(
+            INGEST_RUNS.insert(),
+            {
+                'root_url': '/data/nav-results',
+                'started_utc': '2026-08-09T00:00:00+00:00',
+                'finished_utc': None,
+                'schema_version': SCHEMA_VERSION,
+            },
+        )
+    assert _contents(url).unfinished_runs == 1
+
+
+def test_a_finished_ingest_run_is_not_counted_as_unfinished(tmp_path: Path) -> None:
+    """Otherwise every drop would carry the warning and none would mean it.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    with opened(url) as engine, engine.begin() as connection:
+        connection.execute(
+            INGEST_RUNS.insert(),
+            {
+                'root_url': '/data/nav-results',
+                'started_utc': '2026-08-09T00:00:00+00:00',
+                'finished_utc': '2026-08-09T00:01:00+00:00',
+                'schema_version': SCHEMA_VERSION,
+            },
+        )
+    assert _contents(url).unfinished_runs == 0
+
+
+def test_the_unfinished_count_is_withheld_at_another_schema_version(tmp_path: Path) -> None:
+    """The question is phrased in a column, and a version may have changed it.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    with opened(url) as engine, engine.begin() as connection:
+        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    assert _contents(url).unfinished_runs is None
+
+
+# The opener the drop uses
+
+
+def test_a_sqlite_path_that_is_not_there_is_refused(tmp_path: Path) -> None:
+    """A database that is not there is refused on both backends alike.
+
+    A PostgreSQL database that does not exist is refused by the server, and a
+    typed path deserves the same answer rather than a quiet success over
+    nothing.
+
+    Parameters:
+        tmp_path: Directory the path names a file in.
+    """
+    with pytest.raises(ValueError, match='there is no results index at'):
+        open_database(sqlite_url_for(tmp_path / 'absent.sqlite3'))
+
+
+def test_the_absent_refusal_says_nothing_was_dropped(tmp_path: Path) -> None:
+    """Rather than telling an operator who is deleting one to build one.
+
+    Parameters:
+        tmp_path: Directory the path names a file in.
+    """
+    with pytest.raises(ValueError, match='Nothing was dropped'):
+        open_database(sqlite_url_for(tmp_path / 'absent.sqlite3'))
+
+
+def test_a_refused_path_is_not_created(tmp_path: Path) -> None:
+    """A mistyped URL must not leave an empty database where it pointed.
+
+    Parameters:
+        tmp_path: Directory the path names a file in.
+    """
+    path = tmp_path / 'absent.sqlite3'
+    with pytest.raises(ValueError):
+        open_database(sqlite_url_for(path))
+    assert not path.exists()
+
+
+def test_a_read_only_database_is_refused_before_a_table_goes(tmp_path: Path) -> None:
+    """Refusing beats half-completing, so the question is asked at the open.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    path = tmp_path / 'index.sqlite3'
+    url = _built(path)
+    path.chmod(0o444)
+    try:
+        with pytest.raises(ValueError, match='dropping the index has to write it'):
+            open_database(url)
+    finally:
+        path.chmod(0o644)
+
+
+def test_the_read_only_refusal_does_not_prescribe_ingesting_a_copy(tmp_path: Path) -> None:
+    """The remedy is per operation: a copy answers nothing for a drop.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    path = tmp_path / 'index.sqlite3'
+    url = _built(path)
+    path.chmod(0o444)
+    try:
+        with pytest.raises(ValueError) as excinfo:
+            open_database(url)
+    finally:
+        path.chmod(0o644)
+    assert 'Ingest a writable copy' not in str(excinfo.value)
+
+
+def test_a_url_no_driver_reads_is_refused_as_a_value_error() -> None:
+    """The drop's opener keeps the one-exception-type contract of the other.
+
+    Parameters:
+        None.
+    """
+    with pytest.raises(ValueError, match='no database driver for this URL scheme'):
+        open_database('nosuchbackend://host/db')

--- a/tests/spindoctor/results_index/test_drop.py
+++ b/tests/spindoctor/results_index/test_drop.py
@@ -1,11 +1,13 @@
 """Removing the results index's own tables, and nothing else.
 
-Three things are asked here.  That the drop removes exactly the tables the
-schema declares and no other object of the database.  That it works on the
-databases no opener will accept, since a version the gate refuses is the case
-the drop exists for.  And that whatever it leaves behind is a state the version
-gate reads as "not an index" rather than as a broken one, which is what the
-order the tables go in is for.
+Four things are asked here.  That the drop removes exactly the tables the schema
+declares and no other object of the database.  That it removes them only from a
+database that proved it holds an index of SpinDoctor's, since ``images`` is a
+name anybody may use and a drop deciding from names alone destroys strangers'
+data.  That it works on the databases no opener will accept, since a version the
+gate refuses is the case the drop exists for.  And that an interruption leaves
+the database exactly as it was, on the backend whose driver would otherwise
+commit each ``DROP TABLE`` on its own.
 """
 
 from pathlib import Path
@@ -21,6 +23,7 @@ from spindoctor.results_index import (
     METADATA,
     SCHEMA_META,
     SCHEMA_VERSION,
+    IndexContents,
     drop_index_tables,
     index_contents,
     index_table_names,
@@ -35,6 +38,17 @@ A PostgreSQL server is routinely shared, and a SQLite file is free to hold
 anything, so the drop's promise is about the tables it names rather than about
 the database around them.
 """
+
+COLLIDING_TABLE = IMAGES.name
+"""A table SpinDoctor did not create, under a name SpinDoctor also uses.
+
+The harder half of the same promise, and the one a foreign table called
+``somebody_elses_table`` cannot ask: our names are among the commonest there
+are, so a database is free to hold one of them for a reason of its own.
+"""
+
+SQLITE_SCHEMA = 'main'
+"""The one namespace a SQLite database has, which the drop names explicitly."""
 
 
 def _built(path: Path) -> str:
@@ -68,23 +82,7 @@ def _table_names(url: str) -> list[str]:
         engine.dispose()
 
 
-def _dropped(url: str) -> tuple[str, ...]:
-    """Open a database, drop the index tables from it, and close it.
-
-    Parameters:
-        url: The database URL.
-
-    Returns:
-        The names of the tables that were dropped.
-    """
-    engine = open_database(url)
-    try:
-        return drop_index_tables(engine)
-    finally:
-        engine.dispose()
-
-
-def _contents(url: str) -> Any:
+def _contents(url: str) -> IndexContents:
     """Open a database and read what of the index it holds.
 
     Parameters:
@@ -100,21 +98,69 @@ def _contents(url: str) -> Any:
         engine.dispose()
 
 
+def _dropped(url: str) -> tuple[str, ...]:
+    """Open a database, drop the index tables from it, and close it.
+
+    Parameters:
+        url: The database URL.
+
+    Returns:
+        The names of the tables that were dropped.
+    """
+    engine = open_database(url)
+    try:
+        return drop_index_tables(engine, index_contents(engine))
+    finally:
+        engine.dispose()
+
+
+def _execute(url: str, *statements: str) -> None:
+    """Run statements against a database as somebody other than the index.
+
+    Parameters:
+        url: The database URL.
+        statements: The statements to run, in order.
+    """
+    engine = sqlalchemy.create_engine(url)
+    try:
+        with engine.begin() as connection:
+            for statement in statements:
+                connection.exec_driver_sql(statement)
+    finally:
+        engine.dispose()
+
+
 def _add_foreign_table(url: str) -> None:
     """Create a table in the database that the index does not own.
 
     Parameters:
         url: The database URL.
     """
+    _execute(url, f'CREATE TABLE {FOREIGN_TABLE} (x INTEGER)')
+
+
+def _rows_of(url: str, table: str) -> int:
+    """Return how many rows a table of a database holds.
+
+    Parameters:
+        url: The database URL.
+        table: The table's name.
+
+    Returns:
+        The row count.
+    """
     engine = sqlalchemy.create_engine(url)
     try:
-        with engine.begin() as connection:
-            connection.exec_driver_sql(f'CREATE TABLE {FOREIGN_TABLE} (x INTEGER)')
+        with engine.connect() as connection:
+            counted: Any = connection.exec_driver_sql(f'SELECT count(*) FROM {table}').scalar()
     finally:
         engine.dispose()
+    return int(counted)
 
 
+# ---------------------------------------------------------------------------
 # The order the tables go in
+# ---------------------------------------------------------------------------
 
 
 def test_the_drop_covers_every_table_the_schema_declares() -> None:
@@ -128,12 +174,11 @@ def test_the_drop_covers_every_table_the_schema_declares() -> None:
 
 
 def test_the_stamp_is_dropped_before_anything_it_stamps() -> None:
-    """Every state an interrupted drop can leave is then one with no stamp.
+    """The one state that must never be reached is the one the order forbids.
 
-    A stamp still standing over tables that have gone is the one state that must
-    not be left: the version gate reads it as a healthy index of this version,
-    and every consumer then fails inside its first query instead of being told
-    to ingest.
+    A stamp still standing over tables that have gone is read by the version
+    gate as a healthy index of this version, and every consumer then fails
+    inside its first query instead of being told to ingest.
     """
     assert index_table_names()[0] == SCHEMA_META.name
 
@@ -149,7 +194,9 @@ def test_a_child_table_goes_before_the_table_it_references(child: str) -> None:
     assert order.index(child) < order.index(IMAGES.name)
 
 
+# ---------------------------------------------------------------------------
 # What a drop removes
+# ---------------------------------------------------------------------------
 
 
 def test_the_drop_removes_every_table_of_the_index(tmp_path: Path) -> None:
@@ -196,13 +243,14 @@ def _statements_of_a_drop(url: str) -> list[str]:
     """
     statements: list[str] = []
     engine = open_database(url)
+    contents = index_contents(engine)
     sqlalchemy.event.listen(
         engine,
         'before_cursor_execute',
         lambda conn, cursor, statement, *rest: statements.append(statement.strip()),
     )
     try:
-        drop_index_tables(engine)
+        drop_index_tables(engine, contents)
     finally:
         engine.dispose()
     return statements
@@ -222,7 +270,26 @@ def test_the_drop_issues_one_drop_table_per_index_table(tmp_path: Path) -> None:
     url = _built(tmp_path / 'index.sqlite3')
     issued = _statements_of_a_drop(url)
     destructive = [statement for statement in issued if statement.upper().startswith('DROP')]
-    assert destructive == [f'DROP TABLE {name}' for name in index_table_names()]
+    assert destructive == [f'DROP TABLE {SQLITE_SCHEMA}.{name}' for name in index_table_names()]
+
+
+def test_every_statement_of_the_drop_names_its_schema(tmp_path: Path) -> None:
+    """A bare name is resolved by the server, and a search path may cross schemas.
+
+    Naming the schema is what keeps six names from resolving into two of them,
+    which is how a drop comes to destroy one database's table while leaving the
+    index's own standing.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    destructive = [
+        statement
+        for statement in _statements_of_a_drop(url)
+        if statement.upper().startswith('DROP')
+    ]
+    assert all(f' {SQLITE_SCHEMA}.' in statement for statement in destructive)
 
 
 def test_the_drop_never_utters_a_table_it_does_not_own(tmp_path: Path) -> None:
@@ -249,7 +316,7 @@ def test_a_second_drop_removes_nothing(tmp_path: Path) -> None:
 
 
 def test_a_second_drop_leaves_a_foreign_table_alone(tmp_path: Path) -> None:
-    """A database holding none of the index is not written at all.
+    """A database holding none of the index keeps whatever else is in it.
 
     Parameters:
         tmp_path: Directory the index file is written into.
@@ -261,7 +328,186 @@ def test_a_second_drop_leaves_a_foreign_table_alone(tmp_path: Path) -> None:
     assert _table_names(url) == [FOREIGN_TABLE]
 
 
+def test_a_database_holding_none_of_the_index_is_not_written_at_all(tmp_path: Path) -> None:
+    """Not "nothing was removed" but "no statement was issued".
+
+    A drop that opened a transaction over an empty list would satisfy every
+    assertion about what survived, so what is asserted here is that the drop
+    said nothing to the database at all.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'index.sqlite3')
+    _add_foreign_table(url)
+    assert _statements_of_a_drop(url) == []
+
+
+def test_the_tables_dropped_are_the_tables_that_were_read(tmp_path: Path) -> None:
+    """A destructive command must not act on a list nobody was shown.
+
+    Between the reading an operator answers and the drop that follows, another
+    process is free to put a table back.  What goes is what was read.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    engine = open_database(url)
+    try:
+        contents = index_contents(engine)
+        _execute(url, f'DROP TABLE {INGEST_RUNS.name}', 'CREATE TABLE ingest_runs_copy (x INTEGER)')
+        dropped = drop_index_tables(
+            engine,
+            IndexContents(
+                schema=contents.schema,
+                tables=tuple(table for table in contents.tables if table.name != INGEST_RUNS.name),
+                schema_version=contents.schema_version,
+                unfinished_runs=contents.unfinished_runs,
+                unproven=(),
+            ),
+        )
+    finally:
+        engine.dispose()
+    assert INGEST_RUNS.name not in dropped
+
+
+# ---------------------------------------------------------------------------
+# What proves a database holds an index of ours
+# ---------------------------------------------------------------------------
+
+
+def test_a_table_sharing_one_of_our_names_is_not_evidence_of_an_index(tmp_path: Path) -> None:
+    """``images`` is a name anybody may use, and using it is not consent.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'other.sqlite3')
+    _execute(url, f'CREATE TABLE {COLLIDING_TABLE} (id INTEGER PRIMARY KEY, caption TEXT)')
+    assert _contents(url).schema is None
+
+
+def test_such_a_table_is_named_in_what_the_reading_reports(tmp_path: Path) -> None:
+    """So that a refusal can say what it saw rather than only that it refused.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'other.sqlite3')
+    _execute(url, f'CREATE TABLE {COLLIDING_TABLE} (id INTEGER PRIMARY KEY, caption TEXT)')
+    assert _contents(url).unproven == (COLLIDING_TABLE,)
+
+
+def test_such_a_table_is_not_listed_as_one_of_the_index_tables(tmp_path: Path) -> None:
+    """Listing it would be an account of somebody else's rows as ours.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'other.sqlite3')
+    _execute(url, f'CREATE TABLE {COLLIDING_TABLE} (id INTEGER PRIMARY KEY, caption TEXT)')
+    assert _contents(url).tables == ()
+
+
+def test_such_a_table_is_not_dropped(tmp_path: Path) -> None:
+    """The whole of the finding: a stranger's rows are not ours to remove.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'other.sqlite3')
+    _execute(
+        url,
+        f'CREATE TABLE {COLLIDING_TABLE} (id INTEGER PRIMARY KEY, caption TEXT)',
+        f"INSERT INTO {COLLIDING_TABLE} (caption) VALUES ('somebody elses cat'), ('their dog')",
+    )
+    _dropped(url)
+    assert _rows_of(url, COLLIDING_TABLE) == 2
+
+
+def test_a_database_of_our_names_with_no_stamp_is_not_written_at_all(tmp_path: Path) -> None:
+    """Refused before a transaction is opened, not inside one that drops nothing.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'other.sqlite3')
+    _execute(url, f'CREATE TABLE {COLLIDING_TABLE} (id INTEGER PRIMARY KEY, caption TEXT)')
+    assert _statements_of_a_drop(url) == []
+
+
+def test_a_stamp_table_without_the_marks_of_ours_is_not_evidence(tmp_path: Path) -> None:
+    """A table called ``schema_meta`` is not therefore SpinDoctor's.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'other.sqlite3')
+    _execute(
+        url,
+        f'CREATE TABLE {SCHEMA_META.name} (version_num TEXT)',
+        f'CREATE TABLE {COLLIDING_TABLE} (id INTEGER)',
+    )
+    assert _contents(url).schema is None
+
+
+def test_a_stamp_carrying_the_marks_of_ours_is_evidence(tmp_path: Path) -> None:
+    """The pair of columns is the mark, not the whole column set of this version.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'other.sqlite3')
+    _execute(
+        url,
+        f'CREATE TABLE {SCHEMA_META.name} '
+        f'(singleton INTEGER PRIMARY KEY, schema_version INTEGER, whatever TEXT)',
+    )
+    assert _contents(url).schema == SQLITE_SCHEMA
+
+
+def test_a_database_holding_part_of_a_schema_with_its_stamp_can_be_dropped(
+    tmp_path: Path,
+) -> None:
+    """An interrupted creation leaves one, and no opener will touch it.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'index.sqlite3')
+    engine = sqlalchemy.create_engine(url)
+    try:
+        SCHEMA_META.create(engine)
+        IMAGES.create(engine)
+    finally:
+        engine.dispose()
+    assert _dropped(url) == (SCHEMA_META.name, IMAGES.name)
+
+
+def test_a_database_holding_part_of_a_schema_without_its_stamp_is_left_alone(
+    tmp_path: Path,
+) -> None:
+    """Because nothing tells that state from a database of somebody else's.
+
+    The cost is named rather than hidden: such a database is one the drop
+    declines, and its tables are removed by hand or with the file.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'index.sqlite3')
+    engine = sqlalchemy.create_engine(url)
+    try:
+        IMAGES.create(engine)
+    finally:
+        engine.dispose()
+    assert _dropped(url) == ()
+
+
+# ---------------------------------------------------------------------------
 # The databases no opener accepts
+# ---------------------------------------------------------------------------
 
 
 def test_an_index_stamped_with_another_version_can_be_dropped(tmp_path: Path) -> None:
@@ -289,21 +535,6 @@ def test_the_contents_report_a_version_this_code_does_not_read(tmp_path: Path) -
     assert _contents(url).schema_version == SCHEMA_VERSION + 1
 
 
-def test_a_database_holding_part_of_a_schema_can_be_dropped(tmp_path: Path) -> None:
-    """An interrupted creation leaves one, and no opener will touch it.
-
-    Parameters:
-        tmp_path: Directory the index file is written into.
-    """
-    url = sqlite_url_for(tmp_path / 'index.sqlite3')
-    engine = sqlalchemy.create_engine(url)
-    try:
-        IMAGES.create(engine)
-    finally:
-        engine.dispose()
-    assert _dropped(url) == (IMAGES.name,)
-
-
 def test_a_stamp_whose_columns_are_not_this_version_does_not_stop_the_drop(
     tmp_path: Path,
 ) -> None:
@@ -318,20 +549,222 @@ def test_a_stamp_whose_columns_are_not_this_version_does_not_stop_the_drop(
         tmp_path: Directory the index file is written into.
     """
     url = sqlite_url_for(tmp_path / 'index.sqlite3')
-    engine = sqlalchemy.create_engine(url)
-    try:
-        with engine.begin() as connection:
-            connection.exec_driver_sql(f'CREATE TABLE {SCHEMA_META.name} (something_else INTEGER)')
-    finally:
-        engine.dispose()
+    _execute(
+        url,
+        f'CREATE TABLE {SCHEMA_META.name} '
+        f'(singleton INTEGER PRIMARY KEY, schema_version INTEGER, something_else INTEGER)',
+    )
     assert _contents(url).schema_version is None
 
 
+@pytest.mark.parametrize(
+    'stamp',
+    ["'v6-beta'", 'NULL'],
+    ids=['a-version-that-is-text', 'a-version-that-is-null'],
+)
+def test_a_stamp_that_is_not_a_version_is_reported_as_none(stamp: str, tmp_path: Path) -> None:
+    """Not every way of failing to be an integer is a database error.
+
+    Text where a number belongs, and nothing at all where a number belongs, are
+    both refusals the value raises rather than the database, and a destructive
+    command that let one of them out would end in a traceback.
+
+    Parameters:
+        stamp: The value the stamp column is given.
+        tmp_path: Directory the index file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'index.sqlite3')
+    _execute(
+        url,
+        f'CREATE TABLE {SCHEMA_META.name} '
+        f'(singleton INTEGER PRIMARY KEY, schema_version TEXT, created_utc TEXT)',
+        f'INSERT INTO {SCHEMA_META.name} VALUES (1, {stamp}, NULL)',
+        f'CREATE TABLE {COLLIDING_TABLE} (x INTEGER)',
+    )
+    assert _contents(url).schema_version is None
+
+
+@pytest.mark.parametrize(
+    'stamp',
+    ["'v6-beta'", 'NULL'],
+    ids=['a-version-that-is-text', 'a-version-that-is-null'],
+)
+def test_a_stamp_that_is_not_a_version_does_not_stop_the_drop(stamp: str, tmp_path: Path) -> None:
+    """It is a malformed index, which is one of the states the drop is for.
+
+    Parameters:
+        stamp: The value the stamp column is given.
+        tmp_path: Directory the index file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'index.sqlite3')
+    _execute(
+        url,
+        f'CREATE TABLE {SCHEMA_META.name} '
+        f'(singleton INTEGER PRIMARY KEY, schema_version TEXT, created_utc TEXT)',
+        f'INSERT INTO {SCHEMA_META.name} VALUES (1, {stamp}, NULL)',
+        f'CREATE TABLE {COLLIDING_TABLE} (x INTEGER)',
+    )
+    _dropped(url)
+    assert _table_names(url) == []
+
+
+# ---------------------------------------------------------------------------
+# What an interruption leaves
+# ---------------------------------------------------------------------------
+
+
+def _drop_interrupted_at(url: str, statements_first: int) -> None:
+    """Run a drop and raise ``KeyboardInterrupt`` part of the way through it.
+
+    Ctrl-C at the terminal, reproduced where it lands: between two of the
+    statements the drop issues, with no source of the drop's own modified.
+
+    Parameters:
+        url: The database URL.
+        statements_first: How many statements to let through before the
+            interrupt.
+    """
+    seen = 0
+
+    def interrupt_after_a_few(*args: Any) -> None:
+        nonlocal seen
+        seen += 1
+        if seen > statements_first:
+            raise KeyboardInterrupt
+
+    engine = open_database(url)
+    contents = index_contents(engine)
+    sqlalchemy.event.listen(engine, 'before_cursor_execute', interrupt_after_a_few)
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            drop_index_tables(engine, contents)
+    finally:
+        engine.dispose()
+
+
+def test_an_interrupted_drop_leaves_every_table(tmp_path: Path) -> None:
+    """SQLite's own DDL is transactional; its driver is what does not use it.
+
+    The driver opens a transaction for INSERT, UPDATE and DELETE and for nothing
+    else, so a run of ``DROP TABLE`` statements would stand one at a time.  The
+    drop opens one itself, and this is what says so.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    _drop_interrupted_at(url, statements_first=3)
+    assert _table_names(url) == sorted(METADATA.tables)
+
+
+def test_an_interrupted_drop_leaves_the_rows_that_were_in_them(tmp_path: Path) -> None:
+    """Rows in a table nothing dropped, rather than rows in a rebuilt index.
+
+    An ``images`` left standing by a half-finished drop is the state that is
+    never repaired: the next creating open stamps it, and the incremental skip
+    then passes over every document whose size and modification time it still
+    records.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    with opened(url) as engine, engine.begin() as connection:
+        connection.execute(IMAGES.insert(), image_row())
+    _drop_interrupted_at(url, statements_first=3)
+    assert _rows_of(url, IMAGES.name) == 1
+
+
+def test_an_interrupted_drop_leaves_the_index_openable(tmp_path: Path) -> None:
+    """Which is the whole of "no partially-dropped state": a consumer still reads it.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    _drop_interrupted_at(url, statements_first=3)
+    with opened(url) as engine, engine.connect() as connection:
+        stamped = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).scalar()
+    assert stamped == SCHEMA_VERSION
+
+
+def _add_a_reference_into_images(url: str) -> None:
+    """Give an outside table a foreign key into ``images``, and a row using it.
+
+    A reference from outside the index is what makes ``DROP TABLE images`` fail
+    with foreign keys enforced, which is a database error rather than an
+    interrupt and reaches the same place.
+
+    Parameters:
+        url: The database URL.
+    """
+    _execute(
+        url,
+        'CREATE TABLE their_notes (root_url TEXT, results_path_stub TEXT, note TEXT, '
+        'FOREIGN KEY (root_url, results_path_stub) '
+        'REFERENCES images (root_url, results_path_stub))',
+    )
+    row = image_row()
+    _execute(
+        url,
+        f"INSERT INTO their_notes VALUES ('{row['root_url']}', "
+        f"'{row['results_path_stub']}', 'mine')",
+    )
+
+
+def test_a_drop_a_reference_refuses_leaves_every_table(tmp_path: Path) -> None:
+    """The same guarantee reached by a database error rather than by a key press.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    with opened(url) as engine, engine.begin() as connection:
+        connection.execute(IMAGES.insert(), image_row())
+    _add_a_reference_into_images(url)
+    with pytest.raises(sqlalchemy.exc.SQLAlchemyError):
+        _dropped(url)
+    assert _table_names(url) == sorted([*METADATA.tables, 'their_notes'])
+
+
+def test_a_drop_a_reference_refuses_leaves_the_index_openable(tmp_path: Path) -> None:
+    """The stamp goes first, so a drop that stood would have unstamped it.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    with opened(url) as engine, engine.begin() as connection:
+        connection.execute(IMAGES.insert(), image_row())
+    _add_a_reference_into_images(url)
+    with pytest.raises(sqlalchemy.exc.SQLAlchemyError):
+        _dropped(url)
+    with opened(url) as engine, engine.connect() as connection:
+        stamped = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).scalar()
+    assert stamped == SCHEMA_VERSION
+
+
+def test_the_drop_opens_its_transaction_before_it_drops_anything(tmp_path: Path) -> None:
+    """The statement that makes the rest of them one thing has to come first.
+
+    ``IMMEDIATE`` rather than a plain begin, so that a drop which has to give way
+    to another writer gives way before it has dropped anything, bounded by the
+    busy timeout every connection carries.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    assert _statements_of_a_drop(url)[0] == 'BEGIN IMMEDIATE'
+
+
+# ---------------------------------------------------------------------------
 # What the drop leaves behind
+# ---------------------------------------------------------------------------
 
 
 def test_a_database_with_no_stamp_reads_as_one_nobody_ingested(tmp_path: Path) -> None:
-    """The state an interrupted drop leaves, put to the gate that reads it.
+    """The state a dropped stamp leaves, put to the gate that reads it.
 
     Parameters:
         tmp_path: Directory the index file is written into.
@@ -386,7 +819,19 @@ def test_a_rebuilt_index_holds_none_of_the_dropped_rows(tmp_path: Path) -> None:
     assert remaining == 0
 
 
+# ---------------------------------------------------------------------------
 # What a drop says it is about to remove
+# ---------------------------------------------------------------------------
+
+
+def test_the_contents_name_the_schema_the_tables_are_in(tmp_path: Path) -> None:
+    """Named rather than implied, since it is what every statement then carries.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    assert _contents(url).schema == SQLITE_SCHEMA
 
 
 def test_the_contents_count_the_rows_of_each_table(tmp_path: Path) -> None:
@@ -436,6 +881,19 @@ def test_the_contents_of_a_database_holding_no_index_are_empty(tmp_path: Path) -
     url = sqlite_url_for(tmp_path / 'index.sqlite3')
     _add_foreign_table(url)
     assert _contents(url).tables == ()
+
+
+def test_the_contents_of_a_database_holding_no_index_name_nothing_unproven(
+    tmp_path: Path,
+) -> None:
+    """A database with nothing of these names in it is the state asked for.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'index.sqlite3')
+    _add_foreign_table(url)
+    assert _contents(url).unproven == ()
 
 
 def test_the_contents_count_an_unfinished_ingest_run(tmp_path: Path) -> None:
@@ -493,7 +951,9 @@ def test_the_unfinished_count_is_withheld_at_another_schema_version(tmp_path: Pa
     assert _contents(url).unfinished_runs is None
 
 
+# ---------------------------------------------------------------------------
 # The opener the drop uses
+# ---------------------------------------------------------------------------
 
 
 def test_a_sqlite_path_that_is_not_there_is_refused(tmp_path: Path) -> None:

--- a/tests/spindoctor/results_index/test_drop.py
+++ b/tests/spindoctor/results_index/test_drop.py
@@ -90,6 +90,26 @@ def _table_names(url: str) -> list[str]:
         engine.dispose()
 
 
+def _view_names(url: str) -> list[str]:
+    """Return every view a database holds.
+
+    Views are asked for separately because ``get_table_names`` does not report
+    them, so a test that reads only tables cannot tell a view that survived
+    from one that was dropped.
+
+    Parameters:
+        url: The database URL.
+
+    Returns:
+        The view names, sorted.
+    """
+    engine = sqlalchemy.create_engine(url)
+    try:
+        return sorted(sqlalchemy.inspect(engine).get_view_names())
+    finally:
+        engine.dispose()
+
+
 def _contents(url: str) -> IndexContents:
     """Open a database and read what of the index it holds.
 
@@ -557,6 +577,7 @@ def test_a_view_of_one_of_our_names_does_not_stop_the_drop(tmp_path: Path) -> No
     )
     _dropped(url)
     assert _table_names(url) == []
+    assert _view_names(url) == [FAILED_FILES.name]
 
 
 def test_an_index_whose_run_table_lost_a_column_is_still_read(tmp_path: Path) -> None:

--- a/tests/spindoctor/results_index/test_drop.py
+++ b/tests/spindoctor/results_index/test_drop.py
@@ -10,14 +10,22 @@ the database exactly as it was, on the backend whose driver would otherwise
 commit each ``DROP TABLE`` on its own.
 """
 
+import os
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
 import pytest
 import sqlalchemy
-from tests.spindoctor.results_index.conftest import image_row, opened, sqlite_url_for
+from tests.spindoctor.results_index.conftest import (
+    exploding_factory,
+    image_row,
+    opened,
+    sqlite_url_for,
+)
 
 from spindoctor.results_index import (
+    FAILED_FILES,
     IMAGES,
     INGEST_RUNS,
     METADATA,
@@ -465,6 +473,133 @@ def test_a_stamp_carrying_the_marks_of_ours_is_evidence(tmp_path: Path) -> None:
         f'(singleton INTEGER PRIMARY KEY, schema_version INTEGER, whatever TEXT)',
     )
     assert _contents(url).schema == SQLITE_SCHEMA
+
+
+def test_a_stamp_carrying_only_the_version_mark_is_not_evidence(tmp_path: Path) -> None:
+    """One mark is what any migration table carries, so one mark is not the pair.
+
+    A ``schema_version`` column alone is the shape of every hand-rolled
+    migration table there is, and taking it as proof would let one of those
+    stand as the evidence a whole schema is emptied on.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'other.sqlite3')
+    _execute(
+        url,
+        f'CREATE TABLE {SCHEMA_META.name} (schema_version INTEGER)',
+        f'CREATE TABLE {COLLIDING_TABLE} (id INTEGER)',
+    )
+    assert _contents(url).schema is None
+
+
+def test_a_stamp_carrying_only_the_singleton_mark_is_not_evidence(tmp_path: Path) -> None:
+    """Nor is the other one, so what is required is both of them together.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'other.sqlite3')
+    _execute(
+        url,
+        f'CREATE TABLE {SCHEMA_META.name} (singleton INTEGER PRIMARY KEY)',
+        f'CREATE TABLE {COLLIDING_TABLE} (id INTEGER)',
+    )
+    assert _contents(url).schema is None
+
+
+def test_a_stamp_carrying_only_one_mark_drops_nothing(tmp_path: Path) -> None:
+    """The evidence gate decides what is dropped, not only what is reported.
+
+    Parameters:
+        tmp_path: Directory the database file is written into.
+    """
+    url = sqlite_url_for(tmp_path / 'other.sqlite3')
+    _execute(
+        url,
+        f'CREATE TABLE {SCHEMA_META.name} (schema_version INTEGER)',
+        f'CREATE TABLE {COLLIDING_TABLE} (id INTEGER)',
+    )
+    _dropped(url)
+    assert _table_names(url) == sorted([SCHEMA_META.name, COLLIDING_TABLE])
+
+
+def test_a_view_of_one_of_our_names_is_not_one_of_our_tables(tmp_path: Path) -> None:
+    """``DROP TABLE`` refuses a view, and a refusal takes the whole drop back.
+
+    A view of one of these names is therefore left out of what the drop counts
+    and removes, rather than counted in and then failed on halfway through.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    _execute(
+        url,
+        f'DROP TABLE {FAILED_FILES.name}',
+        f'CREATE VIEW {FAILED_FILES.name} AS SELECT 1 AS root_url',
+    )
+    assert FAILED_FILES.name not in [table.name for table in _contents(url).tables]
+
+
+def test_a_view_of_one_of_our_names_does_not_stop_the_drop(tmp_path: Path) -> None:
+    """The tables that are tables still go, and the view is left where it was.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    _execute(
+        url,
+        f'DROP TABLE {FAILED_FILES.name}',
+        f'CREATE VIEW {FAILED_FILES.name} AS SELECT 1 AS root_url',
+    )
+    _dropped(url)
+    assert _table_names(url) == []
+
+
+def test_an_index_whose_run_table_lost_a_column_is_still_read(tmp_path: Path) -> None:
+    """A stamp says which version wrote a database, not that nothing changed since.
+
+    The unfinished-run count is phrased in a column, and the count is the one
+    thing here that a column can take away.  Losing it costs the count and
+    nothing else: what the database holds is still reported, and the drop the
+    operator came for is still available.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    _execute(url, f'ALTER TABLE {INGEST_RUNS.name} RENAME COLUMN finished_utc TO finished_at')
+    assert _contents(url).unfinished_runs is None
+
+
+def test_an_index_whose_run_table_lost_a_column_still_reports_its_tables(
+    tmp_path: Path,
+) -> None:
+    """The count is what is withheld, not the account it was part of.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    _execute(url, f'ALTER TABLE {INGEST_RUNS.name} RENAME COLUMN finished_utc TO finished_at')
+    assert [table.name for table in _contents(url).tables] == list(index_table_names())
+
+
+def test_an_index_whose_run_table_lost_a_column_can_still_be_dropped(
+    tmp_path: Path,
+) -> None:
+    """It is a database every other program opens, so the drop may not be the one to refuse.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    _execute(url, f'ALTER TABLE {INGEST_RUNS.name} RENAME COLUMN finished_utc TO finished_at')
+    _dropped(url)
+    assert _table_names(url) == []
 
 
 def test_a_database_holding_part_of_a_schema_with_its_stamp_can_be_dropped(
@@ -966,8 +1101,22 @@ def test_a_sqlite_path_that_is_not_there_is_refused(tmp_path: Path) -> None:
     Parameters:
         tmp_path: Directory the path names a file in.
     """
-    with pytest.raises(ValueError, match='there is no results index at'):
+    with pytest.raises(ValueError, match='there is no database at'):
         open_database(sqlite_url_for(tmp_path / 'absent.sqlite3'))
+
+
+def test_the_absent_refusal_calls_it_a_database_rather_than_an_index(tmp_path: Path) -> None:
+    """The drop is pointed at databases that are not indexes, and says so.
+
+    Calling one of those "the results index" in the sentence that refuses it
+    would assert of it the very thing the drop was asked to find out.
+
+    Parameters:
+        tmp_path: Directory the path names a file in.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        open_database(sqlite_url_for(tmp_path / 'absent.sqlite3'))
+    assert 'results index' not in str(excinfo.value)
 
 
 def test_the_absent_refusal_says_nothing_was_dropped(tmp_path: Path) -> None:
@@ -992,37 +1141,73 @@ def test_a_refused_path_is_not_created(tmp_path: Path) -> None:
     assert not path.exists()
 
 
-def test_a_read_only_database_is_refused_before_a_table_goes(tmp_path: Path) -> None:
+@pytest.fixture
+def read_only_database(tmp_path: Path) -> Iterator[str]:
+    """Yield the URL of an index file this user will never be able to write.
+
+    Whether a mode of 444 forbids anything is asked of the filesystem rather
+    than assumed: the superuser writes such a file, and so does any filesystem
+    that records the mode without enforcing it, and a test that read the refusal
+    out of one of those would be asserting on something that had not happened.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+
+    Yields:
+        The URL of the read-only index.
+    """
+    path = tmp_path / 'index.sqlite3'
+    url = _built(path)
+    path.chmod(0o444)
+    try:
+        if os.access(path, os.W_OK):
+            pytest.skip('this user can write a file whose mode forbids writing')
+        yield url
+    finally:
+        # The write-ahead log and the shared-memory index beside the database
+        # inherit its mode, so the directory is left as it was found only by
+        # restoring every one of them.
+        for made_read_only in path.parent.glob(f'{path.name}*'):
+            made_read_only.chmod(0o644)
+
+
+def test_a_read_only_database_is_refused_before_a_table_goes(read_only_database: str) -> None:
     """Refusing beats half-completing, so the question is asked at the open.
 
     Parameters:
-        tmp_path: Directory the index file is written into.
+        read_only_database: URL of an index file this user cannot write.
     """
-    path = tmp_path / 'index.sqlite3'
-    url = _built(path)
-    path.chmod(0o444)
-    try:
-        with pytest.raises(ValueError, match='dropping the index has to write it'):
-            open_database(url)
-    finally:
-        path.chmod(0o644)
+    with pytest.raises(ValueError, match='dropping the index has to write it'):
+        open_database(read_only_database)
 
 
-def test_the_read_only_refusal_does_not_prescribe_ingesting_a_copy(tmp_path: Path) -> None:
+def test_the_read_only_refusal_does_not_prescribe_ingesting_a_copy(
+    read_only_database: str,
+) -> None:
     """The remedy is per operation: a copy answers nothing for a drop.
 
     Parameters:
-        tmp_path: Directory the index file is written into.
+        read_only_database: URL of an index file this user cannot write.
     """
-    path = tmp_path / 'index.sqlite3'
-    url = _built(path)
-    path.chmod(0o444)
-    try:
-        with pytest.raises(ValueError) as excinfo:
-            open_database(url)
-    finally:
-        path.chmod(0o644)
+    with pytest.raises(ValueError) as excinfo:
+        open_database(read_only_database)
     assert 'Ingest a writable copy' not in str(excinfo.value)
+
+
+def test_a_failure_nobody_enumerated_calls_it_a_database_too(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The catch-all names what was being opened, and a drop was not opening an index.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+        monkeypatch: Fixture the failing engine factory is installed through.
+    """
+    url = _built(tmp_path / 'index.sqlite3')
+    monkeypatch.setattr(sqlalchemy, 'create_engine', exploding_factory)
+    with pytest.raises(ValueError, match='could not open the database') as excinfo:
+        open_database(url)
+    assert 'results index' not in str(excinfo.value)
 
 
 def test_a_url_no_driver_reads_is_refused_as_a_value_error() -> None:

--- a/tests/spindoctor/results_index/test_drop_postgres.py
+++ b/tests/spindoctor/results_index/test_drop_postgres.py
@@ -1,0 +1,318 @@
+"""Dropping a results index from a real PostgreSQL server.
+
+Four things about the drop are properties of the server rather than of the
+schema, and none of them can be asked of SQLite.  That the tables it names are
+the only objects of the database it removes, with somebody else's left standing
+beside them -- a shared server being the deployment the promise is for.  That an
+emptied schema and one nothing was ever built in are the same database, which is
+what "indistinguishable from an index that never existed" means where there is
+no file to tell them apart.  That a lock somebody else holds ends the drop
+promptly instead of hanging it.  And that when it does, the transaction takes
+every table back, which is a guarantee PostgreSQL gives and the SQLite driver
+does not.
+
+The tier is opt-in: it is excluded by the default marker filter and skips itself
+when ``SPINDOCTOR_TEST_POSTGRES_URL`` is unset.  What must not regress lives in
+the default tier as well; only what genuinely needs a server is here.
+"""
+
+import threading
+
+import pytest
+import sqlalchemy
+from tests.spindoctor.results_index.conftest import opened
+
+from spindoctor.results_index import (
+    IMAGES,
+    SCHEMA_META,
+    SCHEMA_VERSION,
+    drop,
+    drop_index_tables,
+    index_contents,
+    index_table_names,
+    open_database,
+    open_index,
+)
+
+pytestmark = pytest.mark.postgres
+
+FOREIGN_TABLE = 'somebody_elses_table'
+"""A table of the same schema that SpinDoctor did not create."""
+
+BRIEF_LOCK_WAIT_MS = 500
+"""How long the contended drop waits, so that a held lock costs half a second.
+
+The shipped bound is thirty seconds, which is the right wait for an operator and
+the wrong one for a test; what is under test is that a bound applies at all, and
+that the drop gives the table up rather than waiting on it forever.
+"""
+
+
+def _schema_tables(server_url: str, schema: str) -> list[str]:
+    """Return every table of one schema, whoever created it.
+
+    Scoped to the named schema rather than to a search path, because the
+    catalog spans the server and another worker's schema holds tables of these
+    same names.
+
+    Parameters:
+        server_url: URL of the server, unscoped.
+        schema: The schema to list.
+
+    Returns:
+        The table names, sorted.
+    """
+    engine = sqlalchemy.create_engine(server_url)
+    try:
+        return sorted(sqlalchemy.inspect(engine).get_table_names(schema=schema))
+    finally:
+        engine.dispose()
+
+
+def _add_foreign_table(url: str) -> None:
+    """Create a table the index does not own, in the schema under test.
+
+    Parameters:
+        url: The scoped index URL.
+    """
+    engine = sqlalchemy.create_engine(url)
+    try:
+        with engine.begin() as connection:
+            connection.exec_driver_sql(f'CREATE TABLE {FOREIGN_TABLE} (x INTEGER)')
+    finally:
+        engine.dispose()
+
+
+def _dropped(url: str) -> tuple[str, ...]:
+    """Open a database, drop the index tables from it, and close it.
+
+    Parameters:
+        url: The database URL.
+
+    Returns:
+        The names of the tables that were dropped.
+    """
+    engine = open_database(url)
+    try:
+        return drop_index_tables(engine)
+    finally:
+        engine.dispose()
+
+
+def _refusal_of(url: str) -> str:
+    """Return the message a consumer's open of a database is refused with.
+
+    Parameters:
+        url: The database URL.
+
+    Returns:
+        The refusal message.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        open_index(url)
+    return str(excinfo.value)
+
+
+def test_the_drop_removes_every_index_table_from_the_server(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str
+) -> None:
+    """The metadata's DDL is accepted by a server on the way out as well as in.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+    """
+    with opened(postgres_url, create=True):
+        pass
+    _dropped(postgres_url)
+    assert _schema_tables(postgres_server_url, postgres_schema) == []
+
+
+def test_a_table_the_index_does_not_own_survives_on_the_server(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str
+) -> None:
+    """A shared server is exactly what the "only our tables" promise is for.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+    """
+    with opened(postgres_url, create=True):
+        pass
+    _add_foreign_table(postgres_url)
+    _dropped(postgres_url)
+    assert _schema_tables(postgres_server_url, postgres_schema) == [FOREIGN_TABLE]
+
+
+def test_a_second_drop_removes_nothing_on_the_server(postgres_url: str) -> None:
+    """Idempotent here too, where there is no file whose absence could say so.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True):
+        pass
+    _dropped(postgres_url)
+    assert _dropped(postgres_url) == ()
+
+
+def test_an_emptied_schema_is_refused_exactly_as_an_untouched_one_is(
+    postgres_url: str,
+) -> None:
+    """The whole of "indistinguishable from an index that never existed".
+
+    One URL is asked twice: before anything is built in it, and after an index
+    has been built and dropped.  With no file to tell the two states apart, a
+    consumer's refusal is the entire observable difference between them, and the
+    two messages are compared character for character.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    never_existed = _refusal_of(postgres_url)
+    with opened(postgres_url, create=True):
+        pass
+    _dropped(postgres_url)
+    assert _refusal_of(postgres_url) == never_existed
+
+
+def test_an_emptied_schema_takes_an_ingest_again(postgres_url: str) -> None:
+    """Left usable rather than left broken, on the backend with no file to delete.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True) as engine, engine.begin() as connection:
+        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
+    _dropped(postgres_url)
+    with opened(postgres_url, create=True) as engine, engine.connect() as connection:
+        stamped = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).scalar()
+    assert stamped == SCHEMA_VERSION
+
+
+BOUNDED_WAIT_S = 20.0
+"""How long a test waits for a contended drop before calling the bound broken.
+
+Forty times the shortened bound above.  A drop that is still waiting after this
+has no bound at all, and saying so is what keeps a regression in the bound from
+arriving as a suite that never finishes.
+"""
+
+
+def _drop_while_a_lock_is_held(url: str) -> BaseException:
+    """Hold a lock on one table, run a drop against it, and return what stopped it.
+
+    The drop runs on a thread of its own so that the wait can be bounded by this
+    test rather than by the drop: what is under test is that the drop gives the
+    table up, and a drop with no bound would otherwise take the whole suite down
+    with it.
+
+    Parameters:
+        url: The index URL, whose ``images`` table is the one held.
+
+    Returns:
+        The database failure the drop ended with.
+    """
+    failure: list[BaseException] = []
+
+    def attempt() -> None:
+        try:
+            _dropped(url)
+        except BaseException as exc:
+            failure.append(exc)
+
+    holder = sqlalchemy.create_engine(url)
+    try:
+        with holder.begin() as held:
+            held.execute(sqlalchemy.select(sqlalchemy.func.count()).select_from(IMAGES))
+            worker = threading.Thread(target=attempt, daemon=True)
+            worker.start()
+            worker.join(BOUNDED_WAIT_S)
+            waiting_still = worker.is_alive()
+    finally:
+        holder.dispose()
+    if waiting_still:
+        pytest.fail(f'the drop was still waiting for the lock after {BOUNDED_WAIT_S} seconds')
+    if not failure:
+        pytest.fail('the drop finished although another session held one of its tables')
+    return failure[0]
+
+
+def test_a_lock_another_session_holds_ends_the_drop(
+    postgres_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bounded rather than refused in advance, because no backend can be asked.
+
+    A session that has merely read a table holds ``DROP TABLE`` off for as long
+    as its transaction stays open, and without a bound the drop waits on that
+    silently and forever.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        monkeypatch: Fixture the shipped wait is shortened through.
+    """
+    monkeypatch.setattr(drop, 'DROP_LOCK_TIMEOUT_MS', BRIEF_LOCK_WAIT_MS)
+    with opened(postgres_url, create=True):
+        pass
+    assert 'lock timeout' in str(_drop_while_a_lock_is_held(postgres_url))
+
+
+def test_a_drop_that_could_not_finish_leaves_every_table(
+    postgres_url: str,
+    postgres_server_url: str,
+    postgres_schema: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Refused rather than half-completed: the transaction takes them all back.
+
+    The stamp is dropped first, so a drop that gave up on a later table without
+    a transaction around it would have left the index unstamped.  Here it is
+    exactly as it was.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+        monkeypatch: Fixture the shipped wait is shortened through.
+    """
+    monkeypatch.setattr(drop, 'DROP_LOCK_TIMEOUT_MS', BRIEF_LOCK_WAIT_MS)
+    with opened(postgres_url, create=True):
+        pass
+    _drop_while_a_lock_is_held(postgres_url)
+    assert _schema_tables(postgres_server_url, postgres_schema) == sorted(index_table_names())
+
+
+def test_a_drop_that_could_not_finish_leaves_the_index_openable(
+    postgres_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Which is what "no partially-dropped state" is for: a consumer still reads it.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        monkeypatch: Fixture the shipped wait is shortened through.
+    """
+    monkeypatch.setattr(drop, 'DROP_LOCK_TIMEOUT_MS', BRIEF_LOCK_WAIT_MS)
+    with opened(postgres_url, create=True):
+        pass
+    _drop_while_a_lock_is_held(postgres_url)
+    with opened(postgres_url) as engine, engine.connect() as connection:
+        stamped = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).scalar()
+    assert stamped == SCHEMA_VERSION
+
+
+def test_the_contents_read_from_the_server_count_the_rows(postgres_url: str) -> None:
+    """Counted through the table name alone, which a strict backend still types.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True) as engine, engine.begin() as connection:
+        connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION))
+    engine = open_database(postgres_url)
+    try:
+        contents = index_contents(engine)
+    finally:
+        engine.dispose()
+    assert contents.rows == 1

--- a/tests/spindoctor/results_index/test_drop_postgres.py
+++ b/tests/spindoctor/results_index/test_drop_postgres.py
@@ -1,15 +1,17 @@
 """Dropping a results index from a real PostgreSQL server.
 
-Four things about the drop are properties of the server rather than of the
+Six things about the drop are properties of the server rather than of the
 schema, and none of them can be asked of SQLite.  That the tables it names are
 the only objects of the database it removes, with somebody else's left standing
-beside them -- a shared server being the deployment the promise is for.  That an
-emptied schema and one nothing was ever built in are the same database, which is
-what "indistinguishable from an index that never existed" means where there is
-no file to tell them apart.  That a lock somebody else holds ends the drop
-promptly instead of hanging it.  And that when it does, the transaction takes
-every table back, which is a guarantee PostgreSQL gives and the SQLite driver
-does not.
+beside them -- a shared server being the deployment the promise is for.  That a
+table of one of these names which no stamp of ours stands over is left alone,
+because a server holds databases nobody here created and ``images`` is not a
+name anyone owns.  That a search path crossing schemas cannot make one drop span
+two of them.  That an emptied schema and one nothing was ever built in are the
+same database, which is what "indistinguishable from an index that never
+existed" means where there is no file to tell them apart.  That a lock somebody
+else holds ends the drop promptly instead of hanging it, in the reading as well
+as in the drop.  And that when it does, the transaction takes every table back.
 
 The tier is opt-in: it is excluded by the default marker filter and skips itself
 when ``SPINDOCTOR_TEST_POSTGRES_URL`` is unset.  What must not regress lives in
@@ -17,10 +19,12 @@ the default tier as well; only what genuinely needs a server is here.
 """
 
 import threading
+import uuid
+from collections.abc import Iterator
 
 import pytest
 import sqlalchemy
-from tests.spindoctor.results_index.conftest import opened
+from tests.spindoctor.results_index.conftest import opened, url_scoped_to
 
 from spindoctor.results_index import (
     IMAGES,
@@ -39,6 +43,9 @@ pytestmark = pytest.mark.postgres
 FOREIGN_TABLE = 'somebody_elses_table'
 """A table of the same schema that SpinDoctor did not create."""
 
+COLLIDING_TABLE = IMAGES.name
+"""A table SpinDoctor did not create, under a name SpinDoctor also uses."""
+
 BRIEF_LOCK_WAIT_MS = 500
 """How long the contended drop waits, so that a held lock costs half a second.
 
@@ -46,6 +53,9 @@ The shipped bound is thirty seconds, which is the right wait for an operator and
 the wrong one for a test; what is under test is that a bound applies at all, and
 that the drop gives the table up rather than waiting on it forever.
 """
+
+SERVER_DEFAULT_LOCK_TIMEOUT = '0'
+"""What ``lock_timeout`` reads as on a connection nothing has set it on."""
 
 
 def _schema_tables(server_url: str, schema: str) -> list[str]:
@@ -69,18 +79,48 @@ def _schema_tables(server_url: str, schema: str) -> list[str]:
         engine.dispose()
 
 
+def _execute(url: str, *statements: str) -> None:
+    """Run statements against a database as somebody other than the index.
+
+    Parameters:
+        url: The database URL.
+        statements: The statements to run, in order.
+    """
+    engine = sqlalchemy.create_engine(url)
+    try:
+        with engine.begin() as connection:
+            for statement in statements:
+                connection.exec_driver_sql(statement)
+    finally:
+        engine.dispose()
+
+
+def _rows_of(url: str, qualified: str) -> int:
+    """Return how many rows a schema-qualified table holds.
+
+    Parameters:
+        url: The database URL.
+        qualified: The table, named with its schema.
+
+    Returns:
+        The row count.
+    """
+    engine = sqlalchemy.create_engine(url)
+    try:
+        with engine.connect() as connection:
+            counted = connection.exec_driver_sql(f'SELECT count(*) FROM {qualified}').scalar()
+    finally:
+        engine.dispose()
+    return 0 if counted is None else int(counted)
+
+
 def _add_foreign_table(url: str) -> None:
     """Create a table the index does not own, in the schema under test.
 
     Parameters:
         url: The scoped index URL.
     """
-    engine = sqlalchemy.create_engine(url)
-    try:
-        with engine.begin() as connection:
-            connection.exec_driver_sql(f'CREATE TABLE {FOREIGN_TABLE} (x INTEGER)')
-    finally:
-        engine.dispose()
+    _execute(url, f'CREATE TABLE {FOREIGN_TABLE} (x INTEGER)')
 
 
 def _dropped(url: str) -> tuple[str, ...]:
@@ -94,7 +134,7 @@ def _dropped(url: str) -> tuple[str, ...]:
     """
     engine = open_database(url)
     try:
-        return drop_index_tables(engine)
+        return drop_index_tables(engine, index_contents(engine))
     finally:
         engine.dispose()
 
@@ -111,6 +151,40 @@ def _refusal_of(url: str) -> str:
     with pytest.raises(ValueError) as excinfo:
         open_index(url)
     return str(excinfo.value)
+
+
+@pytest.fixture
+def tenant_schema(postgres_server_url: str) -> Iterator[str]:
+    """Yield a schema standing for another tenant's, holding an ``images`` of its own.
+
+    Created after the fixtures the index is built in, and put in front of the
+    index's schema on the search path only by the tests that ask for it, because
+    a table of one of our names ahead of the index is a state a creating open
+    would itself resolve wrongly.
+
+    Parameters:
+        postgres_server_url: The server URL the schema is created on.
+
+    Yields:
+        The schema's name.
+    """
+    schema = f'ri_tenant_{uuid.uuid4().hex}'
+    admin = sqlalchemy.create_engine(postgres_server_url)
+    try:
+        with admin.begin() as connection:
+            connection.exec_driver_sql(f'CREATE SCHEMA "{schema}"')
+        try:
+            yield schema
+        finally:
+            with admin.begin() as connection:
+                connection.exec_driver_sql(f'DROP SCHEMA "{schema}" CASCADE')
+    finally:
+        admin.dispose()
+
+
+# ---------------------------------------------------------------------------
+# What the drop removes from a server
+# ---------------------------------------------------------------------------
 
 
 def test_the_drop_removes_every_index_table_from_the_server(
@@ -158,6 +232,280 @@ def test_a_second_drop_removes_nothing_on_the_server(postgres_url: str) -> None:
     assert _dropped(postgres_url) == ()
 
 
+def test_the_contents_name_the_schema_the_index_was_found_in(
+    postgres_url: str, postgres_schema: str
+) -> None:
+    """Which is a real name on a server, not the one namespace a file has.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_schema: Name of that schema.
+    """
+    with opened(postgres_url, create=True):
+        pass
+    engine = open_database(postgres_url)
+    try:
+        assert index_contents(engine).schema == postgres_schema
+    finally:
+        engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# A database holding no index of ours, under names it also uses
+# ---------------------------------------------------------------------------
+
+
+def test_a_stranger_s_table_of_one_of_our_names_is_not_dropped(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str
+) -> None:
+    """A database with no SpinDoctor index in it must lose nothing at all.
+
+    A server holds databases nobody here created, and ``images`` is one of the
+    commonest table names there are.  Nothing but our own stamp says a table of
+    that name is ours.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+    """
+    _execute(
+        postgres_url,
+        f'CREATE TABLE {COLLIDING_TABLE} (id serial primary key, caption text)',
+        f"INSERT INTO {COLLIDING_TABLE} (caption) VALUES ('somebody elses cat'), ('their dog')",
+        'CREATE TABLE customers_of_theirs (id serial primary key, name text)',
+    )
+    _dropped(postgres_url)
+    assert _schema_tables(postgres_server_url, postgres_schema) == sorted(
+        [COLLIDING_TABLE, 'customers_of_theirs']
+    )
+
+
+def test_a_stranger_s_rows_survive_a_drop_pointed_at_their_database(
+    postgres_url: str, postgres_schema: str
+) -> None:
+    """The rows are the thing, and the account called them the index's.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_schema: Name of that schema.
+    """
+    _execute(
+        postgres_url,
+        f'CREATE TABLE {COLLIDING_TABLE} (id serial primary key, caption text)',
+        f"INSERT INTO {COLLIDING_TABLE} (caption) VALUES ('somebody elses cat'), ('their dog')",
+    )
+    _dropped(postgres_url)
+    assert _rows_of(postgres_url, f'"{postgres_schema}".{COLLIDING_TABLE}') == 2
+
+
+def test_such_a_database_is_reported_as_holding_no_index(postgres_url: str) -> None:
+    """So that the command refuses rather than reporting a drop of nothing.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    _execute(postgres_url, f'CREATE TABLE {COLLIDING_TABLE} (id serial primary key)')
+    engine = open_database(postgres_url)
+    try:
+        contents = index_contents(engine)
+    finally:
+        engine.dispose()
+    assert contents.schema is None
+
+
+def test_such_a_database_names_the_tables_it_could_not_account_for(postgres_url: str) -> None:
+    """A refusal that named nothing would leave an operator no next step.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    _execute(postgres_url, f'CREATE TABLE {COLLIDING_TABLE} (id serial primary key)')
+    engine = open_database(postgres_url)
+    try:
+        contents = index_contents(engine)
+    finally:
+        engine.dispose()
+    assert contents.unproven == (COLLIDING_TABLE,)
+
+
+# ---------------------------------------------------------------------------
+# A search path that crosses schemas
+# ---------------------------------------------------------------------------
+
+
+def _index_behind_a_tenant(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str, tenant_schema: str
+) -> str:
+    """Build the index, then put another tenant's ``images`` in front of it.
+
+    The order the reviewer's case has: an index built normally, and a search
+    path changed afterwards so that a bare ``images`` reaches somebody else's
+    table while a bare ``schema_meta`` still reaches ours.
+
+    Parameters:
+        postgres_url: URL the index is built through.
+        postgres_server_url: URL of the server, unscoped.
+        postgres_schema: Schema the index was built in.
+        tenant_schema: Schema standing for another tenant's.
+
+    Returns:
+        A URL whose search path names the tenant's schema and then the index's.
+    """
+    with opened(postgres_url, create=True):
+        pass
+    _execute(
+        postgres_server_url,
+        f'CREATE TABLE "{tenant_schema}".{COLLIDING_TABLE} (id int primary key, payload text)',
+        f'INSERT INTO "{tenant_schema}".{COLLIDING_TABLE} VALUES '
+        f"(1, 'not ours'), (2, 'also not ours')",
+    )
+    return url_scoped_to(postgres_server_url, tenant_schema, postgres_schema)
+
+
+def test_a_search_path_crossing_schemas_does_not_reach_the_other_one(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str, tenant_schema: str
+) -> None:
+    """Six bare names resolved one at a time is how one drop spans two schemas.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+        tenant_schema: Schema standing for another tenant's.
+    """
+    crossed = _index_behind_a_tenant(
+        postgres_url, postgres_server_url, postgres_schema, tenant_schema
+    )
+    _dropped(crossed)
+    assert _schema_tables(postgres_server_url, tenant_schema) == [COLLIDING_TABLE]
+
+
+def test_the_other_schema_keeps_its_rows(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str, tenant_schema: str
+) -> None:
+    """And the account did not call them ours on the way past.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+        tenant_schema: Schema standing for another tenant's.
+    """
+    crossed = _index_behind_a_tenant(
+        postgres_url, postgres_server_url, postgres_schema, tenant_schema
+    )
+    _dropped(crossed)
+    assert _rows_of(postgres_server_url, f'"{tenant_schema}".{COLLIDING_TABLE}') == 2
+
+
+def test_the_index_s_own_schema_is_emptied_whole(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str, tenant_schema: str
+) -> None:
+    """The other half of the same failure: our own ``images`` was left standing.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+        tenant_schema: Schema standing for another tenant's.
+    """
+    crossed = _index_behind_a_tenant(
+        postgres_url, postgres_server_url, postgres_schema, tenant_schema
+    )
+    _dropped(crossed)
+    assert _schema_tables(postgres_server_url, postgres_schema) == []
+
+
+def test_the_rows_counted_are_the_rows_of_the_index_s_own_schema(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str, tenant_schema: str
+) -> None:
+    """An account reading another schema's rows is an account of the wrong table.
+
+    The index here holds no image rows and the tenant's table holds two, so the
+    count is the whole of the difference between the two readings.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+        tenant_schema: Schema standing for another tenant's.
+    """
+    crossed = _index_behind_a_tenant(
+        postgres_url, postgres_server_url, postgres_schema, tenant_schema
+    )
+    engine = open_database(crossed)
+    try:
+        counted = {table.name: table.rows for table in index_contents(engine).tables}
+    finally:
+        engine.dispose()
+    assert counted[IMAGES.name] == 0
+
+
+def test_the_schema_the_drop_binds_to_is_the_one_holding_the_stamp(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str, tenant_schema: str
+) -> None:
+    """Named, so that a reading and the drop that follows cannot disagree.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+        tenant_schema: Schema standing for another tenant's.
+    """
+    crossed = _index_behind_a_tenant(
+        postgres_url, postgres_server_url, postgres_schema, tenant_schema
+    )
+    engine = open_database(crossed)
+    try:
+        assert index_contents(engine).schema == postgres_schema
+    finally:
+        engine.dispose()
+
+
+def test_an_index_in_front_on_the_path_is_the_one_that_goes(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str, tenant_schema: str
+) -> None:
+    """Two whole indexes on one path: the one this URL reaches is the one dropped.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+        tenant_schema: Schema standing for another tenant's.
+    """
+    with opened(postgres_url, create=True):
+        pass
+    with opened(url_scoped_to(postgres_server_url, tenant_schema), create=True):
+        pass
+    _dropped(url_scoped_to(postgres_server_url, tenant_schema, postgres_schema))
+    assert _schema_tables(postgres_server_url, postgres_schema) == sorted(index_table_names())
+
+
+def test_the_index_behind_it_on_the_path_is_the_one_left(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str, tenant_schema: str
+) -> None:
+    """The same drop, read from the other side.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+        tenant_schema: Schema standing for another tenant's.
+    """
+    with opened(postgres_url, create=True):
+        pass
+    with opened(url_scoped_to(postgres_server_url, tenant_schema), create=True):
+        pass
+    _dropped(url_scoped_to(postgres_server_url, tenant_schema, postgres_schema))
+    assert _schema_tables(postgres_server_url, tenant_schema) == []
+
+
+# ---------------------------------------------------------------------------
+# A dropped index and one that never existed
+# ---------------------------------------------------------------------------
+
+
 def test_an_emptied_schema_is_refused_exactly_as_an_untouched_one_is(
     postgres_url: str,
 ) -> None:
@@ -192,6 +540,11 @@ def test_an_emptied_schema_takes_an_ingest_again(postgres_url: str) -> None:
     assert stamped == SCHEMA_VERSION
 
 
+# ---------------------------------------------------------------------------
+# A lock somebody else holds
+# ---------------------------------------------------------------------------
+
+
 BOUNDED_WAIT_S = 20.0
 """How long a test waits for a contended drop before calling the bound broken.
 
@@ -201,32 +554,47 @@ arriving as a suite that never finishes.
 """
 
 
-def _drop_while_a_lock_is_held(url: str) -> BaseException:
-    """Hold a lock on one table, run a drop against it, and return what stopped it.
+def _bounded(url: str, work: str) -> BaseException:
+    """Hold ``images`` against a reader, run one step of a drop, and return what stopped it.
 
-    The drop runs on a thread of its own so that the wait can be bounded by this
-    test rather than by the drop: what is under test is that the drop gives the
-    table up, and a drop with no bound would otherwise take the whole suite down
+    The step runs on a thread of its own so that the wait can be bounded by this
+    test rather than by the drop: what is under test is that the step gives the
+    table up, and one with no bound would otherwise take the whole suite down
     with it.
 
     Parameters:
         url: The index URL, whose ``images`` table is the one held.
+        work: Which step to run, ``'read'`` for the reading that precedes the
+            question or ``'drop'`` for the drop itself.
 
     Returns:
-        The database failure the drop ended with.
+        The database failure the step ended with.
     """
     failure: list[BaseException] = []
 
     def attempt() -> None:
         try:
-            _dropped(url)
+            if work == 'drop':
+                _dropped(url)
+            else:
+                engine = open_database(url)
+                try:
+                    index_contents(engine)
+                finally:
+                    engine.dispose()
         except BaseException as exc:
             failure.append(exc)
 
     holder = sqlalchemy.create_engine(url)
     try:
         with holder.begin() as held:
-            held.execute(sqlalchemy.select(sqlalchemy.func.count()).select_from(IMAGES))
+            # A plain read is enough to hold a drop off; an exclusive lock is
+            # what holds a read off too, and is what a VACUUM FULL, an ALTER
+            # TABLE or a second drop takes.
+            if work == 'drop':
+                held.execute(sqlalchemy.select(sqlalchemy.func.count()).select_from(IMAGES))
+            else:
+                held.exec_driver_sql(f'LOCK TABLE {IMAGES.name} IN ACCESS EXCLUSIVE MODE')
             worker = threading.Thread(target=attempt, daemon=True)
             worker.start()
             worker.join(BOUNDED_WAIT_S)
@@ -234,9 +602,9 @@ def _drop_while_a_lock_is_held(url: str) -> BaseException:
     finally:
         holder.dispose()
     if waiting_still:
-        pytest.fail(f'the drop was still waiting for the lock after {BOUNDED_WAIT_S} seconds')
+        pytest.fail(f'the {work} was still waiting for the lock after {BOUNDED_WAIT_S} seconds')
     if not failure:
-        pytest.fail('the drop finished although another session held one of its tables')
+        pytest.fail(f'the {work} finished although another session held one of its tables')
     return failure[0]
 
 
@@ -256,7 +624,50 @@ def test_a_lock_another_session_holds_ends_the_drop(
     monkeypatch.setattr(drop, 'DROP_LOCK_TIMEOUT_MS', BRIEF_LOCK_WAIT_MS)
     with opened(postgres_url, create=True):
         pass
-    assert 'lock timeout' in str(_drop_while_a_lock_is_held(postgres_url))
+    assert 'lock timeout' in str(_bounded(postgres_url, 'drop'))
+
+
+def test_a_lock_another_session_holds_ends_the_reading_too(
+    postgres_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reading counts rows, and counting rows takes a lock of its own.
+
+    A bound that began after the confirmation would leave the command hanging
+    before anybody had been asked anything, which is the hang hardest of all to
+    account for: nothing has been printed and nothing is being waited on that
+    the operator can see.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        monkeypatch: Fixture the shipped wait is shortened through.
+    """
+    monkeypatch.setattr(drop, 'DROP_LOCK_TIMEOUT_MS', BRIEF_LOCK_WAIT_MS)
+    with opened(postgres_url, create=True):
+        pass
+    assert 'lock timeout' in str(_bounded(postgres_url, 'read'))
+
+
+def test_the_lock_bound_lasts_no_longer_than_the_drop(postgres_url: str) -> None:
+    """``SET LOCAL``, so the bound is this transaction's and no later statement's.
+
+    A session-wide setting would work as well for the drop and would then ride
+    the pooled connection into whatever ran on it next, silently bounding
+    statements nobody bounded.  What says the bound was local is that it is gone
+    once the drop's transaction has ended.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    with opened(postgres_url, create=True):
+        pass
+    engine = open_database(postgres_url)
+    try:
+        drop_index_tables(engine, index_contents(engine))
+        with engine.connect() as connection:
+            after = connection.exec_driver_sql('SHOW lock_timeout').scalar()
+    finally:
+        engine.dispose()
+    assert after == SERVER_DEFAULT_LOCK_TIMEOUT
 
 
 def test_a_drop_that_could_not_finish_leaves_every_table(
@@ -280,7 +691,7 @@ def test_a_drop_that_could_not_finish_leaves_every_table(
     monkeypatch.setattr(drop, 'DROP_LOCK_TIMEOUT_MS', BRIEF_LOCK_WAIT_MS)
     with opened(postgres_url, create=True):
         pass
-    _drop_while_a_lock_is_held(postgres_url)
+    _bounded(postgres_url, 'drop')
     assert _schema_tables(postgres_server_url, postgres_schema) == sorted(index_table_names())
 
 
@@ -296,7 +707,7 @@ def test_a_drop_that_could_not_finish_leaves_the_index_openable(
     monkeypatch.setattr(drop, 'DROP_LOCK_TIMEOUT_MS', BRIEF_LOCK_WAIT_MS)
     with opened(postgres_url, create=True):
         pass
-    _drop_while_a_lock_is_held(postgres_url)
+    _bounded(postgres_url, 'drop')
     with opened(postgres_url) as engine, engine.connect() as connection:
         stamped = connection.execute(sqlalchemy.select(SCHEMA_META.c.schema_version)).scalar()
     assert stamped == SCHEMA_VERSION
@@ -316,3 +727,111 @@ def test_the_contents_read_from_the_server_count_the_rows(postgres_url: str) -> 
     finally:
         engine.dispose()
     assert contents.rows == 1
+
+
+# ---------------------------------------------------------------------------
+# A stamp the server's own typing will not read as a version
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'stamp',
+    ["'v6-beta'", 'NULL'],
+    ids=['a-version-that-is-text', 'a-version-that-is-null'],
+)
+def test_a_stamp_that_is_not_a_version_is_reported_as_none(stamp: str, postgres_url: str) -> None:
+    """A strict backend hands back the text, and int() is what refuses it.
+
+    Parameters:
+        stamp: The value the stamp column is given.
+        postgres_url: URL of an empty schema of this test's own.
+    """
+    _execute(
+        postgres_url,
+        f'CREATE TABLE {SCHEMA_META.name} '
+        f'(singleton int primary key, schema_version text, created_utc text)',
+        f'INSERT INTO {SCHEMA_META.name} VALUES (1, {stamp}, NULL)',
+        f'CREATE TABLE {COLLIDING_TABLE} (id int)',
+    )
+    engine = open_database(postgres_url)
+    try:
+        contents = index_contents(engine)
+    finally:
+        engine.dispose()
+    assert contents.schema_version is None
+
+
+@pytest.mark.parametrize(
+    'stamp',
+    ["'v6-beta'", 'NULL'],
+    ids=['a-version-that-is-text', 'a-version-that-is-null'],
+)
+def test_a_stamp_that_is_not_a_version_does_not_stop_the_drop(
+    stamp: str, postgres_url: str, postgres_server_url: str, postgres_schema: str
+) -> None:
+    """It is a malformed index, which is one of the states the drop is for.
+
+    Parameters:
+        stamp: The value the stamp column is given.
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+    """
+    _execute(
+        postgres_url,
+        f'CREATE TABLE {SCHEMA_META.name} '
+        f'(singleton int primary key, schema_version text, created_utc text)',
+        f'INSERT INTO {SCHEMA_META.name} VALUES (1, {stamp}, NULL)',
+        f'CREATE TABLE {COLLIDING_TABLE} (id int)',
+    )
+    _dropped(postgres_url)
+    assert _schema_tables(postgres_server_url, postgres_schema) == []
+
+
+def test_a_table_of_ours_in_another_schema_is_not_counted_as_present_here(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str, tenant_schema: str
+) -> None:
+    """Presence is asked of the bound schema, not of whatever the path reaches.
+
+    The index here is missing one of its tables and the tenant's schema holds a
+    table of that name, so a presence check resolved through the search path
+    answers yes about a table that is not in the index's schema at all.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+        tenant_schema: Schema standing for another tenant's.
+    """
+    with opened(postgres_url, create=True):
+        pass
+    _execute(
+        postgres_server_url,
+        f'DROP TABLE "{postgres_schema}".failed_files',
+        f'CREATE TABLE "{tenant_schema}".failed_files (root_url text)',
+    )
+    crossed = url_scoped_to(postgres_server_url, tenant_schema, postgres_schema)
+    assert 'failed_files' not in _dropped(crossed)
+
+
+def test_such_a_table_survives_in_the_schema_it_belongs_to(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str, tenant_schema: str
+) -> None:
+    """And the drop that skipped it still removed the five that were there.
+
+    Parameters:
+        postgres_url: URL of an empty schema of this test's own.
+        postgres_server_url: URL of the server that schema lives on.
+        postgres_schema: Name of that schema.
+        tenant_schema: Schema standing for another tenant's.
+    """
+    with opened(postgres_url, create=True):
+        pass
+    _execute(
+        postgres_server_url,
+        f'DROP TABLE "{postgres_schema}".failed_files',
+        f'CREATE TABLE "{tenant_schema}".failed_files (root_url text)',
+    )
+    crossed = url_scoped_to(postgres_server_url, tenant_schema, postgres_schema)
+    _dropped(crossed)
+    assert _schema_tables(postgres_server_url, postgres_schema) == []

--- a/tests/spindoctor/results_index/test_drop_postgres.py
+++ b/tests/spindoctor/results_index/test_drop_postgres.py
@@ -54,9 +54,6 @@ the wrong one for a test; what is under test is that a bound applies at all, and
 that the drop gives the table up rather than waiting on it forever.
 """
 
-SERVER_DEFAULT_LOCK_TIMEOUT = '0'
-"""What ``lock_timeout`` reads as on a connection nothing has set it on."""
-
 
 def _schema_tables(server_url: str, schema: str) -> list[str]:
     """Return every table of one schema, whoever created it.
@@ -329,6 +326,107 @@ def test_such_a_database_names_the_tables_it_could_not_account_for(postgres_url:
     assert contents.unproven == (COLLIDING_TABLE,)
 
 
+RESTRICTED_PASSWORD = 'ri-restricted-role'
+"""Password of the role that may read one column of the stamp and not the other."""
+
+
+@pytest.fixture
+def restricted_url(
+    postgres_url: str, postgres_server_url: str, postgres_schema: str
+) -> Iterator[str]:
+    """Yield a URL onto an index whose stamp column this account may not read.
+
+    A schema version is read out of one column of one table, and a column is
+    something an account can be allowed part of.  Reaching that state needs a
+    second role, since the role that owns the tables is allowed everything by
+    definition; a server that will not let this test make one is one the
+    question cannot be put to, and the test says so rather than passing.
+
+    Parameters:
+        postgres_url: URL the index's tables are created through.
+        postgres_server_url: URL of the server, unscoped.
+        postgres_schema: Name of the schema the tables live in.
+
+    Yields:
+        The same scoped URL, connecting as the restricted role.
+    """
+    _execute(
+        postgres_url,
+        f'CREATE TABLE {SCHEMA_META.name} '
+        f'(singleton int primary key, schema_version int, created_utc text)',
+        f'INSERT INTO {SCHEMA_META.name} VALUES (1, {SCHEMA_VERSION}, now()::text)',
+        f'CREATE TABLE {IMAGES.name} (root_url text)',
+        f"INSERT INTO {IMAGES.name} VALUES ('file:///data/nav-results')",
+    )
+    role = f'ri_reader_{uuid.uuid4().hex[:16]}'
+    admin = sqlalchemy.create_engine(postgres_server_url, isolation_level='AUTOCOMMIT')
+    try:
+        try:
+            with admin.connect() as connection:
+                connection.exec_driver_sql(
+                    f'CREATE ROLE "{role}" LOGIN PASSWORD \'{RESTRICTED_PASSWORD}\''
+                )
+        except sqlalchemy.exc.SQLAlchemyError:
+            pytest.skip('this account may not create a role on this server')
+        try:
+            with admin.connect() as connection:
+                connection.exec_driver_sql(f'GRANT USAGE ON SCHEMA "{postgres_schema}" TO "{role}"')
+                connection.exec_driver_sql(
+                    f'GRANT SELECT ON "{postgres_schema}".{IMAGES.name} TO "{role}"'
+                )
+                connection.exec_driver_sql(
+                    f'GRANT SELECT (singleton) ON "{postgres_schema}".{SCHEMA_META.name} '
+                    f'TO "{role}"'
+                )
+            yield (
+                sqlalchemy.engine.make_url(postgres_url)
+                .set(username=role, password=RESTRICTED_PASSWORD)
+                .render_as_string(hide_password=False)
+            )
+        finally:
+            with admin.connect() as connection:
+                connection.exec_driver_sql(f'DROP OWNED BY "{role}"')
+                connection.exec_driver_sql(f'DROP ROLE "{role}"')
+    finally:
+        admin.dispose()
+
+
+def test_a_stamp_this_account_may_not_read_is_reported_as_no_stamp(restricted_url: str) -> None:
+    """A version that will not come out of a database is a version it does not have.
+
+    The read is taken inside a savepoint, because a statement PostgreSQL refuses
+    ends the transaction around it, and every later reading of this account
+    would then fail with the first failure's shadow instead of answering.
+
+    Parameters:
+        restricted_url: URL onto an index whose stamp column is unreadable.
+    """
+    engine = open_database(restricted_url)
+    try:
+        assert index_contents(engine).schema_version is None
+    finally:
+        engine.dispose()
+
+
+def test_a_stamp_this_account_may_not_read_leaves_the_rest_of_the_account(
+    restricted_url: str,
+) -> None:
+    """The stamp is one line of the account, and the tables and their rows are the rest.
+
+    Parameters:
+        restricted_url: URL onto an index whose stamp column is unreadable.
+    """
+    engine = open_database(restricted_url)
+    try:
+        contents = index_contents(engine)
+    finally:
+        engine.dispose()
+    assert [(table.name, table.rows) for table in contents.tables] == [
+        (SCHEMA_META.name, 1),
+        (IMAGES.name, 1),
+    ]
+
+
 # ---------------------------------------------------------------------------
 # A search path that crosses schemas
 # ---------------------------------------------------------------------------
@@ -339,9 +437,9 @@ def _index_behind_a_tenant(
 ) -> str:
     """Build the index, then put another tenant's ``images`` in front of it.
 
-    The order the reviewer's case has: an index built normally, and a search
-    path changed afterwards so that a bare ``images`` reaches somebody else's
-    table while a bare ``schema_meta`` still reaches ours.
+    The index is built normally, and the search path is changed afterwards, so
+    that a bare ``images`` reaches somebody else's table while a bare
+    ``schema_meta`` still reaches the index's own.
 
     Parameters:
         postgres_url: URL the index is built through.
@@ -652,8 +750,9 @@ def test_the_lock_bound_lasts_no_longer_than_the_drop(postgres_url: str) -> None
 
     A session-wide setting would work as well for the drop and would then ride
     the pooled connection into whatever ran on it next, silently bounding
-    statements nobody bounded.  What says the bound was local is that it is gone
-    once the drop's transaction has ended.
+    statements nobody bounded.  What says the bound was local is that the
+    setting reads the same after the drop's transaction has ended as it did
+    before it began, whatever this server's own setting happens to be.
 
     Parameters:
         postgres_url: URL of an empty schema of this test's own.
@@ -662,12 +761,14 @@ def test_the_lock_bound_lasts_no_longer_than_the_drop(postgres_url: str) -> None
         pass
     engine = open_database(postgres_url)
     try:
+        with engine.connect() as connection:
+            before = connection.exec_driver_sql('SHOW lock_timeout').scalar()
         drop_index_tables(engine, index_contents(engine))
         with engine.connect() as connection:
             after = connection.exec_driver_sql('SHOW lock_timeout').scalar()
     finally:
         engine.dispose()
-    assert after == SERVER_DEFAULT_LOCK_TIMEOUT
+    assert after == before
 
 
 def test_a_drop_that_could_not_finish_leaves_every_table(

--- a/tests/spindoctor/results_index/test_drop_postgres.py
+++ b/tests/spindoctor/results_index/test_drop_postgres.py
@@ -326,8 +326,17 @@ def test_such_a_database_names_the_tables_it_could_not_account_for(postgres_url:
     assert contents.unproven == (COLLIDING_TABLE,)
 
 
-RESTRICTED_PASSWORD = 'ri-restricted-role'
-"""Password of the role that may read one column of the stamp and not the other."""
+def _generated_password() -> str:
+    """Return a password for a role this test creates and drops again.
+
+    Generated per run rather than written down, for the same reason the role
+    name is: a literal in a test file is a credential in the repository, and
+    this one is handed to a real server.
+
+    Returns:
+        A password unique to this fixture's role.
+    """
+    return f'ri-pw-{uuid.uuid4().hex}'
 
 
 @pytest.fixture
@@ -359,13 +368,12 @@ def restricted_url(
         f"INSERT INTO {IMAGES.name} VALUES ('file:///data/nav-results')",
     )
     role = f'ri_reader_{uuid.uuid4().hex[:16]}'
+    password = _generated_password()
     admin = sqlalchemy.create_engine(postgres_server_url, isolation_level='AUTOCOMMIT')
     try:
         try:
             with admin.connect() as connection:
-                connection.exec_driver_sql(
-                    f'CREATE ROLE "{role}" LOGIN PASSWORD \'{RESTRICTED_PASSWORD}\''
-                )
+                connection.exec_driver_sql(f'CREATE ROLE "{role}" LOGIN PASSWORD \'{password}\'')
         except sqlalchemy.exc.SQLAlchemyError:
             pytest.skip('this account may not create a role on this server')
         try:
@@ -380,7 +388,7 @@ def restricted_url(
                 )
             yield (
                 sqlalchemy.engine.make_url(postgres_url)
-                .set(username=role, password=RESTRICTED_PASSWORD)
+                .set(username=role, password=password)
                 .render_as_string(hide_password=False)
             )
         finally:

--- a/tests/spindoctor/results_index/test_engine.py
+++ b/tests/spindoctor/results_index/test_engine.py
@@ -30,7 +30,13 @@ from tests.spindoctor.results_index.conftest import (
     without_module,
 )
 
-from spindoctor.results_index import IMAGES, SCHEMA_META, SCHEMA_VERSION, open_index
+from spindoctor.results_index import (
+    IMAGES,
+    SCHEMA_META,
+    SCHEMA_VERSION,
+    open_database,
+    open_index,
+)
 
 MISSING_DRIVER_URL = 'postgresql+psycopg://user@localhost:5432/spindoctor'
 
@@ -164,8 +170,19 @@ def test_a_database_with_no_schema_meta_row_is_refused(tmp_path: Path) -> None:
 
 def test_an_in_memory_database_is_refused_by_a_consumer() -> None:
     """An in-memory URL starts empty every time, so it is never an index."""
-    with pytest.raises(ValueError, match='not a results index'):
+    with pytest.raises(ValueError, match='names an in-memory SQLite database'):
         open_index('sqlite://')
+
+
+def test_an_in_memory_database_is_refused_by_a_drop() -> None:
+    """Every connection to one makes a different empty database.
+
+    A drop answering "nothing to drop" over one would report the state of a
+    database that came into being to be asked and goes when the answer is
+    given.
+    """
+    with pytest.raises(ValueError, match='names an in-memory SQLite database'):
+        open_database('sqlite://')
 
 
 # ---------------------------------------------------------------------------

--- a/tests/spindoctor/results_index/test_engine.py
+++ b/tests/spindoctor/results_index/test_engine.py
@@ -8,7 +8,7 @@ database driver, or -- worse -- a run that quietly reads nothing.
 
 What the opener does with a SQLite file specifically is in
 ``test_engine_sqlite.py``; how it names a URL without naming its password is in
-``test_engine_masking.py``.
+``test_masking.py``.
 """
 
 import dataclasses
@@ -202,7 +202,7 @@ def test_the_version_message_says_to_delete_and_re_ingest(tmp_path: Path) -> Non
         tmp_path: Directory holding the database.
     """
     path = _index_stamped_with_another_version(tmp_path)
-    with pytest.raises(ValueError, match='delete the database and re-run sd_stats_ingest'):
+    with pytest.raises(ValueError, match='empty the database with sd_stats_ingest --drop-index'):
         open_index(sqlite_url_for(path))
 
 

--- a/tests/spindoctor/results_index/test_engine_quoted_causes.py
+++ b/tests/spindoctor/results_index/test_engine_quoted_causes.py
@@ -14,7 +14,7 @@ The other direction is asserted beside it, because a message cleaned of its
 cause would be safe and useless.
 
 The masking of the URL itself, over the corpus of every shape one can be
-written in, is in ``test_engine_masking``.
+written in, is in ``test_masking``.
 """
 
 import dataclasses

--- a/tests/spindoctor/results_index/test_engine_sqlite.py
+++ b/tests/spindoctor/results_index/test_engine_sqlite.py
@@ -622,7 +622,7 @@ def test_an_in_memory_database_that_cannot_be_opened_says_only_that(
         _refusing_with(_DriverError('unable to open database file', 'SQLITE_CANTOPEN')),
     )
     with pytest.raises(ValueError, match='could not open this database'):
-        open_index('sqlite://')
+        open_index('sqlite://', create=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/spindoctor/results_index/test_masking.py
+++ b/tests/spindoctor/results_index/test_masking.py
@@ -588,6 +588,21 @@ NEGATIVE_CASES = [
         'sqlite:///C:/data/index.sqlite3',
         'sqlite:///C:/data/index.sqlite3',
     ),
+    # The two below are the shapes that the scheme rule alone saves. Read as an
+    # authority, a drive letter is a user name and everything to the last
+    # at-sign is a password, and a path ending in something spelled like a query
+    # parameter is one; a path is neither, and a refusal naming a SQLite URL is
+    # the one message an operator reads to correct the path.
+    _Case(
+        'a-local-path-carrying-a-drive-letter-and-an-at-sign',
+        'sqlite:///C:/data/my@dir/index.sqlite3',
+        'sqlite:///C:/data/my@dir/index.sqlite3',
+    ),
+    _Case(
+        'a-local-path-that-ends-like-a-credential-parameter',
+        'sqlite:////data/index.sqlite3?password=x',
+        'sqlite:////data/index.sqlite3?password=x',
+    ),
     _Case(
         'a-cloud-results-root', 'gs://rms-nav/nav-offset-results', 'gs://rms-nav/nav-offset-results'
     ),

--- a/tests/spindoctor/results_index/test_postgres.py
+++ b/tests/spindoctor/results_index/test_postgres.py
@@ -196,7 +196,7 @@ def test_the_version_message_says_to_delete_and_re_ingest(postgres_url: str) -> 
     """
     with opened(postgres_url, create=True) as engine, engine.begin() as connection:
         connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
-    with pytest.raises(ValueError, match='delete the database and re-run sd_stats_ingest'):
+    with pytest.raises(ValueError, match='empty the database with sd_stats_ingest --drop-index'):
         open_index(postgres_url)
 
 


### PR DESCRIPTION
## Purpose

Starting a results tree over -- delete the results, navigate again, ingest again -- is a normal operation, and the index had no counterpart to it. Deleting a SQLite index is `rm`, which is easy enough to have hidden the gap; a PostgreSQL index had no equivalent an operator could reach from SpinDoctor at all, which meant `psql`, the right connection string, and knowing which tables SpinDoctor owns in a database a shared server may hold other things in. The schema version gate makes that worse rather than better: a version bump is deliberately not migrated, so rebuilding is the whole of the remedy the gate prescribes -- and the operation the design depends on was the one with no command behind it.

Closes #487

## Changes

- **`sd_stats_ingest --drop-index`** removes the results index's own tables from whatever backend `--results-db` names and **stops**: it resolves no results root and ingests no document, so dropping is a deliberate act rather than the opening move of a long pass and a mistyped URL costs one command rather than a walk. It needs no `--nav-results-root`, so a machine holding the index and not the tree can drop. `--yes` drops without asking. Both are refused in combination with `--force` or either cloud-tasks mode, and `--yes` alone is refused, on the same "refused rather than ignored" grounds as the existing `--force`-under-completion check.
- **Only the tables the schema declares are touched**, one `DROP TABLE` each, taken from `METADATA` by name. Never `DROP SCHEMA`, never a wildcard, nothing discovered by pattern. A test reads the statements the drop issues off the connection and asserts they are exactly those six names, and another asserts the drop never utters a table it does not own -- including in the statements it issues to find out what is there.
- **`spindoctor/results_index/drop.py`** is the Core-layer operation: `index_contents(engine)` reads which of the index's tables a database holds, with their row counts, the schema stamp and the count of unfinished ingest runs; `drop_index_tables(engine)` removes them. `spindoctor/cli/stats/drop.py` holds the confirmation, the messages and the exit status.
- **`open_database`** is a second opener beside `open_index` in `engine.py`. It applies every URL diagnosis, SQLite probe and masking rule `open_index` does and stops before the version gate, because a database the gate refuses -- one stamped with a version this build does not read, or one an interrupted creation left holding part of a schema -- is precisely what a drop is pointed at. Nothing is read from the database through it, so no column the gate protects is touched. The three openers differ along four axes (creating, writing, must-exist, gated) and an `_Access` record spells each combination out rather than inferring one from another; it carries the read-only and absent-path remedies too, since what to do about an unwritable file differs by operation -- "ingest a writable copy" answers nothing for a drop.
- **A database that is not there is refused on both backends alike.** A PostgreSQL database that does not exist is refused by the server, and a SQLite path that does not exist gets the same answer rather than being created, so a typed path is caught rather than quietly succeeding over nothing. A database that *is* there and holds none of these tables is not written at all, says so, and exits 0: an index already gone is the state asked for, and an idempotent drop has to be visibly idempotent.
- **`schema_meta` is dropped before the tables it stamps.** The drop runs in one transaction, but that transaction is not equally strong on both backends -- PostgreSQL rolls DDL back with everything else, while the SQLite driver commits each `DROP TABLE` outside the surrounding transaction (verified, not assumed) -- so the order is what carries the guarantee. Every state an interruption can leave is then one with no stamp, which the version gate reads as "this is not a results index" and which the next `--create` open rebuilds. The state that must never be left is the opposite one: a stamp still standing over tables that have gone, which the gate reads as healthy and every consumer then fails inside its first query.
- **The version gate's refusal now names the command that carries out the remedy it prescribes** ("empty the database with `sd_stats_ingest --drop-index` and re-run `sd_stats_ingest`").
- **The masking rule moves from `engine.py` to `spindoctor/results_index/masking.py`**, verbatim. The plan already describes it as a named function of the Core layer rather than a private helper of the opener, `spindoctor/support/command_line.py` imports it for a reason that has nothing to do with opening a database, and without the split the opener would pass the 1000-line module cap. `test_engine_masking.py` is renamed `test_masking.py` to mirror the source. Every module stays under 1000 lines (`engine.py` 772, `masking.py` 397, `drop.py` 310).

### The two questions the issue left open

**Whether a drop is allowed while an ingest run is unfinished: allowed, and reported.** An unfinished run is either a pass writing the index at this moment or one that died, and nothing recorded in the index tells the two apart -- there is no heartbeat, no process identity and nothing to ask. A pass that died is also the commonest reason to want a drop, so refusing on that evidence would withhold the command from the case that needs it most in order to guard a case the confirmation already guards. The count is therefore named in the logged account and repeated into the question itself, so the person about to end a live pass is told while there is still an answer to give. What a drop under a live pass costs is that pass, which fails on a table that has gone and leaves nothing behind; no reader is affected, because an unfinished run already reads as "not ingested" to every consumer both before and after. The count is asked only of a database stamped with the version this code reads, because the question is phrased in a column and a column is exactly what a version is free to have changed.

**Whether it is refused when another process holds the database: not refused in advance; the database's own locking decides, promptly and atomically.** Neither backend can be asked the question honestly. SQLite's readers take no lock to observe under write-ahead logging, and a writer between transactions holds none either, so "nobody is using it" would be a guess; a PostgreSQL role need not be allowed to read `pg_stat_activity`, and that view is server-wide in any case. What can be done is to make the attempt fail rather than hang and to leave nothing half-finished when it does. `DROP_LOCK_TIMEOUT_MS` (30 s, matching `SQLITE_BUSY_TIMEOUT_MS` so a contended drop gives up after the same wait on either backend) is issued as `SET LOCAL lock_timeout` inside the drop transaction, so a table another session holds ends the drop promptly and PostgreSQL's transaction puts every table back; on SQLite the per-connection busy timeout already bounds the same wait, and the drop order covers what the driver's non-transactional DDL does not.

## Type of Change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that alters existing behavior or public API)
- [x] Refactor (no functional or API changes)
- [x] Documentation
- [ ] Tests only (no production code change)
- [ ] CI / Build / Dependencies

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] End-to-end tests pass (if applicable)
- [x] New or updated tests for changed code
- [x] Tested manually (describe below if applicable)

New tests, 120 in all: `tests/spindoctor/results_index/test_drop.py` (32, the core operation on SQLite -- drop order, what is removed, what survives, the databases no opener accepts, what is left behind, the account, and `open_database`'s refusals), `tests/spindoctor/results_index/test_drop_postgres.py` (9, postgres tier), and `tests/spindoctor/cli/stats/test_drop_cli.py` (44, the command line) -- plus two masking cases that pin the rule the moved module now states.

**Every test was checked by breaking the source it protects, running it, confirming the failure, and reverting.** 25 mutations; all 25 caught. Three of them found real gaps and were fixed rather than filed: the CLI's own use of `masked_url` was unobservable, because the credentialed URL a default-tier test can drive never opens, so the drop now records which index it is about to drop *before* it opens it -- which a run log wants anyway, and which makes the masking assertable on real bytes with no server; the summary printed to stdout duplicated what the log already carried, so it was removed in favour of a question that carries the index, the totals and the unfinished-run count (`sd_stats_ingest` carries a main logger and is deliberately not one of the print-only programs, so this leaves no bare `print()` behind); and the two contended-drop tests hung for ever under a broken lock bound instead of failing, so they now run the drop on a thread of its own and bound the wait themselves.

Behaviour that must not regress is in the default tier, since `postgres` is deselected by `addopts` and by CI. The postgres tier holds only what genuinely needs a server: that another owner's table is left standing beside ours, that a lock somebody else holds ends the drop rather than hanging it, that the transaction then takes every table back and the index still opens, and -- the strongest form of the indistinguishability claim -- that one URL asked twice, before anything was built in it and after an index was built and dropped, gives **character-for-character identical** refusals, there being no file to tell the two states apart.

**How "indistinguishable from an index that never existed" was proved, against the real consumer paths rather than by assumption.** There are exactly four consumers of the index (`open_index` in `sd_stats_ingest`, `sd_stats_report` and `sd_stats_ingest_cloud_tasks`; `read_result_stubs` in `dataset/results_filter.py`), and both entry points are driven over a dropped index and a never-built one: `read_result_stubs` refuses both, both refusals name `sd_stats_ingest`, and `main_report` exits 1 on both. Beyond refusing alike, the round trip is asserted: `rows_of(url, IMAGES)` after ingest, drop and re-ingest equals what the first ingest wrote, and the rebuilt index carries this schema version.

Manual verification: a real drop of a SQLite index and of a PostgreSQL schema on the live 16.14 server, with `CREATE TABLE somebody_elses (x int)` in the same schema. Our six tables went, `somebody_elses` stayed, and the message read `Dropped from postgresql+psycopg://spindoctor:***@127.0.0.1:55432/spindoctor?options=-csearch_path%3De2e: ...`. Dropping again reported that the database holds none of the index tables and exited 0; a consumer then refused the emptied database with "this is not a results index", and `--create` rebuilt it. With a session holding a read lock on `images` and the bound shortened, the drop was refused with "canceling statement due to lock timeout" and all seven tables were still there.

Full check set on this branch: `ruff check src tests` clean; `ruff format --check` 670 files already formatted; `mypy src tests` 668 files, no issues; `pytest -n 4 --dist=loadfile` 10780 passed, 7 xfailed in 54.6 s (10787 collected, no failures); `pytest -m postgres` 56 passed against the live server; `sphinx -W -b html docs docs/_build` build succeeded; `pymarkdown scan docs/ .cursor/ README.md CONTRIBUTING.md` clean.

## Potential Impacts

Public API: `spindoctor.results_index` gains `open_database`, `stamped_version`, `index_contents`, `index_table_names`, `drop_index_tables`, `IndexContents` and `TableContents`. `masked_url` is re-exported from the package exactly as before; only its defining module moved, and the three in-tree importers were repointed. No behaviour of an existing program changes except the wording of the version-gate refusal, which now names the command that carries out its remedy. `sd_stats_ingest` gains two flags and refuses two combinations it previously would have accepted and half-obeyed. Performance: none -- the drop reads one `SELECT count(*)` per table before asking, which is what makes the confirmation worth answering. `CHANGES.md` does not exist in this repository.

## Notes

Based on `rf_ri_png_removal` (PR #498), which is the last thing to touch `sd_stats_ingest` and the ingest package, so this sequences behind it rather than conflicting with it; the base retargets when #498 merges. `plans/RESULTS_DB_PLAN.md` gains section 2.11 recording the design and both decisions, and section 2.4's remedy now points at it.

The masking split is the one part of the diff that is not the feature. It is not optional: `open_database` and the access record push `engine.py` past the module-size rule, and the masking rule is the half of that module with an importer (`support/command_line.py`) that never opens a database. The move is verbatim -- the only edits are the module docstring, `_SQLITE_BACKEND` becoming `_SQLITE_SCHEME` under a docstring saying why the masking rule reads a scheme rather than a backend name, and `_without_credentials` becoming public as `without_credentials` because the opener still calls it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `sd_stats_ingest --drop-index` to safely empty results indexes, with confirmation and a `--yes` option.
  * Added safeguards for schema ownership, unrelated tables, transactions, locks, and repeated drops.
* **Bug Fixes**
  * Improved credential masking in database URLs and error messages.
  * Updated schema-mismatch guidance to recommend dropping and re-ingesting the index.
* **Documentation**
  * Expanded API, user, developer, and testing documentation for results-index management and PostgreSQL behavior.
* **Tests**
  * Added comprehensive SQLite and PostgreSQL coverage for drop workflows, failures, locking, masking, and data protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->