### PR TITLE
Adopt the rms-polymath 2.0 type stubs and declare the dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,9 @@ dependencies = [
   "rms-pdslogger>=3.2.1",
   "rms-pdstable>=1.0.1",
   "rms-pdstemplate>=2.3.0",
+  "rms-polymath>=2.0",
   "rms-psfmodel",
-  "rms-oops>=0.1.3",
+  "rms-oops>=0.1.5",
   "rms-starcat>=1.0.1",
   "ruamel.yaml",
   "scipy"
@@ -121,10 +122,6 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "pdstemplate.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "polymath.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/src/spindoctor/nav_model/nav_model_body.py
+++ b/src/spindoctor/nav_model/nav_model_body.py
@@ -690,7 +690,7 @@ class NavModelBody(NavModelBodyBase):
             | shift_array(is_dark, (0, 1))
         )
 
-        if not body_mask_valid.any() or incidence_scalar[body_mask_valid].min() >= HALFPI:
+        if not body_mask_valid.any() or incidence_vals[body_mask_valid].min() >= HALFPI:
             local_model: NDArrayFloatType = np.zeros_like(body_mask_valid, dtype=np.float64)
             local_model[body_mask_valid] = 0.01
         else:

--- a/src/spindoctor/nav_model/stars/catalog.py
+++ b/src/spindoctor/nav_model/stars/catalog.py
@@ -126,17 +126,25 @@ def aberrate_star(obs: ObsSnapshot, star: MutableStar) -> None:
     Parameters:
         obs: Observation snapshot supplying ``midtime``, ``path``, and
             ``frame``.
-        star: Star record to mutate.
+        star: Star record to mutate.  Both ``ra`` and ``dec`` are
+            required; the catalog reduction drops records without them
+            before it gets here.
+
+    Raises:
+        ValueError: If the record carries no RA or no DEC.
     """
+    if star.ra is None or star.dec is None:
+        raise ValueError(
+            f'aberrate_star requires a star with RA and DEC, got ra={star.ra!r}, dec={star.dec!r}'
+        )
     event = Event(
         obs.midtime,
         (polymath.Vector3.ZERO, polymath.Vector3.ZERO),
         obs.path,
         obs.frame,
     )
-    # Callers filter out records with no RA/DEC before reaching here.
     event.neg_arr_j2000 = polymath.Vector3.from_ra_dec_length(
-        cast(float, star.ra), cast(float, star.dec), 1.0, recursive=False
+        star.ra, star.dec, 1.0, recursive=False
     )
     abb_ra, abb_dec, _ = event.neg_arr_ap_j2000.to_ra_dec_length(recursive=False)
     star.ra = abb_ra.vals

--- a/src/spindoctor/nav_model/stars/catalog.py
+++ b/src/spindoctor/nav_model/stars/catalog.py
@@ -134,8 +134,9 @@ def aberrate_star(obs: ObsSnapshot, star: MutableStar) -> None:
         obs.path,
         obs.frame,
     )
+    # Callers filter out records with no RA/DEC before reaching here.
     event.neg_arr_j2000 = polymath.Vector3.from_ra_dec_length(
-        star.ra, star.dec, 1.0, recursive=False
+        cast(float, star.ra), cast(float, star.dec), 1.0, recursive=False
     )
     abb_ra, abb_dec, _ = event.neg_arr_ap_j2000.to_ra_dec_length(recursive=False)
     star.ra = abb_ra.vals

--- a/src/spindoctor/reproj/rings.py
+++ b/src/spindoctor/reproj/rings.py
@@ -907,18 +907,20 @@ class RingMosaic:
         Returns:
             Tuple of (u, v) floating-point pixel coordinate arrays.
         """
-        longitude = Scalar(longitude)
-        radius = Scalar(radius)
-
         if orbit_model is not None:
             longitude = orbit_model.corotating_to_inertial(longitude, obs.midtime)
 
         if len(longitude) == 0:
             return np.zeros(0, dtype=float), np.zeros(0, dtype=float)
 
+        longitude_scalar = Scalar(longitude)
+        radius_scalar = Scalar(radius)
+
         ring_surface = _ring_plane_surface(ring_body_name)
         obs_event = oops.Event(obs.midtime, (Vector3.ZERO, Vector3.ZERO), obs.path, obs.frame)
-        _, obs_event = ring_surface.photon_to_event_by_coords(obs_event, (radius, longitude))
+        _, obs_event = ring_surface.photon_to_event_by_coords(
+            obs_event, (radius_scalar, longitude_scalar)
+        )
 
         uv = obs.fov.uv_from_los(obs_event.neg_arr_ap)
         u, v = uv.to_scalars()

