### PR TITLE
Stop an ingest at a directory it cannot list

### DIFF
--- a/docs/user_guide/user_guide_navigation.rst
+++ b/docs/user_guide/user_guide_navigation.rst
@@ -274,22 +274,13 @@ names one file per reason.
 
 **A file the index has no row at all for reads as absent**, and
 ``--has-no-offset-file`` reads absence as "this image was never navigated", so
-it selects that image again. Three passes end that way: one that could not
-retrieve the file, one whose rows the database would not store, and one that did
-not list the directory the file is under. The first two are deliberate -- a
-recorded refusal would be skipped for as long as the file did not change, and
-the next pass would never retry it -- and the third is counted rather than
-silent, by the paragraph on unlisted directories below.
-
-**A document the tree no longer holds keeps its row** and reads as present, so
-``--has-offset-file`` hands on an image whose metadata file is gone and
-``--has-no-offset-file`` skips an image nothing has been written for. A row
-leaves the index only when a pass that listed the whole root finds no file for
-it, and a pass that missed a single directory anywhere under the root removes no
-row at all, having no evidence about the stubs it did not see. One unlistable
-subdirectory therefore holds every stale row of the root, however many passes
-complete in the meantime, which is why this one is not answered by ingesting
-again.
+it selects that image again. Two passes end that way: one that could not
+retrieve the file, and one whose rows the database would not store. Both are
+deliberate -- a recorded refusal would be skipped for as long as the file did
+not change, and the next pass would never retry it. A file under a directory
+nobody listed is not a third: an ingest that cannot list a directory stops
+there rather than completing, so a root the index holds a completed pass over
+is a root every directory of which was listed.
 
 **A document rewritten in place that kept the length and the modification time
 it had before** is one the ingest skips, because those two metrics are
@@ -309,14 +300,11 @@ pass ``--results-db none`` for a run that must read the tree. That age is what
 decides the answer outside the paragraphs above; inside them it decides nothing,
 since each of them survives a pass that finished a second ago.
 
-An ingest that could not list every directory under the root reports the number
-it missed, and every enumeration answered from that index repeats it as a
-warning. It bounds both directions of the snapshot: an image under a directory
-nobody listed is absent from the index whether or not it was navigated, and such
-a pass removes no row anywhere under the root, so a result file deleted before it
-keeps its row until a pass lists the whole root. Fixing what stopped the walk --
-a directory permission, a symbolic link pointing back up the tree -- and
-re-running ``sd_stats_ingest`` clears both.
+An ingest that meets a directory it cannot list stops there, reports it as an
+error, and completes no root from that point on, so no index a consumer reads
+holds a root that was only partly walked. Fix what stopped the walk -- a
+directory permission, a share that was not answering -- and run
+``sd_stats_ingest`` again.
 
 Miscellaneous
 ^^^^^^^^^^^^^

--- a/docs/user_guide/user_guide_navigation.rst
+++ b/docs/user_guide/user_guide_navigation.rst
@@ -302,9 +302,11 @@ since each of them survives a pass that finished a second ago.
 
 An ingest that meets a directory it cannot list stops there, reports it as an
 error, and completes no root from that point on, so no index a consumer reads
-holds a root that was only partly walked. Fix what stopped the walk -- a
-directory permission, a share that was not answering -- and run
-``sd_stats_ingest`` again.
+holds a root that was only partly walked. A results root that cannot be listed
+at all is the other case and does not stop the pass: that root alone is left
+unfinished, which every consumer already refuses, and the ingest goes on to the
+next root. Fix what stopped the walk -- a directory permission, a share that was
+not answering -- and run ``sd_stats_ingest`` again.
 
 Miscellaneous
 ^^^^^^^^^^^^^

--- a/docs/user_guide/user_guide_statistics.rst
+++ b/docs/user_guide/user_guide_statistics.rst
@@ -399,6 +399,25 @@ step 1 onwards, so every consumer reports it as a root nobody has ingested while
 the workers are still writing -- rather than answering from whichever shares
 have landed.
 
+**Abandoning a fan-out costs a full re-ingest of that root.** Step 1 removes the
+rows of documents that have left the tree before any document is read, so a
+pass whose tasks are never queued, or that is given up on, has already shrunk
+the index. Nothing incorrect is lost -- the rows removed are exactly those whose
+documents the listing did not find -- and the root stays unfinished throughout,
+so no consumer reads a wrong answer from it. What it costs is the rest of the
+root's content in the index, which comes back by running the three steps through
+to the end, or an ordinary ``sd_stats_ingest`` over the root.
+
+**Two passes over one root at the same time are a documented limit.** Nothing
+refuses a fan-out over a root whose newest run is still unfinished, and two that
+overlap can leave behind one row whose document has gone: a worker of the first
+writes a stub after the second has read what the index holds and before it
+deletes. The window is narrow, both runs are unfinished while it is open -- so
+no consumer reads the root during it -- and the next pass over the root removes
+the row. Leaving it alone is a decision rather than an oversight: refusing or
+warning about a concurrent pass was considered and not done, and the case for
+either would have to be made afresh. Run one pass over a root at a time.
+
 **Step 3 refuses to finish a root its tasks did not cover.** Step 1 records how
 many files it found; step 3 adds up how many the tasks ingested, skipped and
 refused, counting each task's report once. If the tasks account for fewer files

--- a/docs/user_guide/user_guide_statistics.rst
+++ b/docs/user_guide/user_guide_statistics.rst
@@ -173,11 +173,20 @@ from the index comes than the tree would have made it, and
 ``sd_stats_ingest --force`` reads every document again, which puts the reasons
 and the example files back into the summary.
 
-**A directory the walk cannot list stops the ingest.** One this user may not
-read, or on a share that stopped answering, is reported as an error naming the
-directory, and the pass ends there: the root it was under gets no finish time,
-no root named after it on the same command line is walked, and
+**A directory under a root that the walk cannot list stops the ingest.** One
+this user may not read, or on a share that stopped answering, is reported as an
+error naming the directory, and the pass ends there: the root it was under gets
+no finish time, no root named after it on the same command line is walked, and
 ``sd_stats_ingest`` exits 1. Fix what stopped the walk and run it again.
+
+**A root that cannot be listed does not stop it.** That is the case above --
+the mistyped path, the unmounted share -- and it is charged to the root it is
+about: that root is reported, left unfinished and ingested not at all, every
+other root named on the command line is still walked, and the status is 1 at the
+end. The difference is what the walk knows. A root nobody can list is a root
+this pass has said nothing about, and the next root has nothing to do with it; a
+directory nobody can list sits inside a root the pass is otherwise about to
+declare it has read.
 
 The alternative was tried and is worse. A pass that finished around the gap
 completed, stamped its root as ingested, and left every image under that

--- a/docs/user_guide/user_guide_statistics.rst
+++ b/docs/user_guide/user_guide_statistics.rst
@@ -152,10 +152,7 @@ results tree also holds ``*_metadata.json`` files that are not per-image
 navigation documents at all; each is counted as an error for its own file, the
 run continues, and the closing summary tallies the failures by reason and names
 one file per reason, so several hundred files that were never navigation results
-read as exactly that rather than as a broken ingest. A directory the walk cannot
-list -- one this user may not read, a share that stopped answering -- costs the
-files under it and nothing else: the pass continues over the rest of the root
-and removes no row from it.
+read as exactly that rather than as a broken ingest.
 
 That tally is what this pass read, and not what the root holds. A refused file
 is recorded in ``failed_files``, and every pass after it skips the file
@@ -176,24 +173,40 @@ from the index comes than the tree would have made it, and
 ``sd_stats_ingest --force`` reads every document again, which puts the reasons
 and the example files back into the summary.
 
-**A directory the walk did not list is counted, and absence under it is not an
-answer.** The closing summary reports how many directories a pass did not
-enumerate, and each pass records the number on its ``ingest_runs`` row. Two
-things put a directory in that count: one the walk could not list, and one it
-had already walked under another name, which is what a link pointing back into
-a tree produces. Such a pass still completes, and the rows it wrote are as good
-as any other pass's -- but under one of those directories the index holds no
-rows at all, and **no row there means the walk never looked, not that the image
-was never navigated**. Read a nonzero count as a question about the tree before
-reading any absence beneath it as a result. A pass whose count is zero listed
-every directory of the root, and absence means what it says everywhere.
+**A directory the walk cannot list stops the ingest.** One this user may not
+read, or on a share that stopped answering, is reported as an error naming the
+directory, and the pass ends there: the root it was under gets no finish time,
+no root named after it on the same command line is walked, and
+``sd_stats_ingest`` exits 1. Fix what stopped the walk and run it again.
+
+The alternative was tried and is worse. A pass that finished around the gap
+completed, stamped its root as ingested, and left every image under that
+directory reading as one nothing had ever navigated -- and, because such a pass
+must not remove rows on evidence it does not have, left every document deleted
+since the pass before it reading as present, across any number of later passes
+that completed the same way. Stopping costs an ingest, which is cheap and
+repeatable; finishing cost a wrong answer that no later pass corrected.
+
+**The cost of that is a transient failure ending a long pass.** A share that
+stops answering for a moment, or a permission fixed a minute later, now ends the
+run instead of degrading it. That is the trade, made deliberately: the walk
+happens before any document is read, so what a stopped pass throws away is the
+listing rather than hours of retrieval, and the pass can simply be run again.
+
+**A directory reached a second way is not a gap and does not stop anything.** A
+link pointing back up into the tree, or a volume reachable under two names,
+brings the walk to a directory it has already listed; it says so, declines to
+list it twice, and goes on. The documents under it are already in the listing,
+under the path the walk met first, and walking it again would only write them a
+second time under identifiers no consumer asks about.
 
 **The exit status says whether the pass completed, not what it found.**
 ``sd_stats_ingest`` exits 0 when every named root was walked, whatever mix of
 documents was read, skipped and refused, and 1 when the run could not complete:
 no index or no results root could be resolved, a named root is not a location
-that can be read, the index could not be opened, or a root could not be listed
-at all. A scheduled invocation therefore reads the same status from the same
+that can be read, the index could not be opened, a root could not be listed at
+all, or a directory under one could not be listed, which stops the pass where it
+is found. A scheduled invocation therefore reads the same status from the same
 tree every time, and a status of 1 always means something needs fixing rather
 than that a tree happens to hold no results.
 
@@ -711,13 +724,11 @@ pair with ``ON DELETE CASCADE``.
 ``ingest_runs`` records one row per ingest pass over one root: the root, when
 the pass started and finished (``finished_utc`` is NULL while it is running),
 how many files it saw, ingested, skipped as unchanged, could not read and
-removed, how many directories it did not list (``directories_missed``), and the
-schema version it wrote. A root whose newest row has no finish time, or which
-has no row at all, has not been fully ingested, and a consumer says so rather
-than reading absence of rows as "nothing was navigated". A finished row whose
-``directories_missed`` is nonzero covers the root apart from those directories:
-the rows it wrote are good, and absence of a row under one of them means the
-walk never looked rather than that the image was never navigated.
+removed, and the schema version it wrote. A root whose newest row has no finish
+time, or which has no row at all, has not been fully ingested, and a consumer
+says so rather than reading absence of rows as "nothing was navigated". A row
+that does carry a finish time covers the whole of its root, because a pass that
+could not list a directory stops rather than finishing.
 
 ``failed_files`` records one row per file that is not a current-schema
 navigation document: the root and stub that identify it, the volume it is under,

