### PR TITLE
Scope the C-kernel refusal and report claims to what the code does

### DIFF
--- a/docs/user_guide/instruments/galileo_ssi.rst
+++ b/docs/user_guide/instruments/galileo_ssi.rst
@@ -174,8 +174,8 @@ Corrected-pointing C-kernels
 **No corrected kernels are produced for this instrument.** ``sd_create_ck
 gossi`` is a valid invocation and runs to completion, but every otherwise
 eligible image is omitted with ``rotation_unsupported`` and no kernel, and no
-meta-kernel, is written. The report is still written and names the reason on
-every row.
+meta-kernel, is written. A run that selected images still writes the report,
+naming the reason on every row.
 
 The cause is the rotation fitting described above. A fitted rotation turns
 about a pivot chosen per technique, which the navigation result does not

--- a/docs/user_guide/instruments/galileo_ssi.rst
+++ b/docs/user_guide/instruments/galileo_ssi.rst
@@ -174,8 +174,8 @@ Corrected-pointing C-kernels
 **No corrected kernels are produced for this instrument.** ``sd_create_ck
 gossi`` is a valid invocation and runs to completion, but every otherwise
 eligible image is omitted with ``rotation_unsupported`` and no kernel, and no
-meta-kernel, is written. A run that selected images still writes the report,
-naming the reason on every row.
+meta-kernel, is written. A run that reaches the writing phase still writes the
+report, naming the reason on every row.
 
 The cause is the rotation fitting described above. A fitted rotation turns
 about a pivot chosen per technique, which the navigation result does not

--- a/docs/user_guide/user_guide_ck_kernels.rst
+++ b/docs/user_guide/user_guide_ck_kernels.rst
@@ -542,13 +542,13 @@ every file it wrote, and each of them is a complete, valid kernel.
   over a quiet span, so it is refused by name instead.
 
 * **A metadata document that cannot be read as a navigated image**; an image
-  whose baseline supplied pointing at every record but angular velocity at only
-  some of them; and an exposure whose window is so long that the cadence would
-  need more records than a segment holds, which means the recorded epochs are
-  not an exposure. None has an entry in the closed set of omission reasons, so
-  none is reported as one. An exposure its baseline does not cover is not among
-  them: that one has a reason, ``baseline_coverage_gap``, and omits the one
-  image.
+  whose segment copies its baseline's rates and whose baseline supplied
+  pointing at every record but angular velocity at only some of them; and an
+  exposure whose window is so long that the cadence would need more records
+  than a segment holds, which means the recorded epochs are not an exposure.
+  None has an entry in the closed set of omission reasons, so none is reported
+  as one. An exposure its baseline does not cover is not among them: that one
+  has a reason, ``baseline_coverage_gap``, and omits the one image.
 
 Related chapters
 ================


### PR DESCRIPTION
Two claims in the user guide are stated more broadly than the code supports. Both were raised by CodeRabbit on #485 and fixed on that branch, but the fix landed after #485 had already merged, so it never reached `main`. This carries it over unchanged.

**The refusals list.** It described any image whose baseline supplies pointing without a rate as stopping the run. That refusal is raised in `_baseline_history` (`src/spindoctor/cli/ck/segment.py`), which `build_segment` reaches only through `_corrected_history` on its non-frozen branch; the frozen branch sets `avvs = np.zeros(...)` and never consults the baseline at all. The refusal is therefore structurally unreachable for a frozen segment, which is what the Voyager chapter already says, so the two chapters contradicted each other. The entry now scopes itself to a segment that copies its baseline's rates.

An earlier round on #485 scoped the paragraph that introduces this behavior and left the summary that repeats it, which is how the contradiction survived at a second site. Swept for the rest of the class: the developer chapter already states the exception explicitly, and the Galileo chapter's unconditional phrasing is correct on its own page, since that instrument is not frozen.

**The Galileo report claim.** The chapter said the report is still written when no kernel is. The shared chapter is narrower and correct: a run stopped by a refusal, or one that selected no images, writes no report. The claim is now qualified to a run that selected images. The other three instrument chapters carry no equivalent overclaim.

Verified with `sphinx-build -W -b html docs docs/_build` and `pytest tests/spindoctor/test_instrument_chapters.py` (24 passed). Documentation only; no `.py` files change.

Dispositions for the three findings are recorded inline on #485: https://github.com/SETI/rms-spindoctor/pull/485#discussion_r3746509217, https://github.com/SETI/rms-spindoctor/pull/485#discussion_r3746509215 and https://github.com/SETI/rms-spindoctor/pull/485#discussion_r3746509212. The third, replacing the chapters' implicit section hyperlinks with `:ref:` labels, was declined: the implicit targets resolve, `sphinx-build -W` passes, and applying the convention to two of eight chapters would be worse than either convention applied consistently.

Follow-up to #485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dwrp3cXu28HoEbfaNZR5A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified corrected-pointing C-kernel behavior when selecting images: a report is generated with `rotation_unsupported` recorded for each row, but no kernel or meta-kernel is produced.
  * Clarified corrected-kernel refusal conditions and per-image omission reporting, including baseline coverage gaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->