--- a/tests/shims/backplane.py
+++ b/tests/shims/backplane.py
@@ -42,6 +42,13 @@ class KeyedScalar(polymath.Scalar):
     ``ring_radius`` result to call :meth:`oops.Backplane.border_atop`.
     ``polymath.Scalar`` has no such attribute of its own, so the shim
     declares one here rather than grafting it onto an instance.
+
+    Construction takes the same arguments as ``polymath.Scalar``; the
+    ``key`` attribute is not a constructor argument.  It defaults to
+    ``None`` and :func:`_scalar` assigns it when a caller supplies one,
+    so every arithmetic or indexing result derived from a keyed scalar
+    reports ``key is None`` rather than inheriting a key that no longer
+    describes it.
     """
 
     key: tuple[Any, ...] | None = None
@@ -284,7 +291,17 @@ class FakeBackplane:
     # ------------------------------------------------------------------
 
     def ring_radius(self, ring_target: str) -> KeyedScalar:
-        """Return per-pixel ring-plane radius in km, tagged with its key."""
+        """Return per-pixel ring-plane radius in km, tagged with its key.
+
+        Parameters:
+            ring_target: Ring target name, as keyed into ``per_ring``.
+
+        Returns:
+            :class:`KeyedScalar` of per-pixel radii, masked outside the
+            configured ``ring_mask``, whose ``key`` is the
+            ``('ring_radius', ring_target)`` tuple the production code
+            reads back and hands to :meth:`border_atop`.
+        """
         data = self._ring(ring_target)
         return _scalar(
             data.ring_radius_km,

--- a/tests/shims/backplane.py
+++ b/tests/shims/backplane.py
@@ -28,9 +28,23 @@ import polymath
 __all__ = [
     'BodyBackplaneData',
     'FakeBackplane',
+    'KeyedScalar',
     'RingBackplaneData',
     'plant_circular_body',
 ]
+
+
+class KeyedScalar(polymath.Scalar):
+    """A ``polymath.Scalar`` that also carries a backplane ``key``.
+
+    ``oops.Backplane`` tags each result it returns with the key that
+    produced it, and the navigation pipeline reads that key back off a
+    ``ring_radius`` result to call :meth:`oops.Backplane.border_atop`.
+    ``polymath.Scalar`` has no such attribute of its own, so the shim
+    declares one here rather than grafting it onto an instance.
+    """
+
+    key: tuple[Any, ...] | None = None
 
 
 def _scalar(
@@ -38,8 +52,8 @@ def _scalar(
     mask: np.ndarray | bool | None = None,
     *,
     key: tuple[Any, ...] | None = None,
-) -> polymath.Scalar:
-    """Build a ``polymath.Scalar`` and optionally tag it with a backplane ``key``.
+) -> KeyedScalar:
+    """Build a ``KeyedScalar`` and optionally tag it with a backplane ``key``.
 
     ``polymath.Scalar`` already covers ``.vals`` / ``.mvals`` /
     ``min`` / ``max`` / ``median`` / ``expand_mask`` / ``mask_where`` /
@@ -51,15 +65,16 @@ def _scalar(
     Parameters:
         vals: Numpy array or scalar.
         mask: Optional boolean mask of the same shape as ``vals``.
-        key: Optional opaque key surfaced as ``.key``.
+        key: Optional opaque key surfaced as ``.key``.  A result built
+            without one reports ``key is None``.
 
     Returns:
-        Configured ``polymath.Scalar``.
+        Configured ``KeyedScalar``.
     """
     if mask is None:
-        scalar = polymath.Scalar(np.asarray(vals))
+        scalar = KeyedScalar(np.asarray(vals))
     else:
-        scalar = polymath.Scalar(np.asarray(vals), np.asarray(mask, dtype=bool))
+        scalar = KeyedScalar(np.asarray(vals), np.asarray(mask, dtype=bool))
     if key is not None:
         scalar.key = key
     return scalar
@@ -268,8 +283,8 @@ class FakeBackplane:
     # Ring methods
     # ------------------------------------------------------------------
 