--- a/plans/RESULTS_DB_PLAN.md
+++ b/plans/RESULTS_DB_PLAN.md
@@ -2379,13 +2379,15 @@ File as tracking issues alongside the implementation issue:
 - **A `--since` selector for ingest** (#467). The stat-pair skip makes a re-scan
   cheap in reads but not in listings; a time-bounded scan would cut the
   listing too.
-- **Two overlapping ingest passes over one root can leave a stale row** (#479).
-  A worker of the first writes a stub after the second has read what is
-  recorded and before its delete, for a document that left the tree between the
-  two listings. Narrow, self-healing on the next pass, and invisible to
-  consumers while it is open, since both runs are unfinished; what is undecided
-  is whether a fan-out over a root whose newest run is unfinished should be
-  refused, warned about, or left as it is.
+- **Two overlapping ingest passes over one root can leave a stale row** (#479),
+  **closed as a documented limit.** A worker of the first writes a stub after
+  the second has read what is recorded and before its delete, for a document
+  that left the tree between the two listings. Narrow, self-healing on the next
+  pass, and invisible to consumers while it is open, since both runs are
+  unfinished. Refusing or warning about a fan-out over a root whose newest run
+  is unfinished was considered and not done; the statistics guide says so in
+  those terms, so that a later reader sees a choice rather than a question
+  nobody reached.
 - **A hand-written ingest task file can name a stub outside its root** (#489).
   A task file is an operator-visible artifact, and the worker accepts any string
   as a stub, so a hand-edited one reads a document outside the root it names and
@@ -2395,11 +2397,13 @@ File as tracking issues alongside the implementation issue:
   half of the key was closed for the same threat model; what is undecided is
   whether the worker should validate the stub domain as the log-path and offset
   readers already validate theirs.
-- **An abandoned fan-out has already removed rows** (#480). The prune runs
-  before any document is read, so a pass that is given up on after step 1 has
-  shrunk the index. Only rows whose documents have genuinely left the tree go,
-  and the run is unfinished throughout, so nothing valid is lost and no consumer
-  reads the root; the way back is a full ingest.
+- **An abandoned fan-out has already removed rows** (#480), **closed as a
+  documented limit.** The prune runs before any document is read, so a pass that
+  is given up on after step 1 has shrunk the index. Only rows whose documents
+  have genuinely left the tree go, and the run is unfinished throughout, so
+  nothing valid is lost and no consumer reads the root. The statistics guide
+  states the operator-visible consequence, which is that abandoning a fan-out
+  costs a full re-ingest of that root.
 - **One unlistable directory stopped the prune for the whole root** (#481),
   **closed.** A pass that could not list one directory completed all the same
   and removed no row anywhere under its root, so a deleted document went on

--- a/plans/RESULTS_DB_PLAN.md
+++ b/plans/RESULTS_DB_PLAN.md
@@ -669,48 +669,62 @@ empty completes normally.
 **Every way a directory refuses to be listed is one way.** The walk treats any
 `OSError` as "could not be listed": not there, not a directory, unreadable by
 this user, a share that stopped answering. A permission error is the commonest
-of them on a shared tree, and enumerating only some of the others ends the pass
-on it -- skipping every later root of a multi-root run and never reaching the
-closing summary. A directory that could not be listed costs the files under it
-and nothing else; the pass continues over the rest of the root, and the prune is
-refused for that root because the listing no longer covers all of it.
+of them on a shared tree, and telling them apart would only decide which of them
+ends the pass, since all of them mean the walk can see no result file there,
+which is not the same as there being none.
 
-**A directory the walk did not list is counted, not merely logged.** The pass
-carries a `directories_missed` count, reports it in the closing summary, and
-records it on the `ingest_runs` row. Absence of an `images` row is the
-load-bearing claim of the whole design -- every consumer reads it as "this image
-was never navigated" -- and under a directory nobody enumerated that reading is
-simply false. A run that missed a directory still completes, because the rows it did
-write are as good as any other run's, so the count is the only place the gap
-shows; a consumer that means to read absence as an answer has it on the run row
-rather than in a log file nobody kept. A pass whose count is zero listed the
-whole root and absence means what it says everywhere under it.
+**A directory under a root that will not list ends the pass.** The walk raises
+where it meets the directory; nothing catches it before the driver's console
+entry point, which reports the directory as a fatal error and exits 1. The root
+it was under keeps its NULL finish time, every root named after it on the same
+command line is left without a run at all, and both are therefore roots every
+consumer refuses. Absence of an `images` row is the load-bearing claim of the
+whole design -- every consumer reads it as "this image was never navigated" --
+and under a directory nobody enumerated that reading is simply false; a pass
+that completed around one stamped the root as ingested and made that reading an
+answer, permanently, since a pass with no evidence about the stubs it did not
+see must also remove no row. Every completed run is now a run that listed its
+whole root, which is what lets the prune act on every one of them.
 
-**A directory already walked is not walked again.** The walk records each local
-directory's device and inode as it enters it and skips one it has already
-listed. A link from a subdirectory back to an ancestor otherwise writes the same
-document under a new stub at every level, until the filesystem's own limit on
-link traversal stops it -- forty-one rows for one document, forty of them
-answering for images at paths no consumer will ask about, and the count of
-navigated images wrong by all of them. A directory skipped this way is counted
-as missed, since the walk did not enumerate it there, which is also what refuses
-the prune for that pass. The identity is taken only for a local directory: a
-cloud location has no links to go round in, and asking a bucket about a prefix
-is a paid round trip per directory per run.
+It is raised **at discovery, in the walk**, and not where the prune would
+otherwise be skipped. The walk happens before any document is read, so a pass
+stopped there throws away a listing; a pass stopped at prune time throws away
+every retrieval of an archive-scale root, which is hours of work to reach the
+same conclusion. The cost of the rule is that a transient failure -- a share
+that stops answering for a moment, a permission fixed a minute later -- ends a
+run instead of degrading it. That is the trade, taken deliberately: an ingest is
+reproducible from the tree and cheap to repeat, and the answer the alternative
+leaves behind is one no later pass corrects.
+
+**A directory already walked is not walked again, and is not a gap.** The walk
+records each local directory's device and inode as it enters it and skips one it
+has already listed. A link from a subdirectory back to an ancestor otherwise
+writes the same document under a new stub at every level, until the filesystem's
+own limit on link traversal stops it -- forty-one rows for one document, forty
+of them answering for images at paths no consumer will ask about, and the count
+of navigated images wrong by all of them. Declining the second path is not the
+same as failing to reach it: every document under that directory is in the
+listing already, under the path the walk met first, and the stubs the second
+path would produce name a directory no consumer's lookup spells. So the walk
+logs it and goes on, the root counts as wholly listed, and the pass completes
+and prunes. The identity is taken only for a local directory: a cloud location
+has no links to go round in, and asking a bucket about a prefix is a paid round
+trip per directory per run.
 
 **Rows of documents that have left the tree are removed.** Presence has to mean
 what absence means, so the stubs recorded for a root that this walk did not
 find are deleted, and the count is reported and recorded in `ingest_runs` as
 `files_removed`. The delete cascades to the child tables. This is sound only on
-the evidence of a **complete listing of the root**: the prune reads the walk's
-own listing and refuses one that does not cover the whole root, which is the
-case whenever the root could not be listed or any directory under it could not.
-Section 2.8 states the consequence for a worker that covers a share of a root.
+the evidence of a **listing of the whole root**: the prune reads the walk's own
+listing and refuses one of a root the walk could not list. A listing missing a
+directory under the root never reaches it, because such a walk raises instead of
+returning. Section 2.8 states the consequence for a worker that covers a share
+of a root.
 
 **Per-root bookkeeping.** An `ingest_runs` table records, per root:
 `root_url`, `started_utc`, `finished_utc` (NULL while running),
 `files_seen` / `files_ingested` / `files_skipped` / `files_failed` /
-`files_removed` / `directories_missed`, and `schema_version`, under a surrogate
+`files_removed`, and `schema_version`, under a surrogate
 `run_id` primary key
 (a root legitimately has many runs, and a consumer reads the newest). The row
 is written at
@@ -768,7 +782,8 @@ duplicates apart would put a technique nobody ran into the operator's report.
 **The driver's exit status says whether the pass completed**, not what it found:
 0 when every named root was walked, whatever mix of documents was read, skipped
 and refused, and 1 when the run could not complete -- no index or no root
-resolvable, the index unopenable, or a root that could not be listed. A status
+resolvable, the index unopenable, a root that could not be listed, or a
+directory under one that could not be. A status
 read from a count of ingested documents flips between two passes over one
 unchanged tree, since what one pass ingests or refuses the next one skips, and a
 scheduled run would then see a failure once and never again. **The driver always
@@ -1537,8 +1552,10 @@ Details settled during execution, none of them a change of intent:
   from an earlier state of this phase would otherwise pass the version gate and
   then fail on a column that is not there, which is exactly what the gate exists
   to prevent. Phase 5 raises it again, to 5, on the same reasoning, and the
-  column set changed once more after it -- the summary-PNG flag left both file
-  tables -- which is what makes the current version 6.
+  column set changed twice more after it -- the summary-PNG flag left both file
+  tables, and `directories_missed` left `ingest_runs` when a walk that cannot
+  list a directory began to stop rather than complete -- which is what makes the
+  current version 7.
 - **The CSV export states its line terminator.** `csv.writer` defaults to CRLF;
   the export now names LF. The frozen `images.csv` blobs are LF, so what the
   export writes matches them byte for byte, which the previous implementation's
@@ -1586,12 +1603,15 @@ Details settled during execution, none of them a change of intent:
   root for the key while walking the string as typed made a relative root -- a
   documented spelling -- a traceback out of the driver, with the run row already
   written and its finish time left NULL.
-- **A directory the walk did not list is counted** (section 2.7), reported in
-  the summary and recorded on the `ingest_runs` row, and the walk skips a
-  directory it has already listed rather than descending into it again. The
-  first is what keeps "absence means never navigated" honest for the consumers
-  of Phase 4; the second stops a link back into a tree from writing one
-  document as forty-one rows.
+- **A directory the walk cannot list ends the pass** (section 2.7), and the
+  walk skips a directory it has already listed rather than descending into it
+  again. The first is what keeps "absence means never navigated" honest for the
+  consumers of Phase 4: no run that completes has a gap in it. The second stops
+  a link back into a tree from writing one document as forty-one rows, and is
+  not a gap, so it stops nothing. (Both arrived here as a count of missed
+  directories on the run row, reported by every consumer; the count went with
+  the change that made the first of them stop the pass, which left it always
+  zero.)
 - **Ingest is a package, on the treatment section 3 names for the report.**
   Everything section 2.7 asks of one pass carries `spindoctor/cli/stats/ingest`
   past the 1000-line cap, so it is `ingest/` split along the stages a pass runs
@@ -1626,15 +1646,20 @@ Details settled during execution, none of them a change of intent:
   the workers' writes cannot touch the same stub. Within one fan-out this is an
   ordering guarantee rather than only a set argument: the prune runs before the
   task descriptions are built, so no worker of that pass exists while it runs.
-  Two limits are worth recording. The disjointness is a claim about **one**
-  fan-out: two overlapping fan-outs against one root can leave a stale row, when
-  a worker of the first writes a stub after the second's snapshot of what is
-  recorded and before its delete, for a document that left the tree between the
-  two listings. It is narrow, and the next pass removes the row. And the prune
-  is destructive before any document has been read, so a fan-out that is
-  abandoned shrinks the index -- but only by rows whose documents have genuinely
-  left the tree, and the run is unfinished throughout, so no consumer reads the
-  root either way.
+  Two limits are worth recording, and both are **documented limits** rather
+  than open questions: each is stated in the statistics guide, and each was
+  decided rather than left. The disjointness is a claim about **one** fan-out:
+  two overlapping fan-outs against one root can leave a stale row, when a worker
+  of the first writes a stub after the second's snapshot of what is recorded and
+  before its delete, for a document that left the tree between the two listings.
+  It is narrow, both runs are unfinished while the window is open, and the next
+  pass removes the row; refusing or warning about a fan-out over a root whose
+  newest run is unfinished was considered and not done. And the prune is
+  destructive before any document has been read, so a fan-out that is abandoned
+  shrinks the index -- but only by rows whose documents have genuinely left the
+  tree, and the run is unfinished throughout, so no consumer reads the root
+  either way; what it costs an operator is a full re-ingest of that root, which
+  is the sentence the guide gives them.
 - **Each task's report is counted once, under its `task_id`**; a share counts
   toward a run only when it names that run's root; the account must match the
   listing exactly rather than merely reach it; and a run whose listing was never
@@ -1709,10 +1734,9 @@ Details settled during execution, none of them a change of intent:
   read as a broken ingest rather than as the ordinary thing it is, which is why
   the whole-root pass keeps one example per reason in the first place.
 - **A run row carries what the fan-out found before it is finished.**
-  `files_seen`, `files_removed` and `directories_missed` are written at fan-out
-  with the finish time left NULL, because nothing later in the pass can find
-  them out again and the completion step must not have to list the root to learn
-  them.
+  `files_seen` and `files_removed` are written at fan-out with the finish time
+  left NULL, because nothing later in the pass can find them out again and the
+  completion step must not have to list the root to learn them.
 - **`sd_stats_ingest` and `sd_stats_ingest_cloud_tasks` joined the program
   identity tests** in `tests/spindoctor/config/test_logging_keys.py`, which named
   neither. The interactive driver has declared `PROGRAM_NAME` since Phase 2 and
@@ -2118,31 +2142,15 @@ Details settled during execution, none of them a change of intent:
      came out of is refused too and is not one of these: the tree excludes such
      a file from every error filter as well.
   2. A file that exists and **has no row at all** reads as absent, which is what
-     the absence filters read as "this image was never navigated". Three passes
-     end that way: a file the pass could not retrieve; a document the pass read
-     whose rows the database would not store (section 2.7's isolated write
-     failure); and a file under a directory the walk did not list. The first two
-     are deliberate -- a recorded row would be skipped for as long as the file
-     did not change, and the next pass would never retry it. The third is
-     counted rather than invisible: `ingest_runs.directories_missed` is read
-     with the same query, handed back with the answer, and reported by
-     `ResultsFilter` as a warning naming the root, which is the consumer section
-     2.7 wrote that count for.
-  3. A document **the tree no longer holds** keeps its row and reads as present,
-     so `--has-offset-file` hands on an image whose metadata file is gone and
-     `--has-no-offset-file` skips one nothing has been written for. A row leaves
-     the index only when a pass that listed the whole root does not find a file
-     for it (`_prune_missing`, gated on `covers_whole_root`), and a pass that
-     missed one directory anywhere under the root removes no row at all, having
-     no evidence about the stubs it did not see. One unlistable subdirectory
-     therefore holds every stale row of the root for as long as it stays
-     unlistable, across any number of completed passes -- so this is a live
-     consequence of the prune guard and not only the snapshot's age, and the
-     missed-directory warning says both halves. The prune is the ingest's, and
-     narrowing it to the directories a pass did list is a change to what a
-     listing has to report about itself, which sits with the ingest phases and
-     with the sharded pass that also prunes on partial evidence.
-  4. A document **rewritten in place, keeping the length and the modification
+     the absence filters read as "this image was never navigated". Two passes
+     end that way: a file the pass could not retrieve, and a document the pass
+     read whose rows the database would not store (section 2.7's isolated write
+     failure). Both are deliberate -- a recorded row would be skipped for as
+     long as the file did not change, and the next pass would never retry it. A
+     file under a directory nobody listed is not a third: a walk that cannot
+     list a directory raises where it meets it (section 2.7), so no root a
+     consumer reads has a completed pass that skipped one.
+  3. A document **rewritten in place, keeping the length and the modification
      time it had before,** is skipped by the incremental comparison
      (`_is_unchanged`, which has only `(mtime_ns, size_bytes)` to go on), so its
      row goes on recording what the document before it said and an error filter
@@ -2155,9 +2163,9 @@ Details settled during execution, none of them a change of intent:
      retrieving every document to find out is exactly the cost the skip exists
      to avoid -- a content digest would be paid on every file of every pass to
      catch a case a times-preserving restore produces. `--force` is the remedy
-     and is what the documentation points at. Like member 3, this one is not
-     the snapshot's age: a pass that finished a second ago answers from the
-     document before the rewrite.
+     and is what the documentation points at. This one is not the snapshot's
+     age: a pass that finished a second ago answers from the document before
+     the rewrite.
 - **The answer says how old it is, and what that does not cover.**
   `ingest_runs.finished_utc` is read by the same query as the missed count and
   returned with the stubs, and `ResultsFilter` reports it with the count of what
@@ -2258,9 +2266,7 @@ add a column (increment the version). No issue numbers in any of it.
       status;
    2. a file that has no row at all in the index, because no pass could read or
       record it;
-   3. a document the tree no longer holds, whose row survives every pass that
-      did not list the whole root;
-   4. a document rewritten in place with the length and the modification time it
+   3. a document rewritten in place with the length and the modification time it
       had before, whose row goes on recording what the document before it said.
 
    Each carve-out is stated in the plan, in the module docstring, in the
@@ -2394,15 +2400,16 @@ File as tracking issues alongside the implementation issue:
   shrunk the index. Only rows whose documents have genuinely left the tree go,
   and the run is unfinished throughout, so nothing valid is lost and no consumer
   reads the root; the way back is a full ingest.
-- **One unlistable directory stops the prune for the whole root** (#481).
-  `_prune_missing` runs only for a listing that covers the whole root, so a
-  single directory a walk could not list -- or one it had already walked under
-  another name -- keeps every stale row of that root across any number of
-  completed passes, and a document deleted from the tree goes on reading as
-  present. Phase 5 enumerates it, tests both directions of it, and says so in
-  the missed-directory warning; narrowing the prune means recording which
-  directories a pass did list, which is a change to the listing contract and
-  belongs with the sharded ingest that prunes on the same rule.
+- **One unlistable directory stopped the prune for the whole root** (#481),
+  **closed.** A pass that could not list one directory completed all the same
+  and removed no row anywhere under its root, so a deleted document went on
+  reading as present across any number of finished passes. The walk now raises
+  where it meets such a directory: the pass ends, the root keeps no finish time,
+  and every run that does complete listed its whole root and pruned. A directory
+  reached a second way is no longer counted as a gap either, since its documents
+  are in the listing under the path met first. `ingest_runs.directories_missed`
+  and everything that reported it went with the change, which is what raised the
+  schema version to 7.
 - **A document rewritten in place with the same length and modification time is
   never read again** (#488). Those two metrics are everything a listing supplies,
   so `_is_unchanged` cannot tell such a file from the one already read, and its

--- a/src/spindoctor/cli/sd_stats_ingest.py
+++ b/src/spindoctor/cli/sd_stats_ingest.py
@@ -55,6 +55,7 @@ from spindoctor.cli.stats.drop import drop_results_index
 from spindoctor.cli.stats.ingest import (
     IngestCounts,
     TaskCompletion,
+    UnlistableDirectoryError,
     complete_ingest_tasks,
     distinct_roots,
     fan_out_ingest_tasks,
@@ -217,12 +218,6 @@ def _log_outcome(counts: IngestCounts) -> None:
             counts.failures_by_reason[reason],
             counts.example_by_reason.get(reason, '(none recorded)'),
         )
-    if counts.directories_missed:
-        MAIN_LOGGER.warning(
-            'Directories not listed, whose files were therefore never seen: %d. Absence of '
-            'a row under one of them is not evidence that its image was never navigated.',
-            counts.directories_missed,
-        )
     if counts.roots_unreadable:
         MAIN_LOGGER.error(
             'Roots that could not be listed and are therefore not ingested: %d',
@@ -343,12 +338,6 @@ def _write_cloud_tasks(
     MAIN_LOGGER.info(
         'Rows removed, their document gone from the tree: %d', fan_out.counts.files_removed
     )
-    if fan_out.counts.directories_missed:
-        MAIN_LOGGER.warning(
-            'Directories not listed, whose files were therefore never seen: %d. Absence of '
-            'a row under one of them is not evidence that its image was never navigated.',
-            fan_out.counts.directories_missed,
-        )
     if fan_out.counts.roots_unreadable:
         MAIN_LOGGER.error(
             'Roots that could not be listed and are therefore not ingested: %d',
@@ -471,7 +460,9 @@ def main() -> None:
             named root was walked, whatever mix of documents was read, skipped
             and refused, and 1 when the run could not complete -- no index or no
             root could be resolved, a named root is not a location that can be
-            read, the index could not be opened, or a root could not be listed.
+            read, the index could not be opened, a root could not be listed, or
+            a directory under one could not be, which stops the pass where it
+            is found and leaves every root from there on unfinished.
             A tree of files that are not navigation documents is a completed
             pass and exits 0, and exits 0 again on the next pass over the same
             tree, so a scheduled run's status means the same thing every time it
@@ -574,6 +565,19 @@ def main() -> None:
             status = _complete_cloud_tasks(engine, roots, path=arguments.complete_cloud_tasks_file)
         else:
             status = _run_ingest(engine, roots, force=arguments.force)
+    except UnlistableDirectoryError as exc:
+        # The one failure a pass stops for rather than charging to a file or a
+        # root.  A directory nobody listed holds documents nobody recorded, and
+        # absence of a row is what every consumer reads as "this image was
+        # never navigated", so the alternative to stopping is a completed pass
+        # that answers wrongly and goes on answering wrongly.
+        MAIN_LOGGER.fatal(
+            'Ingest stopped: %s. This root and any named after it have no completed ingest '
+            'run, so no consumer reads absence under them as an answer. Make that directory '
+            'readable and run the ingest again.',
+            exc,
+        )
+        status = 1
     except Exception as exc:
         # The pass enumerates every failure it expects and charges it to one
         # file or one root.  Anything still escaping is a failure nobody

--- a/src/spindoctor/cli/stats/ingest/__init__.py
+++ b/src/spindoctor/cli/stats/ingest/__init__.py
@@ -13,6 +13,7 @@ it the complete listing that alone licenses one.
 Public API:
 
     METADATA_SUFFIX            -- suffix of the per-image navigation document
+    UnlistableDirectoryError   -- a directory under a root that ends the pass
     INGEST_RETRIEVE_BATCH_SIZE -- metadata files retrieved in one download
     INGEST_COMMIT_CHUNK_SIZE   -- images written per database transaction
     INGEST_TASK_SHARE_SIZE     -- metadata files handed to one cloud task
@@ -35,7 +36,8 @@ stage a name lives in:
 * :mod:`~spindoctor.cli.stats.ingest.counts` -- the tally a pass keeps and the
   summary it is read from.
 * :mod:`~spindoctor.cli.stats.ingest.walk` -- the single listing of a root,
-  which every later stage draws on.
+  which every later stage draws on, and which stops the pass rather than
+  returning an account of part of a root.
 * :mod:`~spindoctor.cli.stats.ingest.store` -- what the index already holds
   about a root, and how rows go back into it.
 * :mod:`~spindoctor.cli.stats.ingest.chunks` -- batched retrieval, reading a
@@ -66,7 +68,7 @@ from spindoctor.cli.stats.ingest.tasks import (
     ingest_task_share,
     task_results_from_event_log,
 )
-from spindoctor.cli.stats.ingest.walk import METADATA_SUFFIX
+from spindoctor.cli.stats.ingest.walk import METADATA_SUFFIX, UnlistableDirectoryError
 
 __all__ = [
     'INGEST_COMMIT_CHUNK_SIZE',
@@ -78,6 +80,7 @@ __all__ = [
     'TaskCompletion',
     'TaskResult',
     'TaskResults',
+    'UnlistableDirectoryError',
     'complete_ingest_tasks',
     'distinct_roots',
     'fan_out_ingest_tasks',

--- a/src/spindoctor/cli/stats/ingest/counts.py
+++ b/src/spindoctor/cli/stats/ingest/counts.py
@@ -32,11 +32,6 @@ class IngestCounts:
             delivered, and the ones the database would not store.
         files_removed: Image rows deleted because the tree no longer holds the
             document they came from.
-        directories_missed: Directories under a root that this pass did not
-            list on their own account, so the files under them were never
-            seen.  Absence of a row for a stub beneath one of them says
-            nothing, which is why the number is reported rather than left in a
-            log line.
         roots_unreadable: Roots the walk could not list at all, whose ingest
             run is deliberately left unfinished.
         failures_by_reason: How many files failed for each distinct reason, so
@@ -51,7 +46,6 @@ class IngestCounts:
     files_skipped: int = 0
     files_failed: int = 0
     files_removed: int = 0
-    directories_missed: int = 0
     roots_unreadable: int = 0
     failures_by_reason: dict[str, int] = field(default_factory=dict)
     example_by_reason: dict[str, str] = field(default_factory=dict)
@@ -67,7 +61,6 @@ class IngestCounts:
         self.files_skipped += other.files_skipped
         self.files_failed += other.files_failed
         self.files_removed += other.files_removed
-        self.directories_missed += other.directories_missed
         self.roots_unreadable += other.roots_unreadable
         for reason, count in other.failures_by_reason.items():
             self.failures_by_reason[reason] = self.failures_by_reason.get(reason, 0) + count

--- a/src/spindoctor/cli/stats/ingest/driver.py
+++ b/src/spindoctor/cli/stats/ingest/driver.py
@@ -1,8 +1,8 @@
 """One ingest pass over each of the named results roots.
 
 Each root is walked once; the files the index has already read are dropped from
-what the pass reads; the rest are ingested in chunks; and a root that was
-listed completely is pruned of the rows whose documents have left the tree.
+what the pass reads; the rest are ingested in chunks; and the root is pruned of
+the rows whose documents have left the tree.
 
 What a row is keyed by
 ----------------------
@@ -39,8 +39,14 @@ leaves a row that would answer for an image the tree no longer holds, so the
 rows of one root whose stub the walk did not find are deleted with it.  That is
 sound only for a pass that listed the whole root: a worker handed a share of a
 root has no evidence about the stubs outside its share, and deleting on that
-evidence would delete its peers' work.  The prune therefore reads a complete
+evidence would delete its peers' work.  The prune therefore reads a whole-root
 listing and refuses anything else.
+
+A walk supplies one or it stops: a directory it cannot list ends the pass where
+it finds it, so a run that reaches the prune at all listed every directory
+under its root.  Every completed pass therefore prunes, which is what keeps one
+unreadable subdirectory from holding a root's stale rows across any number of
+passes that finished.
 """
 
 from collections.abc import Sequence
@@ -193,14 +199,14 @@ def _prune_missing(
         How many image rows were deleted.
 
     Raises:
-        ValueError: If the listing covers part of a root rather than all of it.
-            A pass over a share of a root knows nothing about the stubs outside
-            its share, and would delete another worker's rows on that evidence.
+        ValueError: If the listing is not one of the whole root.  A pass over a
+            share of a root knows nothing about the stubs outside its share,
+            and would delete another worker's rows on that evidence.
     """
-    if not listing.covers_whole_root:
+    if not listing.root_listed:
         raise ValueError(
-            f'{root_url}: rows may only be removed on the evidence of a complete listing '
-            f'of the root, and this walk did not produce one'
+            f'{root_url}: rows may only be removed on the evidence of a listing of the '
+            f'whole root, and this walk did not produce one'
         )
     found = {listed.results_path_stub for listed in listing.metadata_files}
     gone = sorted(stub for stub in recorded if stub not in found)
@@ -240,11 +246,11 @@ def ingest_metadata_files(
     read as a current-schema navigation document is counted against its own
     file and the run continues.
 
-    A root this walk lists completely is also pruned: the rows of documents the
-    tree no longer holds are deleted, so that presence of a row means what
-    absence of one means.  A root the walk could not list is left alone
-    entirely, and its ingest run is deliberately not completed, because a
-    mistyped or unmounted root is not an empty one.
+    Each root walked is also pruned: the rows of documents the tree no longer
+    holds are deleted, so that presence of a row means what absence of one
+    means.  A root the walk could not list is left alone entirely, and its
+    ingest run is deliberately not completed, because a mistyped or unmounted
+    root is not an empty one.
 
     Two spellings of one root are one root, and are walked once.
 
@@ -265,6 +271,13 @@ def ingest_metadata_files(
 
     Returns:
         What the pass did, summed over every root.
+
+    Raises:
+        UnlistableDirectoryError: If a directory under any root could not be
+            listed.  The whole pass ends there: the roots already walked keep
+            what they ingested and their completed runs, this root and every
+            root named after it keep no completed run at all, and no consumer
+            reads absence under one of those as an answer.
     """
     total = IngestCounts()
     # The normalized form is what is walked, not the string as typed.  It is
@@ -280,7 +293,6 @@ def ingest_metadata_files(
         logger.info('Ingesting %s', root_url)
         listing = _walk_root(root, logger=logger)
         counts.files_seen = len(listing.metadata_files)
-        counts.directories_missed = listing.directories_missed
         if not listing.root_listed:
             # The run row keeps its NULL finish time, so every consumer treats
             # this root as one nobody has ingested rather than as one that
@@ -306,10 +318,7 @@ def ingest_metadata_files(
                 counts=counts,
                 logger=logger,
             )
-        if listing.covers_whole_root:
-            counts.files_removed = _prune_missing(
-                engine, root_url, listing, recorded, logger=logger
-            )
+        counts.files_removed = _prune_missing(engine, root_url, listing, recorded, logger=logger)
         _finish_run(engine, run_id, counts)
         logger.info(
             'Ingested %d, skipped %d unchanged, failed %d, removed %d of %d file(s) under %s',

--- a/src/spindoctor/cli/stats/ingest/runs.py
+++ b/src/spindoctor/cli/stats/ingest/runs.py
@@ -10,8 +10,8 @@ or unmounted root must read as one nobody has ingested rather than as one that
 holds nothing, and leaving the finish time NULL is what says so.
 
 A pass fanned out over many workers is one run all the same.  What the fan-out
-itself did -- how many files it saw, how many rows it removed, how many
-directories it did not list -- is recorded on the row as soon as it is known,
+itself did -- how many files it saw, how many rows it removed -- is recorded on
+the row as soon as it is known,
 because nothing later in the pass can find it out again; the finish time waits
 for the workers, so the root stays unreadable until every one of their shares
 is accounted for.
@@ -67,14 +67,12 @@ class _UnfinishedRun:
             be accounted for by no shares.
         files_removed: Rows the fan-out deleted, whose documents had left the
             tree.
-        directories_missed: Directories the fan-out's walk did not list.
     """
 
     run_id: int
     root_url: str
     files_seen: int | None
     files_removed: int | None
-    directories_missed: int | None
 
 
 def _record_fan_out(engine: sqlalchemy.Engine, run_id: int, counts: IngestCounts) -> None:
@@ -101,7 +99,6 @@ def _record_fan_out(engine: sqlalchemy.Engine, run_id: int, counts: IngestCounts
                 files_skipped=0,
                 files_failed=0,
                 files_removed=counts.files_removed,
-                directories_missed=counts.directories_missed,
             )
         )
 
@@ -160,7 +157,6 @@ def _unfinished_run(connection: sqlalchemy.Connection, root_url: str) -> _Unfini
             INGEST_RUNS.c.finished_utc,
             INGEST_RUNS.c.files_seen,
             INGEST_RUNS.c.files_removed,
-            INGEST_RUNS.c.directories_missed,
         )
         .where(INGEST_RUNS.c.root_url == root_url)
         .order_by(INGEST_RUNS.c.run_id.desc())
@@ -174,7 +170,6 @@ def _unfinished_run(connection: sqlalchemy.Connection, root_url: str) -> _Unfini
         root_url=str(row.root_url),
         files_seen=row.files_seen,
         files_removed=row.files_removed,
-        directories_missed=row.directories_missed,
     )
 
 
@@ -197,6 +192,5 @@ def _finish_run(engine: sqlalchemy.Engine, run_id: int, counts: IngestCounts) ->
                 files_skipped=counts.files_skipped,
                 files_failed=counts.files_failed,
                 files_removed=counts.files_removed,
-                directories_missed=counts.directories_missed,
             )
         )

--- a/src/spindoctor/cli/stats/ingest/tasks.py
+++ b/src/spindoctor/cli/stats/ingest/tasks.py
@@ -199,8 +199,7 @@ class FanOut:
         tasks: The task descriptions, in the shape a cloud-tasks queue loads:
             each a ``task_id`` and the ``data`` one worker is handed.
         counts: What the fan-out itself did -- the files its walks found, the
-            rows it removed, the directories it did not list, and the roots it
-            could not list at all.
+            rows it removed, and the roots it could not list at all.
     """
 
     tasks: list[dict[str, Any]] = field(default_factory=list)
@@ -341,12 +340,11 @@ def fan_out_ingest_tasks(
 ) -> FanOut:
     """List each root once and divide the documents under it into tasks.
 
-    Each root gets an ingest run, a single walk, and -- when that walk covered
-    the whole root -- the removal of the rows whose documents the tree no longer
-    holds.  What the walk found is recorded on the run immediately, because
-    nothing later in the pass can find it out again; the finish time is left for
-    :func:`complete_ingest_tasks`, so until then every consumer treats the root
-    as one nobody has ingested.
+    Each root gets an ingest run, a single walk, and the removal of the rows
+    whose documents the tree no longer holds.  What the walk found is recorded
+    on the run immediately, because nothing later in the pass can find it out
+    again; the finish time is left for :func:`complete_ingest_tasks`, so until
+    then every consumer treats the root as one nobody has ingested.
 
     A root the walk could not list yields no task and keeps its unfinished run,
     exactly as it does in a pass that reads the documents itself: a mistyped or
@@ -368,6 +366,9 @@ def fan_out_ingest_tasks(
     Raises:
         ValueError: If the share size is not at least one file, which would
             divide a root into no tasks at all and lose every document under it.
+        UnlistableDirectoryError: If a directory under any root could not be
+            listed.  The fan-out ends there and writes no tasks at all, so a
+            queue is never loaded with shares of a root nobody listed whole.
     """
     if share_size < 1:
         raise ValueError(f'a task share holds at least one file, not {share_size}')
@@ -379,17 +380,13 @@ def fan_out_ingest_tasks(
         logger.info('Dividing %s into ingest tasks', root_url)
         listing = _walk_root(root, logger=logger)
         counts.files_seen = len(listing.metadata_files)
-        counts.directories_missed = listing.directories_missed
         if not listing.root_listed:
             counts.roots_unreadable = 1
             fan_out.counts.add(counts)
             continue
-        if listing.covers_whole_root:
-            with engine.connect() as connection:
-                recorded = _recorded_files(connection, root_url)
-            counts.files_removed = _prune_missing(
-                engine, root_url, listing, recorded, logger=logger
-            )
+        with engine.connect() as connection:
+            recorded = _recorded_files(connection, root_url)
+        counts.files_removed = _prune_missing(engine, root_url, listing, recorded, logger=logger)
         _record_fan_out(engine, run_id, counts)
         tasks_of_root = [
             {
@@ -866,7 +863,6 @@ def complete_ingest_tasks(
             continue
         counts.files_seen = run.files_seen
         counts.files_removed = run.files_removed or 0
-        counts.directories_missed = run.directories_missed or 0
         accounted = counts.files_ingested + counts.files_skipped + counts.files_failed
         if accounted != counts.files_seen:
             # What the shares that did report did is written down without a

--- a/src/spindoctor/cli/stats/ingest/walk.py
+++ b/src/spindoctor/cli/stats/ingest/walk.py
@@ -6,10 +6,16 @@ come from the walk.  There is no per-file stat and no per-file existence check:
 on a cloud root each of those is a paid round trip per image per run, which is
 the cost this index exists to remove.
 
-A walk also reports what it did not see.  A directory it could not list, and
-one it had already listed under another name, leave it knowing about part of
-the root rather than all of it -- which is not evidence that a stub it did not
-find has left the tree, and not evidence a prune may act on.
+A walk that cannot list a directory ends the pass there and then.  A directory
+nobody enumerated holds documents nobody recorded, and absence of a row is
+exactly what every consumer reads as "this image was never navigated", so a
+pass that finished around the gap would stamp that reading as an answer.
+Stopping costs a run; finishing costs a wrong answer that outlives it.
+
+A directory the walk has already listed under another name is a different
+thing, and not a gap: its documents are in the listing under the path the walk
+met first, and descending a second time would only write them again under
+stubs no consumer asks about.  The walk declines it, says so, and goes on.
 """
 
 from dataclasses import dataclass, field
@@ -18,10 +24,38 @@ from typing import Any
 from filecache import FCPath
 from pdslogger import PdsLogger
 
-__all__ = ['METADATA_SUFFIX']
+__all__ = ['METADATA_SUFFIX', 'UnlistableDirectoryError']
 
 METADATA_SUFFIX = '_metadata.json'
 """Suffix of the per-image navigation document under the results root."""
+
+
+class UnlistableDirectoryError(Exception):
+    """A directory under a results root that the walk could not list.
+
+    Raised where the walk meets the directory rather than where the damage
+    would show, which is what keeps the cost to the run that has read nothing
+    yet: a pass stopped at prune time has already read every document under an
+    archive-scale root, and discards hours of retrieval to say what it could
+    have said in the first minute.
+
+    A transient failure -- a share that stops answering for a moment, a
+    permission fixed a minute later -- therefore costs a whole pass rather than
+    degrading one.  That is the trade this exception is: an ingest is
+    reproducible from the tree and can simply be run again, and the answer it
+    would otherwise leave behind is one no later pass corrects.
+
+    Parameters:
+        directory: The directory that would not be listed.
+        reason: What the storage layer said when it refused.
+    """
+
+    def __init__(self, directory: str, reason: str) -> None:
+        super().__init__(
+            f'{directory} could not be listed ({reason}), so the documents under it were '
+            f'never seen and an image beneath it would read as one nothing was ever '
+            f'written for'
+        )
 
 
 @dataclass(frozen=True)
@@ -50,29 +84,15 @@ class _RootListing:
             "has this changed", so such a root is re-read in full.
         root_listed: Whether the root itself could be listed.  A root that is
             not there is a different thing from a root that is empty, and only
-            the second one has been ingested when the walk ends.
-        directories_missed: How many directories under the root this walk did
-            not list on their own account -- ones it could not list, and ones
-            it had already walked under another name.  The walk then knows
-            about some of the root rather than all of it, which is not evidence
-            that a stub it did not see is gone.
+            the second one has been ingested when the walk ends.  It is the one
+            directory whose refusal is reported rather than raised, because a
+            pass over several roots accounts for each of them separately and a
+            mistyped root is the commonest thing an operator types.
     """
 
     metadata_files: list[_ListedFile] = field(default_factory=list)
     has_file_metrics: bool = True
     root_listed: bool = True
-    directories_missed: int = 0
-
-    @property
-    def covers_whole_root(self) -> bool:
-        """Whether this listing is a complete account of the root.
-
-        Returns:
-            True when every directory under the root, and the root itself, was
-            listed.  Only such a listing is evidence that a recorded stub it
-            does not hold has left the tree.
-        """
-        return self.root_listed and not self.directories_missed
 
 
 def _metrics_of(entry_metadata: dict[str, Any] | None) -> tuple[int | None, int | None]:
@@ -107,9 +127,10 @@ def _is_directory(path: FCPath, entry_metadata: dict[str, Any] | None) -> bool:
     Returns:
         True when the entry is a directory.  A backend that reported no
         metadata for the entry, or metadata that does not say, is asked
-        directly; one that cannot answer either is treated as a file, since
-        descending into something that is not there would only add a directory
-        the walk could not list.
+        directly; one that cannot answer either is treated as a file rather
+        than ending the pass, because the commonest way to reach that is an
+        entry that has gone away since the listing named it, and a pass that
+        stopped for one would stop for every deletion that lands mid-walk.
     """
     is_dir = None if entry_metadata is None else entry_metadata.get('is_dir')
     if is_dir is not None:
@@ -142,7 +163,12 @@ def _directory_identity(directory: FCPath) -> tuple[int, int] | None:
 
 
 def _list_directory(
-    directory: FCPath, prefix: str, listing: _RootListing, visited: set[tuple[int, int]]
+    directory: FCPath,
+    prefix: str,
+    listing: _RootListing,
+    visited: dict[tuple[int, int], str],
+    *,
+    logger: PdsLogger,
 ) -> bool:
     """Collect one directory's documents and descend into its subdirectories.
 
@@ -151,42 +177,61 @@ def _list_directory(
         prefix: The path of that directory under the root, ending in ``/`` (or
             empty at the root itself).
         listing: Accumulator the walk fills in.
-        visited: Identities of the directories this walk has already listed,
-            which it adds this one to.
+        visited: Where this walk has already listed each directory it has
+            listed, by identity, which it adds this one to.
+        logger: Logger for a directory reached a second way.
 
     Returns:
-        Whether the directory was listed on its own account.  False both for
-        one that could not be listed and for one already walked under another
-        name, because the caller's bookkeeping is the same either way: the walk
-        did not enumerate this directory here, so it must not act on what it
-        did not see.
+        Whether the directory was listed here.  False for the root of the pass
+        when it could not be listed, which its caller reports as a root nobody
+        ingested, and False for a directory already listed under another name,
+        which is not a gap and which the recursive caller has nothing to do
+        about.
+
+    Raises:
+        UnlistableDirectoryError: If a directory under the root could not be
+            listed.  The documents beneath it are then documents this pass
+            cannot see, and a row's absence is what a consumer reads as an
+            answer, so the pass stops instead of finishing around them.
     """
     identity = _directory_identity(directory)
     if identity is not None:
-        if identity in visited:
-            # A link back to a directory already walked.  Descending would
-            # write the same documents again under a second set of stubs --
-            # one row per document per level, until the filesystem stops the
-            # loop at its own link limit -- so the walk stops here instead.
+        listed_as = visited.get(identity)
+        if listed_as is not None:
+            # A second path to a directory this walk has already listed -- a
+            # link back to an ancestor, or one volume reachable two ways.
+            # Descending would write the same documents again under a second
+            # set of stubs, one row per document per level until the
+            # filesystem stops the loop at its own link limit, and no consumer
+            # asks about any of them: a stub comes from the image's own
+            # volume and filespec, which name the directory once.  So the walk
+            # declines it, and the root is still wholly listed, because every
+            # document under it is in this listing under the path met first.
+            logger.info(
+                'Not listing %s, which is %s reached a second way and already listed',
+                directory.as_posix(),
+                listed_as,
+            )
             return False
-        visited.add(identity)
+        visited[identity] = directory.as_posix()
     try:
         entries = list(directory.iterdir_metadata())
-    except OSError:
+    except OSError as exc:
         # Every way a directory can refuse to be listed: it is not there, it
         # stopped being a directory between the parent listing and this call,
         # this user may not read it, the share it lives on has gone away.  All
         # of them mean the same thing to the walk -- it can see no result file
-        # here, which is not the same as there being none -- and treating only
-        # some of them that way ends the run on the commonest of them.
-        return False
+        # here, which is not the same as there being none -- and it is the root
+        # alone that is reported rather than raised.
+        if not prefix:
+            return False
+        raise UnlistableDirectoryError(directory.as_posix(), str(exc)) from exc
     for path, entry_metadata in entries:
         name = path.name
         relative = f'{prefix}{name}'
         is_dir = _is_directory(path, entry_metadata)
         if is_dir:
-            if not _list_directory(path, f'{relative}/', listing, visited):
-                listing.directories_missed += 1
+            _list_directory(path, f'{relative}/', listing, visited, logger=logger)
         elif name.endswith(METADATA_SUFFIX):
             mtime_ns, size_bytes = _metrics_of(entry_metadata)
             if mtime_ns is None or size_bytes is None:
@@ -213,10 +258,17 @@ def _walk_root(root: FCPath, *, logger: PdsLogger) -> _RootListing:
         logger: Logger for the scan summary and the degraded-listing warning.
 
     Returns:
-        What the walk found, with the metadata files in stub order.
+        What the walk found, with the metadata files in stub order.  A listing
+        this returns for a root it listed is a complete account of that root,
+        which is what licenses the prune to act on what it does not hold.
+
+    Raises:
+        UnlistableDirectoryError: If a directory under the root could not be
+            listed, which ends the whole pass rather than this root's part of
+            it.
     """
     listing = _RootListing()
-    listing.root_listed = _list_directory(root, '', listing, set())
+    listing.root_listed = _list_directory(root, '', listing, {}, logger=logger)
     listing.metadata_files.sort(key=lambda listed: listed.results_path_stub)
     if not listing.root_listed:
         logger.error(
@@ -230,14 +282,6 @@ def _walk_root(root: FCPath, *, logger: PdsLogger) -> _RootListing:
         len(listing.metadata_files),
         root.as_posix(),
     )
-    if listing.directories_missed:
-        logger.warning(
-            '%d director(ies) under %s were not listed, so this pass covers some of the '
-            'root rather than all of it and removes no row from it: absence of a row under '
-            'one of them is not evidence that its image was never navigated',
-            listing.directories_missed,
-            root.as_posix(),
-        )
     if not listing.has_file_metrics and listing.metadata_files:
         logger.warning(
             'Listing of %s reports no size or modification time, so every document '

--- a/src/spindoctor/cli/stats/ingest/walk.py
+++ b/src/spindoctor/cli/stats/ingest/walk.py
@@ -127,18 +127,27 @@ def _is_directory(path: FCPath, entry_metadata: dict[str, Any] | None) -> bool:
     Returns:
         True when the entry is a directory.  A backend that reported no
         metadata for the entry, or metadata that does not say, is asked
-        directly; one that cannot answer either is treated as a file rather
-        than ending the pass, because the commonest way to reach that is an
-        entry that has gone away since the listing named it, and a pass that
-        stopped for one would stop for every deletion that lands mid-walk.
+        directly; an entry that is no longer there to answer about is a file
+        as far as this pass is concerned, since a deletion landing mid-walk is
+        ordinary and there is nothing under such an entry to have missed.
+
+    Raises:
+        UnlistableDirectoryError: If the storage layer refuses to say what the
+            entry is for any other reason.  An entry it will not answer about
+            may be a directory holding documents, and calling it a file is
+            exactly the silent gap this pass refuses: the walk would go on, the
+            run would complete, and every document under it would read as an
+            image nothing had navigated.
     """
     is_dir = None if entry_metadata is None else entry_metadata.get('is_dir')
     if is_dir is not None:
         return bool(is_dir)
     try:
         return bool(path.is_dir())
-    except OSError:
+    except (FileNotFoundError, NotADirectoryError):
         return False
+    except OSError as exc:
+        raise UnlistableDirectoryError(path.as_posix(), str(exc)) from exc
 
 
 def _directory_identity(directory: FCPath) -> tuple[int, int] | None:

--- a/src/spindoctor/dataset/results_filter.py
+++ b/src/spindoctor/dataset/results_filter.py
@@ -400,23 +400,6 @@ class ResultsFilter:
             self._nav_results_root,
             _snapshot_age(stubs.ingested_utc),
         )
-        if stubs.directories_missed:
-            # The absence filters read "no row" as "this image was never
-            # navigated", and under a directory nobody listed that reading is
-            # simply false. The pass also removed no row anywhere under the
-            # root, having no evidence about the stubs it did not see, so a
-            # document deleted since the pass before it still reads as present.
-            # The run completed all the same, so this count is the only place
-            # either gap shows.
-            self._logger.warning(
-                'The last ingest of %s did not list %d director%s: an image under one of '
-                'them is absent from the index whether or not it was navigated, and no row '
-                'was removed anywhere under the root, so a document deleted since the '
-                'previous pass still reads as present',
-                self._nav_results_root,
-                stubs.directories_missed,
-                'y' if stubs.directories_missed == 1 else 'ies',
-            )
 
     def _scan_volumes(self, volumes: Sequence[str]) -> None:
         """Walks the results tree under each volume, collecting result files.

--- a/src/spindoctor/results_index/__init__.py
+++ b/src/spindoctor/results_index/__init__.py
@@ -33,8 +33,7 @@ Public API:
     normalize_root_url    -- the one spelling of a results root
     ingested_roots        -- the roots a completed ingest covered
     require_ingested_roots -- refuse to read absence from a root nobody ingested
-    NewestPass            -- what the newest pass over a root recorded about itself
-    newest_pass           -- when that pass finished and how much of the root it missed
+    newest_finish_time    -- when the newest pass over a root finished
     FATAL_STATUS          -- the status the error selection filters match
     SPICE_STATUS_ERROR    -- the status_error the SPICE selection filters match
     ResultStubs           -- what a root holds, as a selection filter asks it
@@ -52,9 +51,8 @@ from spindoctor.results_index.drop import (
 from spindoctor.results_index.engine import open_database, open_index
 from spindoctor.results_index.masking import masked_url
 from spindoctor.results_index.roots import (
-    NewestPass,
     ingested_roots,
-    newest_pass,
+    newest_finish_time,
     normalize_root_url,
     require_ingested_roots,
 )
@@ -90,7 +88,6 @@ __all__ = [
     'TECHNIQUES',
     'UNKNOWN_STATUS',
     'IndexContents',
-    'NewestPass',
     'ResultStubs',
     'TableContents',
     'drop_index_tables',
@@ -98,7 +95,7 @@ __all__ = [
     'index_table_names',
     'ingested_roots',
     'masked_url',
-    'newest_pass',
+    'newest_finish_time',
     'normalize_root_url',
     'open_database',
     'open_index',

--- a/src/spindoctor/results_index/roots.py
+++ b/src/spindoctor/results_index/roots.py
@@ -20,10 +20,10 @@ have to be asked: a document the ingest refused is a file that exists, and it
 has a row in ``failed_files`` and none in ``images``, so a consumer reading the
 absence from ``images`` alone reports a navigated image as one nothing
 navigated.  What a completed run makes true is that absence from *both* tables
-means no file was there to read -- for every directory that run listed.
+means no file was there to read: a pass that could not list a directory stops
+rather than finishing, so a run that has a finish time listed the whole root.
 """
 
-from dataclasses import dataclass
 from pathlib import Path
 
 import sqlalchemy
@@ -33,9 +33,8 @@ from spindoctor.results_index.masking import masked_url
 from spindoctor.results_index.schema import INGEST_RUNS
 
 __all__ = [
-    'NewestPass',
     'ingested_roots',
-    'newest_pass',
+    'newest_finish_time',
     'normalize_root_url',
     'require_ingested_roots',
 ]
@@ -110,35 +109,14 @@ def ingested_roots(connection: sqlalchemy.Connection) -> list[str]:
     return [str(row.root_url) for row in connection.execute(completed)]
 
 
-@dataclass(frozen=True)
-class NewestPass:
-    """What the newest ingest pass over one root recorded about its own reach.
+def newest_finish_time(connection: sqlalchemy.Connection, root_url: str) -> str | None:
+    """Return when the newest pass over one root finished.
 
-    Parameters:
-        finished_utc: When that pass finished, as it stamped it, and None when
-            the root has no run row or the run never finished.  It is the age
-            of the answer a consumer reads out of the index, which is the one
-            fact that says whether the tree has moved on since.
-        directories_missed: How many directories that pass did not list.
-    """
+    The index answers as of that moment and detects no change since, so a
+    consumer reports the moment with the answer rather than leaving it in the
+    head of whoever exported the URL.
 
-    finished_utc: str | None
-    directories_missed: int
-
-
-def newest_pass(connection: sqlalchemy.Connection, root_url: str) -> NewestPass:
-    """Return what the newest pass over one root recorded about itself.
-
-    A directory nobody enumerated holds files nobody recorded, and absence of a
-    row under it therefore says nothing about the image whose document is there.
-    A consumer that reads absence as a positive answer -- "this image was never
-    navigated" -- asks for this and says so when the count is not zero, because
-    the run completed all the same and nothing else in the index shows the gap.
-    It asks for the finish time in the same breath and for the same reason: the
-    index answers as of that moment and detects no change since, so the moment
-    belongs with the answer rather than in the head of whoever exported the URL.
-
-    Both come from the newest run row of the named root alone.  One database
+    It comes from the newest run row of the named root alone.  One database
     serves several roots, and the newest run in the table is routinely another
     root's.
 
@@ -147,23 +125,19 @@ def newest_pass(connection: sqlalchemy.Connection, root_url: str) -> NewestPass:
         root_url: The normalized root to ask about.
 
     Returns:
-        What that pass recorded, with no finish time and a count of zero when
-        the root has no run row at all.
+        The finish time that pass stamped, and None when the root has no run
+        row at all or its newest run never finished.
     """
     newest = (
-        sqlalchemy.select(INGEST_RUNS.c.finished_utc, INGEST_RUNS.c.directories_missed)
+        sqlalchemy.select(INGEST_RUNS.c.finished_utc)
         .where(INGEST_RUNS.c.root_url == root_url)
         .order_by(INGEST_RUNS.c.run_id.desc())
         .limit(1)
     )
     row = connection.execute(newest).first()
-    if row is None:
-        return NewestPass(finished_utc=None, directories_missed=0)
-    missed = row.directories_missed
-    return NewestPass(
-        finished_utc=None if row.finished_utc is None else str(row.finished_utc),
-        directories_missed=0 if missed is None else int(missed),
-    )
+    if row is None or row.finished_utc is None:
+        return None
+    return str(row.finished_utc)
 
 
 def require_ingested_roots(

--- a/src/spindoctor/results_index/schema.py
+++ b/src/spindoctor/results_index/schema.py
@@ -88,7 +88,7 @@ __all__ = [
     'UNKNOWN_STATUS',
 ]
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 """Column-set version of the index.
 
 Incremented by any change to the column set of any table, and by any change to
@@ -330,10 +330,6 @@ INGEST_RUNS = sqlalchemy.Table(
     sqlalchemy.Column('files_failed', sqlalchemy.Integer),
     # Rows whose document is no longer in the tree, deleted by this run.
     sqlalchemy.Column('files_removed', sqlalchemy.Integer),
-    # Directories the run did not list, whose files it therefore never saw.  A
-    # completed run with a nonzero count covers the root apart from those, so
-    # absence of a row under one of them says nothing about its image.
-    sqlalchemy.Column('directories_missed', sqlalchemy.Integer),
     sqlalchemy.Column('schema_version', sqlalchemy.Integer, nullable=False),
     sqlalchemy.Index('ix_ingest_runs_root_url', 'root_url'),
 )

--- a/src/spindoctor/results_index/selection.py
+++ b/src/spindoctor/results_index/selection.py
@@ -35,27 +35,17 @@ never shown answers nobody's question about the selection they got.
   alike about it.
 - **A file that exists and has no row at all in the index** reads as absent,
   which is what the absence filters read as "this image was never navigated".
-  Three passes end that way, and the first two do so deliberately, because a
-  recorded row would be skipped for as long as the file did not change and the
-  next pass would never retry it:
+  Two passes end that way, and both do so deliberately, because a recorded row
+  would be skipped for as long as the file did not change and the next pass
+  would never retry it:
 
   - a file the pass could not retrieve;
-  - a document the pass read whose rows the database would not store;
-  - a file under a directory the walk did not list, either because it could not
-    be listed or because it had already been listed under another name.  That
-    one is counted rather than invisible: the count is on the run row, it is
-    returned as :attr:`ResultStubs.directories_missed`, and the caller reports
-    it rather than reading absence under it in silence.
+  - a document the pass read whose rows the database would not store.
 
-- **A document the tree no longer holds** keeps its row, and reads as present
-  where the tree reads it as absent, which also makes ``--has-no-offset-file``
-  skip an image nothing has been written for.  A row leaves the index only when
-  a pass that listed the whole root finds no file for it, and a pass that missed
-  a single directory anywhere under the root removes no row at all: the stubs it
-  did not see are the ones it has no evidence about.  So one unlistable
-  subdirectory holds every stale row of the root for as long as it stays
-  unlistable, however many passes complete in the meantime, and the count of
-  missed directories is what says so.
+  A file under a directory nobody listed is not a third: an ingest that cannot
+  list a directory stops there rather than completing, so a root with a
+  completed pass is a root every directory of which was listed.
+
 - **A document rewritten in place, keeping the length and the modification time
   it had before,** keeps the row the document before it produced, so an error
   filter answers from what that one recorded.  Those two metrics are everything
@@ -88,7 +78,7 @@ from filecache import FCPath
 from spindoctor.results_index.engine import open_index
 from spindoctor.results_index.masking import masked_url
 from spindoctor.results_index.roots import (
-    newest_pass,
+    newest_finish_time,
     normalize_root_url,
     require_ingested_roots,
 )
@@ -128,16 +118,13 @@ class ResultStubs:
             exists under the root.
         matching_error: Stubs whose document satisfies the error filters that
             were asked for, and empty when none were.
-        directories_missed: How many directories the newest pass over the root
-            did not list, so a caller reading absence as an answer can say that
-            the answer does not cover all of the root.
-        ingested_utc: When that pass finished, so a caller can say how old the
-            answer is, and None when the index recorded no finish time.
+        ingested_utc: When the newest pass over the root finished, so a caller
+            can say how old the answer is, and None when the index recorded no
+            finish time.
     """
 
     with_metadata: frozenset[str]
     matching_error: frozenset[str]
-    directories_missed: int = 0
     ingested_utc: str | None = None
 
 
@@ -319,8 +306,7 @@ def read_result_stubs(
 
     Returns:
         The stubs the root holds, in the two sets the filters test membership
-        in, with how much of the root the pass that recorded them missed and
-        when it finished.
+        in, with when the pass that recorded them finished.
 
     Raises:
         ValueError: If the index cannot be opened, is stamped with another
@@ -347,7 +333,7 @@ def read_result_stubs(
     try:
         with reporting_a_failed_read(url), engine.connect() as connection:
             require_ingested_roots(connection, [root_url], url=url)
-            newest = newest_pass(connection, root_url)
+            ingested_utc = newest_finish_time(connection, root_url)
             for stub, matches_error in connection.execute(query):
                 stub_text = str(stub)
                 with_metadata.add(stub_text)
@@ -358,6 +344,5 @@ def read_result_stubs(
     return ResultStubs(
         with_metadata=frozenset(with_metadata),
         matching_error=frozenset(matching_error),
-        directories_missed=newest.directories_missed,
-        ingested_utc=newest.finished_utc,
+        ingested_utc=ingested_utc,
     )

--- a/tests/spindoctor/cli/stats/test_ingest.py
+++ b/tests/spindoctor/cli/stats/test_ingest.py
@@ -738,16 +738,13 @@ def test_a_file_that_is_not_a_document_is_no_part_of_what_the_walk_found(
     navigation document, and one that merely contains the suffix yields a stub
     with the suffix's length cut off the end of a longer name, naming nothing,
     which the pass then retrieves, fails on, records nothing for, and retrieves
-    again on every pass afterwards.  The missed count is the other half, because
-    a directory in it stops the pass removing rows anywhere under the root, and
-    a file passed over is not a directory that went unlisted.
+    again on every pass afterwards.
     """
     root = _tree_with_a_file_that_is_not_a_document(tmp_path)
     listing = walk_module._walk_root(FCPath(root), logger=quiet_logger)
     assert [found.results_path_stub for found in listing.metadata_files] == [
         'VOL/N1454725799_1_CALIB'
     ]
-    assert listing.directories_missed == 0
 
 
 def test_re_ingesting_an_image_replaces_its_child_rows(

--- a/tests/spindoctor/cli/stats/test_ingest.py
+++ b/tests/spindoctor/cli/stats/test_ingest.py
@@ -729,12 +729,12 @@ def test_a_file_that_is_not_a_document_is_not_a_file_this_pass_saw(
 def test_a_file_that_is_not_a_document_is_no_part_of_what_the_walk_found(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger
 ) -> None:
-    """Both tallies the entry loop can add to, over a tree of ordinary clutter.
+    """What the entry loop collects, over a tree of ordinary clutter.
 
     Every entry is a directory to descend into, a document to collect, or a
-    file to pass over, and only the last leaves both tallies as they were.  A
-    name that ends in the document suffix is what says which, and neither half
-    of that is enough on its own: a file that merely ends in ``.json`` is not a
+    file to pass over, and only the last leaves the listing as it was.  A name
+    that ends in the document suffix is what says which, and neither half of
+    that is enough on its own: a file that merely ends in ``.json`` is not a
     navigation document, and one that merely contains the suffix yields a stub
     with the suffix's length cut off the end of a longer name, naming nothing,
     which the pass then retrieves, fails on, records nothing for, and retrieves

--- a/tests/spindoctor/cli/stats/test_ingest_bookkeeping.py
+++ b/tests/spindoctor/cli/stats/test_ingest_bookkeeping.py
@@ -471,35 +471,6 @@ def test_a_listing_that_does_not_say_what_is_a_directory_is_asked(
     assert counts.files_ingested == 1
 
 
-def test_an_entry_the_filesystem_will_not_classify_is_read_as_a_file(
-    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Asking an entry what it is has to survive the entry refusing to answer.
-
-    The question is only asked when the listing did not say, which is already
-    a degraded backend; the answer can fail for every reason a listing can.
-    Letting it out would end the pass on one entry of one directory. Read as a
-    file, the worst it costs is a subtree the walk did not descend into, which
-    is what the missed-directory bookkeeping is for.
-    """
-    root = tmp_path / 'results'
-    write_metadata(root, 'N1454725799_1_CALIB', metadata_document())
-    (root / 'VOL2').mkdir()
-    real_iterdir = FCPath.iterdir_metadata
-
-    def saying_nothing(self: FCPath) -> Any:
-        for path, _entry_metadata in real_iterdir(self):
-            yield path, None
-
-    def refusing(self: FCPath) -> bool:
-        raise OSError('the share stopped answering')
-
-    monkeypatch.setattr(FCPath, 'iterdir_metadata', saying_nothing)
-    monkeypatch.setattr(FCPath, 'is_dir', refusing)
-    counts = ingest_tree(index_url(tmp_path / 'index.sqlite3'), [root], logger=quiet_logger)
-    assert counts.files_ingested == 1
-
-
 def test_a_metric_less_listing_skips_nothing(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -855,6 +826,72 @@ def test_a_stopped_pass_leaves_its_run_unfinished(
     with pytest.raises(UnlistableDirectoryError):
         ingest_tree(url, [root], logger=quiet_logger)
     assert [time is not None for time in _finish_times(url)] == [False]
+
+
+def _entries_the_listing_says_nothing_about(
+    monkeypatch: pytest.MonkeyPatch, error: type[OSError]
+) -> None:
+    """Strip the listing's metadata and make asking about an entry fail.
+
+    A backend whose listing carries no ``is_dir`` is asked about each entry
+    directly, which is the only path on which the answer can fail at all.
+
+    Parameters:
+        monkeypatch: Fixture the listing and the inspection are wrapped through.
+        error: The exception type asking about an entry raises.
+    """
+    real_iterdir = FCPath.iterdir_metadata
+
+    def without_metadata(self: FCPath) -> Any:
+        for path, _metadata in real_iterdir(self):
+            yield path, None
+
+    def refusing(self: FCPath) -> bool:
+        raise error(self.as_posix())
+
+    monkeypatch.setattr(FCPath, 'iterdir_metadata', without_metadata)
+    monkeypatch.setattr(FCPath, 'is_dir', refusing)
+
+
+def test_an_entry_the_storage_layer_will_not_classify_stops_the_pass(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An entry nobody will answer about may be a directory full of documents.
+
+    Passing it over as a file is the same gap as walking past a directory that
+    would not list, arrived at one step earlier: the walk goes on, the run
+    completes, and everything under it reads as never navigated.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the listing and the inspection are wrapped through.
+    """
+    root = _two_volume_tree(tmp_path)
+    _entries_the_listing_says_nothing_about(monkeypatch, PermissionError)
+    with pytest.raises(UnlistableDirectoryError, match='could not be listed'):
+        ingest_tree(index_url(tmp_path / 'index.sqlite3'), [root], logger=quiet_logger)
+
+
+def test_an_entry_that_has_gone_away_since_the_listing_is_passed_over(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A deletion landing mid-walk is ordinary, and leaves nothing to have missed.
+
+    The pass finishes and ingests what it did find, because an entry that is
+    not there holds no document this pass failed to see.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the listing and the inspection are wrapped through.
+    """
+    root = tmp_path / 'results'
+    write_metadata(root, 'N1454725799_1_CALIB', metadata_document())
+    (root / 'VOL1').mkdir(exist_ok=True)
+    _entries_the_listing_says_nothing_about(monkeypatch, FileNotFoundError)
+    counts = ingest_tree(index_url(tmp_path / 'index.sqlite3'), [root], logger=quiet_logger)
+    assert counts.files_ingested == 1
 
 
 def test_a_root_walked_before_the_one_that_stopped_keeps_its_pass(

--- a/tests/spindoctor/cli/stats/test_ingest_bookkeeping.py
+++ b/tests/spindoctor/cli/stats/test_ingest_bookkeeping.py
@@ -7,7 +7,9 @@ re-downloaded forever.  A document that has left the tree takes its row with
 it, because absence of a row is what every consumer reads as "this image was
 never navigated" and presence therefore has to mean the reverse.  And a root
 the walk could not list at all is not a root that is empty, so its ingest run
-is deliberately left unfinished.
+is deliberately left unfinished -- as is the run of a root holding one
+directory the walk could not list, which stops the pass where it meets it
+rather than completing around the documents it could not see.
 
 The transactions are pinned here too.  A crash costs one chunk rather than a
 whole run, and one image's delete and inserts share one transaction; both are
@@ -26,7 +28,7 @@ import pytest
 import sqlalchemy
 from filecache import FCPath
 
-from spindoctor.cli.stats.ingest import METADATA_SUFFIX
+from spindoctor.cli.stats.ingest import METADATA_SUFFIX, UnlistableDirectoryError
 from spindoctor.cli.stats.ingest import chunks as chunks_module
 from spindoctor.cli.stats.ingest import driver as driver_module
 from spindoctor.cli.stats.ingest import store as store_module
@@ -717,8 +719,9 @@ UNLISTABLE_ERRORS = [
 """Every way a real tree refuses to list a directory.
 
 They are one thing to the walk -- it can see no result file there, which is not
-evidence that there is none -- and enumerating only some of them ends the run on
-the others.  A permission error is the commonest of all on a shared tree.
+evidence that there is none -- and enumerating only some of them lets the others
+through as an empty directory.  A permission error is the commonest of all on a
+shared tree.
 """
 
 
@@ -755,13 +758,90 @@ def _two_volume_tree(tmp_path: Path) -> Path:
 
 
 @pytest.mark.parametrize('error', UNLISTABLE_ERRORS)
-def test_a_partly_listed_root_removes_nothing(
+def test_a_directory_that_cannot_be_listed_stops_the_pass(
     error: type[OSError],
     tmp_path: Path,
     quiet_logger: pdslogger.PdsLogger,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A directory that could not be listed is not a directory that is empty.
+    """A pass that finished around the gap would answer wrongly and go on doing so.
+
+    Absence of a row is what every consumer reads as "this image was never
+    navigated", and under a directory nobody listed that reading is simply
+    false.  A stopped run costs an ingest; a completed one that skipped a
+    directory costs a wrong answer no later pass corrects.
+
+    Parameters:
+        error: The exception type the unlistable directory raises.
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the listing is wrapped through.
+    """
+    root = _two_volume_tree(tmp_path)
+    _unlistable_subdirectory(monkeypatch, error)
+    with pytest.raises(UnlistableDirectoryError, match='could not be listed'):
+        ingest_tree(index_url(tmp_path / 'index.sqlite3'), [root], logger=quiet_logger)
+
+
+@pytest.mark.parametrize('error', UNLISTABLE_ERRORS)
+def test_the_refusal_names_the_directory_that_would_not_list(
+    error: type[OSError],
+    tmp_path: Path,
+    quiet_logger: pdslogger.PdsLogger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The one thing an operator has to go and fix is the one thing it must say.
+
+    Parameters:
+        error: The exception type the unlistable directory raises.
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the listing is wrapped through.
+    """
+    root = _two_volume_tree(tmp_path)
+    _unlistable_subdirectory(monkeypatch, error)
+    with pytest.raises(UnlistableDirectoryError) as excinfo:
+        ingest_tree(index_url(tmp_path / 'index.sqlite3'), [root], logger=quiet_logger)
+    assert (root / 'VOL2').as_posix() in str(excinfo.value)
+
+
+@pytest.mark.parametrize('error', UNLISTABLE_ERRORS)
+def test_the_pass_stops_before_it_reads_a_document(
+    error: type[OSError],
+    tmp_path: Path,
+    quiet_logger: pdslogger.PdsLogger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stopping where the walk finds it is the whole difference in what it costs.
+
+    The same refusal noticed where the prune is skipped instead would discard a
+    pass that had already read every document under the root, which on an
+    archive-scale root is hours of retrieval thrown away to say what the first
+    minute of the walk could have said.
+
+    Parameters:
+        error: The exception type the unlistable directory raises.
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the listing is wrapped through.
+    """
+    root = _two_volume_tree(tmp_path)
+    read: list[Any] = []
+    monkeypatch.setattr(driver_module, '_ingest_chunk', lambda *args, **kwargs: read.append(args))
+    _unlistable_subdirectory(monkeypatch, error)
+    with pytest.raises(UnlistableDirectoryError):
+        ingest_tree(index_url(tmp_path / 'index.sqlite3'), [root], logger=quiet_logger)
+    assert read == []
+
+
+@pytest.mark.parametrize('error', UNLISTABLE_ERRORS)
+def test_a_stopped_pass_leaves_its_run_unfinished(
+    error: type[OSError],
+    tmp_path: Path,
+    quiet_logger: pdslogger.PdsLogger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No finish time is what makes every consumer refuse the root outright.
 
     Parameters:
         error: The exception type the unlistable directory raises.
@@ -771,127 +851,61 @@ def test_a_partly_listed_root_removes_nothing(
     """
     root = _two_volume_tree(tmp_path)
     url = index_url(tmp_path / 'index.sqlite3')
-    ingest_tree(url, [root], logger=quiet_logger)
     _unlistable_subdirectory(monkeypatch, error)
-    ingest_tree(url, [root], logger=quiet_logger)
+    with pytest.raises(UnlistableDirectoryError):
+        ingest_tree(url, [root], logger=quiet_logger)
+    assert [time is not None for time in _finish_times(url)] == [False]
+
+
+def test_a_root_walked_before_the_one_that_stopped_keeps_its_pass(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """What is already ingested and stamped is good, and is not rolled back.
+
+    Parameters:
+        tmp_path: Directory the trees and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the listing is wrapped through.
+    """
+    first = tmp_path / 'first'
+    write_metadata(first, 'VOL1/N1454725801_1_CALIB', metadata_document())
+    second = _two_volume_tree(tmp_path)
+    url = index_url(tmp_path / 'index.sqlite3')
+    _unlistable_subdirectory(monkeypatch, error=PermissionError)
+    with pytest.raises(UnlistableDirectoryError):
+        ingest_tree(url, [first, second], logger=quiet_logger)
+    assert [time is not None for time in _finish_times(url)] == [True, False]
+
+
+def test_a_root_named_after_the_one_that_stopped_is_never_walked(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The pass ends, so a later root gets no run of its own and no rows.
+
+    A root left with no run at all is one every consumer refuses, which is the
+    same answer it gives for the root that stopped.
+
+    Parameters:
+        tmp_path: Directory the trees and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the listing is wrapped through.
+    """
+    stopping = _two_volume_tree(tmp_path)
+    later = tmp_path / 'later'
+    write_metadata(later, 'VOL1/N1454725802_1_CALIB', metadata_document())
+    url = index_url(tmp_path / 'index.sqlite3')
+    _unlistable_subdirectory(monkeypatch, error=PermissionError)
+    with pytest.raises(UnlistableDirectoryError):
+        ingest_tree(url, [stopping, later], logger=quiet_logger)
     engine = open_index(url)
     with engine.connect() as connection:
-        found = _rows(connection, sqlalchemy.select(sqlalchemy.func.count()).select_from(IMAGES))
+        found = _rows(connection, sqlalchemy.select(INGEST_RUNS.c.root_url))
     engine.dispose()
-    assert found[0][0] == 2
-
-
-@pytest.mark.parametrize('error', UNLISTABLE_ERRORS)
-def test_a_directory_that_cannot_be_listed_costs_only_itself(
-    error: type[OSError],
-    tmp_path: Path,
-    quiet_logger: pdslogger.PdsLogger,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """One unreadable subdirectory must not end the pass over the rest of the root.
-
-    Parameters:
-        error: The exception type the unlistable directory raises.
-        tmp_path: Directory the tree and the index live under.
-        quiet_logger: Logger the ingest reports through.
-        monkeypatch: Fixture the listing is wrapped through.
-    """
-    root = _two_volume_tree(tmp_path)
-    _unlistable_subdirectory(monkeypatch, error)
-    counts = ingest_tree(index_url(tmp_path / 'index.sqlite3'), [root], logger=quiet_logger)
-    assert counts.files_ingested == 1
-
-
-@pytest.mark.parametrize('error', UNLISTABLE_ERRORS)
-def test_a_directory_that_cannot_be_listed_leaves_a_completed_run(
-    error: type[OSError],
-    tmp_path: Path,
-    quiet_logger: pdslogger.PdsLogger,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The root itself was listed, so it is a root somebody has ingested part of.
-
-    Parameters:
-        error: The exception type the unlistable directory raises.
-        tmp_path: Directory the tree and the index live under.
-        quiet_logger: Logger the ingest reports through.
-        monkeypatch: Fixture the listing is wrapped through.
-    """
-    root = _two_volume_tree(tmp_path)
-    url = index_url(tmp_path / 'index.sqlite3')
-    _unlistable_subdirectory(monkeypatch, error)
-    ingest_tree(url, [root], logger=quiet_logger)
-    assert [time is not None for time in _finish_times(url)] == [True]
-
-
-@pytest.mark.parametrize('error', UNLISTABLE_ERRORS)
-def test_a_directory_that_cannot_be_listed_is_counted(
-    error: type[OSError],
-    tmp_path: Path,
-    quiet_logger: pdslogger.PdsLogger,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A directory the walk never saw into is the one thing absence cannot mean.
-
-    Every consumer reads a missing row as "this image was never navigated", and
-    under an unlisted directory that reading is simply wrong. The run still
-    completes -- the rows it did write are good -- so the count is the only
-    place the gap shows.
-
-    Parameters:
-        error: The exception type the unlistable directory raises.
-        tmp_path: Directory the tree and the index live under.
-        quiet_logger: Logger the ingest reports through.
-        monkeypatch: Fixture the listing is wrapped through.
-    """
-    root = _two_volume_tree(tmp_path)
-    _unlistable_subdirectory(monkeypatch, error)
-    counts = ingest_tree(index_url(tmp_path / 'index.sqlite3'), [root], logger=quiet_logger)
-    assert counts.directories_missed == 1
-
-
-@pytest.mark.parametrize('error', UNLISTABLE_ERRORS)
-def test_a_directory_that_cannot_be_listed_is_recorded_on_the_run(
-    error: type[OSError],
-    tmp_path: Path,
-    quiet_logger: pdslogger.PdsLogger,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The count outlives the run's log, because the consumers read the row.
-
-    Parameters:
-        error: The exception type the unlistable directory raises.
-        tmp_path: Directory the tree and the index live under.
-        quiet_logger: Logger the ingest reports through.
-        monkeypatch: Fixture the listing is wrapped through.
-    """
-    root = _two_volume_tree(tmp_path)
-    url = index_url(tmp_path / 'index.sqlite3')
-    _unlistable_subdirectory(monkeypatch, error)
-    ingest_tree(url, [root], logger=quiet_logger)
-    engine = open_index(url)
-    with engine.connect() as connection:
-        found = _rows(connection, sqlalchemy.select(INGEST_RUNS.c.directories_missed))
-    engine.dispose()
-    assert [row.directories_missed for row in found] == [1]
-
-
-def test_a_fully_listed_root_records_no_missed_directory(
-    tmp_path: Path, quiet_logger: pdslogger.PdsLogger
-) -> None:
-    """A zero has to mean something, so the ordinary pass has to record one."""
-    root = _two_volume_tree(tmp_path)
-    url = index_url(tmp_path / 'index.sqlite3')
-    ingest_tree(url, [root], logger=quiet_logger)
-    engine = open_index(url)
-    with engine.connect() as connection:
-        found = _rows(connection, sqlalchemy.select(INGEST_RUNS.c.directories_missed))
-    engine.dispose()
-    assert [row.directories_missed for row in found] == [0]
+    assert [row.root_url for row in found] == [stopping.as_posix()]
 
 
 @pytest.mark.skipif(os.geteuid() == 0, reason='the superuser reads a directory of mode 000')
-def test_a_directory_the_filesystem_will_not_open_costs_only_itself(
+def test_a_directory_the_filesystem_will_not_open_stops_the_pass(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger
 ) -> None:
     """The same thing again, against a real directory rather than a stand-in."""
@@ -899,25 +913,24 @@ def test_a_directory_the_filesystem_will_not_open_costs_only_itself(
     closed = root / 'VOL2'
     closed.chmod(0o000)
     try:
-        counts = ingest_tree(index_url(tmp_path / 'index.sqlite3'), [root], logger=quiet_logger)
+        with pytest.raises(UnlistableDirectoryError, match='could not be listed'):
+            ingest_tree(index_url(tmp_path / 'index.sqlite3'), [root], logger=quiet_logger)
     finally:
         closed.chmod(0o755)
-    assert counts.files_ingested == 1
 
 
-@pytest.mark.skipif(os.geteuid() == 0, reason='the superuser reads a directory of mode 000')
-def test_a_directory_the_filesystem_will_not_open_is_counted(
+def test_a_root_the_walk_lists_completely_records_no_refusal(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger
 ) -> None:
-    """And it is counted, against a real directory rather than a stand-in."""
+    """The ordinary pass over the same tree, so the tests above pin the refusal.
+
+    Every assertion above is about a tree one directory of which refuses; this
+    is that tree with nothing wrong with it, and it completes.
+    """
     root = _two_volume_tree(tmp_path)
-    closed = root / 'VOL2'
-    closed.chmod(0o000)
-    try:
-        counts = ingest_tree(index_url(tmp_path / 'index.sqlite3'), [root], logger=quiet_logger)
-    finally:
-        closed.chmod(0o755)
-    assert counts.directories_missed == 1
+    url = index_url(tmp_path / 'index.sqlite3')
+    counts = ingest_tree(url, [root], logger=quiet_logger)
+    assert counts.files_ingested == 2
 
 
 # ---------------------------------------------------------------------------
@@ -961,24 +974,37 @@ def test_a_link_back_to_an_ancestor_writes_one_row_for_one_document(
     assert [row.results_path_stub for row in found] == ['VOL/N1454725799_1_CALIB']
 
 
-def test_a_link_back_to_an_ancestor_is_counted_as_a_missed_directory(
+def test_a_link_back_to_an_ancestor_does_not_stop_the_pass(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger
 ) -> None:
-    """The walk stopped somewhere, and what it did not enumerate has to show."""
-    root = _tree_that_links_to_its_own_ancestor(tmp_path)
-    counts = ingest_tree(index_url(tmp_path / 'index.sqlite3'), [root], logger=quiet_logger)
-    assert counts.directories_missed == 1
+    """A directory reached a second way is not a directory nobody listed.
 
-
-def test_a_link_back_to_an_ancestor_removes_no_row(
-    tmp_path: Path, quiet_logger: pdslogger.PdsLogger
-) -> None:
-    """A walk that stopped early is not evidence that a stub has left the tree."""
+    Its documents are in the listing already, under the path the walk met
+    first, so declining to walk it again leaves the root wholly accounted for
+    and the pass completes.
+    """
     root = _tree_that_links_to_its_own_ancestor(tmp_path)
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [root], logger=quiet_logger)
+    assert [time is not None for time in _finish_times(url)] == [True]
+
+
+def test_a_link_back_to_an_ancestor_still_prunes_a_deleted_document(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger
+) -> None:
+    """And such a pass has the evidence to remove a row, so it removes it.
+
+    This is the difference between a directory that was reached twice and one
+    that was not reached at all: the first leaves presence meaning what absence
+    means, and the second is why a pass that meets one stops.
+    """
+    root = _tree_that_links_to_its_own_ancestor(tmp_path)
+    write_metadata(root, 'VOL/N1454725800_1_CALIB', metadata_document())
+    url = index_url(tmp_path / 'index.sqlite3')
+    ingest_tree(url, [root], logger=quiet_logger)
+    (root / f'VOL/N1454725800_1_CALIB{METADATA_SUFFIX}').unlink()
     counts = ingest_tree(url, [root], logger=quiet_logger)
-    assert counts.files_removed == 0
+    assert counts.files_removed == 1
 
 
 def test_a_link_to_a_directory_outside_the_walk_is_followed(
@@ -998,15 +1024,15 @@ def test_a_link_to_a_directory_outside_the_walk_is_followed(
     assert counts.files_ingested == 1
 
 
-def test_the_prune_refuses_a_listing_of_part_of_a_root(
+def test_the_prune_refuses_a_listing_that_is_not_of_the_whole_root(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger
 ) -> None:
     """A worker holding a share of a root would otherwise delete its peers' rows."""
     url = index_url(tmp_path / 'index.sqlite3')
     engine = open_index(url, create=True)
-    listing = walk_module._RootListing(directories_missed=1)
+    listing = walk_module._RootListing(root_listed=False)
     try:
-        with pytest.raises(ValueError, match='complete listing'):
+        with pytest.raises(ValueError, match='whole root'):
             driver_module._prune_missing(
                 engine, '/data/nav-results', listing, {}, logger=quiet_logger
             )

--- a/tests/spindoctor/cli/stats/test_ingest_cloud_tasks.py
+++ b/tests/spindoctor/cli/stats/test_ingest_cloud_tasks.py
@@ -21,6 +21,7 @@ import sqlalchemy
 
 from spindoctor.cli.stats.ingest import (
     TaskResult,
+    UnlistableDirectoryError,
     fan_out_ingest_tasks,
     ingest_metadata_files,
     ingest_task_share,
@@ -286,10 +287,15 @@ def test_a_share_removes_no_row(tmp_path: Path, quiet_logger: pdslogger.PdsLogge
 
 
 @pytest.mark.skipif(os.geteuid() == 0, reason='the superuser reads a directory of mode 000')
-def test_a_partly_listed_root_is_fanned_out_without_removing_a_row(
+def test_a_root_holding_a_directory_nobody_can_list_is_not_fanned_out(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger
 ) -> None:
-    """A listing of part of a root is not evidence that a stub it missed is gone."""
+    """A fan-out is the one moment a whole root is listed, so it has to be one.
+
+    Shares cut from a listing of part of a root would be ingested, added up, and
+    stamped as a completed pass over the root, and every stub the walk never
+    reached would then read as an image nothing navigated.
+    """
     root = tmp_path / 'results'
     write_metadata(root, 'VOL1/N1454725799_1_CALIB', metadata_document())
     write_metadata(root, 'VOL2/N1454725800_1_CALIB', metadata_document())
@@ -299,14 +305,12 @@ def test_a_partly_listed_root_is_fanned_out_without_removing_a_row(
     try:
         engine = open_index(url)
         try:
-            found = fan_out_ingest_tasks(
-                engine, [root.as_posix()], share_size=2, logger=quiet_logger
-            )
+            with pytest.raises(UnlistableDirectoryError, match='could not be listed'):
+                fan_out_ingest_tasks(engine, [root.as_posix()], share_size=2, logger=quiet_logger)
         finally:
             engine.dispose()
     finally:
         closed.chmod(0o755)
-    assert found.counts.files_removed == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/spindoctor/cli/stats/test_ingest_cloud_tasks_completion.py
+++ b/tests/spindoctor/cli/stats/test_ingest_cloud_tasks_completion.py
@@ -18,7 +18,7 @@ import pdslogger
 import pytest
 from filecache import FCPath
 
-from spindoctor.cli.stats.ingest import TaskResult
+from spindoctor.cli.stats.ingest import TaskResult, UnlistableDirectoryError
 from spindoctor.results_index import (
     INGEST_RUNS,
     SCHEMA_VERSION,
@@ -144,25 +144,22 @@ def unlistable_volume(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(FCPath, 'iterdir_metadata', refusing_vol2)
 
 
-def test_the_run_keeps_the_directories_the_fan_out_could_not_list(
+def test_a_fan_out_that_cannot_list_a_directory_completes_nothing(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Only the fan-out ever saw them, and the completion rewrites the row.
+    """The fan-out is the only step that sees the whole root, so it is where this ends.
 
-    Under a directory nobody enumerated, absence of a row is not evidence that
-    an image was never navigated, and the count on the run row is the only place
-    a consumer can read that.  A completion that did not carry the fan-out's
-    count across would replace it with a zero, and the row would then say the
-    whole root was listed.
+    Its shares would otherwise be ingested and added up into a completed pass
+    over a root nobody listed whole, and every stub under the directory it
+    missed would read as an image nothing navigated.
     """
     root = tmp_path / 'results'
     write_metadata(root, 'VOL1/N1454725799_1_CALIB', metadata_document())
     write_metadata(root, 'VOL2/N1454725800_1_CALIB', metadata_document())
     url = index_url(tmp_path / 'index.sqlite3')
     unlistable_volume(monkeypatch)
-    tasks = fan_out(url, [root], logger=quiet_logger)
-    complete(url, [root], run_shares(url, tasks, logger=quiet_logger), logger=quiet_logger)
-    assert run_rows(url)[-1].directories_missed == 1
+    with pytest.raises(UnlistableDirectoryError, match='could not be listed'):
+        fan_out(url, [root], logger=quiet_logger)
 
 
 def test_a_share_that_never_reported_leaves_the_run_unfinished(

--- a/tests/spindoctor/cli/stats/test_ingest_driver.py
+++ b/tests/spindoctor/cli/stats/test_ingest_driver.py
@@ -202,15 +202,17 @@ def test_a_root_that_is_not_there_is_named_in_the_summary(
     assert any('could not be listed' in line for line in written)
 
 
-@pytest.mark.skipif(os.geteuid() == 0, reason='the superuser reads a directory of mode 000')
-def test_a_missed_directory_is_named_in_the_summary(
+def _run_over_an_unlistable_directory(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A completed run that saw part of a root has to say which part it missed.
+) -> tuple[int | None, list[str]]:
+    """Run the driver over a root one directory of which will not be listed.
 
-    Every consumer of the index reads a missing row as "this image was never
-    navigated". Under a directory nobody listed that reading is wrong, and the
-    summary is where an operator finds out before acting on it.
+    Parameters:
+        tmp_path: Directory the tree, the index and the logs live under.
+        monkeypatch: Fixture the argument vector and logger are replaced through.
+
+    Returns:
+        The exit status, and one entry per line written to the main log.
     """
     monkeypatch.delenv('NAV_RESULTS_DB', raising=False)
     root = tmp_path / 'results'
@@ -219,7 +221,7 @@ def test_a_missed_directory_is_named_in_the_summary(
     closed = root / 'VOL2'
     closed.chmod(0o000)
     try:
-        _status, written = _run(
+        return _run(
             [
                 '--results-db',
                 index_url(tmp_path / 'index.sqlite3'),
@@ -231,7 +233,52 @@ def test_a_missed_directory_is_named_in_the_summary(
         )
     finally:
         closed.chmod(0o755)
-    assert any('Directories not listed' in line for line in written)
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason='the superuser reads a directory of mode 000')
+def test_a_directory_that_cannot_be_listed_stops_the_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The pass ends rather than completing around documents it could not see.
+
+    Every consumer of the index reads a missing row as "this image was never
+    navigated", and under a directory nobody listed that reading is wrong, so
+    the run an operator would otherwise act on is the thing that has to stop.
+    """
+    _status, written = _run_over_an_unlistable_directory(tmp_path, monkeypatch)
+    assert any('Ingest stopped' in line for line in written)
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason='the superuser reads a directory of mode 000')
+def test_the_directory_that_stopped_the_run_is_named(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """It is the one thing the operator has to go and fix."""
+    _status, written = _run_over_an_unlistable_directory(tmp_path, monkeypatch)
+    assert any((tmp_path / 'results' / 'VOL2').as_posix() in line for line in written)
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason='the superuser reads a directory of mode 000')
+def test_a_run_stopped_by_a_directory_exits_nonzero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A scheduled ingest reads its status and nothing else."""
+    status, _written = _run_over_an_unlistable_directory(tmp_path, monkeypatch)
+    assert status == 1
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason='the superuser reads a directory of mode 000')
+def test_the_directory_refusal_is_not_reported_as_an_unenumerated_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The catch-all below exits 1 and says so too, which would hide this one.
+
+    Status and traceback alike are the same for both, so what tells them apart
+    is the message: this failure is one the pass enumerated, and it reads as the
+    directory it is about rather than as something nobody expected.
+    """
+    _status, written = _run_over_an_unlistable_directory(tmp_path, monkeypatch)
+    assert not any('Ingest could not complete' in line for line in written)
 
 
 def test_a_failure_nobody_enumerated_exits_rather_than_raising(

--- a/tests/spindoctor/dataset/conftest.py
+++ b/tests/spindoctor/dataset/conftest.py
@@ -326,16 +326,6 @@ def one_image_tree(tmp_path: Path) -> tuple[Path, list[ImageFile]]:
     ]
 
 
-OTHER_ROOT_MISSED = 5
-"""How many directories the second root's pass did not list.
-
-The second root is ingested last, so its run is the newest in the index: a count
-read from the newest run of the table rather than from the newest run over the
-root being enumerated is this one, and reports a gap the enumerated root does
-not have -- or, with the two the other way round, reports none where it does.
-"""
-
-
 def stamp_run(url: str, root: Path, **values: Any) -> None:
     """Record something about the pass over one root, and about no other root.
 
@@ -360,20 +350,16 @@ def stamp_run(url: str, root: Path, **values: Any) -> None:
         engine.dispose()
 
 
-def index_of_two_roots(tmp_path: Path, root: Path, *, missed: int) -> str:
-    """Ingest a tree, and a second tree whose pass missed directories after it.
+def index_of_two_roots(tmp_path: Path, root: Path) -> str:
+    """Ingest a tree, and a second tree passed over after it.
 
-    The count is written rather than provoked, so that the test is about what a
-    consumer does with a count and not about what makes a walk record one.  The
-    second root carries a count of its own for the same reason the fixture tree
-    is ingested beside a decoy: a query answering from the wrong root's run row
-    passes every single-root assertion.
+    The fixture tree is ingested beside a decoy because a query answering from
+    the wrong root's run row passes every single-root assertion, and the decoy's
+    pass is the newest in the index.
 
     Parameters:
         tmp_path: Directory the index file is written into.
         root: The results root to ingest and describe.
-        missed: How many directories the pass over that root is recorded as
-            having missed.
 
     Returns:
         The connection URL of the index.
@@ -382,8 +368,6 @@ def index_of_two_roots(tmp_path: Path, root: Path, *, missed: int) -> str:
     write_metadata(decoy, SECOND_SUCCESS, metadata_document(image_name='N1000000002_1.IMG'))
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [root, decoy], logger=null_logger())
-    stamp_run(url, root, directories_missed=missed)
-    stamp_run(url, decoy, directories_missed=OTHER_ROOT_MISSED)
     return url
 
 
@@ -394,32 +378,6 @@ def reporting_logger() -> pdslogger.PdsLogger:
         A logger of its own, so raising its level cannot affect another test.
     """
     return pdslogger.PdsLogger(f'results_filter_test_{uuid.uuid4().hex}')
-
-
-UNLISTABLE = 'COISS_2001/data/c'
-"""A directory under the root that one pass cannot list."""
-
-
-def refusing_to_list(monkeypatch: pytest.MonkeyPatch, directory: Path) -> None:
-    """Make one directory refuse to be listed, as a permission or a share can.
-
-    Provoked rather than written into the run row, because what is under test is
-    what the prune does when the walk comes back incomplete, and that is decided
-    by the walk and not by the count it records.
-
-    Parameters:
-        monkeypatch: Fixture the refusal is installed through.
-        directory: The directory that will refuse.
-    """
-    listing = FCPath.iterdir_metadata
-    refused = directory.as_posix()
-
-    def refuse(self: FCPath) -> Any:
-        if self.as_posix() == refused:
-            raise OSError('this directory may not be listed')
-        return listing(self)
-
-    monkeypatch.setattr(FCPath, 'iterdir_metadata', refuse)
 
 
 def index_without_a_table(tmp_path: Path, root: Path, table: str) -> str:

--- a/tests/spindoctor/dataset/test_results_filter_index.py
+++ b/tests/spindoctor/dataset/test_results_filter_index.py
@@ -36,6 +36,7 @@ from tests.spindoctor.dataset.conftest import (
     FATAL_ERRORS,
     NO_RESULT,
     NONSPICE_ERROR,
+    SECOND_SUCCESS,
     SPICE_ERROR,
     VOLUMES,
     WITH_A_DOCUMENT,
@@ -810,3 +811,87 @@ def test_a_database_failure_of_another_class_raises_no_database_exception(
             unbindable, str(root), logger=null_logger(), results_db_url=url, has_offset_file=True
         )
     assert not isinstance(excinfo.value, sqlalchemy.exc.SQLAlchemyError)
+
+
+# ---------------------------------------------------------------------------
+# A document that has left the tree
+# ---------------------------------------------------------------------------
+
+
+def _index_after_a_document_left_the_tree(
+    tmp_path: Path,
+) -> tuple[Path, list[ImageFile], str]:
+    """Ingest a root, delete one of its documents, and ingest it again.
+
+    This was a divergence while a pass that could not list one directory
+    completed anyway and removed no row: the deleted document's row then
+    outlived any number of finished passes.  A pass that meets such a directory
+    now stops instead, so every completed pass is one that listed the whole
+    root and every completed pass prunes, and the two paths answer alike.
+
+    Parameters:
+        tmp_path: Directory the root and the index are written under.
+
+    Returns:
+        The root, the two candidate images, and the connection URL of the index.
+    """
+    root = tmp_path / 'results'
+    write_metadata(root, SECOND_SUCCESS, metadata_document(image_name='N1000000002_1.IMG'))
+    write_metadata(root, SPICE_ERROR, metadata_document(image_name='N1000000004_1.IMG'))
+    images = [
+        ImageFile(
+            image_file_url=FCPath(root / f'{stub}.IMG'),
+            label_file_url=FCPath(root / f'{stub}.LBL'),
+            results_path_stub=stub,
+        )
+        for stub in (SECOND_SUCCESS, SPICE_ERROR)
+    ]
+    url = index_url(tmp_path / 'index.sqlite3')
+    ingest_tree(url, [root], logger=null_logger())
+    (root / f'{SPICE_ERROR}_metadata.json').unlink()
+    ingest_tree(url, [root], logger=null_logger())
+    return root, images, url
+
+
+def test_a_document_that_left_the_tree_reads_as_absent_in_the_tree(tmp_path: Path) -> None:
+    """The walk finds what is there now, which is the answer the index is held to."""
+    root, images, _url = _index_after_a_document_left_the_tree(tmp_path)
+    results_filter = ResultsFilter(VOLUMES, str(root), logger=null_logger(), has_offset_file=True)
+    assert select_from(results_filter, images) == [SECOND_SUCCESS]
+
+
+def test_a_document_that_left_the_tree_reads_as_absent_in_the_index(tmp_path: Path) -> None:
+    """The pass that listed the whole root had the evidence to remove the row, and did.
+
+    Presence of a row means the tree still holds the result, which is what makes
+    absence of one mean that nothing navigated the image.
+    """
+    root, images, url = _index_after_a_document_left_the_tree(tmp_path)
+    results_filter = ResultsFilter(
+        VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_offset_file=True
+    )
+    assert select_from(results_filter, images) == [SECOND_SUCCESS]
+
+
+def test_the_tree_offers_a_document_that_left_it_to_the_absence_filter(tmp_path: Path) -> None:
+    """Nothing has been written for that image now, so the resume idiom picks it up."""
+    root, images, _url = _index_after_a_document_left_the_tree(tmp_path)
+    results_filter = ResultsFilter(
+        VOLUMES, str(root), logger=null_logger(), has_no_offset_file=True
+    )
+    assert select_from(results_filter, images) == [SPICE_ERROR]
+
+
+def test_the_index_offers_a_document_that_left_the_tree_to_the_absence_filter(
+    tmp_path: Path,
+) -> None:
+    """The other direction of the same row, and the costlier one to get wrong.
+
+    ``--has-no-offset-file`` is the resume idiom, so a row that outlived its
+    document is an image the run silently declines to navigate again.
+    """
+    root, images, url = _index_after_a_document_left_the_tree(tmp_path)
+    results_filter = ResultsFilter(
+        VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_no_offset_file=True
+    )
+    assert select_from(results_filter, images) == [SPICE_ERROR]

--- a/tests/spindoctor/dataset/test_results_filter_index_divergence.py
+++ b/tests/spindoctor/dataset/test_results_filter_index_divergence.py
@@ -29,13 +29,10 @@ from tests.spindoctor.cli.stats.conftest import (
     write_metadata,
 )
 from tests.spindoctor.dataset.conftest import (
-    SECOND_SUCCESS,
     SPICE_ERROR,
-    UNLISTABLE,
     VOLUMES,
     null_logger,
     one_image_tree,
-    refusing_to_list,
     select_from,
 )
 
@@ -202,137 +199,6 @@ def test_a_document_the_database_would_not_store_reads_as_absent(
     monkeypatch.undo()
     results_filter = ResultsFilter(
         VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_offset_file=True
-    )
-    assert select_from(results_filter, images) == []
-
-
-def _tree_of_two_documents(tmp_path: Path) -> tuple[Path, list[ImageFile]]:
-    """Write a root holding two documents in two directories, and an empty third.
-
-    Parameters:
-        tmp_path: Directory the root is written under.
-
-    Returns:
-        The root, and the two candidate images in enumeration order.
-    """
-    root = tmp_path / 'results'
-    write_metadata(root, SECOND_SUCCESS, metadata_document(image_name='N1000000002_1.IMG'))
-    write_metadata(root, SPICE_ERROR, metadata_document(image_name='N1000000004_1.IMG'))
-    (root / UNLISTABLE).mkdir(parents=True, exist_ok=True)
-    return root, [
-        ImageFile(
-            image_file_url=FCPath(root / f'{stub}.IMG'),
-            label_file_url=FCPath(root / f'{stub}.LBL'),
-            results_path_stub=stub,
-        )
-        for stub in (SECOND_SUCCESS, SPICE_ERROR)
-    ]
-
-
-def _index_after_a_document_left_the_tree(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, listing_the_whole_root: bool
-) -> tuple[Path, list[ImageFile], str]:
-    """Ingest a root, delete one of its documents, and ingest it again.
-
-    The second pass either lists the whole root or finds one directory it cannot
-    list.  Both passes complete and stamp a finish time, so a consumer accepts
-    the root either way; what differs is whether the pass had the evidence to
-    remove the row of the document that has gone.
-
-    Parameters:
-        tmp_path: Directory the root and the index are written under.
-        monkeypatch: Fixture the unlistable directory is installed through.
-        listing_the_whole_root: Whether the second pass lists every directory.
-
-    Returns:
-        The root, the two candidate images, and the connection URL of the index.
-    """
-    root, images = _tree_of_two_documents(tmp_path)
-    url = index_url(tmp_path / 'index.sqlite3')
-    ingest_tree(url, [root], logger=null_logger())
-    (root / f'{SPICE_ERROR}_metadata.json').unlink()
-    if not listing_the_whole_root:
-        refusing_to_list(monkeypatch, root / UNLISTABLE)
-    ingest_tree(url, [root], logger=null_logger())
-    monkeypatch.undo()
-    return root, images, url
-
-
-def test_a_document_that_left_the_tree_reads_as_absent_in_the_tree(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The walk finds what is there now, which is the answer the index is held to."""
-    root, images, _url = _index_after_a_document_left_the_tree(
-        tmp_path, monkeypatch, listing_the_whole_root=True
-    )
-    results_filter = ResultsFilter(VOLUMES, str(root), logger=null_logger(), has_offset_file=True)
-    assert select_from(results_filter, images) == [SECOND_SUCCESS]
-
-
-def test_a_document_that_left_the_tree_is_pruned_by_a_pass_that_listed_it_all(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A complete pass has the evidence to remove the row, and removes it.
-
-    This is what makes the divergence below a consequence of the incomplete
-    listing rather than a property of an index: presence means what absence
-    means again as soon as one pass lists the whole root.
-    """
-    root, images, url = _index_after_a_document_left_the_tree(
-        tmp_path, monkeypatch, listing_the_whole_root=True
-    )
-    results_filter = ResultsFilter(
-        VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_offset_file=True
-    )
-    assert select_from(results_filter, images) == [SECOND_SUCCESS]
-
-
-def test_a_document_that_left_the_tree_survives_a_pass_that_missed_a_directory(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """One unlistable directory holds every stale row of the root, not only its own.
-
-    A pass that did not list the whole root has no evidence about the stubs it
-    did not see, so it removes none of them, and the row of a document deleted
-    from a directory it did list survives with them.  The index then hands a
-    presence filter an image whose document is not there, for as long as that
-    one directory stays unlistable.
-    """
-    root, images, url = _index_after_a_document_left_the_tree(
-        tmp_path, monkeypatch, listing_the_whole_root=False
-    )
-    results_filter = ResultsFilter(
-        VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_offset_file=True
-    )
-    assert select_from(results_filter, images) == [SECOND_SUCCESS, SPICE_ERROR]
-
-
-def test_the_tree_offers_a_document_that_left_it_to_the_absence_filter(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Nothing has been written for that image now, so the resume idiom picks it up."""
-    root, images, _url = _index_after_a_document_left_the_tree(
-        tmp_path, monkeypatch, listing_the_whole_root=False
-    )
-    results_filter = ResultsFilter(
-        VOLUMES, str(root), logger=null_logger(), has_no_offset_file=True
-    )
-    assert select_from(results_filter, images) == [SPICE_ERROR]
-
-
-def test_the_absence_filter_skips_a_document_the_tree_no_longer_holds(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The other direction of the same stale row, and the costlier one.
-
-    ``--has-no-offset-file`` is the resume idiom, so an image whose document was
-    deleted is one the run silently declines to navigate again.
-    """
-    root, images, url = _index_after_a_document_left_the_tree(
-        tmp_path, monkeypatch, listing_the_whole_root=False
-    )
-    results_filter = ResultsFilter(
-        VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_no_offset_file=True
     )
     assert select_from(results_filter, images) == []
 

--- a/tests/spindoctor/dataset/test_results_filter_index_reporting.py
+++ b/tests/spindoctor/dataset/test_results_filter_index_reporting.py
@@ -1,14 +1,13 @@
 """What the filter says about the pass whose answer it is handing on.
 
 An index answers as of the pass that filled it and detects no change since, so
-two things travel with the answer: how much of the root that pass did not list,
-which bounds what absence means under it, and when it finished, which is what a
+one thing travels with the answer: when that pass finished, which is what a
 reader compares against what they know they have navigated.
 
-Both are read from the newest run row of the root being enumerated, and every
-test here builds a second root whose pass ran afterwards and recorded different
-values, so an answer taken from the newest run of the table rather than of the
-root says so.
+It is read from the newest run row of the root being enumerated, and every test
+here builds a second root whose pass ran afterwards and recorded a time of its
+own, so an answer taken from the newest run of the table rather than of the root
+says so.
 """
 
 from datetime import UTC, datetime, timedelta
@@ -28,69 +27,6 @@ from tests.spindoctor.dataset.conftest import (
 from spindoctor.dataset.results_filter import ResultsFilter
 
 
-def test_an_ingest_that_missed_a_directory_is_reported(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """Absence under a directory nobody listed is not an answer, and says so.
-
-    The run completed, so nothing else in the index shows the gap; a run that
-    missed a directory otherwise makes an absence filter re-navigate every image
-    under it without a word.
-    """
-    root, _images = one_image_tree(tmp_path)
-    url = index_of_two_roots(tmp_path, root, missed=2)
-    ResultsFilter(
-        VOLUMES,
-        str(root),
-        logger=reporting_logger(),
-        results_db_url=url,
-        has_no_offset_file=True,
-    )
-    assert 'did not list 2 directories' in capsys.readouterr().out
-
-
-def test_the_report_of_a_gap_says_that_nothing_was_removed_either(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """A pass that missed a directory removes no row anywhere under the root.
-
-    That is the half of the cost an operator can act on: a document deleted
-    since the pass before keeps its row for as long as the directory stays
-    unlistable, so ``--has-offset-file`` hands on an image whose document is
-    gone, and this is the only place it is said.
-    """
-    root, _images = one_image_tree(tmp_path)
-    url = index_of_two_roots(tmp_path, root, missed=2)
-    ResultsFilter(
-        VOLUMES,
-        str(root),
-        logger=reporting_logger(),
-        results_db_url=url,
-        has_no_offset_file=True,
-    )
-    assert 'no row was removed anywhere under the root' in capsys.readouterr().out
-
-
-def test_a_complete_ingest_is_reported_as_nothing(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """A pass that listed the whole root leaves absence meaning what it says.
-
-    The other root's pass is the newest in the index and missed directories, so
-    a count read without naming this root warns about a root that has no gap.
-    """
-    root, _images = one_image_tree(tmp_path)
-    url = index_of_two_roots(tmp_path, root, missed=0)
-    ResultsFilter(
-        VOLUMES,
-        str(root),
-        logger=reporting_logger(),
-        results_db_url=url,
-        has_no_offset_file=True,
-    )
-    assert 'did not list' not in capsys.readouterr().out
-
-
 def test_the_report_says_how_old_the_index_answer_is(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -101,7 +37,7 @@ def test_the_report_says_how_old_the_index_answer_is(
     decides whether this run is affected by it.
     """
     root, _images = one_image_tree(tmp_path)
-    url = index_of_two_roots(tmp_path, root, missed=0)
+    url = index_of_two_roots(tmp_path, root)
     stamp_run(url, root, finished_utc=(datetime.now(UTC) - timedelta(days=2)).isoformat())
     ResultsFilter(
         VOLUMES,
@@ -119,7 +55,7 @@ def test_the_report_names_the_moment_as_well_as_the_interval(
     """The interval is what a reader compares against; the stamp names the pass to re-run."""
     root, _images = one_image_tree(tmp_path)
     stamp = '2026-02-03T04:05:06+00:00'
-    url = index_of_two_roots(tmp_path, root, missed=0)
+    url = index_of_two_roots(tmp_path, root)
     stamp_run(url, root, finished_utc=stamp)
     ResultsFilter(
         VOLUMES,
@@ -136,7 +72,7 @@ def test_the_age_is_that_of_this_roots_pass_and_not_another(
 ) -> None:
     """The second root was passed over afterwards, and says nothing about this answer."""
     root, _images = one_image_tree(tmp_path)
-    url = index_of_two_roots(tmp_path, root, missed=0)
+    url = index_of_two_roots(tmp_path, root)
     stamp_run(url, root, finished_utc='2026-02-03T04:05:06+00:00')
     stamp_run(url, tmp_path / OTHER_ROOT_NAME, finished_utc='2026-03-04T05:06:07+00:00')
     ResultsFilter(
@@ -158,7 +94,7 @@ def test_a_finish_time_that_will_not_parse_is_reported_as_it_stands(
     index restored from somewhere else is exactly where one would come from.
     """
     root, _images = one_image_tree(tmp_path)
-    url = index_of_two_roots(tmp_path, root, missed=0)
+    url = index_of_two_roots(tmp_path, root)
     stamp_run(url, root, finished_utc='whenever it was')
     ResultsFilter(
         VOLUMES,
@@ -181,7 +117,7 @@ def test_a_finish_time_in_the_future_is_reported_as_it_stands(
     ago" would state an interval that is not one.
     """
     root, _images = one_image_tree(tmp_path)
-    url = index_of_two_roots(tmp_path, root, missed=0)
+    url = index_of_two_roots(tmp_path, root)
     stamp = (datetime.now(UTC) + timedelta(days=2)).isoformat()
     stamp_run(url, root, finished_utc=stamp)
     ResultsFilter(
@@ -205,7 +141,7 @@ def test_a_finish_time_with_no_offset_is_read_as_utc(
     crash of the enumeration rather than an answer about the index.
     """
     root, _images = one_image_tree(tmp_path)
-    url = index_of_two_roots(tmp_path, root, missed=0)
+    url = index_of_two_roots(tmp_path, root)
     naive = (datetime.now(UTC) - timedelta(days=2)).replace(tzinfo=None).isoformat()
     stamp_run(url, root, finished_utc=naive)
     ResultsFilter(
@@ -231,7 +167,7 @@ def test_a_recorded_finish_time_of_nothing_is_reported_as_nothing(
 
     """
     root, _images = one_image_tree(tmp_path)
-    url = index_of_two_roots(tmp_path, root, missed=0)
+    url = index_of_two_roots(tmp_path, root)
     stamp_run(url, root, finished_utc=blank)
     ResultsFilter(
         VOLUMES,

--- a/tests/spindoctor/results_index/test_enumeration_lists.py
+++ b/tests/spindoctor/results_index/test_enumeration_lists.py
@@ -27,7 +27,6 @@ from spindoctor.results_index import selection
 ENUMERATION_MEMBERS = {
     'a document the ingest refused': 'the ingest refused',
     'a file with no row': 'has no row at all',
-    'a document that left the tree': 'the tree no longer holds',
     'a document rewritten in place': 'rewritten in place',
 }
 """The answers the index gives differently from the tree, and what names each.
@@ -41,7 +40,9 @@ member is deleted and an unrelated paragraph is emphasized in its place.
 The phrase is chosen to be the one wording every statement of that member shares
 and no other member's carries.  Adding a member means adding it here, to the
 module docstring, to the navigation guide and to the plan's two lists, in one
-commit.
+commit; so does removing one that has stopped being a divergence, which is how
+the row of a document the tree no longer holds left this list when an ingest
+that cannot list a directory began to stop rather than complete.
 
 What this can and cannot check
 ------------------------------

--- a/tests/spindoctor/results_index/test_postgres.py
+++ b/tests/spindoctor/results_index/test_postgres.py
@@ -511,12 +511,11 @@ def _seed_selection_rows(url: str) -> None:
                     'root_url': root_url,
                     'started_utc': stamp,
                     'finished_utc': stamp,
-                    'directories_missed': missed,
                     'schema_version': SCHEMA_VERSION,
                 }
-                for root_url, stamp, missed in (
-                    (SELECTION_ROOT, SELECTION_INGESTED, None),
-                    (SELECTION_OTHER_ROOT, SELECTION_OTHER_INGESTED, 4),
+                for root_url, stamp in (
+                    (SELECTION_ROOT, SELECTION_INGESTED),
+                    (SELECTION_OTHER_ROOT, SELECTION_OTHER_INGESTED),
                 )
             ],
         )
@@ -595,21 +594,6 @@ def test_the_error_filter_answers_for_one_root_on_postgresql(postgres_url: str) 
         postgres_url, SELECTION_ROOT, [SELECTION_VOLUME], has_offset_spice_error=True
     )
     assert stubs.matching_error == frozenset()
-
-
-def test_the_missed_count_answers_for_one_root_on_postgresql(postgres_url: str) -> None:
-    """The run table is keyed by root as well, and the newest run in it is another's.
-
-    This root's run records no count at all, which on a strictly typed backend
-    is a NULL integer rather than a zero, and the other root's -- the newer of
-    the two -- records four.
-
-    Parameters:
-        postgres_url: URL of an empty schema of this test's own.
-    """
-    _seed_selection_rows(postgres_url)
-    stubs = read_result_stubs(postgres_url, SELECTION_ROOT, [SELECTION_VOLUME])
-    assert stubs.directories_missed == 0
 
 
 def test_the_snapshot_time_answers_for_one_root_on_postgresql(postgres_url: str) -> None:

--- a/tests/spindoctor/results_index/test_postgres.py
+++ b/tests/spindoctor/results_index/test_postgres.py
@@ -457,9 +457,9 @@ def _seed_selection_rows(url: str) -> None:
     satisfied by answering nothing.
 
     The two roots' run rows differ the same way.  The other root is passed over
-    second, so its run is the newest in the index, and it is the only one that
-    records a missed directory: what the pass over this root recorded about
-    itself is therefore visibly its own.
+    second, so its run is the newest in the index and its finish time is not
+    this root's: what the pass over this root recorded about itself is
+    therefore visibly its own.
 
     Parameters:
         url: The index to create and write into.

--- a/tests/spindoctor/results_index/test_roots.py
+++ b/tests/spindoctor/results_index/test_roots.py
@@ -9,9 +9,9 @@ by a trailing slash or by being relative to the working directory.
 These are assertions about the functions' contracts rather than about any one
 backend's behavior: that two spellings of one root produce one string, that the
 filesystem root -- the one root whose separator is its whole name -- survives
-intact, that what one pass recorded about its own reach is read from the runs
-over the root it was asked about, and that the refusal of a root nobody ingested
-names its index without its password and its roots exactly as they were given.
+intact, that when a pass finished is read from the runs over the root it was
+asked about, and that the refusal of a root nobody ingested names its index
+without its password and its roots exactly as they were given.
 """
 
 from pathlib import Path
@@ -23,7 +23,7 @@ from tests.spindoctor.results_index.conftest import opened, sqlite_url_for
 from spindoctor.results_index import (
     INGEST_RUNS,
     SCHEMA_VERSION,
-    newest_pass,
+    newest_finish_time,
     normalize_root_url,
     open_index,
     require_ingested_roots,
@@ -170,9 +170,9 @@ def _index_with_two_passed_over_roots(tmp_path: Path) -> str:
     """Build an index whose two roots were each passed over, the second one last.
 
     The second root's pass is therefore the newest run in the index, and it
-    records a finish time and a missed count the first root's never records.  A
-    query that read the newest run of the table rather than the newest run of
-    the root it was asked about would answer with that one.
+    records a finish time of its own.  A query that read the newest run of the
+    table rather than the newest run of the root it was asked about would
+    answer with that one.
 
     Parameters:
         tmp_path: Directory the index file is written into.
@@ -189,58 +189,43 @@ def _index_with_two_passed_over_roots(tmp_path: Path) -> str:
                     'root_url': root_url,
                     'started_utc': finished,
                     'finished_utc': finished,
-                    'directories_missed': missed,
                     'schema_version': SCHEMA_VERSION,
                 }
-                for root_url, finished, missed in (
-                    (FIRST_ROOT, FIRST_FINISHED, 0),
-                    (SECOND_ROOT, SECOND_FINISHED, 4),
+                for root_url, finished in (
+                    (FIRST_ROOT, FIRST_FINISHED),
+                    (SECOND_ROOT, SECOND_FINISHED),
                 )
             ],
         )
     return url
 
 
-def test_the_missed_count_is_read_from_the_root_it_was_asked_about(tmp_path: Path) -> None:
-    """One index serves several roots, and the newest run in it is routinely another's."""
-    url = _index_with_two_passed_over_roots(tmp_path)
-    with opened(url) as engine, engine.connect() as connection:
-        assert newest_pass(connection, FIRST_ROOT).directories_missed == 0
-
-
 def test_the_finish_time_is_read_from_the_root_it_was_asked_about(tmp_path: Path) -> None:
     """How old one root's answer is has nothing to do with when another was walked."""
     url = _index_with_two_passed_over_roots(tmp_path)
     with opened(url) as engine, engine.connect() as connection:
-        assert newest_pass(connection, FIRST_ROOT).finished_utc == FIRST_FINISHED
+        assert newest_finish_time(connection, FIRST_ROOT) == FIRST_FINISHED
 
 
 def test_the_other_root_is_answered_for_on_the_same_terms(tmp_path: Path) -> None:
-    """The gap the second root does have is reported when the second root is asked about."""
+    """And the root whose pass is the newest in the table is answered for as itself."""
     url = _index_with_two_passed_over_roots(tmp_path)
     with opened(url) as engine, engine.connect() as connection:
-        assert newest_pass(connection, SECOND_ROOT).directories_missed == 4
-
-
-def test_a_root_with_no_run_row_has_no_gap(tmp_path: Path) -> None:
-    """A root this index never passed over borrows no other root's coverage."""
-    url = _index_with_two_passed_over_roots(tmp_path)
-    with opened(url) as engine, engine.connect() as connection:
-        assert newest_pass(connection, '/data/never-ingested').directories_missed == 0
+        assert newest_finish_time(connection, SECOND_ROOT) == SECOND_FINISHED
 
 
 def test_a_root_with_no_run_row_has_no_finish_time(tmp_path: Path) -> None:
-    """Nothing was recorded for it, which is a different thing from a recorded zero."""
+    """Nothing was recorded for it, which is a different thing from a recorded time."""
     url = _index_with_two_passed_over_roots(tmp_path)
     with opened(url) as engine, engine.connect() as connection:
-        assert newest_pass(connection, '/data/never-ingested').finished_utc is None
+        assert newest_finish_time(connection, '/data/never-ingested') is None
 
 
-def test_a_pass_that_recorded_no_count_reads_as_no_gap(tmp_path: Path) -> None:
-    """The column is nullable, and a NULL there is not a gap of unknown size.
+def test_a_run_that_never_finished_has_no_finish_time(tmp_path: Path) -> None:
+    """The column is nullable, and a NULL there is a pass that did not reach the end.
 
-    A run row is written when the pass starts and its count is stamped when the
-    pass ends, so a NULL is a pass that did not reach the end -- which the
+    A run row is written when the pass starts and stamped when the pass ends, so
+    a NULL is a pass still in flight or one that died -- which the
     completed-ingest check refuses before any of this is read.
     """
     url = sqlite_url_for(tmp_path / 'index.sqlite3')
@@ -252,10 +237,9 @@ def test_a_pass_that_recorded_no_count_reads_as_no_gap(tmp_path: Path) -> None:
                     'root_url': FIRST_ROOT,
                     'started_utc': FIRST_FINISHED,
                     'finished_utc': None,
-                    'directories_missed': None,
                     'schema_version': SCHEMA_VERSION,
                 }
             ],
         )
     with opened(url) as engine, engine.connect() as connection:
-        assert newest_pass(connection, FIRST_ROOT).directories_missed == 0
+        assert newest_finish_time(connection, FIRST_ROOT) is None

--- a/tests/spindoctor/results_index/test_schema.py
+++ b/tests/spindoctor/results_index/test_schema.py
@@ -126,7 +126,6 @@ INGEST_RUNS_COLUMNS: tuple[tuple[str, ColumnType, bool], ...] = (
     ('files_skipped', sqlalchemy.Integer, True),
     ('files_failed', sqlalchemy.Integer, True),
     ('files_removed', sqlalchemy.Integer, True),
-    ('directories_missed', sqlalchemy.Integer, True),
     ('schema_version', sqlalchemy.Integer, False),
 )
 
@@ -145,7 +144,7 @@ SCHEMA_META_COLUMNS: tuple[tuple[str, ColumnType, bool], ...] = (
     ('created_utc', sqlalchemy.Text, False),
 )
 
-COLUMN_SET_VERSION = 6
+COLUMN_SET_VERSION = 7
 """The schema version the column sets above make up.
 
 An index is readable only by code whose column set is the one that wrote it, and

--- a/tests/spindoctor/results_index/test_selection.py
+++ b/tests/spindoctor/results_index/test_selection.py
@@ -78,15 +78,15 @@ SPICE = 'missing_spice_data'
 INGESTED = '2026-02-03T04:05:06+00:00'
 """When the newest pass over the root under test finished."""
 
+EARLIER_INGESTED = '2026-01-02T03:04:05+00:00'
+"""When an earlier pass over that same root finished."""
+
 OTHER_ROOT_INGESTED = '2026-03-04T05:06:07+00:00'
-"""When the newest pass over the other root finished, which is not when this one did."""
+"""When the newest pass over the other root finished, which is not when this one did.
 
-OTHER_ROOT_MISSED = 7
-"""How many directories the other root's newest pass did not list.
-
-It is not zero, and that pass is the newest in the index, so a count read from
-the newest run of the table rather than from the newest run of the root under
-test reports this number instead of that root's own.
+That pass is the newest in the index, so a finish time read from the newest run
+of the table rather than from the newest run of the root under test reports this
+moment instead of that root's own.
 """
 
 
@@ -125,14 +125,11 @@ def _document(stub: str, **columns: Any) -> dict[str, Any]:
     )
 
 
-def _completed_run(
-    root_url: str, *, directories_missed: int = 0, finished_utc: str | None = None
-) -> dict[str, Any]:
+def _completed_run(root_url: str, *, finished_utc: str | None = None) -> dict[str, Any]:
     """Return an ``ingest_runs`` row saying a pass over one root completed.
 
     Parameters:
         root_url: The root the run covered.
-        directories_missed: How many directories that pass did not list.
         finished_utc: When the pass finished, defaulting to now for the tests
             that do not read the time back.
 
@@ -144,7 +141,6 @@ def _completed_run(
         'root_url': root_url,
         'started_utc': stamp,
         'finished_utc': stamp,
-        'directories_missed': directories_missed,
         'schema_version': SCHEMA_VERSION,
     }
 
@@ -153,14 +149,12 @@ def _other_roots_newest_run() -> dict[str, Any]:
     """Return the run row that makes a root-blind run query answer wrongly.
 
     It is inserted last, so it is the newest run in the index, and it records a
-    finish time and a missed count that the root under test never records.
+    finish time the root under test never records.
 
     Returns:
         A mapping ready to insert.
     """
-    return _completed_run(
-        OTHER_ROOT, directories_missed=OTHER_ROOT_MISSED, finished_utc=OTHER_ROOT_INGESTED
-    )
+    return _completed_run(OTHER_ROOT, finished_utc=OTHER_ROOT_INGESTED)
 
 
 @pytest.fixture
@@ -471,16 +465,6 @@ def test_a_refused_document_matches_no_error_filter(two_roots: str) -> None:
     assert REFUSED not in _stubs(two_roots, has_offset_error=True).matching_error
 
 
-def test_a_complete_pass_leaves_nothing_for_the_caller_to_report(two_roots: str) -> None:
-    """A pass that listed the whole root makes absence mean what it says.
-
-    The other root's pass is the newest in the index and missed directories, so
-    a count read without naming this root reports that gap against a root that
-    has none.
-    """
-    assert _stubs(two_roots).directories_missed == 0
-
-
 def test_the_answer_carries_the_time_of_the_pass_that_recorded_it(two_roots: str) -> None:
     """The index detects no change since that moment, so the moment travels with it.
 
@@ -490,73 +474,53 @@ def test_the_answer_carries_the_time_of_the_pass_that_recorded_it(two_roots: str
     assert _stubs(two_roots).ingested_utc == INGESTED
 
 
-def _index_with_runs(tmp_path: Path, counts: list[int]) -> str:
-    """Build an index whose root was passed over once per count, in that order.
+def _index_with_runs(tmp_path: Path, finish_times: list[str]) -> str:
+    """Build an index whose root was passed over once per time, in that order.
 
-    A second root is passed over after all of them, missing directories and
-    finishing at a moment of its own, so that a count or a finish time read from
-    the newest run in the index rather than from the newest run over this root
-    is that second root's and is visibly wrong.
+    A second root is passed over after all of them, finishing at a moment of its
+    own, so that a finish time read from the newest run in the index rather than
+    from the newest run over this root is that second root's and is visibly
+    wrong.
 
     Parameters:
         tmp_path: Directory the index file is written into.
-        counts: How many directories each completed pass over the root under
-            test did not list, oldest pass first.
+        finish_times: When each completed pass over the root under test
+            finished, oldest pass first.
 
     Returns:
         The connection URL of the index.
     """
-    url = sqlite_url_for(tmp_path / 'missed.sqlite3')
+    url = sqlite_url_for(tmp_path / 'passes.sqlite3')
     with opened(url, create=True) as engine, engine.begin() as connection:
         connection.execute(IMAGES.insert(), [_document(SECOND_SUCCESS)])
         connection.execute(
             INGEST_RUNS.insert(),
-            [
-                _completed_run(ROOT, directories_missed=missed, finished_utc=INGESTED)
-                for missed in counts
-            ]
+            [_completed_run(ROOT, finished_utc=finished) for finished in finish_times]
             + [_other_roots_newest_run()],
         )
     return url
 
 
-def test_a_pass_that_missed_a_directory_hands_the_count_back(tmp_path: Path) -> None:
-    """Absence under a directory nobody listed is not an answer, and says so.
+def test_the_time_comes_from_the_newest_pass_over_the_root(tmp_path: Path) -> None:
+    """A root passed over twice is as old as the second pass, not the first.
 
-    The run completed, so nothing else in the index shows the gap; the count on
-    the run row is the only place it appears, and the caller that reads absence
-    as "this image was never navigated" is the one that has to be told.
+    The age belongs to a pass and not to a root, and an answer dated by the
+    oldest pass over the root reads as stale on every enumeration until the end
+    of time.
     """
-    stubs = read_result_stubs(_index_with_runs(tmp_path, [0, 3]), ROOT, [VOLUME])
-    assert stubs.directories_missed == 3
-
-
-def test_the_count_comes_from_the_newest_pass(tmp_path: Path) -> None:
-    """A later complete pass answers for the tree an earlier half-read one left.
-
-    The count belongs to a pass and not to a root: the whole root was listed
-    this time, so absence under it means what it says again, and reporting the
-    older pass's gap would cry wolf on every enumeration until the end of time.
-    """
-    stubs = read_result_stubs(_index_with_runs(tmp_path, [3, 0]), ROOT, [VOLUME])
-    assert stubs.directories_missed == 0
-
-
-def test_another_roots_gap_is_not_this_roots(tmp_path: Path) -> None:
-    """The count is read from the runs over the named root and no others.
-
-    One index serves several roots, and the newest run in it is routinely
-    another root's: a count read without the root warns of a gap this root does
-    not have, or -- with the two passes the other way round -- reports none when
-    this root has one.
-    """
-    stubs = read_result_stubs(_index_with_runs(tmp_path, [0]), ROOT, [VOLUME])
-    assert stubs.directories_missed == 0
+    url = _index_with_runs(tmp_path, [EARLIER_INGESTED, INGESTED])
+    stubs = read_result_stubs(url, ROOT, [VOLUME])
+    assert stubs.ingested_utc == INGESTED
 
 
 def test_another_roots_pass_is_not_when_this_answer_was_recorded(tmp_path: Path) -> None:
-    """The finish time comes from the same run row as the count, and by the same rule."""
-    stubs = read_result_stubs(_index_with_runs(tmp_path, [0]), ROOT, [VOLUME])
+    """The finish time is read from the runs over the named root and no others.
+
+    One index serves several roots, and the newest run in it is routinely
+    another root's: a time read without the root dates this answer by whenever
+    somebody last passed over an unrelated tree.
+    """
+    stubs = read_result_stubs(_index_with_runs(tmp_path, [INGESTED]), ROOT, [VOLUME])
     assert stubs.ingested_utc == INGESTED
 
 


### PR DESCRIPTION
## Purpose

One unlistable directory anywhere under a results root suppressed the prune for the whole root, so every row whose document had been deleted survived across arbitrarily many *completed* ingest passes. The run stamped `finished_utc`, so `require_ingested_roots` accepted the root, and `--has-offset-file` handed on images whose metadata file was gone while `--has-no-offset-file` — the resume idiom — silently declined to re-navigate them. Documenting that would have left a wrong answer in place, so the operator's disposition on #481 was to make an unreachable directory an error that aborts the whole ingest.

The two sibling questions were dispositioned as documented limits: #479 (two overlapping passes over one root can leave one stale row) and #480 (an abandoned fan-out has already removed rows).

Closes #481
Closes #479
Closes #480

## Changes

- **The walk raises where it meets a directory it cannot list.** `UnlistableDirectoryError` names the directory and what the storage layer said; nothing catches it before `sd_stats_ingest`, which reports it as a fatal error and exits 1. The root keeps its NULL finish time and every root named after it on the same command line is never walked, so both are roots every consumer refuses.
- **Raised at discovery, not at prune time.** The walk precedes every retrieval, so a stopped pass throws away a listing rather than hours of reading on an archive-scale root. The cost — a transient blip now ends a run instead of degrading it — is recorded as the deliberate trade it is, in the exception's docstring, in the plan, and in the statistics guide.
- **The root itself is still the exception**: a mistyped or unmounted root is reported per root and the pass moves on, exactly as before.
- **A directory reached a second way is no longer a gap.** A link back up the tree, or a volume reachable under two names, brings the walk to a directory it has already listed: its documents are in the listing under the path met first, and the stubs the second path would produce name a directory no consumer's lookup spells. The walk logs it, declines it, and the root still counts as wholly listed — so such a pass completes *and prunes*, which it did not before.
- **Every completed run therefore listed its whole root**, which removes "a document the tree no longer holds keeps its row" from the index-versus-tree enumeration. All four statements of that list (the `selection` module docstring, the navigation guide, the plan's Phase 5 entry, acceptance criterion 1) and `ENUMERATION_MEMBERS` change together; the member's tests move from the divergence file to the parity file and now assert that the two paths agree, as that file's own docstring prescribes.
- **`ingest_runs.directories_missed` is gone**, with `IngestCounts.directories_missed`, `NewestPass` (now `newest_finish_time`), `ResultStubs.directories_missed`, the `ResultsFilter` warning and the two `sd_stats_ingest` warnings. Either half of the change leaves it permanently zero, and a column no run can make nonzero is a warning no test can fail on. **Schema version 6 -> 7**, so an existing index must be dropped and rebuilt (`sd_stats_ingest --drop-index`).
- `_prune_missing` now refuses a listing of a root the walk could not list, rather than one that "does not cover the whole root" — the narrower guard is the only one a `_RootListing` can still violate.
- Documentation of the two limits: abandoning a fan-out costs a full re-ingest of that root, and running two passes over one root at a time is a decision (refusing or warning was considered and not done) rather than a question nobody reached.

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (fix or feature that alters existing behavior or public API)
- [ ] Refactor (no functional or API changes)
- [x] Documentation
- [ ] Tests only (no production code change)
- [ ] CI / Build / Dependencies

Breaking twice over: an ingest that used to complete over a root with an unreadable directory now stops, and the schema version bump means every existing index has to be rebuilt.

## Testing

- [x] Unit tests pass — 11456 passed, 7 xfailed (`-n 4 --dist=loadfile`, BLAS/OMP threads pinned to 1)
- [x] Integration tests pass (if applicable) — the `postgres` tier passes too: 107 passed against `postgres:16-alpine`
- [ ] End-to-end tests pass (if applicable)
- [x] New or updated tests for changed code
- [ ] Tested manually (describe below if applicable)

New tests: the pass stops for each of the four ways a directory refuses (`FileNotFoundError`, `NotADirectoryError`, `PermissionError`, `TimeoutError`) and for a real directory of mode 000; the refusal names the directory; no document is read before it stops (asserted by spying on `_ingest_chunk`, which is what pins "at discovery" rather than "at prune time"); the stopped root's run stays unfinished; a root walked before it keeps its completed pass and a root named after it gets no run at all; the fan-out stops the same way and writes no tasks file; a link back to an ancestor does not stop the pass and does prune a deleted document; and, at the CLI, the message, the named directory, the exit status, and that the message is *not* the catch-all's ("Ingest could not complete"), which exits 1 and would otherwise satisfy a status-only test.

`sphinx -W` and `ruff check` / `ruff format --check` are clean; `mypy src tests` is clean over 685 files.

## Potential Impacts

Operators must run `sd_stats_ingest --drop-index` and re-ingest: the schema version gate refuses an index stamped 6. Any ingest over a tree with an unreadable directory or a stale mount now exits 1 rather than completing — which is the point, but it will surprise a scheduled run that had been "succeeding".

`origin/main` is merged in first (this branch was cut before #505 landed, and `mypy` fails on the polymath 2.0 stubs without it); the integration branch carries the same merge, so the merge commit here is a fast-forward of it rather than new content.

## Notes

The base is `rf_results_index`, not `main`. Issues closed by a PR into a non-default branch do not auto-close, so #479, #480 and #481 are closed by hand on merge.

This is the last item before Phase 6 (documentation): it had to land first because it removes a member of the tree-versus-index divergence enumeration that Phase 6 would otherwise have documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directory-listing failures now stop ingestion with a clear error and nonzero exit status.
  * Incomplete roots are not made available to index consumers.
  * Revisited directories are skipped safely without being reported as failures.
  * Pruning occurs only after a root has been successfully listed.

* **Improvements**
  * Results use the newest completed ingest timestamp for each root.
  * Removed missed-directory reporting from ingest results and status information.
  * Updated documentation for cloud-task limitations and recovery steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->