-    def ring_radius(self, ring_target: str) -> polymath.Scalar:
-        """Return per-pixel ring-plane radius in km."""
+    def ring_radius(self, ring_target: str) -> KeyedScalar:
+        """Return per-pixel ring-plane radius in km, tagged with its key."""
         data = self._ring(ring_target)
         return _scalar(
             data.ring_radius_km,

--- a/tests/shims_tests/test_shims_self.py
+++ b/tests/shims_tests/test_shims_self.py
@@ -125,8 +125,8 @@ def test_fake_backplane_ring_methods_round_trip() -> None:
     bp = FakeBackplane(per_ring={'saturn:ring': ring})
     radii_scalar = bp.ring_radius('saturn:ring')
     assert not radii_scalar.is_all_masked()
-    assert radii_scalar.min().vals == pytest.approx(70_000.0)
-    assert radii_scalar.max().vals == pytest.approx(140_000.0)
+    assert radii_scalar.min(builtins=True) == pytest.approx(70_000.0)
+    assert radii_scalar.max(builtins=True) == pytest.approx(140_000.0)
     res = bp.ring_radial_resolution('saturn:ring')
     assert np.all(np.asarray(res.vals) == 200.0)
 

--- a/tests/spindoctor/nav_model/stars/test_catalog.py
+++ b/tests/spindoctor/nav_model/stars/test_catalog.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any, cast
 
 import numpy as np
@@ -14,6 +15,7 @@ from spindoctor.nav_model.stars.catalog import (
     _find_stars_in_one_catalog,
     _mark_visual_overlaps,
     _merge_catalogs,
+    aberrate_star,
     select_radec_list,
 )
 from spindoctor.support.types import MutableStar
@@ -73,6 +75,22 @@ def test_select_radec_list_without_proper_motion() -> None:
         _as_stars([_FakeStar(ra=0.5, dec=1.5)]), use_proper_motion=False, midtime=0.0
     )
     assert out == [(0.5, 1.5)]
+
+
+def test_aberrate_star_rejects_a_record_with_no_ra() -> None:
+    """A star carrying no RA is a caller error, not silent garbage."""
+    star = cast(MutableStar, _FakeStar(ra=None, dec=2.0))
+    obs = cast(Any, SimpleNamespace(midtime=0.0, path=None, frame=None))
+    with pytest.raises(ValueError, match='requires a star with RA and DEC'):
+        aberrate_star(obs, star)
+
+
+def test_aberrate_star_rejects_a_record_with_no_dec() -> None:
+    """A star carrying no DEC is a caller error, not silent garbage."""
+    star = cast(MutableStar, _FakeStar(ra=1.0, dec=None))
+    obs = cast(Any, SimpleNamespace(midtime=0.0, path=None, frame=None))
+    with pytest.raises(ValueError, match='requires a star with RA and DEC'):
+        aberrate_star(obs, star)
 
 
 def test_merge_catalogs_drops_exact_duplicates() -> None:

--- a/tests/spindoctor/reproj/test_bodies_reproject.py
+++ b/tests/spindoctor/reproj/test_bodies_reproject.py
@@ -16,7 +16,7 @@ Contract sources: the ``reproject()`` / ``BodyMosaic`` docstrings in
 
 import math
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from unittest.mock import patch
 
 import numpy as np
@@ -234,8 +234,10 @@ class FakeObs:
             coords: (longitude, latitude) polymath Scalars in radians.
         """
         lon, lat = coords
-        lon_v = np.asarray(polymath.Scalar.as_scalar(lon).vals, dtype=np.float64)
-        lat_v = np.asarray(polymath.Scalar.as_scalar(lat).vals, dtype=np.float64)
+        lon_scalar = cast(polymath.Scalar, polymath.Scalar.as_scalar(lon))
+        lat_scalar = cast(polymath.Scalar, polymath.Scalar.as_scalar(lat))
+        lon_v = np.asarray(lon_scalar.vals, dtype=np.float64)
+        lat_v = np.asarray(lat_scalar.vals, dtype=np.float64)
         lon_bins = np.round(lon_v / _LON_RES)
         u = lon_bins - self._lon0 + self._frac_u
         v = np.round((lat_v + _HALF_PI) / _LAT_RES) - self._lat0 + self._frac_v


### PR DESCRIPTION
## Purpose

The nightly scheduled run turned red in the Lint job: `mypy src tests` reports 33 errors. Nothing in the repo changed — rms-polymath 2.0 did. It ships `py.typed` and a full set of `.pyi` stubs, so mypy now sees real types where every polymath expression previously resolved to `Any`, and strict mode flags six places where the navigation code and its test shims were leaning on that `Any`. All four test jobs pass; this is a typing-only break.

This PR adopts the stubs rather than suppressing them, declares the polymath dependency the code has always had, and raises the rms-oops floor.

## Changes

- `NavModelBody._render_body` read the lit-pixel floor through `Scalar.__getitem__`, which the stubs type as returning `Qube` — and `min` lives on `Scalar`, not `Qube`. The surrounding block already unpacks `incidence_vals = incidence_scalar.vals` and uses it for `is_lit` / `is_dark`, so the check now reads the same array. Only unmasked entries are ever indexed (the `body_mask_valid.any()` guard short-circuits first), so the value is identical; verified on 200 random masked arrays plus a fill-value edge case.
- `aberrate_star` casts `star.ra` / `star.dec` to `float`. `MutableStar` declares them optional and the only caller filters `None` records out before calling, but that narrowing does not propagate into the function. This matches the existing `cast` at the two `ra_dec_with_pm` call sites in the same module.
- `RingMosaic.longitude_radius_to_pixels` no longer rebinds its `NDArrayFloatType` parameters to `Scalar`. The co-rotating conversion now runs on the raw array — which is what `RingOrbitModel.corotating_to_inertial` is annotated to accept, so this removes a latent mismatch as well — and the `Scalar`s are built afterwards under their own names. Call order and the empty-input short circuit are unchanged, including the empty-plus-orbit-model path.
- The `FakeBackplane` test shim declares a `KeyedScalar(polymath.Scalar)` subclass carrying the `key` that `oops.Backplane` attaches to a result, instead of grafting the attribute onto a `Scalar` instance. Confirmed polymath preserves the subclass through indexing, arithmetic, `as_scalar`, `mask_where`, and `deepcopy`, and the shim's `isinstance(..., polymath.Scalar)` assertions still hold. Unkeyed results now report `key is None` rather than raising `AttributeError`.
- Two tests read `.vals` off methods the stubs type as returning the broad `_Arraylike` union. The min / max asserts request plain floats with `builtins=True` (the idiom already used in `rings.py`), and the two `as_scalar` results are cast.
- `pyproject.toml`: added `rms-polymath>=2.0` and raised `rms-oops>=0.1.3` to `>=0.1.5`. The navigation code imports polymath directly throughout `src/` but declared no dependency on it, picking it up transitively through rms-oops; it is now declared at the version whose stubs the code is type-checked against. The per-module `ignore_missing_imports` override for `polymath.*` is dropped — it does nothing for a `py.typed` package and would misread as "polymath is untyped". The remaining overrides still cover the untyped parts of the science stack.

No production behavior changes; every source edit is either a `cast` (a runtime no-op) or an expression proven equivalent to the one it replaces.

## Type of Change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that alters existing behavior or public API)
- [x] Refactor (no functional or API changes)
- [ ] Documentation
- [ ] Tests only (no production code change)
- [x] CI / Build / Dependencies

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] End-to-end tests pass (if applicable)
- [ ] New or updated tests for changed code
- [x] Tested manually (describe below if applicable)

`pytest -n 4 --dist=loadfile` with BLAS/OMP threads pinned to 1: 5898 passed, 7 xfailed.

`mypy src tests`: Success, no issues found in 609 source files (from 33 errors in 6 files). `ruff check`, `ruff format --check`, `sphinx-build -W`, and `pymarkdown scan` are all clean — the last two never ran in the failing CI job, since mypy aborted it first.

Integration spot-check of the touched render path, `tests/integration/test_render_diffs.py` and `tests/integration/test_baselines.py`: 4 passed, 2 failed. Both failures reproduce identically on unmodified `main` with the same numbers (N1597846115 at offset 5.600 / 1.079, confidence 0.809), so they are the known pre-existing stragglers and not a regression from this branch.

No new tests: the change is type-level, and the behavior at each site is already covered by the existing suite.

## Potential Impacts

Public API: none. Performance: none (`incidence_vals[mask].min()` avoids building a throwaway `Scalar`, which is marginally cheaper on the body-render path, but not measurably so).

Downstream: the added `rms-polymath>=2.0` floor is the notable one. An environment resolving an older polymath will now fail at install time instead of at type-check time. Nothing in the diff needs polymath 2.0 at runtime — `cast` compiles away — so the constraint is about keeping the typed contract honest, not about runtime capability.

## Checklist

- [x] Code follows project style (`ruff check`, `ruff format`)
- [x] Type annotations present and `mypy` passes
- [ ] Docstrings and Sphinx docs updated (if applicable)
- [ ] CHANGES.md updated (if user-facing change)
- [x] No temporary or debug code left in
- [x] Breaking changes flagged in Type of Change above

Docstrings at the edited sites were updated where the contract moved (the shim's `_scalar` / `ring_radius`); no guide or plan file mentions polymath, so there was nothing to reconcile there. The repo keeps no CHANGES.md.

## Notes

This is the second dependency release to turn CI red without a code change on our side, which is the case #391 (pin ruff and the other lint tools) is making. This PR does not close it — polymath is a runtime dependency rather than a lint tool, so the fix there would be a different mechanism — but it is worth recording as a data point.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation behavior when all observed objects are in shadow.
  - Corrected star-position calculations for records with valid coordinate data.
  - Improved ring and body coordinate reprojection, including handling of empty inputs.
  - Increased consistency when calculating minimum and maximum ring-radius values.

- **Compatibility**
  - Updated Polymath and OOPS compatibility requirements to support the latest calculations and scalar handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->