### PR TITLE
Report over a stream of records, not a database (#510)

### DIFF
--- a/docs/dev_guide/dev_guide_introduction.rst
+++ b/docs/dev_guide/dev_guide_introduction.rst
@@ -150,8 +150,9 @@ Every CLI listed in ``[project.scripts]`` is installed onto ``$PATH`` by
        over a queue of workers. ``sd_stats_ingest --drop-index`` empties the
        index instead. See :doc:`/user_guide/user_guide_results_index`.
    * - ``sd_stats_report``
-     - Write the navigation statistics report and its charts from the index.
-       See :doc:`/user_guide/user_guide_statistics`.
+     - Write the navigation statistics report and its charts, over a
+       navigation-results tree or over the index. See
+       :doc:`/user_guide/user_guide_statistics`.
    * - ``sd_consolidate_metadata``
      - Copy each image's metadata JSON and summary PNG into one flat directory.
        See :doc:`/user_guide/user_guide_navigation`.

--- a/docs/dev_guide/dev_guide_results_index.rst
+++ b/docs/dev_guide/dev_guide_results_index.rst
@@ -367,7 +367,7 @@ a row is an answer, so presence has to mean the tree still holds the document,
 which is why each pass removes the rows of documents its walk did not find. A
 worker handed a share of a root has no evidence about the stubs outside its
 share and would delete its peers' rows, so nothing hands a worker a listing. The
-licence is a type rather than a check: one function builds the listing the prune
+license is a type rather than a check: one function builds the listing the prune
 takes, it builds one only for a root it listed entirely, and it carries the root
 it listed --- so a share of a root, a partial listing and a prune of one root on
 the evidence of another are all unrepresentable rather than refused. In a

--- a/docs/dev_guide/dev_guide_results_index.rst
+++ b/docs/dev_guide/dev_guide_results_index.rst
@@ -125,19 +125,23 @@ so a source holding more than one root refuses it, naming them.
 
 :meth:`~spindoctor.nav_records.RecordSource.records` takes a selection and
 yields the records it covers, one at a time. It is what a program that
-summarizes or sweeps asks once per run: the kernel writer reading a mission, the
-statistics report reading a root. It also takes an explicit list of stubs, which
-is what a queue task carries --- a worker must read exactly the files it was
-given, and read them in batches, so looping the per-image call would cost it a
-round trip apiece on the storage that batching exists for.
+summarizes or sweeps asks once per run --- the kernel writer reading a
+mission. It also takes an explicit list of stubs, which is what a queue task
+carries --- a worker must read exactly the files it was given, and read them in
+batches, so looping the per-image call would cost it a round trip apiece on the
+storage that batching exists for.
 
 :meth:`~spindoctor.nav_records.RecordSource.facts` takes a selection and yields
 what every image it covers says about itself --- the image's own values, one
 entry per technique that reported, and the aggregated inventory of the features
-the models offered. It is what a program reading every field of every image asks
-for, because a record cannot carry that: a record is defined as looking like the
-document it stands for, so the index rebuilds one out of the columns its consumer
-selected and invents no field the document did not have, and no record carries a
+the models offered. It is what the statistics report asks for, being the one
+program that reads every field of every image: it makes a single pass of
+accumulators over this stream and formats every section of its output from
+them, so a report over a tree and a report over an index are one
+implementation of every statistic rather than two obliged to agree forever. A
+record cannot carry those fields: it is defined as looking like the document it
+stands for, so the index rebuilds one out of the columns its consumer selected
+and invents no field the document did not have, and no record carries a
 per-technique or per-feature row at all. The facts are the whole row --- what
 the index column set holds about an image, in the shape both storages hold it
 in --- so the columns a consumer named narrow its records and never its facts.
@@ -171,11 +175,13 @@ records, says what that order is, and a caller needing a total order calls
 
 **A failure arrives from** ``next()``. A file that could not be read is yielded
 into the stream as an :class:`~spindoctor.nav_records.UnreadableFile` rather
-than raised, so one of them costs itself and not the rest of the pass. A
-refusal that ends a pass --- a
-directory nobody can list, an index that stops answering --- surfaces in the
-middle of the caller's loop, so a program using the stream finishes its pass
-before it writes its output.
+than raised, so one of them costs itself and not the rest of the pass. What
+becomes of it is the caller's: the ingest records it in ``failed_files``, and
+the statistics report counts them and prints the count, so a summary says how
+much of a root it could not read rather than quietly covering less. A refusal
+that ends a pass --- a directory nobody can list, an index that stops
+answering --- surfaces in the middle of the caller's loop, so a program using
+the stream finishes its pass before it writes its output.
 
 Two backends, and why the package is split
 ------------------------------------------
@@ -267,6 +273,19 @@ consumer is caught rather than read as absent by everything.
 **A record read from a document carries every field it has; one rebuilt from a
 row carries what its consumer selected.** That is the one difference a consumer
 has to know about, and it is why the columns are pinned rather than assumed.
+
+**A stream of records narrows on the document; a stream of facts narrows on the
+facts.** A record is the document, so a walk reads the mission and the exposure
+midtime out of the document it has just parsed: one it can attribute to another
+mission, or place outside the span, is passed over, and one it cannot place at
+all is reported rather than dropped from every run there is. The facts are the
+row an ingest of the same file writes, so a walk narrowing them compares the
+fields the row holds, which are the fields a query narrows on --- and a file
+that yields no facts is an unreadable file under every selection, because
+nothing was read out of it for a filter to compare. That is what makes the two
+storages cover the same images under one filter by construction rather than by
+testing: under a filter on the facts there is no value one of them reads and the
+other does not.
 
 **A key is checked where it is written, not where it is read.** A results root
 is normalized to one absolute, resolved spelling by

--- a/docs/introduction_overview.rst
+++ b/docs/introduction_overview.rst
@@ -76,7 +76,7 @@ Navigation Phase
   results index (see :doc:`/user_guide/user_guide_results_index`).
 
 * ``sd_stats_report`` - Generate success/failure, technique-usage, offset, and
-  agreement reports from the results index (see
+  agreement reports from a navigation results tree or the results index (see
   :doc:`/user_guide/user_guide_statistics`).
 
 Reprojection and Mosaic Phase

--- a/docs/user_guide/user_guide_results_index.rst
+++ b/docs/user_guide/user_guide_results_index.rst
@@ -105,7 +105,11 @@ Which programs read it
      - Writes one share of it, as a queue worker.
    * - ``sd_stats_report``
      - Every section of the report. Given no index it reads the results tree
-       instead, and the report is the same either way.
+       instead, and over the records both storages can read the report is the
+       same either way. The count of files that yielded no record is the one
+       exception: a file the storage could not deliver at all is counted from a
+       tree and not from an index, because the ingest deliberately records no
+       refusal for a retrieval that failed once.
    * - ``sd_offset``
      - The results-based selection filters (``--has-offset-file``,
        ``--has-no-offset-file``, the error filters), which otherwise walk the

--- a/docs/user_guide/user_guide_results_index.rst
+++ b/docs/user_guide/user_guide_results_index.rst
@@ -26,9 +26,8 @@ reachable.
 
 This chapter is the index: when to build one, how programs are pointed at it,
 what it does and does not promise, how to build, share, rebuild and query one,
-and the tables it holds. :doc:`user_guide_statistics` documents the one
-program that reads an index and nothing else, ``sd_stats_report``, which turns
-one into the navigation statistics report.
+and the tables it holds. :doc:`user_guide_statistics` documents
+``sd_stats_report``, which turns one into the navigation statistics report.
 
 Nothing requires an index
 =========================
@@ -37,9 +36,12 @@ Every program runs with no index at all, and that is the default. A run that
 names no index reads the results tree exactly as it always has; there is no
 fallback path to get wrong, because reading files *is* the ordinary path.
 
-``sd_stats_report`` is the one exception in the other direction: it has no
-file-reading mode, and it fails naming ``--results-db`` when no index is
-resolved.
+``sd_stats_report`` is the one worth a word before it is pointed at a tree. It
+reads every document under every root it is given, on every run --- which is
+exactly the cost an index exists to remove. For a local tree and a single
+report that is the right trade; for a cloud root, or a report you will run
+again, build an index first. :doc:`user_guide_statistics` says so beside the
+option.
 
 **A program becomes index-backed by declaring** ``--results-db``, never by
 inheriting an exported ``NAV_RESULTS_DB``. A program whose selection is meant
@@ -102,7 +104,8 @@ Which programs read it
    * - ``sd_stats_ingest_cloud_tasks``
      - Writes one share of it, as a queue worker.
    * - ``sd_stats_report``
-     - Reads it and nothing else; the one program an index is not optional for.
+     - Every section of the report. Given no index it reads the results tree
+       instead, and the report is the same either way.
    * - ``sd_offset``
      - The results-based selection filters (``--has-offset-file``,
        ``--has-no-offset-file``, the error filters), which otherwise walk the
@@ -264,7 +267,10 @@ Absence of a row would otherwise read as "this image was never navigated", so
 a consumer pointed at an index that has never covered its root fails with a
 message naming the root and the roots the index does hold. A pass that is
 still running, or one that stopped, leaves its root in exactly that state until
-it is completed.
+it is completed. A consumer that names no root of its own -- the statistics
+report is the one that may -- is bound to the roots that do have a completed
+ingest and names the others as roots it covered nothing of, which is the same
+rule stated about a set of roots rather than about one.
 
 **Ingestion is never automatic.** No batch driver runs it as a side effect. The
 index is a snapshot of the tree as of the last ingest: there is no staleness
@@ -282,6 +288,14 @@ navigation documents at all; each is counted as an error for its own file, the
 run continues, and the closing summary tallies the failures by reason and names
 one file per reason, so several hundred files that were never navigation results
 read as exactly that rather than as a broken ingest.
+
+A file that could not be retrieved at all is the one failure the pass records
+nowhere. It is counted in the pass's own tally and no ``failed_files`` row is
+written for it, deliberately: a retrieval that failed once is worth trying again
+on the next pass, where a file that was read and refused will be refused again
+for as long as it does not change. So a report over the documents counts such a
+file among the files that yielded no record and a report from an index does not,
+and running the ingest again is what closes the gap.
 
 That tally is what this pass read, and not what the root holds. A refused file
 is recorded in ``failed_files``, and every pass after it skips the file

--- a/docs/user_guide/user_guide_statistics.rst
+++ b/docs/user_guide/user_guide_statistics.rst
@@ -16,11 +16,17 @@ being a single non-interactive invocation:
         --instrument coiss --start-date 2005-03-01 --end-date 2005-03-01 \
         --output-dir day_report
 
-**The report reads a navigation results tree or a results index, and it is the
-same report either way.** Every number in it comes from one pass over the
-per-image records, and the two storages hand that pass the same records, so a
-report over a tree and a report from an index built from that tree carry the
-same text and the same charts.
+**The report reads a navigation results tree or a results index, and over the
+records both storages can read it is the same report either way.** Every number
+in it comes from one pass over the per-image records, and the two storages hand
+that pass the same records, so a report over a tree and a report from an index
+built from that tree carry the same text and the same charts.
+
+One count is the exception, and it is the count of files that yielded no record:
+a file the storage could not deliver at all is counted from a tree and not from
+an index, because the ingest deliberately records no refusal for a retrieval
+that failed once. The **Files that yielded no record** entry below says what
+that means for the number printed.
 
 An index is optional here exactly as it is everywhere else, and
 ``--results-db`` is resolved the same way: from the command line, then the
@@ -115,8 +121,11 @@ Three options control drill-down output:
   their order is whatever the storage yields them in -- the directory order of
   a tree, the server's own order for an index -- and the two do not agree.
   ``results_path_stub`` is the first column so that putting them in order is
-  one shell command, ``sort -t, -k1,1 images.csv``, holding the header line out
-  of the sort where that matters.
+  one shell pipeline, with the header line held out of the sort:
+
+  .. code-block:: bash
+
+      { head -n 1 images.csv; tail -n +2 images.csv | sort -t, -k1,1; } > sorted-images.csv
 
 The first two write *image names* rather than file names -- ``N1454725799``
 rather than ``N1454725799_1_CALIB.IMG`` -- because that is the token the

--- a/docs/user_guide/user_guide_statistics.rst
+++ b/docs/user_guide/user_guide_statistics.rst
@@ -1,76 +1,122 @@
 Navigation Statistics
 =====================
 
-``sd_stats_report`` turns a results index into a deterministic report: Markdown
-text plus PNG charts. It is the standing quality check on a production run --
-success and failure rates, which techniques and models carry the load, offset
-distributions, how well the techniques agree with one another, and whether the
-confidence tiers behave as designed -- and it is cron-friendly, being a single
-non-interactive invocation:
+``sd_stats_report`` turns the results of a navigation run into a deterministic
+report: Markdown text plus PNG charts. It is the standing quality check on a
+production run -- success and failure rates, which techniques and models carry
+the load, offset distributions, how well the techniques agree with one another,
+and whether the confidence tiers behave as designed -- and it is cron-friendly,
+being a single non-interactive invocation:
 
 .. code-block:: bash
 
-    sd_stats_report --results-db sqlite:////data/nav-offset-results/index.sqlite3 \
+    sd_stats_report --nav-results-root /data/nav-offset-results \
         --output-dir stats_report
     sd_stats_report --results-db sqlite:////data/nav-offset-results/index.sqlite3 \
         --instrument coiss --start-date 2005-03-01 --end-date 2005-03-01 \
         --output-dir day_report
 
-**The report reads a results index and nothing else.** The index is a database
-built from the navigation results tree by a separate pass,
-``sd_stats_ingest``, and :doc:`user_guide_results_index` is where it is
+**The report reads a navigation results tree or a results index, and it is the
+same report either way.** Every number in it comes from one pass over the
+per-image records, and the two storages hand that pass the same records, so a
+report over a tree and a report from an index built from that tree carry the
+same text and the same charts.
+
+An index is optional here exactly as it is everywhere else, and
+``--results-db`` is resolved the same way: from the command line, then the
+``environment.results_db`` configuration variable, then the ``NAV_RESULTS_DB``
+environment variable, with the literal ``none`` at any level meaning no index.
+The index is a database built from the navigation results tree by a separate
+pass, ``sd_stats_ingest``, and :doc:`user_guide_results_index` is where it is
 documented: how it is named and resolved, how to build and rebuild one, the
 tables it holds, and how to query it directly for the questions this report
-does not answer. Build one before running the report:
+does not answer.
 
 .. code-block:: bash
 
     sd_stats_ingest --nav-results-root /data/nav-offset-results \
         --results-db sqlite:////data/nav-offset-results/index.sqlite3
+    sd_stats_report --results-db sqlite:////data/nav-offset-results/index.sqlite3
 
-Every other program that reads an index takes ``--results-db`` as an option
-and reads files without it. This one has no file-reading mode, and it fails
-naming ``--results-db`` when no index is resolved from the command line, the
-``environment.results_db`` configuration variable or the ``NAV_RESULTS_DB``
-environment variable.
+With no index the navigation results tree is read instead. The roots to read
+come from ``--nav-results-root`` (repeatable), then the ``nav_results_root``
+configuration variable, then ``NAV_RESULTS_ROOT``, as they do for the ingest.
+On a machine where an index is configured, ``--results-db none`` is how a
+single run is made to read the tree anyway:
 
-``sd_stats_report [--results-db URL] [--root ROOT] [--output-dir DIR]
-[--instrument NAME] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD]
-[--min-image NAME] [--max-image NAME] [--top-n N] [--filelists]
-[--suspect-fraction F] [--csv]`` writes ``report.md`` and its charts into the
-output directory. All filters combine and apply to every section; dates are
-inclusive UTC image dates, so a single day's run is ``--start-date D
---end-date D``. An image records its epoch as the midtime of the observation
-that was loaded for it, so an image whose load failed has no date and either
-bound passes it over. ``--min-image`` / ``--max-image`` bound the numeric
-portion of the image name (the first digit run in the basename, so
+.. code-block:: bash
+
+    sd_stats_report --nav-results-root /data/nav-offset-results \
+        --results-db none
+
+**Reading a tree costs one full read of every document under every root, on
+every report run.** That is exactly the cost an index exists to remove -- a
+Cassini-scale root is several hundred thousand documents, and on a cloud root
+each one is a paid round trip. For a local tree and a single report that is
+the right trade; for a cloud root, or for a report you will run more than
+once, build an index with ``sd_stats_ingest`` first and name it.
+
+A root, or a directory under one, that cannot be listed fails the run, and no
+report is written. A report that quietly covered less than the tree could not
+be told apart from one that covered all of it, so the pass stops instead.
+
+``sd_stats_report [--results-db URL] [--nav-results-root ROOT] [--root ROOT]
+[--output-dir DIR] [--instrument NAME] [--start-date YYYY-MM-DD]
+[--end-date YYYY-MM-DD] [--min-image NAME] [--max-image NAME] [--top-n N]
+[--filelists] [--suspect-fraction F] [--csv]`` writes ``report.md`` and its
+charts into the output directory. All filters combine and apply to every
+section; dates are inclusive UTC image dates, so a single day's run is
+``--start-date D --end-date D``. An image records its epoch as the midtime of
+the observation that was loaded for it, so an image whose load failed has no
+date and either bound passes it over. ``--min-image`` / ``--max-image`` bound
+the numeric portion of the image name (the first digit run in the basename, so
 ``--min-image N1454725799`` and ``--min-image 1454725799`` are equivalent);
 both bounds are inclusive and either may be given alone. The same inputs
 always produce the same numbers and the same charts.
 
-``--root`` restricts the report to one ingested navigation-results root and may
-be given more than once; with none given the report covers every root the index
-holds. A report legitimately spans roots where a per-image lookup never does.
-Naming a root the index has not fully ingested is an error rather than an empty
-report.
+``--root`` restricts an index-backed report to one ingested navigation-results
+root and may be given more than once; with none given the report covers every
+root the index holds a completed ingest of. A root whose newest ingest run did
+not finish is passed over rather than counted, because no absence under it can
+be read as an image nothing navigated; naming such a root outright is an error
+rather than an empty report. A report legitimately spans roots where a
+per-image lookup never does.
+
+**A report that passed a root over says so.** Its header names the roots it
+covered as the narrowing they are, and a ``Roots dropped`` line under them names
+the ones it left out; nothing under a dropped root is reported, neither its
+images nor its files that yielded no record, because a half-covered root is
+worse than an uncovered one. Ingest such a root and the next report covers it.
+
+Because ``--root`` selects among the roots one index holds, it is a different
+thing from ``--nav-results-root``, and it is refused when no index is named
+rather than read as a second spelling of it.
 
 Three options control drill-down output:
 
 - ``--top-n N`` makes each categorical section (failure reasons, failure
   taxonomy, ensemble exclusions, suspect offsets) list up to N example
   image names per category and instrument, caps the suspect-offset and
-  worst-BOTSIM-pair tables at N rows, and lists the N slowest images.
+  worst-BOTSIM-pair tables at N rows, and lists the N slowest images. The
+  default is 0, which turns the example lists, the worst-pair table and the
+  slowest-image list off entirely -- but leaves the suspect-offset table
+  uncapped, so it prints one row for every suspect image the selection holds.
 - ``--filelists`` writes one plain-text file per category and instrument
   (one image name per line, the full list rather than the top N) into the
   ``filelists/`` subdirectory of the output directory, ready to feed back
   into re-runs and triage scripts.
-- ``--csv`` writes ``images.csv`` next to ``report.md``: one row per image
-  with every ``images`` column in schema order -- ``root_url`` and
-  ``results_path_stub`` through ``mtime_ns`` and ``size_bytes`` -- plus
+- ``--csv`` writes ``images.csv`` next to ``report.md``: one row per image,
+  ``results_path_stub`` first and then every remaining per-image field in
+  schema order -- ``root_url`` through ``mtime_ns`` and ``size_bytes`` -- plus
   ``n_technique_rows``, ``n_feature_sources``, ``n_features`` and ``n_gated``
   aggregates, for pandas or spreadsheet analysis. Rows end with a single
   newline on every platform, and a JSON column that holds nothing is an empty
-  cell.
+  cell. Each row is written as it is read, so the rows are **not sorted**:
+  their order is whatever the storage yields them in -- the directory order of
+  a tree, the server's own order for an index -- and the two do not agree.
+  ``results_path_stub`` is the first column so that putting them in order is
+  one shell command, ``sort -t, -k1,1 images.csv``, holding the header line out
+  of the sort where that matters.
 
 The first two write *image names* rather than file names -- ``N1454725799``
 rather than ``N1454725799_1_CALIB.IMG`` -- because that is the token the
@@ -96,6 +142,27 @@ The report contains:
   The date bounds are found independently of the image ordering, so a
   single image with no recorded epoch at either end of the number range
   cannot hide the instrument's real time span.
+- **Files that yielded no record** -- how many files named like a navigation
+  document no record could be read out of: one that could not be retrieved,
+  one that is not JSON, or JSON that is not a navigation document of the
+  current schema. The line is printed whether the count is zero or not,
+  because a line that vanished at zero could not be told apart from a report
+  that never looked for such files at all. **The count covers the whole of
+  every selected root and is not narrowed by ``--instrument``,
+  ``--start-date`` or ``--min-image``**: a file no record could be read out of
+  carries no instrument, no date and no image number, so it cannot obey a
+  filter that compares one. For the same reason it is kept out of the
+  per-instrument count tables, whose percentages are of images.
+
+  One of those kinds is counted from a tree and not from an index: a file the
+  storage could not deliver at all. The ingest deliberately records no refusal
+  for it, because a retrieval that failed once is worth trying again on the next
+  pass rather than being remembered as a file that will not read, so a
+  tree-backed count of unreadable files can exceed an index-backed one over the
+  same root by the number of files that would not come back. Every other kind --
+  a file that is not JSON, JSON that is not an object, and JSON that is not a
+  navigation document of the current schema -- is counted alike by both, under
+  the same reason.
 - **Success / failure counts** with a breakdown of failure reasons. The
   reason table carries each reason's status, so errors (SPICE-related or
   not) are visible alongside outright navigation failures.
@@ -152,4 +219,4 @@ The report contains:
   instrument is selected): minimum, maximum, mean, median, standard
   deviation, and total of the per-image wall-clock run times, a run-time
   histogram, and (with ``--top-n``) the slowest images. The section is
-  omitted when no ingested document carries timing data.
+  omitted when no selected image carries timing data.

--- a/plans/RESULTS_DB_PLAN.md
+++ b/plans/RESULTS_DB_PLAN.md
@@ -960,15 +960,16 @@ differ (`json_each` vs `jsonb_array_elements_text`).
 
 It reads through the record seam rather than the database. One pass of
 accumulators over `facts(selection)` answers every section, so the report runs
-over a results tree or an index and needs no database at all; no SQL, no
-connection and no `where_clause` survives in the report modules, whose only
-remaining database reader is the ingest package beside them.
+over a results tree or an index with no query of its own: no SQL, no connection
+and no `where_clause` lives in the report modules. Over a tree that means no
+database is opened at all; over an index it means one is read, through
+`IndexRecordSource`, which is the seam's reader rather than the report's.
 `--nav-results-root` and its ladder name the trees to read; `--root` selects
 among the roots one index holds, and is refused rather than read as a second
 spelling of it. With
 no `--root`, an index-backed report covers the roots whose newest ingest run
 completed rather than every row `images` happens to hold, since under a
-half-ingested root a report reads absence it has no licence to read.
+half-ingested root a report reads absence it has no license to read.
 `images.csv` is written a row at a time and is therefore unsorted, with
 `results_path_stub` as its first column so an operator sorts it in the shell.
 A file that yielded no record is counted and the count is printed whether it
@@ -2411,7 +2412,7 @@ Details settled during execution, none of them a change of intent:
   more than one, naming them: a bare stub does not say which root it belongs to,
   and an index-backed source checks each root's ingest bookkeeping once at
   opening rather than per query.
-- **The prune's licence became a type rather than a check.** One function builds
+- **The prune's license became a type rather than a check.** One function builds
   the listing the prune takes, it builds one only for a root it listed entirely,
   and the listing carries the root it was of -- so a share of a root, a partial
   listing, and a prune of one root on the evidence of another are all
@@ -2445,7 +2446,7 @@ Details settled during execution, none of them a change of intent:
   `nav_records` probe keeps its no-SQLAlchemy half, which is load-bearing, and
   drops its oops half.
 
-Behaviour changes review must see:
+Behavior changes review must see:
 
 - **The kernel writer refuses a root it cannot list whole**, where it used to
   write a short mission and report a clean run. It also refuses a root it cannot
@@ -2503,7 +2504,7 @@ Behaviour changes review must see:
    fails. It matches text, so it cannot tell whether an entry says something
    true about its member; that is what each member's own behavioral test is for.
    Neither carve-out is asserted to be complete: a divergence outside them is a
-   defect of the enumeration, to be fixed or enumerated, and not a licence to
+   defect of the enumeration, to be fixed or enumerated, and not a license to
    differ.
    `sd_stats_report`'s criterion is section 4 Phase 2's old-vs-new
    byte-identical report.

--- a/plans/RESULTS_DB_PLAN.md
+++ b/plans/RESULTS_DB_PLAN.md
@@ -43,10 +43,9 @@ index when it is given.
 - Replacing the JSON documents. They remain the authoritative record. The
   index is derived and disposable; deleting it costs nothing but the time to
   rebuild.
-- Making any pipeline program require a database. Every program except
-  `sd_stats_report` (which has no file-reading mode today and reads only a
-  database by construction) must run correctly with no index at all, and
-  that path stays the default.
+- Making any program require a database. Every program, `sd_stats_report`
+  included, must run correctly with no index at all, and that path stays the
+  default.
 - Writing the index from the navigation pipeline. Navigation writes JSON;
   ingest reads it. Nothing in the navigation path gains a database
   dependency.
@@ -77,9 +76,9 @@ index when it is given.
 A database whose rows are derived from the results tree by a separate ingest
 step. A consumer given `--results-db` answers its questions with SQL instead
 of file reads. A consumer given no such option behaves exactly as it does
-today, reading files. (`sd_stats_report` is the one exception in both
-directions: it reads only a database today and after this work, and it is
-the one program for which the index is not optional.)
+today, reading files. `sd_stats_report` is answered by whichever storage it
+is pointed at: one pass of accumulators over the per-image facts the record
+seam yields, so an index makes the same report cheaper rather than possible.
 
 The index is a **snapshot**. It reflects the tree as of the last ingest over
 the roots it covers. Consumers trust its contents as given: there is no
@@ -131,8 +130,9 @@ simulated dataset) -- and `image_number`, computed by the existing
 `image_number_from_name` logic at ingest time. `results_path_stub` alone
 carries a non-unique index. Every consumer lookup filters on
 `root_url = <its normalized root>`; `sd_stats_report` gains `--root`
-(repeatable, default: all ingested roots), since a report legitimately spans
-roots where a pipeline lookup never does.
+(repeatable, default: every root the index holds a completed ingest of, and
+refused when no index was named to hold it against), since a report
+legitimately spans roots where a pipeline lookup never does.
 
 `images` carries two further non-unique indexes, `image_date` and
 `instrument`, which the statistics report groups and filters on across a whole
@@ -554,13 +554,14 @@ something, and an operator who writes an empty option is not asking for whatever
 the machine exports. It is not silent: the level that carries it is named in a
 warning saying that the value names no index, and how to ask for that on
 purpose. The warning stops there. What follows from having no index is the
-caller's, because one resolver serves `sd_offset`, which then reads files, and
-the two statistics programs, which have no file-reading mode and refuse; a
-warning that stated either would be false for the others and would arrive one
-line before their own message said the opposite. The caller supplies the sink as
-well as the meaning, so a program whose output is terminal text for a person
-prints the line where its other diagnostics go rather than having a run-log line
-routed into its report. Passing it on instead is what an unset variable
+caller's, because one resolver serves the programs that then read the tree --
+`sd_offset` and the report among them -- and `sd_stats_ingest`, which writes an
+index and has nowhere to put its rows without one; a warning that stated either
+meaning would be false for the other, and would arrive one line before their
+own message said the opposite. The caller supplies the sink as well as the
+meaning, so a program whose output is terminal text for a person prints the
+line where its other diagnostics go rather than having a run-log line routed
+into its report. Passing it on instead is what an unset variable
 expanded in a wrapper script produces, and it reaches the URL parser as a name
 that is not there, whose refusal begins with the colon after nothing and stops
 every run on the machine.
@@ -956,6 +957,24 @@ invocations in `docs/user_guide/user_guide_statistics.rst` change with it,
 and that page's "plain SQLite" framing is rewritten around the URL scheme
 with each direct-SQL example shown in both dialect spellings where they
 differ (`json_each` vs `jsonb_array_elements_text`).
+
+It reads through the record seam rather than the database. One pass of
+accumulators over `facts(selection)` answers every section, so the report runs
+over a results tree or an index and needs no database at all; no SQL, no
+connection and no `where_clause` survives in the report modules, whose only
+remaining database reader is the ingest package beside them.
+`--nav-results-root` and its ladder name the trees to read; `--root` selects
+among the roots one index holds, and is refused rather than read as a second
+spelling of it. With
+no `--root`, an index-backed report covers the roots whose newest ingest run
+completed rather than every row `images` happens to hold, since under a
+half-ingested root a report reads absence it has no licence to read.
+`images.csv` is written a row at a time and is therefore unsorted, with
+`results_path_stub` as its first column so an operator sorts it in the shell.
+A file that yielded no record is counted and the count is printed whether it
+is zero or not; it is scoped to the whole of every selected root rather than
+to the selection, because a refused file carries no instrument, date or image
+number for a filter to compare.
 
 **`sd_backplanes`.** Reads `status`, `status_error`, and the top-level
 `offset` for one stub. With an index it reads one row. A stub absent from
@@ -1435,8 +1454,11 @@ record types, the document rules, root identity, `Selection`, the
 `spindoctor/support/nav_document.py` and `spindoctor/cli/stats/ingest/walk.py`
 are gone. What has *not* moved onto the seam is the enumeration
 (`spindoctor/dataset/results_filter.py` still carries its own walk, its own
-parser, its own batching and its own copy of the suffix), the statistics
-report, and the ingest's retrieve-and-parse loop.
+parser, its own batching and its own copy of the suffix) and the ingest's
+retrieve-and-parse loop. The statistics report has moved:
+`spindoctor/cli/stats/report_accumulate.py` fills one set of accumulators from
+`facts(selection)`, and `report.py` and `report_sections.py` format every
+section out of those rather than issuing a statement apiece.
 
 The flattening the second paragraph above describes has moved as well.
 **`spindoctor/nav_records/facts.py`** holds `facts_from_document`, which turns

--- a/src/spindoctor/cli/sd_stats_report.py
+++ b/src/spindoctor/cli/sd_stats_report.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Generate a deterministic statistics report (Markdown + charts).
 
-Dispatch script for the ``sd_stats_report`` console entry point; reads the
-results index written by ``sd_stats_ingest``.  See ``spindoctor.cli.stats``.
+Dispatch script for the ``sd_stats_report`` console entry point; reads a
+navigation results tree, or the results index written by ``sd_stats_ingest``
+where one is named.  See ``spindoctor.cli.stats``.
 
 This program keeps ``print()`` and takes no logging configuration: its output
 *is* terminal text for a person reading a report, and a logger would wrap that

--- a/src/spindoctor/cli/stats/__init__.py
+++ b/src/spindoctor/cli/stats/__init__.py
@@ -1,7 +1,8 @@
 """Navigation statistics system: metadata ingestion and reporting.
 
-Two programs cooperate over the results index, the database that
-:mod:`spindoctor.results_index` defines:
+Two programs, one of which builds the results index that
+:mod:`spindoctor.results_index` defines and one of which reads navigation
+records from wherever they are kept:
 
 - ``sd_stats_ingest`` (:mod:`spindoctor.cli.stats.ingest`, with the column
   mapping in :mod:`spindoctor.nav_records.facts`) walks one or more
@@ -10,21 +11,26 @@ Two programs cooperate over the results index, the database that
   writes one row per image keyed by its root and its results path stub.  A
   document whose recorded size and modification time still match the tree is
   not read again, so a second pass over an unchanged root costs one listing.
-- ``sd_stats_report`` (:mod:`spindoctor.cli.stats.report`, with section
-  builders in :mod:`spindoctor.cli.stats.report_sections` and shared helpers
-  in :mod:`spindoctor.cli.stats.report_common`) queries the index and emits a
-  deterministic report (Markdown text plus PNG charts): success/failure counts
-  with failure reasons, a failure taxonomy by scene content with per-body
-  failure shares, technique and model usage, offset statistics (overall and by
-  instrument/image size), a suspect-offset screen against the configured search
-  limits, Cassini BOTSIM NAC/WAC pair consistency, cross-technique agreement,
-  confidence-tier calibration against observed agreement, and run-time
-  statistics.  Optional drill-down flags list example images per category,
-  write per-category filelists, and export a one-row-per-image CSV.
+- ``sd_stats_report`` (:mod:`spindoctor.cli.stats.report`, with the pass over
+  the records in :mod:`spindoctor.cli.stats.report_accumulate`, the section
+  builders in :mod:`spindoctor.cli.stats.report_sections`, and the shared state
+  and helpers in :mod:`spindoctor.cli.stats.report_common`) reads every record
+  once and emits a deterministic report (Markdown text plus PNG charts):
+  success/failure counts with failure reasons, a failure taxonomy by scene
+  content with per-body failure shares, technique and model usage, offset
+  statistics (overall and by instrument/image size), a suspect-offset screen
+  against the configured search limits, Cassini BOTSIM NAC/WAC pair
+  consistency, cross-technique agreement, confidence-tier calibration against
+  observed agreement, and run-time statistics.  Optional drill-down flags list
+  example images per category, write per-category filelists, and export a
+  one-row-per-image CSV.
 
 Both are cron-friendly single commands and work over any date range and any
 instrument.  Both take the index as a connection URL, so the same pair of
 commands works against a local SQLite file and against a PostgreSQL server.
+The report needs no index: named one, it reads its rows, and named none it
+reads the documents themselves, one file read per image in place of one query
+per run.
 """
 
 from spindoctor.cli.stats.ingest import ingest_metadata_files

--- a/src/spindoctor/cli/stats/report.py
+++ b/src/spindoctor/cli/stats/report.py
@@ -792,7 +792,10 @@ def main_report(cmdline: list[str] | None = None) -> int:
 
     An index is optional here as it is everywhere else.  Named, its rows are
     read; unnamed, the navigation results tree is read, one document per image.
-    Both answer the same seam, so both produce the same report.
+    Both answer the same seam, so over the records both of them can read they
+    produce the same report; the count of files that yielded no record is the
+    one exception, a file the storage could not deliver at all being counted
+    from a tree and not from an index.
 
     Parameters:
         cmdline: Argument list; None uses ``sys.argv``.
@@ -816,6 +819,16 @@ def main_report(cmdline: list[str] | None = None) -> int:
     )
     _add_arguments(parser)
     arguments = parser.parse_args(cmdline)
+    # Checked here, before any storage is opened, so that the one thing a
+    # ValueError out of the pass can still mean is a storage that stopped
+    # answering.  Left to the pass, an unparseable bound and an index that
+    # cannot be read arrive as the same exception at the same place, and the
+    # exit code the caller reads then says usage error for both.
+    try:
+        _image_bound(arguments.min_image, option='--min-image')
+        _image_bound(arguments.max_image, option='--max-image')
+    except ValueError as exc:
+        parser.error(str(exc))
 
     url = get_results_db_url(arguments, DEFAULT_CONFIG, warn=_to_stderr)
     if url is None:
@@ -866,7 +879,7 @@ def _report_from_an_index(
 
     The roots read are the roots the index holds a completed ingest of, and no
     others.  Under a half-ingested root the absence of a row says nothing, so a
-    report that counted one would be reading absence it has no licence to read.
+    report that counted one would be reading absence it has no license to read.
 
     Parameters:
         url: Connection URL of the results index.
@@ -874,7 +887,9 @@ def _report_from_an_index(
         parser: The parser, for the refusals it reports as usage errors.
 
     Returns:
-        Process exit code.
+        Process exit code: 0 on success, and 1 when the index cannot be opened,
+        when it holds no completed ingest of any root, or when it stops
+        answering while the pass streams from it.
 
     Raises:
         SystemExit: With status 2, from the parser, for a ``--root`` that is not
@@ -921,7 +936,11 @@ def _report_from_an_index(
         with IndexRecordSource(engine, held, url, ()) as source:
             report_path = _report_written_from(source, arguments, covered, dropped)
     except ValueError as exc:
-        parser.error(str(exc))
+        # The stream issues its queries while the pass reads them, so an index
+        # that stops answering fails here rather than where it was opened.  That
+        # is a run that failed on what it found, not a command line to reject.
+        print(f'Cannot read the results index: {exc}', file=sys.stderr)
+        return 1
     print(f'Wrote {report_path}')
     return 0
 
@@ -939,8 +958,9 @@ def _report_over_a_tree(arguments: argparse.Namespace, parser: argparse.Argument
         parser: The parser, for the refusals it reports as usage errors.
 
     Returns:
-        Process exit code: 0 on success, and 1 when a root cannot be resolved or
-        cannot be read whole.
+        Process exit code: 0 on success, and 1 when no root can be resolved, or
+        when a root cannot be read whole -- one that cannot be listed, and one
+        that stops answering while the pass reads it.
 
     Raises:
         SystemExit: With status 2, from the parser, for a command line that names
@@ -974,12 +994,12 @@ def _report_over_a_tree(arguments: argparse.Namespace, parser: argparse.Argument
     try:
         with TreeRecordSource(roots) as source:
             report_path = _report_written_from(source, arguments, ())
-    except UnlistableDirectoryError as exc:
+    except (UnlistableDirectoryError, ValueError) as exc:
         # A root the walk could not read whole is a report that would cover less
-        # than the tree and say nothing about it.
+        # than the tree and say nothing about it, and a tree that stops answering
+        # part way through is the same report.  Both are runs that failed on what
+        # they found rather than command lines to reject.
         print(f'Cannot read the navigation results tree: {exc}', file=sys.stderr)
         return 1
-    except ValueError as exc:
-        parser.error(str(exc))
     print(f'Wrote {report_path}')
     return 0

--- a/src/spindoctor/cli/stats/report.py
+++ b/src/spindoctor/cli/stats/report.py
@@ -1,117 +1,92 @@
-"""Generate a deterministic statistics report (Markdown + charts) from the index.
+"""Generate a deterministic statistics report (Markdown + charts) from the records.
 
-The report is the one program for which the results index is not optional: it
-has never had a file-reading mode, and it answers every question with a query.
-Its output is deterministic -- the same index and the same options always
-produce byte-identical Markdown -- so a difference between two runs is a
-difference in the data or a defect, never noise.
+One pass over the record seam answers every section.  The pass reads a results
+tree or an ingested results index -- whichever the run was pointed at -- and
+fills the accumulators in :mod:`spindoctor.cli.stats.report_accumulate`; the
+sections here and in :mod:`spindoctor.cli.stats.report_sections` then turn those
+into text.  A results index makes the pass cheaper and is required by none of
+it.
 
-Every statement runs on either backend.  The reason tables read
-``COALESCE(status_reason, status_error)``, because the two are separate columns
-holding separate vocabularies and a failure is described by whichever of them
-the document carried; the boolean columns are used as booleans rather than as
-zeroes and ones; and every join onto ``images`` matches the pair that keys an
-image rather than its name, which two volumes may share.
+The output is deterministic: the same records and the same options always
+produce byte-identical Markdown, whichever storage answered, so a difference
+between two runs is a difference in the data or a defect and never noise.  That
+holds without the stream being ordered, because every section either counts,
+reduces to a minimum, or sorts what it prints on a key that includes the pair
+that identifies an image -- an image name alone is not unique across roots.
 """
 
 import argparse
-import itertools
-import json
-import math
 import statistics
 import sys
+from array import array
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
 
-import sqlalchemy
 from filecache import FCPath
 
+from spindoctor.cli.stats.report_accumulate import RangeFilters, accumulate_statistics
 from spindoctor.cli.stats.report_common import (
-    IMAGE_JOIN,
     ReportContext,
+    ReportStatistics,
     add_drilldown,
     add_instrument_count_table,
-    connector,
     count_pct,
     fmt,
     image_name_from_filename,
-    image_order,
     offset_stats,
     percentile,
-    rows,
     safe_filename,
-    where_clause,
     write_offset_hist,
     write_stacked_bar_chart,
 )
 from spindoctor.cli.stats.report_sections import (
+    CsvExport,
     add_botsim_section,
+    add_csv_export_section,
     add_failure_taxonomy_section,
+    add_narrowing_section,
     add_offset_by_group_section,
     add_runtime_section,
     add_suspect_offset_section,
-    write_csv_export,
 )
-from spindoctor.config import DEFAULT_CONFIG, get_results_db_url
-from spindoctor.nav_records.derived import datetime_from_image_et, image_number_from_name
-from spindoctor.results_index import normalize_root_url, open_index, require_ingested_roots
+from spindoctor.config import DEFAULT_CONFIG, get_nav_results_root, get_results_db_url
+from spindoctor.nav_records import (
+    RecordSource,
+    Selection,
+    TreeRecordSource,
+    UnlistableDirectoryError,
+    datetime_from_image_et,
+    distinct_roots,
+    image_number_from_name,
+)
+from spindoctor.results_index import (
+    IndexRecordSource,
+    RootNotIngestedError,
+    ingested_roots,
+    normalize_root_url,
+    open_index_for_roots,
+    unfinished_roots,
+)
 
 __all__ = ['build_report', 'main_report']
-
-# Which of the two reason vocabularies describes a non-success outcome depends
-# on how the navigation ended: the navigator's own explanation when it ran, and
-# the fatal error when it never got that far.  They are separate columns, and a
-# report of failure reasons wants whichever one the document carried.
-FAILURE_REASON = 'COALESCE({alias}status_reason, {alias}status_error)'
 
 # Confidence tiers, in descending-confidence order, always reported.
 _CONFIDENCE_TIERS: tuple[str, ...] = ('high', 'medium', 'low', 'failed', 'conflicted')
 
+_NO_RECORD_PROSE = """\
+A file named like a navigation document that no record could be read out of is counted here and
+nowhere else: it records no instrument, no date and no image number, so this count covers the whole
+of every selected root and none of the filters above narrows it. One kind of such file is counted
+by a report over the documents and by no report from an index: one the storage could not deliver at
+all. An ingest records no refusal for that, because a retrieval that failed once is worth trying
+again rather than being remembered as a file that will not read."""
+"""The paragraph that explains what the count of unreadable files covers.
 
-def _pairwise_disagreements(
-    ctx: ReportContext,
-) -> tuple[dict[tuple[str, str, str], list[float]], dict[tuple[str, str], list[float]]]:
-    """Cross-technique agreement data.
-
-    Returns:
-        ``(per_pair, per_image_rank)`` where ``per_pair`` maps an
-        ``(instrument, technique_a, technique_b)`` triple (the technique
-        names sorted) to the Euclidean distances between those techniques'
-        offsets on images where both produced non-spurious results, and
-        ``per_image_rank`` maps an ``(instrument, confidence_rank)`` pair
-        to each such image's maximum pairwise disagreement.  Images with a
-        NULL ``confidence_rank`` contribute to ``per_pair`` but not to
-        ``per_image_rank``.
-    """
-    sql = (
-        'SELECT t.root_url, t.results_path_stub, i.instrument, i.confidence_rank, '
-        't.technique_name, t.offset_dv, t.offset_du '
-        'FROM techniques t '
-        + IMAGE_JOIN.format(alias='t.')
-        + ctx.where_i
-        + connector(ctx.where_i)
-        + 'NOT t.spurious AND t.offset_dv IS NOT NULL AND t.offset_du IS NOT NULL '
-        'ORDER BY t.root_url, t.results_path_stub, t.technique_name'
-    )
-    per_pair: dict[tuple[str, str, str], list[float]] = {}
-    per_image_rank: dict[tuple[str, str], list[float]] = {}
-    for _image, group in itertools.groupby(
-        rows(ctx.connection, sql, ctx.params_i), key=lambda r: (r[0], r[1])
-    ):
-        entries = list(group)
-        if len(entries) < 2:
-            continue
-        instrument = str(entries[0][2])
-        rank = entries[0][3]
-        image_max = 0.0
-        for a, b in itertools.combinations(entries, 2):
-            delta = math.hypot(a[5] - b[5], a[6] - b[6])
-            pair = (instrument, min(a[4], b[4]), max(a[4], b[4]))
-            per_pair.setdefault(pair, []).append(delta)
-            image_max = max(image_max, delta)
-        if rank is not None:
-            per_image_rank.setdefault((instrument, str(rank)), []).append(image_max)
-    return per_pair, per_image_rank
+Written with the wrapping it is printed with, and holding no number, so that the
+prose of the section is a constant.  The count is a line of its own after it,
+which keeps the width of every line here independent of how many digits the
+count runs to.
+"""
 
 
 def _extreme_image_name(ctx: ReportContext, instrument: str, *, last: bool) -> str:
@@ -126,18 +101,11 @@ def _extreme_image_name(ctx: ReportContext, instrument: str, *, last: bool) -> s
         The image name, or ``'-'`` when the instrument has no selected
         image whose name contains a number.
     """
-    order = 'DESC' if last else 'ASC'
-    found = rows(
-        ctx.connection,
-        f'SELECT image_name FROM images{ctx.where}'
-        + connector(ctx.where)
-        + 'instrument = :for_instrument AND image_number IS NOT NULL '
-        f'ORDER BY image_number {order}, {image_order()} LIMIT 1',
-        {**ctx.params, 'for_instrument': instrument},
-    )
-    if len(found) == 0:
+    held = ctx.stats.last_image if last else ctx.stats.first_image
+    found = held.get(instrument)
+    if found is None:
         return '-'
-    return image_name_from_filename(instrument, str(found[0][0]))
+    return image_name_from_filename(instrument, found[1])
 
 
 def _extreme_times(ctx: ReportContext, instrument: str) -> tuple[str, str]:
@@ -156,18 +124,9 @@ def _extreme_times(ctx: ReportContext, instrument: str) -> tuple[str, str]:
         ``(first, last)`` UTC timestamps to the second, each ``'-'`` when
         no selected image of that instrument has an epoch.
     """
-    found = rows(
-        ctx.connection,
-        f'SELECT MIN(image_et), MAX(image_et) FROM images{ctx.where}'
-        + connector(ctx.where)
-        + 'instrument = :for_instrument AND image_et IS NOT NULL',
-        {**ctx.params, 'for_instrument': instrument},
-    )
-    if len(found) == 0:
-        return '-', '-'
     return (
-        datetime_from_image_et(found[0][0]) or '-',
-        datetime_from_image_et(found[0][1]) or '-',
+        datetime_from_image_et(ctx.stats.first_et.get(instrument)) or '-',
+        datetime_from_image_et(ctx.stats.last_et.get(instrument)) or '-',
     )
 
 
@@ -178,6 +137,9 @@ def _add_selection_section(ctx: ReportContext) -> None:
     and last image are reported per instrument and never pooled.  The image
     and time bounds are found independently, so the first image is not
     necessarily the one at the first available time.
+
+    Parameters:
+        ctx: Report context.
     """
     ctx.lines += ['## Images selected', '']
     if ctx.total_images == 0:
@@ -199,17 +161,34 @@ def _add_selection_section(ctx: ReportContext) -> None:
     ctx.lines += ['', f'Total images: {ctx.total_images}', '']
 
 
+def _add_unreadable_files_section(ctx: ReportContext) -> None:
+    """Append how many files under the selected roots yielded no record.
+
+    Printed whether the count is zero or not.  A line that disappeared at zero
+    could not be told apart by a reader from a report that never looked, and a
+    summary that quietly covered less than the tree is worse than one that says
+    how much less.
+
+    Parameters:
+        ctx: Report context.
+    """
+    ctx.lines += [
+        '## Files that yielded no record',
+        '',
+        *_NO_RECORD_PROSE.splitlines(),
+        '',
+        f'Files that yielded no record: {ctx.stats.unreadable_files}',
+        '',
+    ]
+
+
 def _add_status_sections(ctx: ReportContext) -> None:
-    """Append the success/failure counts and the failure-reason breakdown."""
-    status_rows = rows(
-        ctx.connection,
-        f'SELECT status, instrument, COUNT(*) FROM images{ctx.where} '
-        'GROUP BY status, instrument ORDER BY status, instrument',
-        ctx.params,
-    )
-    by_status: dict[str, dict[str, int]] = {}
-    for status, instrument, count in status_rows:
-        by_status.setdefault(str(status), {})[str(instrument)] = int(count)
+    """Append the success/failure counts and the failure-reason breakdown.
+
+    Parameters:
+        ctx: Report context.
+    """
+    by_status = ctx.stats.status_counts
     statuses = sorted(by_status, key=lambda name: (name != 'success', name))
     ctx.lines += ['## Success / failure', '']
     add_instrument_count_table(
@@ -229,23 +208,10 @@ def _add_status_sections(ctx: ReportContext) -> None:
     ctx.lines += ['![status](status_counts.png)', '']
 
     # Every non-success status is a failure for reporting purposes, so
-    # `error` rows (SPICE and otherwise) appear here alongside `failed`.
-    reason_column = FAILURE_REASON.format(alias='')
-    reason_rows = rows(
-        ctx.connection,
-        f'SELECT status, {reason_column}, instrument, COUNT(*) FROM images{ctx.where}'
-        + connector(ctx.where)
-        + f"status != 'success' GROUP BY status, {reason_column}, instrument "
-        f'ORDER BY status, {reason_column}, instrument',
-        ctx.params,
-    )
-    if len(reason_rows) == 0:
+    # `error` images (SPICE and otherwise) appear here alongside `failed`.
+    by_reason = ctx.stats.reason_counts
+    if len(by_reason) == 0:
         return
-    by_reason: dict[tuple[str, str], dict[str, int]] = {}
-    for status, reason, instrument, count in reason_rows:
-        by_reason.setdefault((str(status), str(reason or '(none)')), {})[str(instrument)] = int(
-            count
-        )
     ordered = sorted(by_reason, key=lambda key: (-sum(by_reason[key].values()), key))
     ctx.lines += ['### Failure reasons', '']
     add_instrument_count_table(
@@ -253,18 +219,7 @@ def _add_status_sections(ctx: ReportContext) -> None:
         [([status, reason], by_reason[(status, reason)]) for status, reason in ordered],
         headers=['status', 'reason'],
     )
-    name_rows = rows(
-        ctx.connection,
-        f'SELECT {reason_column}, instrument, image_name FROM images{ctx.where}'
-        + connector(ctx.where)
-        + f"status != 'success' ORDER BY {image_order()}",
-        ctx.params,
-    )
-    names_by_reason: dict[str, list[tuple[str, str]]] = {}
-    for reason, instrument, image_name in name_rows:
-        names_by_reason.setdefault(str(reason or '(none)'), []).append(
-            (str(instrument), str(image_name))
-        )
+    names_by_reason = ctx.stats.failure_names
     add_drilldown(
         ctx,
         [
@@ -290,27 +245,21 @@ def _add_status_sections(ctx: ReportContext) -> None:
 
 
 def _add_technique_usage_section(ctx: ReportContext) -> None:
-    """Append per-technique image counts, spurious shares, and mean confidence."""
-    # One row per technique per image is a constraint of the schema, so counting
-    # rows counts images, and no count of distinct column pairs is needed.
-    tech_rows = rows(
-        ctx.connection,
-        'SELECT t.technique_name, i.instrument, COUNT(*), '
-        'SUM(CASE WHEN t.spurious THEN 0 ELSE 1 END), AVG(t.confidence) '
-        'FROM techniques t '
-        + IMAGE_JOIN.format(alias='t.')
-        + ctx.where_i
-        + ' GROUP BY t.technique_name, i.instrument '
-        'ORDER BY t.technique_name, i.instrument',
-        ctx.params_i,
-    )
-    if len(tech_rows) == 0:
+    """Append per-technique image counts, spurious shares, and mean confidence.
+
+    The mean is taken over the retained confidences with an exact sum, so it is
+    the same number whatever order the records reached the pass in.
+
+    Parameters:
+        ctx: Report context.
+    """
+    stats = ctx.stats
+    if len(stats.technique_images) == 0:
         return
+    empty: array[float] = array('d')
     images: dict[str, dict[str, int]] = {}
-    detail: dict[tuple[str, str], tuple[int, int, float | None]] = {}
-    for name, instrument, n_images, n_good, mean_conf in tech_rows:
-        images.setdefault(str(name), {})[str(instrument)] = int(n_images)
-        detail[(str(name), str(instrument))] = (int(n_images), int(n_good), mean_conf)
+    for (name, instrument), count in stats.technique_images.items():
+        images.setdefault(name, {})[instrument] = count
     techniques = sorted(images, key=lambda name: (-sum(images[name].values()), name))
     ctx.lines += ['## Technique usage', '', 'Images on which each technique ran.', '']
     add_instrument_count_table(
@@ -324,10 +273,14 @@ def _add_technique_usage_section(ctx: ReportContext) -> None:
     ]
     for name in techniques:
         for instrument in ctx.instruments:
-            entry = detail.get((name, instrument))
-            if entry is None:
+            n_images = stats.technique_images.get((name, instrument))
+            if n_images is None:
                 continue
-            n_images, n_good, mean_conf = entry
+            n_good = stats.technique_good.get((name, instrument), 0)
+            # Only the entries that recorded a confidence are in the population,
+            # and a group where none did prints a dash rather than a zero.
+            reported = stats.technique_confidence.get((name, instrument), empty)
+            mean_conf = statistics.fmean(reported) if len(reported) > 0 else None
             images_cell = count_pct(n_images, ctx.images_by_instrument[instrument])
             ctx.lines.append(
                 f'| {name} | {instrument} | {images_cell} '
@@ -349,32 +302,17 @@ def _add_technique_usage_section(ctx: ReportContext) -> None:
 
 
 def _add_source_usage_section(ctx: ReportContext) -> None:
-    """Append the per-model / per-source feature-usage tables."""
-    # An image can hold several feature types from one source, so the inner
-    # query collapses each image to one row per source before the outer one
-    # counts images.  Counting distinct values of the column pair that keys an
-    # image would need a spelling no backend shares.
-    source_rows = rows(
-        ctx.connection,
-        'SELECT source_model, source_name, instrument, COUNT(*), '
-        'SUM(n_features), SUM(n_gated) FROM ('
-        'SELECT s.source_model, s.source_name, i.instrument, s.root_url, s.results_path_stub, '
-        'SUM(s.n_features) AS n_features, SUM(s.n_gated) AS n_gated '
-        'FROM feature_sources s '
-        + IMAGE_JOIN.format(alias='s.')
-        + ctx.where_i
-        + ' GROUP BY s.source_model, s.source_name, i.instrument, s.root_url, s.results_path_stub'
-        ') per_image GROUP BY source_model, source_name, instrument '
-        'ORDER BY source_model, source_name, instrument',
-        ctx.params_i,
-    )
-    if len(source_rows) == 0:
+    """Append the per-model / per-source feature-usage tables.
+
+    Parameters:
+        ctx: Report context.
+    """
+    stats = ctx.stats
+    if len(stats.source_images) == 0:
         return
     images: dict[tuple[str, str], dict[str, int]] = {}
-    features: dict[tuple[str, str, str], tuple[int, int]] = {}
-    for model, name, instrument, n_images, n_features, n_gated in source_rows:
-        images.setdefault((str(model), str(name)), {})[str(instrument)] = int(n_images)
-        features[(str(model), str(name), str(instrument))] = (int(n_features), int(n_gated))
+    for (model, name, instrument), count in stats.source_images.items():
+        images.setdefault((model, name), {})[instrument] = count
     sources = sorted(images, key=lambda key: (key[0], -sum(images[key].values()), key[1]))
     ctx.lines += ['## Model and source usage', '', 'Images in which each source appears.', '']
     add_instrument_count_table(
@@ -390,11 +328,34 @@ def _add_source_usage_section(ctx: ReportContext) -> None:
     ]
     for model, name in sources:
         for instrument in ctx.instruments:
-            entry = features.get((model, name, instrument))
+            entry = stats.source_features.get((model, name, instrument))
             if entry is None:
                 continue
             ctx.lines.append(f'| {model} | {name} | {instrument} | {entry[0]} | {entry[1]} |')
     ctx.lines.append('')
+
+
+def _pooled_offsets(ctx: ReportContext) -> dict[tuple[str, str], tuple[array[float], array[float]]]:
+    """The fused offsets of the successful images, by instrument and camera.
+
+    The pass keys them by image size as well, because the finer breakdown needs
+    that; this pools over the sizes rather than the pass keeping a second copy
+    of every value.
+
+    Parameters:
+        ctx: Report context.
+
+    Returns:
+        Per ``(instrument, camera)``, the V-axis and U-axis offsets.
+    """
+    pooled: dict[tuple[str, str], tuple[array[float], array[float]]] = {}
+    for key in sorted(ctx.stats.offsets):
+        instrument, camera, _size = key
+        values = ctx.stats.offsets[key]
+        entry = pooled.setdefault((instrument, camera), (array('d'), array('d')))
+        entry[0].extend(values[0])
+        entry[1].extend(values[1])
+    return pooled
 
 
 def _add_offset_section(ctx: ReportContext) -> None:
@@ -404,20 +365,11 @@ def _add_offset_section(ctx: ReportContext) -> None:
     the distributions are grouped by ``(instrument, camera)`` and never
     pooled (a Cassini NAC pixel is a tenth of a WAC pixel, so pooling the
     two would describe neither).
+
+    Parameters:
+        ctx: Report context.
     """
-    offset_rows = rows(
-        ctx.connection,
-        f'SELECT instrument, camera, offset_dv, offset_du FROM images{ctx.where}'
-        + connector(ctx.where)
-        + "status = 'success' AND offset_dv IS NOT NULL AND offset_du IS NOT NULL "
-        'ORDER BY instrument, camera',
-        ctx.params,
-    )
-    by_camera: dict[tuple[str, str], tuple[list[float], list[float]]] = {}
-    for instrument, camera, dv, du in offset_rows:
-        entry = by_camera.setdefault((str(instrument), str(camera or '(unknown)')), ([], []))
-        entry[0].append(float(dv))
-        entry[1].append(float(du))
+    by_camera = _pooled_offsets(ctx)
     ctx.lines += [
         '## Offset statistics (successful images)',
         '',
@@ -456,8 +408,13 @@ def _add_offset_section(ctx: ReportContext) -> None:
 
 
 def _add_agreement_sections(ctx: ReportContext) -> None:
-    """Append the cross-technique agreement and confidence-calibration tables."""
-    per_pair, per_image_rank = _pairwise_disagreements(ctx)
+    """Append the cross-technique agreement and confidence-calibration tables.
+
+    Parameters:
+        ctx: Report context.
+    """
+    per_pair = ctx.stats.pair_deltas
+    per_image_rank = ctx.stats.rank_disagreement
     ctx.lines += [
         '## Cross-technique agreement',
         '',
@@ -476,20 +433,12 @@ def _add_agreement_sections(ctx: ReportContext) -> None:
         )
     ctx.lines.append('')
 
-    rank_rows = rows(
-        ctx.connection,
-        f'SELECT confidence_rank, instrument, COUNT(*) FROM images{ctx.where}'
-        + connector(ctx.where)
-        + 'confidence_rank IS NOT NULL GROUP BY confidence_rank, instrument '
-        'ORDER BY confidence_rank, instrument',
-        ctx.params,
-    )
     by_tier: dict[str, dict[str, int]] = {tier: {} for tier in _CONFIDENCE_TIERS}
-    for rank, instrument, count in rank_rows:
-        by_tier.setdefault(str(rank), {})[str(instrument)] = int(count)
+    for tier, counts in ctx.stats.tier_counts.items():
+        by_tier.setdefault(tier, {}).update(counts)
     # The standard tiers always appear, in tier order, so an empty tier reads
-    # as a real zero rather than a missing row.  Any unrecognized rank from
-    # the database is listed after them rather than dropped.
+    # as a real zero rather than a missing row.  Any unrecognized rank the
+    # records carry is listed after them rather than dropped.
     tiers = [*_CONFIDENCE_TIERS, *sorted(set(by_tier) - set(_CONFIDENCE_TIERS))]
     ctx.lines += [
         '## Confidence calibration (agreement as accuracy proxy)',
@@ -506,10 +455,11 @@ def _add_agreement_sections(ctx: ReportContext) -> None:
         '| p95 (px) |',
         '|---|---|---|---|---|---|',
     ]
+    empty: array[float] = array('d')
     for tier in tiers:
         for instrument in ctx.instruments:
             count = by_tier[tier].get(instrument, 0)
-            disagreements = per_image_rank.get((instrument, tier), [])
+            disagreements = per_image_rank.get((instrument, tier), empty)
             ctx.lines.append(
                 f'| {tier} | {instrument} '
                 f'| {count_pct(count, ctx.images_by_instrument[instrument])} '
@@ -523,7 +473,7 @@ def _add_agreement_sections(ctx: ReportContext) -> None:
             ctx.output_dir / 'agreement_by_tier.png',
             tiers,
             {
-                instrument: [len(per_image_rank.get((instrument, tier), [])) for tier in tiers]
+                instrument: [len(per_image_rank.get((instrument, tier), empty)) for tier in tiers]
                 for instrument in ctx.instruments
             },
             ctx.instruments,
@@ -533,65 +483,15 @@ def _add_agreement_sections(ctx: ReportContext) -> None:
         ctx.lines += ['![agreement by tier](agreement_by_tier.png)', '']
 
 
-def _excluded_techniques(excluded: Any) -> list[str]:
-    """The technique names one image's exclusion column holds.
-
-    A textual statement carries no column types, so a JSON column arrives as
-    whatever the driver makes of it: decoded by a backend with a native JSON
-    type, and as the stored text by one that keeps JSON in a text column.
-
-    Parameters:
-        excluded: The value as the driver returned it.
-
-    Returns:
-        The names, or an empty list when the column is empty or unreadable.
-    """
-    value = excluded
-    if isinstance(value, str):
-        try:
-            value = json.loads(value)
-        except json.JSONDecodeError:
-            return []
-    if not isinstance(value, list):
-        return []
-    return [str(name) for name in value]
-
-
 def _add_exclusions_section(ctx: ReportContext) -> None:
     """Append the ensemble outlier-exclusion breakdown.
 
-    The exclusion set is a JSON column, and the empty set is filtered out here
-    rather than in SQL: comparing a JSON value against a literal is spelled
-    differently on every backend, and the rows are already being read.
-
-    The names are sorted before they are joined into the label this section
-    groups on.  The column holds them in whatever order the document recorded
-    them, so two images that excluded the same techniques in two orders would
-    otherwise be counted as two different exclusion sets; what this section
-    counts is the set, and a label built from it has to name the same set the
-    same way.
+    Parameters:
+        ctx: Report context.
     """
-    excluded_rows = rows(
-        ctx.connection,
-        f'SELECT excluded_from_consensus, instrument, image_name FROM images{ctx.where}'
-        + connector(ctx.where)
-        + f'excluded_from_consensus IS NOT NULL ORDER BY {image_order()}',
-        ctx.params,
-    )
-    labelled = [
-        (', '.join(sorted(names)), str(instrument), str(image_name))
-        for excluded, instrument, image_name in excluded_rows
-        for names in [_excluded_techniques(excluded)]
-        if len(names) > 0
-    ]
-    if len(labelled) == 0:
+    by_exclusion = ctx.stats.exclusion_counts
+    if len(by_exclusion) == 0:
         return
-    by_exclusion: dict[str, dict[str, int]] = {}
-    names_by_exclusion: dict[str, list[tuple[str, str]]] = {}
-    for label, instrument, image_name in labelled:
-        counts = by_exclusion.setdefault(label, {})
-        counts[instrument] = counts.get(instrument, 0) + 1
-        names_by_exclusion.setdefault(label, []).append((instrument, image_name))
     ordered = sorted(by_exclusion, key=lambda key: (-sum(by_exclusion[key].values()), key))
     ctx.lines += ['## Ensemble outlier exclusions', '']
     add_instrument_count_table(
@@ -601,7 +501,7 @@ def _add_exclusions_section(ctx: ReportContext) -> None:
     )
     add_drilldown(
         ctx,
-        [(label, names_by_exclusion.get(label, [])) for label in ordered],
+        [(label, ctx.stats.exclusion_names.get(label, [])) for label in ordered],
         label='exclusion set',
         stub_prefix='excluded',
     )
@@ -629,7 +529,7 @@ def _image_bound(value: str | None, *, option: str) -> int | None:
 
 
 def build_report(
-    connection: sqlalchemy.Connection,
+    source: RecordSource,
     output_dir: str | Path | FCPath,
     *,
     instrument: str | None = None,
@@ -637,19 +537,24 @@ def build_report(
     end_date: str | None = None,
     min_image: str | None = None,
     max_image: str | None = None,
-    roots: list[str] | None = None,
+    roots: Sequence[str] = (),
+    dropped_roots: Sequence[str] = (),
     top_n: int = 0,
     filelists: bool = False,
     suspect_fraction: float = 0.9,
     csv_export: bool = False,
 ) -> FCPath:
-    """Query the results index and write ``report.md`` plus charts.
+    """Read every record once and write ``report.md`` plus charts.
 
-    The report is deterministic: the same index and options always produce
-    byte-identical Markdown.  All filters combine and apply to every section.
+    The report is deterministic: the same records and options always produce
+    byte-identical Markdown.  All filters combine and apply to every section,
+    with one stated exception -- the count of files that yielded no record is of
+    the whole of every selected root, because such a file records no instrument,
+    date or image number for a filter to compare.
 
     Parameters:
-        connection: Open connection to the results index.
+        source: The record source to read, over a results tree or over an
+            ingested results index.
         output_dir: Directory receiving ``report.md``, the PNG charts, and
             (with ``filelists`` / ``csv_export``) the ``filelists/``
             subdirectory and ``images.csv`` (created if missing).  A local
@@ -663,9 +568,17 @@ def build_report(
             number.
         max_image: Optional inclusive upper bound on the numeric portion
             of the image name.
-        roots: Optional normalized results-root URLs to restrict to; None
-            reports over every root the index holds, which a report may
-            legitimately do where a per-image lookup never does.
+        roots: Optional normalized results-root URLs to restrict to, of the
+            roots the source holds; empty reports over every one of them, which
+            a report may legitimately do where a per-image lookup never does.
+            Named in the report as the restriction they are.
+        dropped_roots: Roots the caller was pointed at and could not bind the
+            source to, which the report names as roots it covers nothing of.  A
+            root with no completed ingest is one of these: nothing under it is
+            reported, its files that yielded no record included, because a
+            half-covered root is worse than an uncovered one.  A caller passing
+            any of these passes the roots it did cover as ``roots``, so that the
+            report says what it covered as well as what it did not.
         top_n: When positive, categorical sections list up to this many
             example image names per category, the suspect-offset and
             worst-BOTSIM-pair tables are capped at this many rows, and the
@@ -677,60 +590,63 @@ def build_report(
             pointing offset at or beyond which a fused offset is flagged
             as suspect.
         csv_export: When True, write the flattened one-row-per-image
-            ``images.csv`` next to ``report.md``.
+            ``images.csv`` next to ``report.md``, one row per image as the pass
+            reads it.
 
     Returns:
         The path of the written ``report.md``.
 
     Raises:
-        ValueError: If ``min_image`` or ``max_image`` contains no digits.
+        ValueError: If ``min_image`` or ``max_image`` contains no digits, or if
+            the source cannot honour the selection or cannot be read.
+        UnlistableDirectoryError: If a selected root, or a directory under one,
+            could not be listed.
     """
     output_path = FCPath(output_dir)
     min_image_num = _image_bound(min_image, option='min_image')
     max_image_num = _image_bound(max_image, option='max_image')
-    where, params = where_clause(
-        instrument=instrument,
+    selection = Selection(roots=tuple(roots), instrument=instrument)
+    filters = RangeFilters(
         start_date=start_date,
         end_date=end_date,
         min_image_num=min_image_num,
         max_image_num=max_image_num,
-        roots=roots,
     )
-    # Joined queries alias the images table as ``i``; same filter, qualified.
-    where_i, params_i = where_clause(
-        instrument=instrument,
-        start_date=start_date,
-        end_date=end_date,
-        min_image_num=min_image_num,
-        max_image_num=max_image_num,
-        roots=roots,
-        alias='i.',
+    stats = ReportStatistics(
+        top_n=top_n,
+        retain_names=top_n > 0 or filelists,
+        suspect_fraction=suspect_fraction,
     )
+    if csv_export:
+        with CsvExport(output_path / 'images.csv') as export:
+            accumulate_statistics(source, selection, stats, filters=filters, csv_export=export)
+    else:
+        accumulate_statistics(source, selection, stats, filters=filters)
+
     ctx = ReportContext(
-        connection=connection,
         output_dir=output_path,
-        where=where,
-        params=params,
-        where_i=where_i,
-        params_i=params_i,
+        stats=stats,
         top_n=top_n,
         filelists=filelists,
         suspect_fraction=suspect_fraction,
     )
     ctx.lines += ['# Navigation statistics report', '']
-    filters = [
-        f'instrument = {instrument}' if instrument is not None else None,
-        f'from {start_date}' if start_date is not None else None,
-        f'to {end_date}' if end_date is not None else None,
-        f'image number >= {min_image_num}' if min_image_num is not None else None,
-        f'image number <= {max_image_num}' if max_image_num is not None else None,
-        f'root in {", ".join(roots)}' if roots else None,
+    active = [
+        text
+        for text in (
+            f'instrument = {instrument}' if instrument is not None else None,
+            f'from {start_date}' if start_date is not None else None,
+            f'to {end_date}' if end_date is not None else None,
+            f'image number >= {min_image_num}' if min_image_num is not None else None,
+            f'image number <= {max_image_num}' if max_image_num is not None else None,
+            f'root in {", ".join(roots)}' if roots else None,
+        )
+        if text is not None
     ]
-    active = [f for f in filters if f is not None]
-    ctx.lines.append(f'Filters: {", ".join(active) if len(active) > 0 else "none (full database)"}')
-    ctx.lines.append('')
+    add_narrowing_section(ctx, filters=active, dropped_roots=dropped_roots)
 
     _add_selection_section(ctx)
+    _add_unreadable_files_section(ctx)
     _add_status_sections(ctx)
     add_failure_taxonomy_section(ctx)
     _add_technique_usage_section(ctx)
@@ -743,7 +659,7 @@ def build_report(
     _add_exclusions_section(ctx)
     add_runtime_section(ctx)
     if csv_export:
-        write_csv_export(ctx)
+        add_csv_export_section(ctx)
 
     report_path = output_path / 'report.md'
     report_path.write_text('\n'.join(ctx.lines) + '\n', encoding='utf-8')
@@ -763,30 +679,12 @@ def _to_stderr(message: str) -> None:
     print(message, file=sys.stderr)
 
 
-def main_report(cmdline: list[str] | None = None) -> int:
-    """Entry point for ``sd_stats_report``.
-
-    This program keeps ``print()`` rather than a logger.  Its output *is*
-    terminal text for a person reading a report, and a logger would wrap that
-    in run-log machinery it has no use for.
+def _add_arguments(parser: argparse.ArgumentParser) -> None:
+    """Declare every option this program accepts.
 
     Parameters:
-        cmdline: Argument list; None uses ``sys.argv``.
-
-    Returns:
-        Process exit code: 0 on success, and 1 when no index was named or the
-        one that was cannot be read.
-
-    Raises:
-        SystemExit: With status 2, from the argument parser, for a command line
-            it will not accept -- an unknown flag, an unparseable bound, a root
-            that is not a location that can be read, or a root the index holds no
-            completed ingest of, the last of which is a value the index rather
-            than the parser rejects but is reported the same way.
+        parser: The parser to declare them on.
     """
-    parser = argparse.ArgumentParser(
-        description='Generate a navigation statistics report from an ingested results index.'
-    )
     parser.add_argument(
         '--results-db',
         default=None,
@@ -794,7 +692,21 @@ def main_report(cmdline: list[str] | None = None) -> int:
         help='Connection URL of the results index written by sd_stats_ingest '
         '(a sqlite: URL naming a local path, or a postgresql+psycopg: URL); '
         'overrides the environment.results_db configuration variable and '
-        'NAV_RESULTS_DB',
+        'NAV_RESULTS_DB. Without one the navigation results tree is read '
+        'instead, one document per image. Pass --results-db none to read the '
+        'tree even where an index is configured',
+    )
+    parser.add_argument(
+        '--nav-results-root',
+        action='append',
+        dest='nav_results_roots',
+        default=None,
+        metavar='ROOT',
+        help='Root directory of a navigation results tree to report on (a local '
+        'directory or any URL the filecache layer accepts); may be specified '
+        'multiple times. Overrides NAV_RESULTS_ROOT and the nav_results_root '
+        'configuration variable. Read only when no index is named, and then '
+        'every document under it is read once',
     )
     parser.add_argument(
         '--root',
@@ -802,7 +714,8 @@ def main_report(cmdline: list[str] | None = None) -> int:
         default=None,
         metavar='ROOT',
         help='Restrict the report to one ingested navigation-results root; may '
-        'be given more than once. Default: every root the index holds',
+        'be given more than once. Default: every root the index holds. Refused '
+        'when no index is named, since there is then nothing to select among',
     )
     parser.add_argument(
         '--output-dir',
@@ -866,46 +779,205 @@ def main_report(cmdline: list[str] | None = None) -> int:
         default=False,
         help='Write a flattened one-row-per-image images.csv next to report.md',
     )
+
+
+def main_report(cmdline: list[str] | None = None) -> int:
+    """Entry point for ``sd_stats_report``.
+
+    This program keeps ``print()`` rather than a logger.  Its output *is*
+    terminal text for a person reading a report, and a logger would wrap that
+    in run-log machinery it has no use for.
+
+    An index is optional here as it is everywhere else.  Named, its rows are
+    read; unnamed, the navigation results tree is read, one document per image.
+    Both answer the same seam, so both produce the same report.
+
+    Parameters:
+        cmdline: Argument list; None uses ``sys.argv``.
+
+    Returns:
+        Process exit code: 0 on success, and 1 when the index that was named
+        cannot be read, when it holds no completed ingest of anything, when no
+        tree can be resolved to read instead, or when a tree cannot be read
+        whole.
+
+    Raises:
+        SystemExit: With status 2, from the argument parser, for a command line
+            it will not accept -- an unknown flag, an unparseable bound, a root
+            that is not a location that can be read, a root the index holds no
+            completed ingest of (a value the index rather than the parser
+            rejects, reported the same way), or ``--root`` with no index to hold
+            it against.
+    """
+    parser = argparse.ArgumentParser(
+        description='Generate a navigation statistics report from a results tree or an index.'
+    )
+    _add_arguments(parser)
     arguments = parser.parse_args(cmdline)
 
     url = get_results_db_url(arguments, DEFAULT_CONFIG, warn=_to_stderr)
     if url is None:
-        print(
-            'sd_stats_report reads a results index and has no file-reading mode. '
-            'Name one with --results-db, the environment.results_db configuration '
-            'variable, or NAV_RESULTS_DB, and build it with sd_stats_ingest.',
-            file=sys.stderr,
-        )
-        return 1
+        return _report_over_a_tree(arguments, parser)
+    return _report_from_an_index(url, arguments, parser)
+
+
+def _report_written_from(
+    source: RecordSource,
+    arguments: argparse.Namespace,
+    roots: Sequence[str],
+    dropped_roots: Sequence[str] = (),
+) -> FCPath:
+    """Write the report from one open source, whichever storage it reads.
+
+    Parameters:
+        source: The open record source.
+        arguments: The parsed command line.
+        roots: Normalized roots to restrict the report to, and empty for every
+            root the source holds.
+        dropped_roots: Roots this run was pointed at that the source could not
+            be bound to, which the report names as covering none of.
+
+    Returns:
+        Where the report was written.
+    """
+    return build_report(
+        source,
+        arguments.output_dir,
+        instrument=arguments.instrument,
+        start_date=arguments.start_date,
+        end_date=arguments.end_date,
+        min_image=arguments.min_image,
+        max_image=arguments.max_image,
+        roots=roots,
+        dropped_roots=dropped_roots,
+        top_n=arguments.top_n,
+        filelists=arguments.filelists,
+        suspect_fraction=arguments.suspect_fraction,
+        csv_export=arguments.csv,
+    )
+
+
+def _report_from_an_index(
+    url: str, arguments: argparse.Namespace, parser: argparse.ArgumentParser
+) -> int:
+    """Report from an index somebody built, which is the cheap way to run twice.
+
+    The roots read are the roots the index holds a completed ingest of, and no
+    others.  Under a half-ingested root the absence of a row says nothing, so a
+    report that counted one would be reading absence it has no licence to read.
+
+    Parameters:
+        url: Connection URL of the results index.
+        arguments: The parsed command line.
+        parser: The parser, for the refusals it reports as usage errors.
+
+    Returns:
+        Process exit code.
+
+    Raises:
+        SystemExit: With status 2, from the parser, for a ``--root`` that is not
+            a location or that the index holds no completed ingest of.
+    """
     try:
         roots = [normalize_root_url(root) for root in arguments.root or []]
     except ValueError as exc:
         parser.error(f'a --root is not a location that can be read: {exc}')
     try:
-        engine = open_index(url)
+        engine = open_index_for_roots(url, roots)
+    except RootNotIngestedError as exc:
+        # A value the operator typed, so it is reported as a usage error like
+        # every other bad value on this command line, rather than as a run that
+        # failed on something it found.
+        parser.error(str(exc))
     except ValueError as exc:
         print(f'Cannot read the results index: {exc}', file=sys.stderr)
         return 1
     try:
         with engine.connect() as connection:
-            require_ingested_roots(connection, roots, url=url)
-            report_path = build_report(
-                connection,
-                arguments.output_dir,
-                instrument=arguments.instrument,
-                start_date=arguments.start_date,
-                end_date=arguments.end_date,
-                min_image=arguments.min_image,
-                max_image=arguments.max_image,
-                roots=roots,
-                top_n=arguments.top_n,
-                filelists=arguments.filelists,
-                suspect_fraction=arguments.suspect_fraction,
-                csv_export=arguments.csv,
-            )
+            # A run that named its roots was refused above unless every one of
+            # them has a completed ingest, so it drops none; one that named
+            # none is bound to the roots that have one, and names the rest as
+            # roots it covers nothing of.
+            held = list(roots) or ingested_roots(connection)
+            dropped = [] if roots else unfinished_roots(connection)
+    except Exception:
+        engine.dispose()
+        raise
+    if len(held) == 0:
+        engine.dispose()
+        print(
+            f'The results index {url} holds no completed ingest of any root, so there is '
+            f'nothing it can be asked about. Run sd_stats_ingest over a root first, or '
+            f'report over the tree with --results-db none.',
+            file=sys.stderr,
+        )
+        return 1
+    # A run that dropped a root covers fewer roots than the index holds rows
+    # for, so the roots it did cover are the restriction the report prints.
+    covered = held if dropped else list(roots)
+    try:
+        with IndexRecordSource(engine, held, url, ()) as source:
+            report_path = _report_written_from(source, arguments, covered, dropped)
     except ValueError as exc:
         parser.error(str(exc))
-    finally:
-        engine.dispose()
+    print(f'Wrote {report_path}')
+    return 0
+
+
+def _report_over_a_tree(arguments: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
+    """Report over a results tree, reading one document per image.
+
+    What it costs is one full read of every document under the roots, which is
+    exactly the cost an index exists to remove.  That is the right trade for a
+    local tree and one report, and the wrong one for a cloud root or a repeated
+    report; the statistics guide says so beside the option.
+
+    Parameters:
+        arguments: The parsed command line.
+        parser: The parser, for the refusals it reports as usage errors.
+
+    Returns:
+        Process exit code: 0 on success, and 1 when a root cannot be resolved or
+        cannot be read whole.
+
+    Raises:
+        SystemExit: With status 2, from the parser, for a command line that names
+            ``--root`` with no index to hold it against, or a root that is not a
+            location that can be read.
+    """
+    if arguments.root:
+        # Refused rather than read as a second spelling of --nav-results-root.
+        # --root selects among the roots one index holds, and there is no index
+        # here to hold anything.
+        parser.error(
+            '--root restricts a report to a root the index holds, and no index was named. '
+            'Name the trees to report on with --nav-results-root, or name an index with '
+            '--results-db.'
+        )
+    try:
+        named = arguments.nav_results_roots or [get_nav_results_root(arguments, DEFAULT_CONFIG)]
+    except ValueError as exc:
+        print(
+            f'No results index and no navigation results root: {exc}. Name a tree with '
+            f'--nav-results-root, the nav_results_root configuration variable or '
+            f'NAV_RESULTS_ROOT, or name an index with --results-db.',
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        roots = distinct_roots(named)
+    except ValueError as exc:
+        parser.error(f'a navigation results root is not a location that can be read: {exc}')
+    print(f'Reading {", ".join(roots)}')
+    try:
+        with TreeRecordSource(roots) as source:
+            report_path = _report_written_from(source, arguments, ())
+    except UnlistableDirectoryError as exc:
+        # A root the walk could not read whole is a report that would cover less
+        # than the tree and say nothing about it.
+        print(f'Cannot read the navigation results tree: {exc}', file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        parser.error(str(exc))
     print(f'Wrote {report_path}')
     return 0

--- a/src/spindoctor/cli/stats/report.py
+++ b/src/spindoctor/cli/stats/report.py
@@ -15,6 +15,8 @@ reduces to a minimum, or sorts what it prints on a key that includes the pair
 that identifies an image -- an image name alone is not unique across roots.
 """
 
+from __future__ import annotations
+
 import argparse
 import statistics
 import sys

--- a/src/spindoctor/cli/stats/report_accumulate.py
+++ b/src/spindoctor/cli/stats/report_accumulate.py
@@ -1,0 +1,568 @@
+"""One pass over the navigation records, into everything the report says.
+
+The report reads the record seam once, and every section's numbers fall out of
+accumulators filled as the records go by.  That is what makes the storage
+irrelevant: a stream of records comes out of a results tree as readily as out of
+an ingested results index, and one report is written over either.
+
+Nothing here can be answered by looking back over what the pass has seen.  A
+count table divides by the per-instrument totals, and those are known only when
+the pass ends, so nothing here formats a line: the accumulators are the whole
+output of this module and :mod:`spindoctor.cli.stats.report_sections` turns them
+into text afterwards.
+
+Two of the report's filters are applied here rather than by the seam.  The date
+bounds compare the calendar date a record's epoch renders to, and the image
+bounds compare the number in its name; a selection carries neither, and widening
+one to carry them would be widening it for one consumer.  Everything else the
+report narrows by -- the roots and the mission -- is a selection field, and the
+storage applies it where it is cheapest.
+
+The stream also carries files no record could be read out of, and this counts
+them.  That count is of the whole of every selected root: a refused file records
+no mission, no date and no image number, so none of the filters above can be
+applied to it, and the report says so where it prints the number.
+"""
+
+import math
+import re
+from array import array
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Any, TypeVar
+
+from spindoctor.cli.stats.report_common import (
+    BotsimFrame,
+    ReportStatistics,
+    SuspectOffset,
+    TimedImage,
+)
+from spindoctor.cli.stats.report_sections import (
+    CsvExport,
+    content_category,
+    resolve_offset_limit,
+    source_kind,
+)
+from spindoctor.nav_records import ImageFacts, RecordSource, Selection, UnreadableFile
+
+__all__ = [
+    'RangeFilters',
+    'accumulate_statistics',
+]
+
+_Key = TypeVar('_Key')
+"""Whatever a count table groups by: a name, or a pair of them."""
+
+_BOTSIM_NAME_RE = re.compile(r'^([NW])(\d{10})')
+"""What a Cassini image name has to look like to name a spacecraft-clock count."""
+
+
+@dataclass(frozen=True)
+class RangeFilters:
+    """The two report filters no selection carries, applied to each record here.
+
+    Both compare a value a record derives rather than one it records: the
+    calendar date its epoch falls on, and the number inside its image name.  A
+    record that derives neither is outside every bound, since an image that
+    cannot be placed in time or in a numbering cannot be shown to be inside one.
+
+    Parameters:
+        start_date: Inclusive UTC start date (``YYYY-MM-DD``), or None.
+        end_date: Inclusive UTC end date, or None.
+        min_image_num: Inclusive lower bound on the number in the image name,
+            or None.
+        max_image_num: Inclusive upper bound on it, or None.
+    """
+
+    start_date: str | None = None
+    end_date: str | None = None
+    min_image_num: int | None = None
+    max_image_num: int | None = None
+
+    def keeps(self, image: dict[str, Any]) -> bool:
+        """Whether one image's facts are inside every bound this places.
+
+        Parameters:
+            image: The image's own values, keyed by column name.
+
+        Returns:
+            True when the image is selected.  A bound that is placed and a
+            value that is absent is not selected: an image whose epoch or whose
+            name yielded no number cannot be shown to be inside the range.
+        """
+        date = image['image_date']
+        if self.start_date is not None and (date is None or date < self.start_date):
+            return False
+        if self.end_date is not None and (date is None or date > self.end_date):
+            return False
+        number = image['image_number']
+        if self.min_image_num is not None and (number is None or number < self.min_image_num):
+            return False
+        return not (
+            self.max_image_num is not None and (number is None or number > self.max_image_num)
+        )
+
+
+def accumulate_statistics(
+    source: RecordSource,
+    selection: Selection,
+    stats: ReportStatistics,
+    *,
+    filters: RangeFilters,
+    csv_export: CsvExport | None = None,
+) -> None:
+    """Read every record the selection covers, into the report's accumulators.
+
+    Parameters:
+        source: The record source, over a results tree or over an index.
+        selection: What to read: the roots and the mission the report was
+            narrowed to.
+        stats: The accumulators, filled in place.  Their ``top_n``,
+            ``retain_names`` and ``suspect_fraction`` are read here and decide
+            what is retained.
+        filters: The date and image-number bounds, applied per record.
+        csv_export: The open export to write each image into, or None when no
+            CSV was asked for.
+
+    Raises:
+        ValueError: If the source cannot honour the selection, or cannot be
+            read; raised as the stream is consumed, which is where a storage
+            discovers it.
+        UnlistableRootError: If a selected root could not be listed, or
+            :class:`~spindoctor.nav_records.UnlistableDirectoryError` if a
+            directory under one could not be.  A report covering less than the
+            tree it names is worse than no report.
+    """
+    for facts in source.facts(selection):
+        if isinstance(facts, UnreadableFile):
+            stats.unreadable_files += 1
+            continue
+        if not filters.keeps(facts.image):
+            continue
+        _add_image(stats, facts)
+        if csv_export is not None:
+            csv_export.add(facts)
+            stats.csv_rows += 1
+
+
+def _add_image(stats: ReportStatistics, facts: ImageFacts) -> None:
+    """Fold one image's facts into every accumulator that counts it.
+
+    Parameters:
+        stats: The accumulators.
+        facts: What the image's record says.
+    """
+    instrument = str(facts.image['instrument'])
+    stats.images_by_instrument[instrument] = stats.images_by_instrument.get(instrument, 0) + 1
+    _add_extremes(stats, facts, instrument)
+    _add_status(stats, facts, instrument)
+    _add_bodies(stats, facts, instrument)
+    _add_techniques(stats, facts, instrument)
+    _add_sources(stats, facts, instrument)
+    _add_offsets(stats, facts, instrument)
+    _add_agreement(stats, facts, instrument)
+    _add_exclusions(stats, facts, instrument)
+    _add_suspect(stats, facts, instrument)
+    _add_botsim(stats, facts, instrument)
+    _add_runtime(stats, facts, instrument)
+
+
+def _bump(counts: dict[_Key, dict[str, int]], key: _Key, instrument: str) -> None:
+    """Count one image under a key, in the two-level shape a count table reads.
+
+    Every count table the report prints has one column per instrument and a
+    total column, so every counter behind one is keyed by the section's own key
+    and then by instrument.
+
+    Parameters:
+        counts: The counter.
+        key: The section's key, whatever shape that section groups by.
+        instrument: The image's instrument.
+    """
+    bucket = counts.setdefault(key, {})
+    bucket[instrument] = bucket.get(instrument, 0) + 1
+
+
+def _add_extremes(stats: ReportStatistics, facts: ImageFacts, instrument: str) -> None:
+    """Hold the numbered ends and the timed ends of one instrument's images.
+
+    Image numbers are only comparable within one instrument, and the two ends
+    are found independently of the epochs beside them, so an image with no
+    recorded epoch at one end of the number range does not hide the instrument's
+    time span.
+
+    Parameters:
+        stats: The accumulators.
+        facts: What the image's record says.
+        instrument: The image's instrument.
+    """
+    image = facts.image
+    number = image['image_number']
+    if number is not None:
+        name = str(image['image_name'])
+        root_url = str(image['root_url'])
+        stub = str(image['results_path_stub'])
+        first = (int(number), name, root_url, stub)
+        held_first = stats.first_image.get(instrument)
+        if held_first is None or first < held_first:
+            stats.first_image[instrument] = first
+        # The other end is the highest number and, among any that tie, the
+        # lowest name: a maximum on the number and a minimum on the tie-break,
+        # rather than a maximum on the tuple.
+        last = (-int(number), name, root_url, stub)
+        held_last = stats.last_image.get(instrument)
+        if held_last is None or last < held_last:
+            stats.last_image[instrument] = last
+    image_et = image['image_et']
+    if image_et is None:
+        return
+    epoch = float(image_et)
+    held_earliest = stats.first_et.get(instrument)
+    if held_earliest is None or epoch < held_earliest:
+        stats.first_et[instrument] = epoch
+    held_latest = stats.last_et.get(instrument)
+    if held_latest is None or epoch > held_latest:
+        stats.last_et[instrument] = epoch
+
+
+def _failure_reason(image: dict[str, Any]) -> str:
+    """Which of the two reason vocabularies describes a non-success outcome.
+
+    The navigator's own explanation when it ran, and the fatal error when it
+    never got that far.  They are separate values holding separate vocabularies,
+    and a report of failure reasons wants whichever one the document carried.
+
+    Parameters:
+        image: The image's own values.
+
+    Returns:
+        The reason, or ``'(none)'`` when the record carries neither.
+    """
+    reason = image['status_reason'] if image['status_reason'] is not None else image['status_error']
+    return str(reason or '(none)')
+
+
+def _add_status(stats: ReportStatistics, facts: ImageFacts, instrument: str) -> None:
+    """Count one image's outcome, and classify it when the outcome is not success.
+
+    Every non-success status is a failure for reporting purposes, so an image
+    that ended in a fatal error is classified beside one the navigator failed.
+
+    Parameters:
+        stats: The accumulators.
+        facts: What the image's record says.
+        instrument: The image's instrument.
+    """
+    image = facts.image
+    status = str(image['status'])
+    _bump(stats.status_counts, status, instrument)
+    if status == 'success':
+        return
+    stats.failed_images += 1
+    reason = _failure_reason(image)
+    _bump(stats.reason_counts, (status, reason), instrument)
+    category = content_category(
+        [(str(entry['source_model']), str(entry['source_name'])) for entry in facts.feature_sources]
+    )
+    _bump(stats.content_counts, category, instrument)
+    _bump(stats.content_reason_counts, (category, reason), instrument)
+    if not stats.retain_names:
+        return
+    image_name = str(image['image_name'])
+    stats.failure_names.setdefault(reason, []).append((instrument, image_name))
+    stats.content_names.setdefault(category, []).append((instrument, image_name))
+
+
+def _add_bodies(stats: ReportStatistics, facts: ImageFacts, instrument: str) -> None:
+    """Count one image against each named body its feature inventory holds.
+
+    An image contributes several feature rows for one body -- one per feature
+    type -- and this table counts images, so the names are collapsed to a set
+    first.
+
+    Parameters:
+        stats: The accumulators.
+        facts: What the image's record says.
+        instrument: The image's instrument.
+    """
+    bodies = {
+        str(entry['source_name'])
+        for entry in facts.feature_sources
+        if source_kind(str(entry['source_model'])) == 'body'
+        and str(entry['source_name']) != '(none)'
+    }
+    if len(bodies) == 0:
+        return
+    failed = str(facts.image['status']) != 'success'
+    counts = stats.body_failed if failed else stats.body_success
+    for body in sorted(bodies):
+        key = (body, instrument)
+        counts[key] = counts.get(key, 0) + 1
+        if failed and stats.retain_names:
+            stats.body_failed_names.setdefault(key, []).append(str(facts.image['image_name']))
+
+
+def _add_techniques(stats: ReportStatistics, facts: ImageFacts, instrument: str) -> None:
+    """Count the techniques that reported on one image, and what they reported.
+
+    A technique reports once per image, so counting entries counts images.  The
+    confidences are kept, one value per entry that recorded one, and the entries
+    that recorded none are no part of that population: a technique that recorded
+    none has no mean rather than a zero.  Keeping the values rather than a
+    running total is what makes the mean the same number whatever order the
+    records arrive in.
+
+    Parameters:
+        stats: The accumulators.
+        facts: What the image's record says.
+        instrument: The image's instrument.
+    """
+    for entry in facts.techniques:
+        key = (str(entry['technique_name']), instrument)
+        stats.technique_images[key] = stats.technique_images.get(key, 0) + 1
+        if not entry['spurious']:
+            stats.technique_good[key] = stats.technique_good.get(key, 0) + 1
+        confidence = entry['confidence']
+        if confidence is None:
+            continue
+        stats.technique_confidence.setdefault(key, array('d')).append(float(confidence))
+
+
+def _add_sources(stats: ReportStatistics, facts: ImageFacts, instrument: str) -> None:
+    """Count one image against each model and source its features came from.
+
+    The inventory holds one entry per feature type and source, and this table
+    counts images, so the entries are collapsed to one per source first and the
+    two feature counts are summed across the types before the image is counted.
+
+    Parameters:
+        stats: The accumulators.
+        facts: What the image's record says.
+        instrument: The image's instrument.
+    """
+    per_source: dict[tuple[str, str], list[int]] = {}
+    for entry in facts.feature_sources:
+        key = (str(entry['source_model']), str(entry['source_name']))
+        tally = per_source.setdefault(key, [0, 0])
+        tally[0] += int(entry['n_features'])
+        tally[1] += int(entry['n_gated'])
+    for (model, name), tally in per_source.items():
+        key3 = (model, name, instrument)
+        stats.source_images[key3] = stats.source_images.get(key3, 0) + 1
+        totals = stats.source_features.setdefault(key3, [0, 0])
+        totals[0] += tally[0]
+        totals[1] += tally[1]
+
+
+def _fused_offset(image: dict[str, Any]) -> tuple[float, float] | None:
+    """The fused offset of a successful image, where there is one to screen.
+
+    Parameters:
+        image: The image's own values.
+
+    Returns:
+        The pair, or None when the image did not succeed or recorded no offset.
+    """
+    if str(image['status']) != 'success':
+        return None
+    offset_dv = image['offset_dv']
+    offset_du = image['offset_du']
+    if offset_dv is None or offset_du is None:
+        return None
+    return float(offset_dv), float(offset_du)
+
+
+def _add_offsets(stats: ReportStatistics, facts: ImageFacts, instrument: str) -> None:
+    """Hold one successful image's fused offset under its camera and image size.
+
+    Pointing error is a property of the camera, so the distributions are never
+    pooled across cameras; the per-camera section pools these over the image
+    sizes rather than keeping a second copy of every value.
+
+    Parameters:
+        stats: The accumulators.
+        facts: What the image's record says.
+        instrument: The image's instrument.
+    """
+    image = facts.image
+    offset = _fused_offset(image)
+    if offset is None:
+        return
+    camera = str(image['camera'] or '(unknown)')
+    shape_v = image['image_shape_v']
+    shape_u = image['image_shape_u']
+    size = f'{shape_v}x{shape_u}' if shape_v is not None and shape_u is not None else '(none)'
+    values = stats.offsets.setdefault((instrument, camera, size), (array('d'), array('d')))
+    values[0].append(offset[0])
+    values[1].append(offset[1])
+
+
+def _add_agreement(stats: ReportStatistics, facts: ImageFacts, instrument: str) -> None:
+    """Hold how far one image's techniques disagreed with one another.
+
+    Only the techniques that produced a non-spurious offset take part, and only
+    an image where two of them did contributes anything.  An image with no
+    confidence tier contributes to the per-pair distances and not to the
+    per-tier ones, since there is no tier to attribute its disagreement to.
+
+    Parameters:
+        stats: The accumulators.
+        facts: What the image's record says.
+        instrument: The image's instrument.
+    """
+    rank = facts.image['confidence_rank']
+    if rank is not None:
+        _bump(stats.tier_counts, str(rank), instrument)
+    offsets = sorted(
+        (str(entry['technique_name']), float(entry['offset_dv']), float(entry['offset_du']))
+        for entry in facts.techniques
+        if not entry['spurious']
+        and entry['offset_dv'] is not None
+        and entry['offset_du'] is not None
+    )
+    if len(offsets) < 2:
+        return
+    largest = 0.0
+    for first, second in combinations(offsets, 2):
+        delta = math.hypot(first[1] - second[1], first[2] - second[2])
+        pair = (instrument, min(first[0], second[0]), max(first[0], second[0]))
+        stats.pair_deltas.setdefault(pair, array('d')).append(delta)
+        largest = max(largest, delta)
+    if rank is not None:
+        stats.rank_disagreement.setdefault((instrument, str(rank)), array('d')).append(largest)
+
+
+def _excluded_techniques(excluded: Any) -> list[str]:
+    """The technique names one image's exclusion value holds.
+
+    Parameters:
+        excluded: The recorded exclusion set, as the facts carry it.
+
+    Returns:
+        The names, or an empty list when nothing was excluded or the value is
+        no list of names.
+    """
+    if not isinstance(excluded, list):
+        return []
+    return [str(name) for name in excluded]
+
+
+def _add_exclusions(stats: ReportStatistics, facts: ImageFacts, instrument: str) -> None:
+    """Count one image under the set of techniques the ensemble excluded.
+
+    The names are sorted before they are joined into the label the section
+    groups on.  A record holds them in whatever order it was written in, so two
+    images that excluded the same techniques in two orders would otherwise be
+    counted as two different exclusion sets.
+
+    Parameters:
+        stats: The accumulators.
+        facts: What the image's record says.
+        instrument: The image's instrument.
+    """
+    names = _excluded_techniques(facts.image['excluded_from_consensus'])
+    if len(names) == 0:
+        return
+    label = ', '.join(sorted(names))
+    _bump(stats.exclusion_counts, label, instrument)
+    if stats.retain_names:
+        stats.exclusion_names.setdefault(label, []).append(
+            (instrument, str(facts.image['image_name']))
+        )
+
+
+def _add_suspect(stats: ReportStatistics, facts: ImageFacts, instrument: str) -> None:
+    """Screen one successful image's offset against the configured search limit.
+
+    Parameters:
+        stats: The accumulators.
+        facts: What the image's record says.
+        instrument: The image's instrument.
+    """
+    image = facts.image
+    offset = _fused_offset(image)
+    if offset is None:
+        return
+    image_name = str(image['image_name'])
+    limit = resolve_offset_limit(instrument, image_name, image['image_shape_v'])
+    if isinstance(limit, str):
+        reason = f'{instrument}: {limit}'
+        stats.unresolved[reason] = stats.unresolved.get(reason, 0) + 1
+        return
+    stats.screened[instrument] = stats.screened.get(instrument, 0) + 1
+    limit_v, limit_u = limit
+    ratio = max(abs(offset[0]) / limit_v, abs(offset[1]) / limit_u)
+    if ratio < stats.suspect_fraction:
+        return
+    stats.suspect_counts[instrument] = stats.suspect_counts.get(instrument, 0) + 1
+    stats.suspects.append(
+        SuspectOffset(
+            ratio=ratio,
+            image_name=image_name,
+            instrument=instrument,
+            offset_dv=offset[0],
+            offset_du=offset[1],
+            magnitude=math.hypot(offset[0], offset[1]),
+            limit_text=f'({limit_v:.1f}, {limit_u:.1f})',
+            root_url=str(image['root_url']),
+            results_path_stub=str(image['results_path_stub']),
+        )
+    )
+
+
+def _add_botsim(stats: ReportStatistics, facts: ImageFacts, instrument: str) -> None:
+    """Hold one Cassini image under the spacecraft-clock count its name carries.
+
+    Two images of one camera sharing a clock count is a tree nobody expects, and
+    the one with the smallest identity is the one held, so which of them stands
+    for the camera does not depend on the order the records arrived in.
+
+    Parameters:
+        stats: The accumulators.
+        facts: What the image's record says.
+        instrument: The image's instrument.
+    """
+    if instrument != 'coiss':
+        return
+    image = facts.image
+    image_name = str(image['image_name'])
+    match = _BOTSIM_NAME_RE.match(image_name.rsplit('/', 1)[-1].upper())
+    if match is None:
+        return
+    camera, clock = match.group(1), match.group(2)
+    frame = BotsimFrame(
+        image_name=image_name,
+        root_url=str(image['root_url']),
+        results_path_stub=str(image['results_path_stub']),
+        status=str(image['status']),
+        offset_dv=image['offset_dv'],
+        offset_du=image['offset_du'],
+    )
+    frames = stats.botsim.setdefault(clock, {})
+    held = frames.get(camera)
+    if held is None or frame.identity < held.identity:
+        frames[camera] = frame
+
+
+def _add_runtime(stats: ReportStatistics, facts: ImageFacts, instrument: str) -> None:
+    """Hold one image's run time, and offer it to the slowest-image list.
+
+    Parameters:
+        stats: The accumulators.
+        facts: What the image's record says.
+        instrument: The image's instrument.
+    """
+    image = facts.image
+    elapsed = image['elapsed_s']
+    if elapsed is None:
+        return
+    stats.elapsed_by_instrument.setdefault(instrument, array('d')).append(float(elapsed))
+    stats.slowest.add(
+        TimedImage(
+            elapsed_s=float(elapsed),
+            image_name=str(image['image_name']),
+            instrument=instrument,
+            root_url=str(image['root_url']),
+            results_path_stub=str(image['results_path_stub']),
+        )
+    )

--- a/src/spindoctor/cli/stats/report_common.py
+++ b/src/spindoctor/cli/stats/report_common.py
@@ -1,52 +1,55 @@
-"""Shared context, query, formatting, and chart helpers for the statistics report.
+"""Shared state, accumulators, formatting, and chart helpers for the statistics report.
 
-Every query the report issues goes through :func:`rows`, which runs textual SQL
-with named bind parameters against a SQLAlchemy Core connection.  Named binds
-rather than positional ones because the same filter fragment is spliced into
-statements that already carry binds of their own, and a filter that had to know
-how many came before it would be a filter that broke whenever a section grew a
-condition.
+The report is one pass over the record seam followed by a formatting run over
+what that pass accumulated, and this module holds the join between the two
+halves.  :class:`ReportStatistics` is what a section's numbers are read off, and
+:class:`ReportContext` is what carries it to each section builder alongside the
+output directory and the drill-down options.
 
-Nothing here is dialect-specific.  The filters compare columns -- including
-``image_number``, which is ingested rather than computed by a function
-registered on one connection -- so the same statement runs on SQLite and on
-PostgreSQL and means the same thing on both.
+The accumulators are declared here rather than beside the pass that fills them
+because :class:`ReportContext` names one and the section builders name a
+context, so the pass is written on top of this module rather than under it.
+
+Every number a section prints comes from the accumulators, and the accumulators
+come from whichever storage answered the seam, so one report is written over a
+results tree and over an index ingested from it.
 """
 
+import heapq
 import math
 import re
 import statistics
-from collections.abc import Callable
+from array import array
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from io import BytesIO
 from typing import Any
 
-import sqlalchemy
 from filecache import FCPath
 
 __all__ = [
-    'IMAGE_JOIN',
+    'BotsimFrame',
     'ReportContext',
+    'ReportStatistics',
+    'SlowestImages',
+    'SuspectOffset',
+    'TimedImage',
     'add_drilldown',
     'add_instrument_count_table',
-    'connector',
     'count_pct',
     'fmt',
     'image_name_from_filename',
-    'image_order',
     'instrument_color',
     'offset_stats',
     'percentile',
-    'rows',
     'safe_filename',
-    'where_clause',
     'write_offset_hist',
     'write_stacked_bar_chart',
     'write_stacked_value_hist',
 ]
 
 
-# The database records ``observation.image_name``, which is the source file's
+# A record carries ``observation.image_name``, which is the source file's
 # basename (``N1454725799_1_CALIB.IMG``).  The dataset layer's notion of an
 # image name is the shorter token its ``--image-filelist`` selection matches
 # against (``N1454725799``), so every name the report prints or writes to a
@@ -68,11 +71,11 @@ def image_name_from_filename(instrument: str, filename: str) -> str:
     """The dataset-level image name for a recorded image filename.
 
     Parameters:
-        instrument: Registered instrument name from the database
+        instrument: Registered instrument name the record carries
             (``coiss`` / ``vgiss`` / ``gossi`` / ``nhlorri``); an
             unregistered name only has its extension stripped.
-        filename: The recorded ``images.image_name`` value (a basename,
-            possibly with a directory prefix).
+        filename: The recorded image name (a basename, possibly with a
+            directory prefix).
 
     Returns:
         The image name in the form ``--image-filelist`` selects on, e.g.
@@ -87,33 +90,310 @@ def image_name_from_filename(instrument: str, filename: str) -> str:
     return rule(stem) if rule is not None else stem
 
 
-def image_order(alias: str = '') -> str:
-    """A total ordering over images, for a query that lists them by name.
-
-    Image name alone is not unique: two volumes may hold images with the same
-    basename, and the pair that keys the row breaks the tie.  Without it two
-    rows with one name would come back in whatever order the backend liked, and
-    the report would not be the same twice.
+@dataclass(frozen=True)
+class SuspectOffset:
+    """One successful image whose fused offset reaches near the search limit.
 
     Parameters:
-        alias: Table alias prefix (e.g. ``'i.'``) qualifying the column names.
-
-    Returns:
-        The ``ORDER BY`` column list.
+        ratio: How far into the search box the offset reaches, as a fraction of
+            the per-axis limit, over whichever axis reaches further.
+        image_name: The recorded image filename.
+        instrument: The image's instrument.
+        offset_dv: The fused V-axis offset, in pixels.
+        offset_du: The fused U-axis offset, in pixels.
+        magnitude: The offset's length, in pixels.
+        limit_text: The per-axis limit, rendered as the table cell shows it.
+        root_url: The results root the image was read under.
+        results_path_stub: The image's key under that root.
     """
-    return f'{alias}image_name, {alias}root_url, {alias}results_path_stub'
+
+    ratio: float
+    image_name: str
+    instrument: str
+    offset_dv: float
+    offset_du: float
+    magnitude: float
+    limit_text: str
+    root_url: str
+    results_path_stub: str
+
+    @property
+    def rank(self) -> tuple[float, str, str, str]:
+        """Where this image sorts in the suspect table.
+
+        Returns:
+            Worst ratio first, then the image name, then the pair that keys the
+            image.  The pair is part of the key because an image name is not
+            unique across roots: two roots holding one basename would otherwise
+            be separated by whatever order the records arrived in, which is an
+            order no source promises.
+        """
+        return (-self.ratio, self.image_name, self.root_url, self.results_path_stub)
 
 
-IMAGE_JOIN = (
-    'JOIN images i ON i.root_url = {alias}root_url '
-    'AND i.results_path_stub = {alias}results_path_stub'
-)
-"""How a child table joins to the image it belongs to.
+@dataclass(frozen=True)
+class BotsimFrame:
+    """One frame of a possible BOTSIM pair, as the pair check reads it.
 
-An image is keyed by the pair, so a child row is matched on the pair.  Joining
-on the image name alone would merge two volumes' images of the same name into
-one, which is precisely the confusion the pair exists to prevent.
-"""
+    Parameters:
+        image_name: The recorded image filename.
+        root_url: The results root the image was read under.
+        results_path_stub: The image's key under that root.
+        status: The image's navigation status.
+        offset_dv: The fused V-axis offset, or None when none was recorded.
+        offset_du: The fused U-axis offset, or None when none was recorded.
+    """
+
+    image_name: str
+    root_url: str
+    results_path_stub: str
+    status: str
+    offset_dv: float | None
+    offset_du: float | None
+
+    @property
+    def identity(self) -> tuple[str, str, str]:
+        """What decides which frame stands for a clock count and a camera.
+
+        Returns:
+            The image name and the pair that keys the image.  Two images of one
+            camera sharing a clock count is a tree nobody expects, and the one
+            with the smallest identity is taken, so the answer does not depend
+            on which of them the source happened to yield first.
+        """
+        return (self.image_name, self.root_url, self.results_path_stub)
+
+
+@dataclass(frozen=True)
+class TimedImage:
+    """One image's run time, ordered as the slowest-image list orders it.
+
+    Parameters:
+        elapsed_s: What the run recorded for this image, in seconds.
+        image_name: The recorded image filename.
+        instrument: The image's instrument.
+        root_url: The results root the image was read under.
+        results_path_stub: The image's key under that root.
+    """
+
+    elapsed_s: float
+    image_name: str
+    instrument: str
+    root_url: str
+    results_path_stub: str
+
+    @property
+    def rank(self) -> tuple[float, str, str, str]:
+        """Where this image sorts in the slowest-image list.
+
+        Returns:
+            Slowest first, then the image name, then the pair that keys the
+            image, for the reason :attr:`SuspectOffset.rank` carries the pair.
+        """
+        return (-self.elapsed_s, self.image_name, self.root_url, self.results_path_stub)
+
+    def __lt__(self, other: 'TimedImage') -> bool:
+        """Compare two images the opposite way round from how they are listed.
+
+        A heap hands back its smallest element, and what a bounded slowest-N
+        wants to hand back is the one it would print last, so the comparison is
+        inverted here rather than at every use of the heap.
+
+        Parameters:
+            other: The image to compare against.
+
+        Returns:
+            True when this image sorts *later* in the printed list.
+        """
+        return self.rank > other.rank
+
+
+class SlowestImages:
+    """The slowest images of a pass, kept without holding the rest.
+
+    A list of every image's run time is retained anyway, packed, because the
+    quantiles and the histogram need every value.  The names are not: the
+    slowest list is the only thing that wants them, it is bounded by ``--top-n``,
+    and a name is the expensive half of a per-image retention.
+
+    Parameters:
+        limit: How many to keep.  Zero keeps none, which is what the default
+            ``--top-n 0`` asks for, and the section then prints no list at all.
+    """
+
+    def __init__(self, limit: int) -> None:
+        self._limit = max(0, limit)
+        self._held: list[TimedImage] = []
+
+    def add(self, image: TimedImage) -> None:
+        """Offer one image to the list, keeping it only if it belongs there.
+
+        Parameters:
+            image: The image and what it took.
+        """
+        if self._limit == 0:
+            return
+        if len(self._held) < self._limit:
+            heapq.heappush(self._held, image)
+            return
+        heapq.heappushpop(self._held, image)
+
+    @property
+    def entries(self) -> list[TimedImage]:
+        """The images kept, in the order the report lists them.
+
+        Returns:
+            Slowest first, ties broken by name and then by the pair that keys
+            the image.
+        """
+        return sorted(self._held, key=lambda image: image.rank)
+
+
+@dataclass
+class ReportStatistics:
+    """Every number the report prints, accumulated in one pass over the records.
+
+    Each field is keyed exactly as the section that reads it groups: a counter
+    where the section counts, a packed array where it needs every value for a
+    mean, a median, a percentile or a histogram, and a bounded structure where
+    it prints a top-N list.  Two retentions grow with the images rather than
+    with a fixed space of keys, and each is described where it is declared: the
+    suspect list, which is the one always-on section printing a row per image
+    and which ``--top-n 0`` leaves uncapped, and the Cassini frame held per
+    spacecraft-clock count for the BOTSIM pairing.  Everything else that names
+    an image -- the four drill-down lists and the filelists -- is held only
+    where one of those was asked for.
+
+    The two-level counters carry the section's key and then the instrument,
+    because every count table has one column per instrument and a total.
+
+    Parameters:
+        top_n: How many rows the capped tables print, and how many names a
+            drill-down shows.
+        retain_names: Whether any section will name images, which is true when
+            examples or filelists were asked for.  Off, the four drill-down
+            lists retain nothing at all.
+        suspect_fraction: Fraction of the per-axis search limit at or beyond
+            which a fused offset is screened as suspect.
+        images_by_instrument: Selected images per instrument.
+        unreadable_files: Files under the selected roots named like a
+            navigation document that no record could be read out of.  Root
+            scoped rather than selection scoped: such a file records no
+            instrument, date or image number, so no filter can be applied to it.
+        failed_images: Selected images whose status is not ``success``.
+        csv_rows: Rows the CSV export wrote, for the line naming the file.
+        first_image: Per instrument, the lowest ``(image_number, image_name,
+            root_url, results_path_stub)`` of the images that carry a number.
+        last_image: The same, with the number negated, so the entry held is the
+            highest-numbered image and the lowest name among any that tie.
+        first_et: Per instrument, the earliest recorded epoch.
+        last_et: Per instrument, the latest recorded epoch.
+        status_counts: Images per status.
+        reason_counts: Images per ``(status, failure reason)``.
+        failure_names: Per failure reason, the images that carried it; retained
+            only under ``retain_names``.
+        content_counts: Failed images per scene-content category.
+        content_reason_counts: Failed images per ``(content, failure reason)``.
+        content_names: Per content category, the failed images in it; retained
+            only under ``retain_names``.
+        body_failed: Failed images naming each ``(body, instrument)``.
+        body_success: Successful images naming each ``(body, instrument)``.
+        body_failed_names: Per ``(body, instrument)``, the failed images naming
+            it; retained only under ``retain_names``.
+        technique_images: Images each ``(technique, instrument)`` ran on.
+        technique_good: How many of those the technique did not call spurious.
+        technique_confidence: Per ``(technique, instrument)``, every confidence
+            it reported, packed.  A confidence that was never recorded is no
+            part of the population, so the mean skips it and a group that
+            reported none has no mean rather than a zero.  The values are held
+            rather than folded into a running total so that the mean is one
+            call over the population, whose answer is the same whatever order
+            the records arrived in.  An exact running total would be order-free
+            too -- the non-overlapping partials an exact sum is made of are a
+            couple of floats however many values go by -- but that is a small
+            algorithm to write and a smaller one to get quietly wrong, against
+            a packed array costing a few percent of the pass's peak.
+        source_images: Images each ``(model, source, instrument)`` appears in,
+            counted once per image however many feature types it supplied.
+        source_features: The features and gated features it supplied, summed.
+        offsets: Per ``(instrument, camera, image size)``, the fused offsets of
+            the successful images, packed per axis.  The per-camera section
+            pools these over the sizes rather than keeping a second copy.
+        pair_deltas: Per ``(instrument, technique, technique)``, the distances
+            between the two techniques' offsets on the images where both
+            reported non-spuriously.
+        rank_disagreement: Per ``(instrument, confidence tier)``, each image's
+            largest such distance.
+        tier_counts: Images per confidence tier.
+        exclusion_counts: Images per set of techniques the ensemble excluded.
+        exclusion_names: The images in each such set; retained only under
+            ``retain_names``.
+        screened: Successful images whose search limit could be resolved.
+        suspect_counts: How many of those reached the limit.
+        unresolved: Per reason, the images whose limit could not be resolved.
+        suspects: Every suspect image, uncapped.
+        botsim: Cassini images that name a clock count, by clock count and then
+            by camera letter.
+        elapsed_by_instrument: Per instrument, every recorded run time.
+        slowest: The slowest images, bounded by ``top_n``.
+    """
+
+    top_n: int = 0
+    retain_names: bool = False
+    suspect_fraction: float = 0.9
+
+    images_by_instrument: dict[str, int] = field(default_factory=dict)
+    unreadable_files: int = 0
+    failed_images: int = 0
+    csv_rows: int = 0
+
+    first_image: dict[str, tuple[int, str, str, str]] = field(default_factory=dict)
+    last_image: dict[str, tuple[int, str, str, str]] = field(default_factory=dict)
+    first_et: dict[str, float] = field(default_factory=dict)
+    last_et: dict[str, float] = field(default_factory=dict)
+
+    status_counts: dict[str, dict[str, int]] = field(default_factory=dict)
+    reason_counts: dict[tuple[str, str], dict[str, int]] = field(default_factory=dict)
+    failure_names: dict[str, list[tuple[str, str]]] = field(default_factory=dict)
+
+    content_counts: dict[str, dict[str, int]] = field(default_factory=dict)
+    content_reason_counts: dict[tuple[str, str], dict[str, int]] = field(default_factory=dict)
+    content_names: dict[str, list[tuple[str, str]]] = field(default_factory=dict)
+    body_failed: dict[tuple[str, str], int] = field(default_factory=dict)
+    body_success: dict[tuple[str, str], int] = field(default_factory=dict)
+    body_failed_names: dict[tuple[str, str], list[str]] = field(default_factory=dict)
+
+    technique_images: dict[tuple[str, str], int] = field(default_factory=dict)
+    technique_good: dict[tuple[str, str], int] = field(default_factory=dict)
+    technique_confidence: dict[tuple[str, str], array[float]] = field(default_factory=dict)
+
+    source_images: dict[tuple[str, str, str], int] = field(default_factory=dict)
+    source_features: dict[tuple[str, str, str], list[int]] = field(default_factory=dict)
+
+    offsets: dict[tuple[str, str, str], tuple[array[float], array[float]]] = field(
+        default_factory=dict
+    )
+
+    pair_deltas: dict[tuple[str, str, str], array[float]] = field(default_factory=dict)
+    rank_disagreement: dict[tuple[str, str], array[float]] = field(default_factory=dict)
+    tier_counts: dict[str, dict[str, int]] = field(default_factory=dict)
+
+    exclusion_counts: dict[str, dict[str, int]] = field(default_factory=dict)
+    exclusion_names: dict[str, list[tuple[str, str]]] = field(default_factory=dict)
+
+    screened: dict[str, int] = field(default_factory=dict)
+    suspect_counts: dict[str, int] = field(default_factory=dict)
+    unresolved: dict[str, int] = field(default_factory=dict)
+    suspects: list[SuspectOffset] = field(default_factory=list)
+
+    botsim: dict[str, dict[str, BotsimFrame]] = field(default_factory=dict)
+
+    elapsed_by_instrument: dict[str, array[float]] = field(default_factory=dict)
+    slowest: SlowestImages = field(default_factory=lambda: SlowestImages(0))
+
+    def __post_init__(self) -> None:
+        """Size the two structures that are bounded by an option rather than by the data."""
+        self.slowest = SlowestImages(self.top_n)
 
 
 @dataclass
@@ -121,16 +401,11 @@ class ReportContext:
     """Mutable state threaded through every report section builder.
 
     Parameters:
-        connection: Open connection to the results index.
         output_dir: Directory receiving ``report.md``, charts, and the
             optional ``filelists/`` subdirectory; a local directory or
             any URL the ``filecache`` layer accepts.
-        where: Images-table filter from :func:`where_clause` (empty string
-            or a leading-space ``' WHERE ...'`` fragment).
-        params: Bind values matching ``where``, by name.
-        where_i: The same filter built with ``alias='i.'`` for queries
-            that join the ``images`` table as ``i``.
-        params_i: Bind values matching ``where_i``, by name.
+        stats: What the pass over the records accumulated.  Every number a
+            section prints is read off this and nothing else.
         lines: Markdown lines accumulated so far.
         top_n: When positive, categorical sections list up to this many
             example image names per category.
@@ -139,17 +414,13 @@ class ReportContext:
         suspect_fraction: Fraction of the per-axis search limit at or
             beyond which a fused offset is flagged as suspect.
         images_by_instrument: Selected image count per instrument, in
-            instrument-name order; filled in from the database.
+            instrument-name order; read off the accumulators.
         instruments: The selected instrument names, in name order.
         total_images: Total selected images across all instruments.
     """
 
-    connection: sqlalchemy.Connection
     output_dir: FCPath
-    where: str
-    params: dict[str, Any]
-    where_i: str
-    params_i: dict[str, Any]
+    stats: ReportStatistics
     lines: list[str] = field(default_factory=list)
     top_n: int = 0
     filelists: bool = False
@@ -159,14 +430,13 @@ class ReportContext:
     total_images: int = 0
 
     def __post_init__(self) -> None:
-        """Load the per-instrument image counts the whole report reports against."""
-        counts = rows(
-            self.connection,
-            f'SELECT instrument, COUNT(*) FROM images{self.where} '
-            'GROUP BY instrument ORDER BY instrument',
-            self.params,
-        )
-        self.images_by_instrument = {str(name): int(count) for name, count in counts}
+        """Read the per-instrument image counts the whole report reports against.
+
+        In instrument-name order, because that is the order every count table
+        lays its columns out in and the order the charts stack their segments
+        in, and a pass over records promises no order of its own.
+        """
+        self.images_by_instrument = dict(sorted(self.stats.images_by_instrument.items()))
         self.instruments = list(self.images_by_instrument)
         self.total_images = sum(self.images_by_instrument.values())
 
@@ -189,100 +459,6 @@ class ReportContext:
         body = f'# {stub} ({len(names)} image(s))\n' + ''.join(f'{name}\n' for name in names)
         (self.output_dir / relative).write_text(body, encoding='utf-8')
         return relative
-
-
-def where_clause(
-    *,
-    instrument: str | None,
-    start_date: str | None,
-    end_date: str | None,
-    min_image_num: int | None = None,
-    max_image_num: int | None = None,
-    roots: list[str] | None = None,
-    alias: str = '',
-) -> tuple[str, dict[str, Any]]:
-    """Build the images-table filter shared by every query.
-
-    The binds are named rather than positional because the fragment is spliced
-    into statements that carry binds of their own; a positional fragment would
-    have to know how many came before it.
-
-    ``image_number`` is a column, so the range filter is an ordinary comparison
-    on any backend rather than a call into a function registered on whichever
-    connection happened to be open.
-
-    Parameters:
-        instrument: Optional instrument filter value.
-        start_date: Optional inclusive UTC start date (``YYYY-MM-DD``).
-        end_date: Optional inclusive UTC end date (``YYYY-MM-DD``).
-        min_image_num: Optional inclusive lower bound on the numeric
-            portion of the image name.
-        max_image_num: Optional inclusive upper bound on the numeric
-            portion of the image name.
-        roots: Optional normalized results-root URLs to restrict to; None or
-            an empty list reports over every root the index holds.
-        alias: Table alias prefix (e.g. ``'i.'``) qualifying the column
-            names, for queries that join the ``images`` table.
-
-    Returns:
-        ``(where, params)`` where ``where`` is ``''`` or a leading-space
-        ``' WHERE ...'`` fragment and ``params`` the bound values by name.
-    """
-    clauses: list[str] = []
-    params: dict[str, Any] = {}
-    if instrument is not None:
-        clauses.append(f'{alias}instrument = :instrument')
-        params['instrument'] = instrument
-    if start_date is not None:
-        clauses.append(f'{alias}image_date >= :start_date')
-        params['start_date'] = start_date
-    if end_date is not None:
-        clauses.append(f'{alias}image_date <= :end_date')
-        params['end_date'] = end_date
-    if min_image_num is not None:
-        clauses.append(f'{alias}image_number >= :min_image_num')
-        params['min_image_num'] = min_image_num
-    if max_image_num is not None:
-        clauses.append(f'{alias}image_number <= :max_image_num')
-        params['max_image_num'] = max_image_num
-    if roots:
-        names = [f'root_{index}' for index in range(len(roots))]
-        placeholders = ', '.join(f':{name}' for name in names)
-        clauses.append(f'{alias}root_url IN ({placeholders})')
-        params.update(zip(names, roots, strict=True))
-    if len(clauses) == 0:
-        return '', {}
-    return ' WHERE ' + ' AND '.join(clauses), params
-
-
-def connector(where: str) -> str:
-    """The keyword joining an extra condition onto a ``where_clause`` result.
-
-    Parameters:
-        where: A filter fragment from :func:`where_clause` (empty string
-            or a leading-space ``' WHERE ...'`` fragment).
-
-    Returns:
-        ``' AND '`` when ``where`` already has conditions, else
-        ``' WHERE '``.
-    """
-    return ' AND ' if len(where) > 0 else ' WHERE '
-
-
-def rows(
-    connection: sqlalchemy.Connection, sql: str, params: dict[str, Any]
-) -> list[tuple[Any, ...]]:
-    """Execute a query and return all result rows as a list.
-
-    Parameters:
-        connection: Open connection to the results index.
-        sql: SQL statement with ``:name`` bind placeholders.
-        params: Bind values by name.
-
-    Returns:
-        All result rows, in query order, as plain tuples.
-    """
-    return [tuple(row) for row in connection.execute(sqlalchemy.text(sql), params)]
 
 
 def fmt(value: float | None, digits: int = 3) -> str:
@@ -350,7 +526,7 @@ def add_instrument_count_table(
     ctx.lines.append('')
 
 
-def offset_stats(values: list[float]) -> dict[str, float] | None:
+def offset_stats(values: Sequence[float]) -> dict[str, float] | None:
     """Mean / median / stdev / min / max summary of a value list.
 
     Parameters:
@@ -372,7 +548,7 @@ def offset_stats(values: list[float]) -> dict[str, float] | None:
     }
 
 
-def percentile(values: list[float], fraction: float) -> float:
+def percentile(values: Sequence[float], fraction: float) -> float:
     """Nearest-rank percentile of a non-empty value list.
 
     Parameters:
@@ -571,7 +747,7 @@ def write_stacked_bar_chart(
 
 def write_stacked_value_hist(
     path: FCPath,
-    values_by_instrument: dict[str, list[float]],
+    values_by_instrument: Mapping[str, Sequence[float]],
     instruments: list[str],
     *,
     title: str,
@@ -606,7 +782,9 @@ def write_stacked_value_hist(
     _save_figure(fig, plt, path)
 
 
-def write_offset_hist(path: FCPath, dv: list[float], du: list[float], *, title: str) -> None:
+def write_offset_hist(
+    path: FCPath, dv: Sequence[float], du: Sequence[float], *, title: str
+) -> None:
     """Write a two-panel V/U offset histogram PNG for one instrument.
 
     Parameters:

--- a/src/spindoctor/cli/stats/report_common.py
+++ b/src/spindoctor/cli/stats/report_common.py
@@ -15,6 +15,8 @@ come from whichever storage answered the seam, so one report is written over a
 results tree and over an index ingested from it.
 """
 
+from __future__ import annotations
+
 import heapq
 import math
 import re
@@ -192,7 +194,7 @@ class TimedImage:
         """
         return (-self.elapsed_s, self.image_name, self.root_url, self.results_path_stub)
 
-    def __lt__(self, other: 'TimedImage') -> bool:
+    def __lt__(self, other: TimedImage) -> bool:
         """Compare two images the opposite way round from how they are listed.
 
         A heap hands back its smallest element, and what a bounded slowest-N

--- a/src/spindoctor/cli/stats/report_common.py
+++ b/src/spindoctor/cli/stats/report_common.py
@@ -394,7 +394,7 @@ class ReportStatistics:
     slowest: SlowestImages = field(default_factory=lambda: SlowestImages(0))
 
     def __post_init__(self) -> None:
-        """Size the two structures that are bounded by an option rather than by the data."""
+        """Size the slowest-image heap, which ``top_n`` bounds rather than the data."""
         self.slowest = SlowestImages(self.top_n)
 
 

--- a/src/spindoctor/cli/stats/report_sections.py
+++ b/src/spindoctor/cli/stats/report_sections.py
@@ -11,6 +11,8 @@ here rather than beside the pass because what a column of it holds is a decision
 about the export, and the pass has no opinion about any of them.
 """
 
+from __future__ import annotations
+
 import contextlib
 import csv
 import heapq
@@ -679,7 +681,7 @@ class CsvExport:
         self._stack = contextlib.ExitStack()
         self._writer: Any = None
 
-    def __enter__(self) -> 'CsvExport':
+    def __enter__(self) -> CsvExport:
         """Open the file and write its header.
 
         Returns:

--- a/src/spindoctor/cli/stats/report_sections.py
+++ b/src/spindoctor/cli/stats/report_sections.py
@@ -617,8 +617,9 @@ _SORT_COLUMN = 'results_path_stub'
 
 The rows are not sorted.  Sorting them means holding every one of them, which is
 what a streaming write exists not to do, so the file leads with the column an
-operator would sort on -- ``sort -t, -k1,1 images.csv`` -- and the root each row
-came from stays a column of its own further right.
+operator would sort on -- field 1 of a ``sort -t,``, once the header line has
+been held out of the sort -- and the root each row came from stays a column of
+its own further right.
 """
 
 _EXPORT_IMAGE_COLUMNS: tuple[str, ...] = (

--- a/src/spindoctor/cli/stats/report_sections.py
+++ b/src/spindoctor/cli/stats/report_sections.py
@@ -1,43 +1,105 @@
-"""Report sections: failure taxonomy, suspect offsets, BOTSIM, run time, CSV export."""
+"""Report sections: failure taxonomy, suspect offsets, BOTSIM, run time, CSV export.
 
+Every section here formats what the pass over the records already counted.  None
+of them reads a record, and none of them holds anything of its own beyond the
+lines it appends, so the cost of a section is the size of its table rather than
+the size of the tree.
+
+The CSV export is the exception, because it is not a section: it writes one row
+per image as the pass reads it, and only its closing line is a section.  It is
+here rather than beside the pass because what a column of it holds is a decision
+about the export, and the pass has no opinion about any of them.
+"""
+
+import contextlib
 import csv
+import heapq
 import json
 import math
-import re
 import statistics
-from io import StringIO
+from array import array
+from collections.abc import Sequence
+from types import TracebackType
 from typing import Any
 
 from filecache import FCPath
 
 from spindoctor.cli.stats.report_common import (
-    IMAGE_JOIN,
     ReportContext,
     add_drilldown,
     add_instrument_count_table,
-    connector,
     count_pct,
     fmt,
     image_name_from_filename,
-    image_order,
     percentile,
-    rows,
     write_stacked_value_hist,
 )
 from spindoctor.config import DEFAULT_CONFIG, Config
+from spindoctor.nav_records import ImageFacts
 from spindoctor.results_index import IMAGES
 
 __all__ = [
+    'CONTENT_CATEGORIES',
     'CSV_LINE_TERMINATOR',
+    'EXPORT_COLUMNS',
     'IMAGE_COLUMNS',
+    'CsvExport',
     'add_botsim_section',
+    'add_csv_export_section',
     'add_failure_taxonomy_section',
+    'add_narrowing_section',
     'add_offset_by_group_section',
     'add_runtime_section',
     'add_suspect_offset_section',
+    'content_category',
     'resolve_offset_limit',
-    'write_csv_export',
+    'source_kind',
 ]
+
+
+# ---------------------------------------------------------------------------
+# What the report was narrowed to
+# ---------------------------------------------------------------------------
+
+_DROPPED_ROOTS_PROSE = """\
+The index holds no completed ingest of the roots named below, so under one of them the absence of a
+row means nothing at all, and none of them is covered here: neither its images nor the files under
+it that yielded no record. Ingest such a root and it joins the roots the filters above name; name it
+with --root and the run is refused rather than quietly narrowed."""
+"""The paragraph that explains what a root the report could not cover contributes.
+
+Written with the wrapping it is printed with, and naming no root, so that the
+prose is a constant and the roots are a line of its own after it.
+"""
+
+
+def add_narrowing_section(
+    ctx: ReportContext, *, filters: Sequence[str], dropped_roots: Sequence[str]
+) -> None:
+    """Append what the report was narrowed to, and what it could not cover.
+
+    A report that covered fewer roots than it was pointed at has to say so.  The
+    roots it did cover are one of the filters, named as a filter, and the ones it
+    dropped are named under the paragraph that says what dropping one costs.
+
+    Parameters:
+        ctx: Report context.
+        filters: What narrowed the report, already rendered, in the order to
+            print them; empty means nothing narrowed it.
+        dropped_roots: The roots the source could not be bound to, in the order
+            to name them; empty means it was bound to every root it was pointed
+            at.
+    """
+    narrowing = ', '.join(filters) if len(filters) > 0 else 'none (every image read)'
+    ctx.lines += [f'Filters: {narrowing}', '']
+    if len(dropped_roots) == 0:
+        return
+    ctx.lines += [
+        *_DROPPED_ROOTS_PROSE.splitlines(),
+        '',
+        f'Roots dropped: {", ".join(dropped_roots)}',
+        '',
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -71,11 +133,11 @@ def resolve_offset_limit(
     keyed by image size, the recorded ``image_shape_v`` selects the entry).
 
     Parameters:
-        instrument: Registered instrument name from the database.
+        instrument: Registered instrument name the record carries.
         image_name: Image name (used to pick the Cassini ISS detector and
             config block).
         image_shape_v: Recorded V-axis image size, or None when the
-            database row has no shape.
+            record carries no shape.
         config: Configuration to read; None uses ``DEFAULT_CONFIG``.
 
     Returns:
@@ -103,7 +165,7 @@ def resolve_offset_limit(
         return f'config section {source!r} has no extfov_margin_vu'
     if isinstance(entry, dict):
         if image_shape_v is None:
-            return 'image shape not recorded in the database'
+            return 'image shape not recorded'
         if image_shape_v not in entry:
             return f'{source!r} has no extfov_margin_vu entry for image size {image_shape_v}'
         entry = entry[image_shape_v]
@@ -121,16 +183,16 @@ def add_suspect_offset_section(ctx: ReportContext) -> None:
     correlation artifact as a real pointing error, so any image with
     ``|dV|`` or ``|dU|`` at or beyond ``suspect_fraction`` times the
     per-axis limit is listed for operator review.
+
+    This is the one always-on section that prints a row per image, and
+    ``--top-n`` caps it only when it is given: the default lists every suspect,
+    because an operator screening a run needs the whole list rather than the
+    worst few of it.
+
+    Parameters:
+        ctx: Report context.
     """
-    image_rows = rows(
-        ctx.connection,
-        f'SELECT image_name, instrument, offset_dv, offset_du, image_shape_v '
-        f'FROM images{ctx.where}'
-        + connector(ctx.where)
-        + "status = 'success' AND offset_dv IS NOT NULL AND offset_du IS NOT NULL "
-        f'ORDER BY {image_order()}',
-        ctx.params,
-    )
+    stats = ctx.stats
     ctx.lines += [
         '## Suspect offsets (near the search limit)',
         '',
@@ -140,71 +202,43 @@ def add_suspect_offset_section(ctx: ReportContext) -> None:
         'offsets may be correlation artifacts pinned to the search boundary.',
         '',
     ]
-    suspects: list[tuple[float, str, str, float, float, float, str]] = []
-    unresolved: dict[str, int] = {}
-    screened: dict[str, int] = {}
-    suspect_counts: dict[str, int] = {}
-    for image_name, instrument, dv, du, shape_v in image_rows:
-        limit = resolve_offset_limit(str(instrument), str(image_name), shape_v)
-        if isinstance(limit, str):
-            reason = f'{instrument}: {limit}'
-            unresolved[reason] = unresolved.get(reason, 0) + 1
-            continue
-        screened[str(instrument)] = screened.get(str(instrument), 0) + 1
-        limit_v, limit_u = limit
-        ratio = max(abs(float(dv)) / limit_v, abs(float(du)) / limit_u)
-        if ratio >= ctx.suspect_fraction:
-            suspect_counts[str(instrument)] = suspect_counts.get(str(instrument), 0) + 1
-            suspects.append(
-                (
-                    ratio,
-                    str(image_name),
-                    str(instrument),
-                    float(dv),
-                    float(du),
-                    math.hypot(float(dv), float(du)),
-                    f'({fmt(limit_v, 1)}, {fmt(limit_u, 1)})',
-                )
-            )
-    suspects.sort(key=lambda s: (-s[0], s[1]))
-    n_screened = sum(screened.values())
+    suspects = sorted(stats.suspects, key=lambda suspect: suspect.rank)
+    n_screened = sum(stats.screened.values())
     ctx.lines += [
         f'Suspect images: {count_pct(len(suspects), ctx.total_images)} of {n_screened} screened.',
         '',
     ]
-    add_instrument_count_table(ctx, [(['suspect'], suspect_counts)], headers=['category'])
+    add_instrument_count_table(ctx, [(['suspect'], stats.suspect_counts)], headers=['category'])
     if len(suspects) > 0:
         shown = suspects[: ctx.top_n] if ctx.top_n > 0 else suspects
         ctx.lines += [
             '| image | instrument | dV | dU | magnitude | limit (v, u) |',
             '|---|---|---|---|---|---|',
         ]
-        for _ratio, filename, instrument, dv, du, magnitude, limit_text in shown:
-            name = image_name_from_filename(instrument, filename)
+        for suspect in shown:
+            name = image_name_from_filename(suspect.instrument, suspect.image_name)
             ctx.lines.append(
-                f'| {name} | {instrument} | {fmt(dv)} | {fmt(du)} | '
-                f'{fmt(magnitude)} | {limit_text} |'
+                f'| {name} | {suspect.instrument} | {fmt(suspect.offset_dv)} '
+                f'| {fmt(suspect.offset_du)} | {fmt(suspect.magnitude)} | {suspect.limit_text} |'
             )
         ctx.lines.append('')
         add_drilldown(
             ctx,
-            [('suspect', [(s[2], s[1]) for s in suspects])],
+            [('suspect', [(suspect.instrument, suspect.image_name) for suspect in suspects])],
             label='category',
             stub_prefix='suspect_offsets',
         )
-    if len(unresolved) > 0:
+    if len(stats.unresolved) > 0:
         ctx.lines.append('Search limit could not be resolved for some images:')
         ctx.lines.append('')
-        for reason in sorted(unresolved):
-            ctx.lines.append(f'- {reason} ({unresolved[reason]} image(s))')
+        for reason in sorted(stats.unresolved):
+            ctx.lines.append(f'- {reason} ({stats.unresolved[reason]} image(s))')
         ctx.lines.append('')
 
 
 # ---------------------------------------------------------------------------
 # BOTSIM pair consistency (Cassini ISS)
 # ---------------------------------------------------------------------------
-
-_BOTSIM_NAME_RE = re.compile(r'^([NW])(\d{10})')
 
 
 def add_botsim_section(ctx: ReportContext) -> None:
@@ -216,34 +250,32 @@ def add_botsim_section(ctx: ReportContext) -> None:
     ``NAC offset ~= 10 x WAC offset`` per axis, making the per-axis
     residual ``NAC - 10 x WAC`` an end-to-end accuracy check that needs
     no ground truth.
+
+    Parameters:
+        ctx: Report context.
     """
-    image_rows = rows(
-        ctx.connection,
-        f'SELECT image_name, status, offset_dv, offset_du FROM images{ctx.where}'
-        + connector(ctx.where)
-        + f"instrument = 'coiss' ORDER BY {image_order()}",
-        ctx.params,
-    )
-    by_clock: dict[str, dict[str, tuple[str, str, Any, Any]]] = {}
-    for image_name, status, dv, du in image_rows:
-        match = _BOTSIM_NAME_RE.match(str(image_name).rsplit('/', 1)[-1].upper())
-        if match is None:
-            continue
-        camera, clock = match.group(1), match.group(2)
-        by_clock.setdefault(clock, {}).setdefault(camera, (str(image_name), str(status), dv, du))
-    pairs = {clock: entry for clock, entry in by_clock.items() if len(entry) == 2}
+    pairs = {clock: frames for clock, frames in ctx.stats.botsim.items() if len(frames) == 2}
     residuals: list[tuple[float, str, str, str, float, float]] = []
     for clock in sorted(pairs):
         nac = pairs[clock]['N']
         wac = pairs[clock]['W']
-        if nac[1] != 'success' or wac[1] != 'success':
+        if nac.status != 'success' or wac.status != 'success':
             continue
-        if None in (nac[2], nac[3], wac[2], wac[3]):
+        nac_dv, nac_du = nac.offset_dv, nac.offset_du
+        wac_dv, wac_du = wac.offset_dv, wac.offset_du
+        if nac_dv is None or nac_du is None or wac_dv is None or wac_du is None:
             continue
-        residual_dv = float(nac[2]) - 10.0 * float(wac[2])
-        residual_du = float(nac[3]) - 10.0 * float(wac[3])
+        residual_dv = nac_dv - 10.0 * wac_dv
+        residual_du = nac_du - 10.0 * wac_du
         residuals.append(
-            (math.hypot(residual_dv, residual_du), clock, nac[0], wac[0], residual_dv, residual_du)
+            (
+                math.hypot(residual_dv, residual_du),
+                clock,
+                nac.image_name,
+                wac.image_name,
+                residual_dv,
+                residual_du,
+            )
         )
     ctx.lines += [
         '## BOTSIM pair consistency (Cassini ISS)',
@@ -259,23 +291,30 @@ def add_botsim_section(ctx: ReportContext) -> None:
         f'| pairs with both navigated | {len(residuals)} |',
     ]
     if len(residuals) > 0:
-        magnitudes = [r[0] for r in residuals]
+        magnitudes = [residual[0] for residual in residuals]
         ctx.lines += [
             f'| median residual (px) | {fmt(statistics.median(magnitudes))} |',
             f'| p95 residual (px) | {fmt(percentile(magnitudes, 0.95))} |',
         ]
     ctx.lines.append('')
     if len(residuals) > 0 and ctx.top_n > 0:
-        residuals.sort(key=lambda r: (-r[0], r[1]))
+        # A clock count belongs to one pair, so the key is a total order over
+        # the residuals and the worst few come off a bounded heap.  What that
+        # bounds is the selection rather than the section: the residuals above
+        # are built whatever --top-n says, because the median and the
+        # percentile need every one of them.  What it saves is the copy a full
+        # sort makes of them, which over a hundred thousand pairs is a few
+        # kilobytes against ten megabytes.
+        worst = heapq.nsmallest(
+            ctx.top_n, residuals, key=lambda residual: (-residual[0], residual[1])
+        )
         ctx.lines += [
-            f'Worst {min(ctx.top_n, len(residuals))} pair(s):',
+            f'Worst {len(worst)} pair(s):',
             '',
             '| clock | NAC image | WAC image | residual dV | residual dU | residual |',
             '|---|---|---|---|---|---|',
         ]
-        for magnitude, clock, nac_name, wac_name, residual_dv, residual_du in residuals[
-            : ctx.top_n
-        ]:
+        for magnitude, clock, nac_name, wac_name, residual_dv, residual_du in worst:
             nac_image = image_name_from_filename('coiss', nac_name)
             wac_image = image_name_from_filename('coiss', wac_name)
             ctx.lines.append(
@@ -289,7 +328,7 @@ def add_botsim_section(ctx: ReportContext) -> None:
 # Failure taxonomy by image content
 # ---------------------------------------------------------------------------
 
-_CONTENT_CATEGORIES = (
+CONTENT_CATEGORIES = (
     'stars-only',
     'single-body',
     'multi-body',
@@ -297,10 +336,18 @@ _CONTENT_CATEGORIES = (
     'body+rings',
     'no-features',
 )
+"""Scene-content categories a failed image is classified into, in report order."""
 
 
-def _source_kind(source_model: str) -> str:
-    """Coarse feature-source kind (``stars`` / ``rings`` / ``body``) of a model name."""
+def source_kind(source_model: str) -> str:
+    """Coarse feature-source kind of a model name.
+
+    Parameters:
+        source_model: The recorded ``source_model`` of a feature source.
+
+    Returns:
+        ``'stars'``, ``'rings'`` or ``'body'``.
+    """
     kind = source_model.split(':', 1)[0].lower()
     if kind in ('star', 'stars'):
         return 'stars'
@@ -309,12 +356,19 @@ def _source_kind(source_model: str) -> str:
     return 'body'
 
 
-def _content_category(entries: list[tuple[str, str]]) -> str:
-    """Classify an image's ``(source_model, source_name)`` inventory."""
+def content_category(entries: list[tuple[str, str]]) -> str:
+    """Classify an image's ``(source_model, source_name)`` inventory.
+
+    Parameters:
+        entries: The image's feature sources, as model and source name.
+
+    Returns:
+        One of :data:`CONTENT_CATEGORIES`.
+    """
     if len(entries) == 0:
         return 'no-features'
-    body_names = {name for model, name in entries if _source_kind(model) == 'body'}
-    has_rings = any(_source_kind(model) == 'rings' for model, _ in entries)
+    body_names = {name for model, name in entries if source_kind(model) == 'body'}
+    has_rings = any(source_kind(model) == 'rings' for model, _ in entries)
     if len(body_names) > 0 and has_rings:
         return 'body+rings'
     if has_rings:
@@ -332,48 +386,14 @@ def add_failure_taxonomy_section(ctx: ReportContext) -> None:
     Content comes from the ``feature_sources`` inventory recorded per
     image; a body whose failure share is far above its peers points at a
     modeling problem for that body rather than a pipeline-wide issue.
+
+    Parameters:
+        ctx: Report context.
     """
-    failed_rows = rows(
-        ctx.connection,
-        'SELECT root_url, results_path_stub, image_name, instrument, '
-        f'COALESCE(status_reason, status_error) FROM images{ctx.where}'
-        + connector(ctx.where)
-        + f"status != 'success' ORDER BY {image_order()}",
-        ctx.params,
-    )
-    if len(failed_rows) == 0:
+    stats = ctx.stats
+    if stats.failed_images == 0:
         return
-    source_rows = rows(
-        ctx.connection,
-        'SELECT s.root_url, s.results_path_stub, i.image_name, i.instrument, i.status, '
-        's.source_model, s.source_name '
-        'FROM feature_sources s '
-        + IMAGE_JOIN.format(alias='s.')
-        + ctx.where_i
-        + f' ORDER BY {image_order("i.")}, s.source_model, s.source_name',
-        ctx.params_i,
-    )
-    sources_by_image: dict[tuple[str, str], list[tuple[str, str]]] = {}
-    for root_url, stub, _image_name, _instrument, _status, source_model, source_name in source_rows:
-        sources_by_image.setdefault((str(root_url), str(stub)), []).append(
-            (str(source_model), str(source_name))
-        )
-
-    by_category: dict[str, list[tuple[str, str]]] = {
-        category: [] for category in _CONTENT_CATEGORIES
-    }
-    category_counts: dict[str, dict[str, int]] = {category: {} for category in _CONTENT_CATEGORIES}
-    reason_counts: dict[tuple[str, str], dict[str, int]] = {}
-    for root_url, stub, image_name, instrument, status_reason in failed_rows:
-        category = _content_category(sources_by_image.get((str(root_url), str(stub)), []))
-        by_category[category].append((str(instrument), str(image_name)))
-        counts = category_counts[category]
-        counts[str(instrument)] = counts.get(str(instrument), 0) + 1
-        key = (category, str(status_reason or '(none)'))
-        reason_bucket = reason_counts.setdefault(key, {})
-        reason_bucket[str(instrument)] = reason_bucket.get(str(instrument), 0) + 1
-
-    populated = [c for c in _CONTENT_CATEGORIES if len(by_category[c]) > 0]
+    populated = [category for category in CONTENT_CATEGORIES if category in stats.content_counts]
     ctx.lines += [
         '## Failure taxonomy by image content',
         '',
@@ -383,84 +403,94 @@ def add_failure_taxonomy_section(ctx: ReportContext) -> None:
     ]
     add_instrument_count_table(
         ctx,
-        [([category], category_counts[category]) for category in populated],
+        [([category], stats.content_counts[category]) for category in populated],
         headers=['content'],
     )
     ordered_reasons = sorted(
-        reason_counts,
+        stats.content_reason_counts,
         key=lambda key: (
-            _CONTENT_CATEGORIES.index(key[0]),
-            -sum(reason_counts[key].values()),
+            CONTENT_CATEGORIES.index(key[0]),
+            -sum(stats.content_reason_counts[key].values()),
             key[1],
         ),
     )
     add_instrument_count_table(
         ctx,
         [
-            ([category, reason], reason_counts[(category, reason)])
+            ([category, reason], stats.content_reason_counts[(category, reason)])
             for category, reason in ordered_reasons
         ],
         headers=['content', 'reason'],
     )
     add_drilldown(
         ctx,
-        [(category, by_category[category]) for category in _CONTENT_CATEGORIES],
+        [(category, stats.content_names.get(category, [])) for category in CONTENT_CATEGORIES],
         label='content category',
         stub_prefix='failed_content',
     )
+    _add_per_body_shares(ctx)
 
-    # Per-body failure shares over all images (successful and failed).  An
-    # image can contribute several rows for one body, so each bucket holds the
-    # key that identifies an image rather than its name, which two volumes may
-    # share; the name rides along for the drill-down list.
-    body_status: dict[tuple[str, str], dict[str, set[tuple[str, str, str]]]] = {}
-    for root_url, stub, image_name, instrument, status, source_model, source_name in source_rows:
-        if _source_kind(str(source_model)) != 'body' or str(source_name) == '(none)':
-            continue
-        buckets = body_status.setdefault(
-            (str(source_name), str(instrument)), {'failed': set(), 'success': set()}
+
+def _add_per_body_shares(ctx: ReportContext) -> None:
+    """Append the per-body failure shares over all images, failed and successful.
+
+    Parameters:
+        ctx: Report context.
+    """
+    stats = ctx.stats
+    bodies = set(stats.body_failed) | set(stats.body_success)
+    if len(bodies) == 0:
+        return
+    ranked = sorted(
+        bodies,
+        key=lambda key: (-_failure_share(ctx, key), -stats.body_failed.get(key, 0), key),
+    )
+    ctx.lines += [
+        '### Per-body failure shares',
+        '',
+        'How often each named body appears in failed versus successful',
+        'images; a body with a high failure share is a modeling problem.',
+        '',
+        '| body | instrument | failed images | successful images | failure share |',
+        '|---|---|---|---|---|',
+    ]
+    for key in ranked:
+        body, instrument = key
+        n_failed = stats.body_failed.get(key, 0)
+        n_success = stats.body_success.get(key, 0)
+        total = ctx.images_by_instrument[instrument]
+        ctx.lines.append(
+            f'| {body} | {instrument} | {count_pct(n_failed, total)} '
+            f'| {count_pct(n_success, total)} | {_failure_share(ctx, key):.3f} |'
         )
-        bucket = 'success' if str(status) == 'success' else 'failed'
-        buckets[bucket].add((str(image_name), str(root_url), str(stub)))
-    if len(body_status) > 0:
-        ranked = sorted(
-            body_status.items(),
-            key=lambda item: (
-                -len(item[1]['failed']) / (len(item[1]['failed']) + len(item[1]['success'])),
-                -len(item[1]['failed']),
-                item[0],
-            ),
-        )
-        ctx.lines += [
-            '### Per-body failure shares',
-            '',
-            'How often each named body appears in failed versus successful',
-            'images; a body with a high failure share is a modeling problem.',
-            '',
-            '| body | instrument | failed images | successful images | failure share |',
-            '|---|---|---|---|---|',
-        ]
-        for (body, instrument), buckets in ranked:
-            n_failed = len(buckets['failed'])
-            n_success = len(buckets['success'])
-            share = n_failed / (n_failed + n_success)
-            total = ctx.images_by_instrument[instrument]
-            ctx.lines.append(
-                f'| {body} | {instrument} | {count_pct(n_failed, total)} '
-                f'| {count_pct(n_success, total)} | {share:.3f} |'
-            )
-        ctx.lines.append('')
-        by_body: dict[str, list[tuple[str, str]]] = {}
-        for (body, instrument), buckets in ranked:
-            by_body.setdefault(body, []).extend(
-                (instrument, entry[0]) for entry in sorted(buckets['failed'])
-            )
-        add_drilldown(
-            ctx,
-            [(body, entries) for body, entries in by_body.items() if len(entries) > 0],
-            label='body',
-            stub_prefix='failed_body',
-        )
+    ctx.lines.append('')
+    by_body: dict[str, list[tuple[str, str]]] = {}
+    for body, instrument in ranked:
+        names = stats.body_failed_names.get((body, instrument), [])
+        by_body.setdefault(body, []).extend((instrument, name) for name in sorted(names))
+    add_drilldown(
+        ctx,
+        [(body, entries) for body, entries in by_body.items() if len(entries) > 0],
+        label='body',
+        stub_prefix='failed_body',
+    )
+
+
+def _failure_share(ctx: ReportContext, key: tuple[str, str]) -> float:
+    """The fraction of one body's images that failed.
+
+    Parameters:
+        ctx: Report context.
+        key: The body and the instrument.
+
+    Returns:
+        Failed images over all images naming that body under that instrument.
+        The key comes from the union of the two counters, so at least one of
+        them is non-zero and the denominator is never zero.
+    """
+    n_failed = ctx.stats.body_failed.get(key, 0)
+    n_success = ctx.stats.body_success.get(key, 0)
+    return n_failed / (n_failed + n_success)
 
 
 # ---------------------------------------------------------------------------
@@ -469,20 +499,20 @@ def add_failure_taxonomy_section(ctx: ReportContext) -> None:
 
 
 def add_runtime_section(ctx: ReportContext) -> None:
-    """Summarize per-image run times; skipped when no timing data exists."""
-    timing_rows = rows(
-        ctx.connection,
-        f'SELECT image_name, instrument, elapsed_s FROM images{ctx.where}'
-        + connector(ctx.where)
-        + f'elapsed_s IS NOT NULL ORDER BY {image_order()}',
-        ctx.params,
-    )
-    if len(timing_rows) == 0:
+    """Summarize per-image run times; skipped when no timing data exists.
+
+    Every statistic in the table is a function of the set of run times and not
+    of the sequence they arrived in: the total is summed exactly, the mean sums
+    exactly, and the rest are extremes or sort what they are given.  The pooled
+    row is therefore a plain concatenation of the per-instrument arrays.
+
+    Parameters:
+        ctx: Report context.
+    """
+    stats = ctx.stats
+    by_instrument = stats.elapsed_by_instrument
+    if len(by_instrument) == 0:
         return
-    elapsed = [float(r[2]) for r in timing_rows]
-    by_instrument: dict[str, list[float]] = {}
-    for _image_name, instrument, seconds in timing_rows:
-        by_instrument.setdefault(str(instrument), []).append(float(seconds))
     ctx.lines += [
         '## Run-time statistics',
         '',
@@ -490,20 +520,27 @@ def add_runtime_section(ctx: ReportContext) -> None:
         '| stdev (s) |',
         '|---|---|---|---|---|---|---|---|',
     ]
-    series: list[tuple[str, list[float], int]] = [
-        (instrument, by_instrument.get(instrument, []), ctx.images_by_instrument[instrument])
+    series: list[tuple[str, array[float], int]] = [
+        (
+            instrument,
+            by_instrument.get(instrument, array('d')),
+            ctx.images_by_instrument[instrument],
+        )
         for instrument in ctx.instruments
     ]
     # The pooled row only says something new once more than one instrument
     # contributed to it.
     if len(ctx.instruments) > 1:
-        series.append(('(all)', elapsed, ctx.total_images))
+        pooled = array('d')
+        for instrument in ctx.instruments:
+            pooled.extend(by_instrument.get(instrument, array('d')))
+        series.append(('(all)', pooled, ctx.total_images))
     for instrument, values, denominator in series:
         if len(values) == 0:
             continue
         stdev = statistics.stdev(values) if len(values) > 1 else 0.0
         ctx.lines.append(
-            f'| {instrument} | {count_pct(len(values), denominator)} | {fmt(sum(values))} '
+            f'| {instrument} | {count_pct(len(values), denominator)} | {fmt(math.fsum(values))} '
             f'| {fmt(min(values))} | {fmt(max(values))} | {fmt(statistics.fmean(values))} '
             f'| {fmt(statistics.median(values))} | {fmt(stdev)} |'
         )
@@ -516,17 +553,17 @@ def add_runtime_section(ctx: ReportContext) -> None:
         xlabel='elapsed (s)',
     )
     ctx.lines += ['![run time](runtime_hist.png)', '']
-    if ctx.top_n > 0:
-        slowest = sorted(timing_rows, key=lambda r: (-float(r[2]), str(r[0])))[: ctx.top_n]
+    slowest = stats.slowest.entries
+    if ctx.top_n > 0 and len(slowest) > 0:
         ctx.lines += [
             f'Slowest {len(slowest)} image(s):',
             '',
             '| image | instrument | elapsed (s) |',
             '|---|---|---|',
         ]
-        for image_name, instrument, seconds in slowest:
-            name = image_name_from_filename(str(instrument), str(image_name))
-            ctx.lines.append(f'| {name} | {instrument} | {fmt(float(seconds))} |')
+        for image in slowest:
+            name = image_name_from_filename(image.instrument, image.image_name)
+            ctx.lines.append(f'| {name} | {image.instrument} | {fmt(image.elapsed_s)} |')
         ctx.lines.append('')
 
 
@@ -536,21 +573,12 @@ def add_runtime_section(ctx: ReportContext) -> None:
 
 
 def add_offset_by_group_section(ctx: ReportContext) -> None:
-    """Break the fused-offset statistics down by (instrument, camera, image size)."""
-    image_rows = rows(
-        ctx.connection,
-        f'SELECT instrument, camera, image_shape_v, image_shape_u, offset_dv, offset_du '
-        f'FROM images{ctx.where}'
-        + connector(ctx.where)
-        + "status = 'success' AND offset_dv IS NOT NULL AND offset_du IS NOT NULL "
-        'ORDER BY instrument, camera, image_shape_v, image_shape_u',
-        ctx.params,
-    )
-    groups: dict[tuple[str, str, str], list[tuple[float, float]]] = {}
-    for instrument, camera, shape_v, shape_u, dv, du in image_rows:
-        size = f'{shape_v}x{shape_u}' if shape_v is not None and shape_u is not None else '(none)'
-        key = (str(instrument), str(camera or '(unknown)'), size)
-        groups.setdefault(key, []).append((float(dv), float(du)))
+    """Break the fused-offset statistics down by (instrument, camera, image size).
+
+    Parameters:
+        ctx: Report context.
+    """
+    groups = ctx.stats.offsets
     if len(groups) == 0:
         return
     ctx.lines += [
@@ -562,12 +590,10 @@ def add_offset_by_group_section(ctx: ReportContext) -> None:
         '|---|---|---|---|---|---|---|---|---|---|---|---|',
     ]
     for instrument, camera, size in sorted(groups):
-        offsets = groups[(instrument, camera, size)]
-        dv = [o[0] for o in offsets]
-        du = [o[1] for o in offsets]
+        dv, du = groups[(instrument, camera, size)]
         stdev_dv = statistics.stdev(dv) if len(dv) > 1 else 0.0
         stdev_du = statistics.stdev(du) if len(du) > 1 else 0.0
-        images = count_pct(len(offsets), ctx.images_by_instrument[instrument])
+        images = count_pct(len(dv), ctx.images_by_instrument[instrument])
         ctx.lines.append(
             f'| {instrument} | {camera} | {size} | {images} '
             f'| {fmt(statistics.fmean(dv))} | {fmt(stdev_dv)} | {fmt(min(dv))} | {fmt(max(dv))} '
@@ -582,76 +608,131 @@ def add_offset_by_group_section(ctx: ReportContext) -> None:
 
 
 IMAGE_COLUMNS: tuple[str, ...] = tuple(IMAGES.columns.keys())
-"""Every ``images`` column, in schema order, as the CSV export lists them."""
+"""Every column of one image's facts, in the order the column set declares them."""
+
+_SORT_COLUMN = 'results_path_stub'
+"""The column the export leads with, so an operator can sort the file in a shell.
+
+The rows are not sorted.  Sorting them means holding every one of them, which is
+what a streaming write exists not to do, so the file leads with the column an
+operator would sort on -- ``sort -t, -k1,1 images.csv`` -- and the root each row
+came from stays a column of its own further right.
+"""
+
+_EXPORT_IMAGE_COLUMNS: tuple[str, ...] = (
+    _SORT_COLUMN,
+    *(column for column in IMAGE_COLUMNS if column != _SORT_COLUMN),
+)
+"""The image's own columns, in the order the export writes them."""
+
+_AGGREGATE_COLUMNS: tuple[str, ...] = (
+    'n_technique_rows',
+    'n_feature_sources',
+    'n_features',
+    'n_gated',
+)
+"""What the export adds beside the image's own columns, counted off its children."""
+
+EXPORT_COLUMNS: tuple[str, ...] = (*_EXPORT_IMAGE_COLUMNS, *_AGGREGATE_COLUMNS)
+"""Every column of ``images.csv``, in the order the export writes them."""
 
 CSV_LINE_TERMINATOR = '\n'
 """What ends a row of the CSV export, on every platform."""
-
-_CHILD_KEY = 'WHERE {alias}root_url = i.root_url AND {alias}results_path_stub = i.results_path_stub'
-"""How a correlated subquery finds one image's child rows."""
 
 
 def _csv_value(value: Any) -> Any:
     """Render one column value for the CSV.
 
-    Whether a JSON column arrives as a Python container is the driver's
-    decision rather than the column's: this export reads through raw SQL, so
-    SQLite hands back the JSON text such a column stores and PostgreSQL decodes
-    one into a list or a dict first.  A CSV carrying a Python container's
-    repr is one nothing else can read back, so a container goes out as the JSON
-    text the column holds and everything else goes out as it came.
+    A structured column arrives as the container it holds -- a matrix, a list of
+    names, a mapping of diagnostics -- whichever storage answered, so a CSV
+    carrying a Python container's repr is one nothing else can read back.  Such a
+    value goes out as JSON text and everything else goes out as it came.
 
     Parameters:
-        value: The value as the driver returned it.
+        value: The value the facts carry for this column.
 
     Returns:
-        The value to write: JSON text for a list or a dict, and the value
-        itself for anything else.
+        JSON text for a list or a dict, and the value itself for anything else.
     """
     if isinstance(value, (list, dict)):
         return json.dumps(value)
     return value
 
 
-def write_csv_export(ctx: ReportContext) -> FCPath:
-    """Write a flattened one-row-per-image CSV next to ``report.md``.
+class CsvExport:
+    """The flattened one-row-per-image export, written as the pass reads.
 
-    Columns are the ``images`` table columns (schema order) plus
-    ``n_technique_rows``, ``n_feature_sources``, ``n_features``, and
-    ``n_gated`` aggregates, ordered by image name.
+    Rows are written where they are read rather than collected and written at
+    the end, so a report over an archive-scale root pays for the file rather
+    than for a copy of it in memory.  What that costs is the row order: the seam
+    promises none and the two storages find records in two orders, so the file
+    says which images were exported rather than in what sequence.  The first
+    column is what an operator would sort on, for exactly that reason.
 
-    Returns:
-        The path of the written ``images.csv``.
+    Parameters:
+        path: Where to write, a local path or any URL the ``filecache`` layer
+            accepts.
     """
-    columns = ', '.join(f'i.{column}' for column in IMAGE_COLUMNS)
-    technique_key = _CHILD_KEY.format(alias='t.')
-    source_key = _CHILD_KEY.format(alias='s.')
-    csv_rows = rows(
-        ctx.connection,
-        f'SELECT {columns}, '
-        f'(SELECT COUNT(*) FROM techniques t {technique_key}), '
-        f'(SELECT COUNT(*) FROM feature_sources s {source_key}), '
-        f'(SELECT COALESCE(SUM(s.n_features), 0) FROM feature_sources s {source_key}), '
-        f'(SELECT COALESCE(SUM(s.n_gated), 0) FROM feature_sources s {source_key}) '
-        'FROM images i' + ctx.where_i + f' ORDER BY {image_order("i.")}',
-        ctx.params_i,
-    )
-    csv_path = ctx.output_dir / 'images.csv'
-    buffer = StringIO()
-    # Stated rather than left to the module default, which is CRLF: this file is
-    # read back by the regression comparison and by whatever an operator points
-    # at it, and a line ending that changes with a library default is a diff
-    # nobody asked for.
-    writer = csv.writer(buffer, lineterminator=CSV_LINE_TERMINATOR)
-    writer.writerow(
-        [*IMAGE_COLUMNS, 'n_technique_rows', 'n_feature_sources', 'n_features', 'n_gated']
-    )
-    writer.writerows([_csv_value(value) for value in row] for row in csv_rows)
-    csv_path.write_text(buffer.getvalue(), encoding='utf-8')
+
+    def __init__(self, path: FCPath) -> None:
+        self._path = path
+        self._stack = contextlib.ExitStack()
+        self._writer: Any = None
+
+    def __enter__(self) -> 'CsvExport':
+        """Open the file and write its header.
+
+        Returns:
+            The export itself, which the pass hands each image to.
+        """
+        # Stated rather than left to the module default, which is CRLF: this
+        # file is read back by whatever an operator points at it, and a line
+        # ending that changes with a library default is a diff nobody asked for.
+        handle = self._stack.enter_context(self._path.open('w', newline='', encoding='utf-8'))
+        self._writer = csv.writer(handle, lineterminator=CSV_LINE_TERMINATOR)
+        self._writer.writerow(EXPORT_COLUMNS)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close the file, whether the pass finished or failed.
+
+        Parameters:
+            exc_type: The exception's class, when the pass is leaving on one.
+            exc: The exception, when the pass is leaving on one.
+            traceback: Its traceback, when the pass is leaving on one.
+        """
+        self._stack.close()
+
+    def add(self, facts: ImageFacts) -> None:
+        """Write one image's row.
+
+        Parameters:
+            facts: What the image's record says, in the shape both storages
+                answer in.
+        """
+        image = facts.image
+        row = [_csv_value(image[column]) for column in _EXPORT_IMAGE_COLUMNS]
+        row.append(len(facts.techniques))
+        row.append(len(facts.feature_sources))
+        row.append(sum(int(entry['n_features']) for entry in facts.feature_sources))
+        row.append(sum(int(entry['n_gated']) for entry in facts.feature_sources))
+        self._writer.writerow(row)
+
+
+def add_csv_export_section(ctx: ReportContext) -> None:
+    """Append the line naming the export the pass wrote.
+
+    Parameters:
+        ctx: Report context.
+    """
     ctx.lines += [
         '## CSV export',
         '',
-        f'One row per image: images.csv ({len(csv_rows)} row(s)).',
+        f'One row per image: images.csv ({ctx.stats.csv_rows} row(s)).',
         '',
     ]
-    return csv_path

--- a/src/spindoctor/nav_records/tree.py
+++ b/src/spindoctor/nav_records/tree.py
@@ -63,6 +63,16 @@ flattened into the facts it holds.  The two file metrics the facts carry are the
 listing's own, threaded through from the walk that found the document, so
 nothing here stats a file and nothing walks a root a second time to answer the
 second question about it.
+
+Each of the two narrows on what it read.  A record is the document, so a stream
+of records reads the mission and the exposure midtime out of the document, and a
+document recording neither is reported rather than passed over, which is the
+only thing such a stream can say about one.  The facts are the row an ingest of
+the same file writes, so a stream of facts narrows on the facts: a file that
+yields none is an unreadable file whatever the selection asks for, and a file
+that yields facts is compared on the same two values an index compares its rows
+on.  That is what makes one selection over one tree cover the same images out of
+either storage.
 """
 
 from collections.abc import Iterator, Sequence
@@ -120,20 +130,21 @@ NAMES_NO_INSTRUMENT = 'names no instrument to attribute it to a mission'
 
 Not one of the reasons in :mod:`spindoctor.nav_records.document`, which are the
 ways a file yields no document at all.  This one is a document, read and parsed,
-that no mission-filtered read can place: only a document that *names* a mission
-can be another mission's, so one naming none is reported rather than passed over
-silently, which is how a truncated or corrupted document would otherwise vanish
-from every mission's run without a trace.
+that a mission-filtered stream of records cannot place: only a document that
+*names* a mission can be another mission's, so one naming none is reported
+rather than passed over silently, which is how a truncated or corrupted document
+would otherwise vanish from every mission's run without a trace.
 """
 
 RECORDS_NO_MIDTIME = 'records no exposure midtime to place it in a span of time'
 """Why a document that read perfectly well is still not one span's record.
 
-The time filter's half of :data:`NAMES_NO_INSTRUMENT`, and reported for the same
-reason: only a document that records a usable midtime can be shown to lie outside
-a span, so one recording none is reported rather than passed over.  A truncated
-document, or one whose midtime is a NaN that would otherwise satisfy every bound
-at once, would vanish from every time-bounded run without a trace.
+The time filter's half of :data:`NAMES_NO_INSTRUMENT`, reported by the same
+stream and for the same reason: only a document that records a usable midtime
+can be shown to lie outside a span, so one recording none is reported rather
+than passed over.  A truncated document, or one whose midtime is a NaN that
+would otherwise satisfy every bound at once, would vanish from every
+time-bounded run without a trace.
 """
 
 
@@ -528,7 +539,7 @@ class TreeRecordSource:
                 caller reads, and not at all when the selection names its own
                 stubs, which lists nothing.
         """
-        return (found for _origin, found in self._found(selection))
+        return self._selected_records(self._found(selection), selection)
 
     def facts(self, selection: Selection) -> Iterator[ImageFacts | UnreadableFile]:
         """Return what every document the selection covers says about its image.
@@ -552,7 +563,14 @@ class TreeRecordSource:
             :class:`~spindoctor.nav_records.record.UnreadableFile` per file that
             did not.  A file that is no navigation document is one of those,
             carrying the reason the document reader refuses it by, which is the
-            reason an ingest of the same tree records for it.
+            reason an ingest of the same tree records for it.  The mission
+            filter and the time bounds are then applied to the facts, which are
+            the values an index filters its rows on, so a file that yields no
+            facts is always an unreadable file and a file that yields facts is
+            narrowed on exactly what the other storage narrows on.  An image
+            whose facts record no midtime is therefore not selected under a
+            time bound, in place of being reported: a row recording none
+            satisfies no bound either.
 
         Raises:
             ValueError: If the selection names stubs without resolving to
@@ -561,24 +579,27 @@ class TreeRecordSource:
                 not be listed, or :class:`UnlistableRootError` if a selected
                 root could not be listed at all.
         """
-        return (self._facts_of(origin, found) for origin, found in self._found(selection))
+        return self._selected_facts(self._found(selection), selection)
 
     def _found(
         self, selection: Selection
     ) -> Iterator[tuple[DocumentOrigin, NavRecord | UnreadableFile]]:
-        """Read the documents the selection covers, each with where it came from.
+        """Read the documents the selection names a place for, with where each came from.
 
-        The one stream both public reads are built on.  What the selection asks
-        for is checked here rather than inside the generator, so a selection
-        this source cannot honour is refused where a caller asked rather than
-        partway through its loop.
+        The one stream both public reads are built on, and the reason each of
+        them applies the selection's restrictions itself: the two read different
+        things out of one document, and each narrows on what it read.  What the
+        selection asks for is checked here rather than inside the generator, so
+        a selection this source cannot honour is refused where a caller asked
+        rather than partway through its loop.
 
         Parameters:
-            selection: Which documents to read.
+            selection: Which documents to read, for the roots, the subtrees and
+                the stubs it names.
 
         Returns:
-            One pair per document the selection covers: where it came from, and
-            the record or the unreadable file it produced.
+            One pair per document read: where it came from, and the record or
+            the unreadable file it produced.
 
         Raises:
             ValueError: If the selection names stubs without resolving to
@@ -593,7 +614,48 @@ class TreeRecordSource:
             ListedRecord(stub=stub, path=document_path(root, stub), mtime_ns=None, size_bytes=None)
             for stub in selection.stubs
         )
-        return self._found_of_root(root, root_url, listed, selection)
+        return self._found_of_root(root, root_url, listed)
+
+    def _selected_records(
+        self,
+        found: Iterator[tuple[DocumentOrigin, NavRecord | UnreadableFile]],
+        selection: Selection,
+    ) -> Iterator[NavRecord | UnreadableFile]:
+        """Yield the records of the documents the selection covers.
+
+        Parameters:
+            found: What was read, document by document.
+            selection: The selection, for the restrictions a document answers.
+
+        Yields:
+            One record per document the selection covers, and one unreadable
+            file per document that yielded none or that cannot be placed
+            against a restriction the selection makes.
+        """
+        for _origin, one in found:
+            selected = self._document_selected(one, selection)
+            if selected is not None:
+                yield selected
+
+    def _selected_facts(
+        self,
+        found: Iterator[tuple[DocumentOrigin, NavRecord | UnreadableFile]],
+        selection: Selection,
+    ) -> Iterator[ImageFacts | UnreadableFile]:
+        """Yield the facts of the documents the selection covers.
+
+        Parameters:
+            found: What was read, document by document.
+            selection: The selection, for the restrictions the facts answer.
+
+        Yields:
+            One set of facts per document the selection covers, and one
+            unreadable file per document that yielded none.
+        """
+        for origin, one in found:
+            facts = self._facts_of(origin, one)
+            if isinstance(facts, UnreadableFile) or self._facts_selected(facts, selection):
+                yield facts
 
     @staticmethod
     def _facts_of(
@@ -645,16 +707,15 @@ class TreeRecordSource:
 
         Parameters:
             roots: The normalized roots to read, in the order to read them.
-            selection: The selection, for the subtrees to walk and the
-                restrictions a document has to be opened to answer.
+            selection: The selection, for the subtrees to walk.
 
         Yields:
-            One pair per document the selection covers.
+            One pair per document under those subtrees.
         """
         for root_url in roots:
             root = FCPath(root_url)
             listed = self._listing_of_root(root, selection.subtrees)
-            yield from self._found_of_root(root, root_url, listed, selection)
+            yield from self._found_of_root(root, root_url, listed)
 
     def describe(self) -> str:
         """Return where these records came from, for the run log.
@@ -707,13 +768,13 @@ class TreeRecordSource:
             )
 
     def _found_of_root(
-        self,
-        root: FCPath,
-        root_url: str,
-        listed: Iterator[ListedRecord],
-        selection: Selection,
+        self, root: FCPath, root_url: str, listed: Iterator[ListedRecord]
     ) -> Iterator[tuple[DocumentOrigin, NavRecord | UnreadableFile]]:
         """Retrieve one root's documents in batches and yield them one at a time.
+
+        Every document read is yielded.  What a selection restricts is applied
+        to what was read out of a document, and the two public reads read
+        different things out of one document, so nothing here narrows.
 
         Parameters:
             root: The results root the stubs are keys under.
@@ -721,12 +782,9 @@ class TreeRecordSource:
                 where it came from.
             listed: The documents to read, which arrive lazily when they come
                 from a listing.
-            selection: The selection, for the restrictions a document has to be
-                opened to answer.
 
         Yields:
-            One pair per listed document that survives the selection's
-            restrictions.
+            One pair per listed document, read and unfiltered.
         """
         for batch in in_batches(listed, RETRIEVE_BATCH_SIZE):
             sub_paths: list[str | Path] = [f'{entry.stub}{METADATA_SUFFIX}' for entry in batch]
@@ -737,9 +795,8 @@ class TreeRecordSource:
                 list[Path | Exception], root.retrieve(sub_paths, exception_on_fail=False)
             )
             for entry, local_path in zip(batch, local_paths, strict=True):
-                found = self._record_of(root, entry.stub, local_path, selection)
-                if found is not None:
-                    yield self._origin_of(root_url, entry, found), found
+                found = self._read_of(root, entry.stub, local_path)
+                yield self._origin_of(root_url, entry, found), found
 
     @staticmethod
     def _origin_of(
@@ -766,9 +823,10 @@ class TreeRecordSource:
             size_bytes=listed.size_bytes,
         )
 
-    def _record_of(
-        self, root: FCPath, stub: str, local_path: Path | Exception, selection: Selection
-    ) -> NavRecord | UnreadableFile | None:
+    @staticmethod
+    def _read_of(
+        root: FCPath, stub: str, local_path: Path | Exception
+    ) -> NavRecord | UnreadableFile:
         """Read one retrieved document, or say why it yielded no record.
 
         Parameters:
@@ -776,6 +834,32 @@ class TreeRecordSource:
             stub: The image's results path stub.
             local_path: What the retrieval produced for it: a local file, or the
                 exception that says it never arrived.
+
+        Returns:
+            The record the document holds, or the unreadable file it is instead.
+        """
+        path = document_path(root, stub)
+        if isinstance(local_path, BaseException):
+            return UnreadableFile(path=path, stub=stub, reason=COULD_NOT_RETRIEVE)
+        metadata = document_or_refusal(FCPath(local_path))
+        if isinstance(metadata, str):
+            return UnreadableFile(path=path, stub=stub, reason=metadata)
+        return NavRecord(path=path, stub=stub, metadata=metadata)
+
+    def _document_selected(
+        self, found: NavRecord | UnreadableFile, selection: Selection
+    ) -> NavRecord | UnreadableFile | None:
+        """Apply the selection's restrictions to one document, as a record.
+
+        A record is the document, so the mission and the span are read out of
+        the document itself: what a stream of records hands back is what the
+        file says, and the field a filter compares is the field the file
+        records.
+
+        Parameters:
+            found: The record read out of the document, or the unreadable file
+                it was instead, which no restriction can be applied to and which
+                every run reports.
             selection: The selection, for the restrictions a document has to be
                 opened to answer.
 
@@ -789,26 +873,48 @@ class TreeRecordSource:
             instead: it cannot be shown to be another run's, so passing over it
             would drop it out of every run there is.
         """
-        path = document_path(root, stub)
-        if isinstance(local_path, BaseException):
-            return UnreadableFile(path=path, stub=stub, reason=COULD_NOT_RETRIEVE)
-        metadata = document_or_refusal(FCPath(local_path))
-        if isinstance(metadata, str):
-            return UnreadableFile(path=path, stub=stub, reason=metadata)
+        if isinstance(found, UnreadableFile):
+            return found
+        metadata = found.metadata
         if selection.instrument is not None:
             observation = metadata.get('observation')
             instrument = observation.get('instrument') if isinstance(observation, dict) else None
             if not isinstance(instrument, str):
-                return UnreadableFile(path=path, stub=stub, reason=NAMES_NO_INSTRUMENT)
+                return UnreadableFile(path=found.path, stub=found.stub, reason=NAMES_NO_INSTRUMENT)
             if instrument != selection.instrument:
                 return None
         if selection.bounded_in_time:
             midtime = record_midtime_et(metadata)
             if midtime is None:
-                return UnreadableFile(path=path, stub=stub, reason=RECORDS_NO_MIDTIME)
+                return UnreadableFile(path=found.path, stub=found.stub, reason=RECORDS_NO_MIDTIME)
             if not self._within(midtime, selection):
                 return None
-        return NavRecord(path=path, stub=stub, metadata=metadata)
+        return found
+
+    def _facts_selected(self, facts: ImageFacts, selection: Selection) -> bool:
+        """Whether one document's facts are inside the selection's restrictions.
+
+        The mission and the midtime are read off the facts, which are the values
+        a row carries and the values a query over rows compares, so the two
+        storages narrow one tree to the same images.  A document that carries
+        neither is refused before it gets here -- the facts hold an instrument
+        or they are not a navigation document's -- so the only value that can be
+        absent is the midtime, and an image with none is not selected under a
+        bound, exactly as a row with none satisfies no comparison.
+
+        Parameters:
+            facts: What the document says about its image.
+            selection: The selection, for the mission and the time bounds.
+
+        Returns:
+            True when the image is inside every restriction the selection makes.
+        """
+        if selection.instrument is not None and facts.image['instrument'] != selection.instrument:
+            return False
+        if not selection.bounded_in_time:
+            return True
+        midtime = facts.image['midtime_et']
+        return midtime is not None and self._within(float(midtime), selection)
 
     @staticmethod
     def _within(midtime: float, selection: Selection) -> bool:

--- a/src/spindoctor/results_index/__init__.py
+++ b/src/spindoctor/results_index/__init__.py
@@ -33,8 +33,10 @@ Public API:
     normalize_root_url    -- the one spelling of a results root
     ingested_roots        -- the roots a completed ingest covered
     require_ingested_roots -- refuse to read absence from a root nobody ingested
+    RootNotIngestedError  -- what that refusal is, for a caller that reports it its own way
     open_index_for_roots  -- open an index, refusing a root it has not ingested
     newest_finish_time    -- when the newest pass over a root finished
+    unfinished_roots      -- the roots whose newest pass never finished
     FATAL_STATUS          -- the status the error selection filters match
     SPICE_STATUS_ERROR    -- the status_error the SPICE selection filters match
     ResultStubs           -- what a root holds, as a selection filter asks it
@@ -68,11 +70,13 @@ from spindoctor.results_index.masking import masked_url
 from spindoctor.results_index.rebuild import RECORD_FIELDS, RecordField, record_from_row
 from spindoctor.results_index.record_source import IndexRecordSource, open_record_source
 from spindoctor.results_index.roots import (
+    RootNotIngestedError,
     ingested_roots,
     newest_finish_time,
     normalize_root_url,
     open_index_for_roots,
     require_ingested_roots,
+    unfinished_roots,
 )
 from spindoctor.results_index.schema import (
     FAILED_FILES,
@@ -109,6 +113,7 @@ __all__ = [
     'IndexRecordSource',
     'RecordField',
     'ResultStubs',
+    'RootNotIngestedError',
     'TableContents',
     'drop_index_tables',
     'index_contents',
@@ -125,4 +130,5 @@ __all__ = [
     'record_from_row',
     'reporting_a_failed_read',
     'require_ingested_roots',
+    'unfinished_roots',
 ]

--- a/src/spindoctor/results_index/record_source.py
+++ b/src/spindoctor/results_index/record_source.py
@@ -78,24 +78,32 @@ counts it, because a document the ingest refused is a file that exists and a
 listing answers what is there.
 
 **A refused file is reported here under every mission filter and every time
-bound, and by the walk only where the document does not answer the filter.**  A
+bound, and a stream of facts over the documents reports it under both too.**  A
 ``failed_files`` row holds no mission and no epoch, so no filter can exclude it
-and every stream yields it.  The walk has the document rather than a row, and it
-reads the filters out of the document before it decides whether the document is
-a navigation result at all: one it can attribute to another mission, or place
-outside the span, is passed over and never refused, and one it cannot place is
-reported under the walk's own reason for what the filter found rather than under
-the reason an ingest of the same file records.  So the two agree about a refused
-file exactly while the selection places no restriction a document has to be
-opened to answer.  A run that has to compare the two under a filter reads the
-refusals unfiltered from both.
+and every stream yields it.  The walk refuses a file before any filter is
+applied to it and then narrows on the facts it read, which are the values the
+rows here are narrowed on, so the same files are refused and the same images
+selected whichever storage answered.
 
-**A row that cannot be placed is not a refusal here.**  The walk has only the
-document, so one naming no mission or recording no usable midtime is a file it
-can say nothing about, and it reports it.  The index has a row: a row whose
-instrument or midtime is absent satisfies no filter and is simply not selected,
-exactly as a row outside the span is not.  A run that has to account for those
-images reads the documents.
+A stream of *records* is the one that differs, and deliberately: a record is the
+document, so the walk reads the mission and the midtime out of the document
+itself.  A document it can attribute to another mission, or place outside the
+span, is passed over and never refused -- including a file this half holds a
+refusal for -- and one it cannot place at all is reported under the walk's own
+reason for what the filter found rather than under the reason an ingest of the
+same file records.  A run that has to compare the two streams of records under a
+filter reads the refusals unfiltered from both.
+
+**A row that cannot be placed in time is not a refusal here.**  ``instrument``
+is not nullable and a document naming none is refused before an ingest could
+write a row for it, so every row names a mission; ``midtime_et`` is nullable,
+and a row recording none satisfies no bound and is simply not selected, exactly
+as a row outside the span is not.  A stream of facts over the documents reads
+such an image the same way, because the bound is applied to the midtime the
+facts carry.  A stream of records does not: the walk reports a document
+recording no usable midtime, since a record it cannot place cannot be shown to
+be another run's.  A run that has to account for those images reads them under
+no bound.
 
 **A stub both tables record is one file, read as the record it is.**  The ingest
 writes the two tables independently and a pass divided into shares can leave a
@@ -723,8 +731,8 @@ class IndexRecordSource:
         Returns:
             The conditions, empty when the selection restricts neither.  A row
             with no recorded midtime satisfies no bound, since a comparison with
-            NULL is not true -- which is how the walk reads a document
-            recording none.
+            NULL is not true -- which is how a stream of facts over the
+            documents reads one recording none.
         """
         conditions: list[sqlalchemy.ColumnElement[bool]] = []
         if selection.instrument is not None:

--- a/src/spindoctor/results_index/roots.py
+++ b/src/spindoctor/results_index/roots.py
@@ -36,12 +36,25 @@ from spindoctor.results_index.masking import masked_url
 from spindoctor.results_index.schema import INGEST_RUNS
 
 __all__ = [
+    'RootNotIngestedError',
     'ingested_roots',
     'newest_finish_time',
     'normalize_root_url',
     'open_index_for_roots',
     'require_ingested_roots',
+    'unfinished_roots',
 ]
+
+
+class RootNotIngestedError(ValueError):
+    """A root the index holds no completed ingest of.
+
+    A ``ValueError`` like every other refusal this layer raises, so a caller
+    that reports them all alike is unaffected.  It is a type of its own because
+    two callers report it differently from the refusals beside it: it names a
+    value the operator typed, and a program with a usage convention reports a
+    bad value as a usage error rather than as a failed run.
+    """
 
 
 def ingested_roots(connection: sqlalchemy.Connection) -> list[str]:
@@ -73,6 +86,38 @@ def ingested_roots(connection: sqlalchemy.Connection) -> list[str]:
         .order_by(INGEST_RUNS.c.root_url)
     )
     return [str(row.root_url) for row in connection.execute(completed)]
+
+
+def unfinished_roots(connection: sqlalchemy.Connection) -> list[str]:
+    """Return every root the index knows of whose newest ingest run did not complete.
+
+    The other half of :func:`ingested_roots` over the same table, and the half a
+    consumer needs to be able to say what it left out.  A run that reads only
+    the roots with a completed run covers less than the index holds rows for,
+    and a narrowing nobody can name is one an operator reads as an answer about
+    the whole index.
+
+    Parameters:
+        connection: An open connection to the index.
+
+    Returns:
+        The normalized root URLs, in name order.
+    """
+    newest = (
+        sqlalchemy.select(
+            INGEST_RUNS.c.root_url,
+            sqlalchemy.func.max(INGEST_RUNS.c.run_id).label('run_id'),
+        )
+        .group_by(INGEST_RUNS.c.root_url)
+        .subquery()
+    )
+    unfinished = (
+        sqlalchemy.select(INGEST_RUNS.c.root_url)
+        .join(newest, INGEST_RUNS.c.run_id == newest.c.run_id)
+        .where(INGEST_RUNS.c.finished_utc.is_(None))
+        .order_by(INGEST_RUNS.c.root_url)
+    )
+    return [str(row.root_url) for row in connection.execute(unfinished)]
 
 
 def newest_finish_time(connection: sqlalchemy.Connection, root_url: str) -> str | None:
@@ -124,19 +169,19 @@ def require_ingested_roots(
         url: The index URL, so the message says which index was asked.
 
     Raises:
-        ValueError: If any named root has no completed ingest run, naming the
-            roots that are missing and the roots the index does hold.  Under
-            such a root, absence of a row must never be read as "nothing was
-            navigated".  Under an ingested one it may be, but only once the
-            refusal table has been asked too: a completed run makes absence
-            from both tables meaningful, not absence from ``images`` alone.
+        RootNotIngestedError: If any named root has no completed ingest run,
+            naming the roots that are missing and the roots the index does hold.
+            Under such a root, absence of a row must never be read as "nothing
+            was navigated".  Under an ingested one it may be, but only once the
+            refusal table has been asked too: a completed run makes absence from
+            both tables meaningful, not absence from ``images`` alone.
     """
     available = ingested_roots(connection)
     missing = [root for root in roots if root not in available]
     if not missing:
         return
     held = ', '.join(available) if available else '(none)'
-    raise ValueError(
+    raise RootNotIngestedError(
         f'{masked_url(url)}: the results index has no completed ingest of {", ".join(missing)}. '
         f'It holds: {held}. Run sd_stats_ingest over that root first; until then the '
         f'index cannot say whether an image under it was navigated.'
@@ -171,11 +216,14 @@ def open_index_for_roots(url: str, roots: Sequence[str]) -> Engine:
         The open index, which the caller closes when it is done with it.
 
     Raises:
+        RootNotIngestedError: If any named root has no completed ingest run in
+            the index.  A caller that reports a value the operator typed
+            differently from a run that failed catches this one first; the rest
+            catch the ``ValueError`` it is a kind of.
         ValueError: If the URL cannot be opened, does not name an index, or names
-            one written by another version of the schema; if the index cannot be
-            read; or if any named root has no completed ingest run in it.  The
-            engine is disposed of before the refusal leaves here, so a refused
-            caller has nothing to close.
+            one written by another version of the schema, or if the index cannot
+            be read.  The engine is disposed of before any refusal leaves here,
+            so a refused caller has nothing to close.
     """
     engine = open_index(url, create=False)
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,24 +54,25 @@ def directory_naming_no_index(tmp_path_factory: pytest.TempPathFactory) -> Path:
 def no_ambient_results_index_for_the_session(
     directory_naming_no_index: Path,
 ) -> Iterator[None]:
-    """Close both ambient levels for everything a session runs, not only tests.
+    """Close every ambient level for everything a session runs, not only tests.
 
     The per-test fixture below cannot reach a fixture of a broader scope: pytest
     builds a module- or session-scoped one before any function-scoped fixture of
     the test that first asked for it, so a fixture that ingests a tree or runs a
     report would run against the working directory and the environment the suite
-    was started with.  Closing both here as well makes the guarantee one about
+    was started with.  Closing them here as well makes the guarantee one about
     the session rather than about test bodies.
 
     Parameters:
         directory_naming_no_index: The working directory to run under.
 
     Yields:
-        Nothing; both levels are closed for the life of the session.
+        Nothing; every level is closed for the life of the session.
     """
     with pytest.MonkeyPatch.context() as patch:
         patch.chdir(directory_naming_no_index)
         patch.delenv('NAV_RESULTS_DB', raising=False)
+        patch.delenv('NAV_RESULTS_ROOT', raising=False)
         yield
 
 
@@ -79,7 +80,7 @@ def no_ambient_results_index_for_the_session(
 def no_ambient_results_index(
     monkeypatch: pytest.MonkeyPatch, directory_naming_no_index: Path
 ) -> Iterator[None]:
-    """Close both ways a test could reach a results index nobody named.
+    """Close every way a test could reach a results index or tree nobody named.
 
     A results index URL is resolved from three places in order: the argument,
     the ``environment.results_db`` configuration variable, and the
@@ -89,6 +90,13 @@ def no_ambient_results_index(
     against a file an ingest may be holding, and for a report a read of every
     row in it.  Both are closed here rather than in each test, because the level
     an author forgets is the level nothing then tests.
+
+    The navigation results root is closed on the same terms, and for a sharper
+    reason: a program that resolves one *walks* it.  ``sd_stats_report`` with no
+    index reads every document under the tree it resolves, so a test naming
+    neither an index nor a root would read whatever ``NAV_RESULTS_ROOT`` the
+    machine exports -- several hundred thousand documents on a working machine,
+    from a test that means to assert a refusal.
 
     The configuration level is closed by moving the working directory.  The user
     override file is ``nav_default_config.yaml`` beside the process, so a
@@ -112,15 +120,17 @@ def no_ambient_results_index(
         directory_naming_no_index: The working directory to run under.
 
     Yields:
-        Nothing; the test runs with neither ambient level reachable.
+        Nothing; the test runs with no ambient level reachable.
     """
     monkeypatch.chdir(directory_naming_no_index)
     monkeypatch.delenv('NAV_RESULTS_DB', raising=False)
+    monkeypatch.delenv('NAV_RESULTS_ROOT', raising=False)
     # A configuration merged before this test ran -- by a test that named its own
     # override file, or by one that ran before the working directory moved --
     # outlives it: the merge is into a process-global configuration and nothing
     # takes it back out.
     monkeypatch.delitem(DEFAULT_CONFIG.environment, 'results_db', raising=False)
+    monkeypatch.delitem(DEFAULT_CONFIG.environment, 'nav_results_root', raising=False)
     yield
     left_behind = sorted(entry.name for entry in directory_naming_no_index.iterdir())
     for entry in directory_naming_no_index.iterdir():

--- a/tests/spindoctor/cli/stats/conftest.py
+++ b/tests/spindoctor/cli/stats/conftest.py
@@ -7,6 +7,12 @@ is what only the statistics tests read.
 The cloud-task helpers run the same pass in its three separate stages -- divide
 a root into shares, ingest a share, add the shares up -- so that a test asserting
 on one of them does not have to restate the other two.
+
+:class:`ReplayedFacts` is here for the same reason: a source promises no order,
+and the way to measure that a report does not depend on one is to hand it the
+same facts in an order the test chose.  Two modules do that -- one over a whole
+report, one over a section whose reduction has two candidates to choose
+between -- so the stand-in source is written once.
 """
 
 import json
@@ -14,6 +20,7 @@ import os
 import uuid
 from collections.abc import Iterator, Sequence
 from pathlib import Path
+from types import TracebackType
 from typing import Any
 
 import pdslogger
@@ -40,7 +47,21 @@ from spindoctor.cli.stats.ingest import (
     ingest_task_share,
 )
 from spindoctor.cli.stats.report import build_report
-from spindoctor.results_index import INGEST_RUNS, normalize_root_url, open_index
+from spindoctor.nav_records import (
+    ImageFacts,
+    ListedRecord,
+    NavRecord,
+    RecordSource,
+    Selection,
+    TreeRecordSource,
+    UnreadableFile,
+)
+from spindoctor.results_index import (
+    INGEST_RUNS,
+    IndexRecordSource,
+    normalize_root_url,
+    open_index,
+)
 
 # The statistics postgres tier runs against a schema of its own, exactly as the
 # results-index tier does; re-exporting rather than restating keeps one
@@ -54,7 +75,120 @@ RESULTS_TREE = DATA_DIR / 'results_tree'
 """Fixture results tree the report regression is measured over."""
 
 GOLDEN_DIR = DATA_DIR / 'golden'
-"""Report and CSV output this tree produced before the move onto the index."""
+"""Frozen report and CSV output this tree produces, which a change must reproduce."""
+
+GOLDEN_VARIANTS: dict[str, dict[str, Any]] = {
+    'full': {'top_n': 5, 'filelists': True, 'csv_export': True},
+    'filtered': {
+        'instrument': 'coiss',
+        'min_image': '1294561202',
+        'max_image': '1294563000',
+        'top_n': 3,
+        'csv_export': True,
+    },
+}
+"""The two report invocations the frozen output under :data:`GOLDEN_DIR` holds.
+
+Between them they cover the report with every drill-down on and with a narrowing
+that leaves one instrument, so the parity of the two storages is measured over
+the same two invocations the frozen output pins.
+"""
+
+
+class ReplayedFacts:
+    """A record source handing back facts a test already read, in an order it chose.
+
+    The seam promises no order, so the way to measure that the report does not
+    depend on one is to give it the same facts several times over in several
+    orders.  Reading them out of a real source once and replaying them is what
+    makes the orders comparable: two storages differ in more than their order,
+    and a difference in the output would then say nothing about which.
+
+    Parameters:
+        facts: What to yield, in the order to yield it.
+    """
+
+    def __init__(self, facts: Sequence[ImageFacts | UnreadableFile]) -> None:
+        self._facts = tuple(facts)
+
+    def record(self, stub: str) -> NavRecord:
+        """Refuse the per-image lookup, which nothing being measured here asks for.
+
+        Parameters:
+            stub: The image's results path stub.
+
+        Raises:
+            NotImplementedError: Always.
+        """
+        raise NotImplementedError('replayed facts answer no per-image lookup')
+
+    def records(self, selection: Selection) -> Iterator[NavRecord | UnreadableFile]:
+        """Refuse the record stream, which nothing being measured here asks for.
+
+        Parameters:
+            selection: Which records were asked for.
+
+        Raises:
+            NotImplementedError: Always.
+        """
+        raise NotImplementedError('replayed facts answer no record stream')
+
+    def facts(self, selection: Selection) -> Iterator[ImageFacts | UnreadableFile]:
+        """Yield the held facts, in the order this source was built with.
+
+        Parameters:
+            selection: Which images were asked for; the facts were already
+                narrowed when they were read, so this narrows nothing further.
+
+        Returns:
+            The facts, one at a time.
+        """
+        return iter(self._facts)
+
+    def listing(self, selection: Selection) -> Iterator[ListedRecord]:
+        """Refuse the listing, which nothing being measured here asks for.
+
+        Parameters:
+            selection: Which files were asked for.
+
+        Raises:
+            NotImplementedError: Always.
+        """
+        raise NotImplementedError('replayed facts answer no listing')
+
+    def describe(self) -> str:
+        """Say where these records came from, for a run log.
+
+        Returns:
+            A phrase naming the replay rather than a storage.
+        """
+        return 'facts replayed in an order chosen by a test'
+
+    def close(self) -> None:
+        """Release what this source holds open, which is nothing."""
+
+    def __enter__(self) -> RecordSource:
+        """Enter a run's use of this source.
+
+        Returns:
+            The source itself.
+        """
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Leave a run's use of this source.
+
+        Parameters:
+            exc_type: The exception's class, when the run is leaving on one.
+            exc: The exception, when the run is leaving on one.
+            traceback: Its traceback, when the run is leaving on one.
+        """
+        self.close()
 
 
 @pytest.fixture
@@ -204,31 +338,54 @@ def recorded_lines(
     return written
 
 
+def index_source(url: str, roots: Sequence[Path]) -> IndexRecordSource:
+    """Open a record source over the rows an index holds for the given roots.
+
+    Parameters:
+        url: The index URL, which must already carry the schema and the rows.
+        roots: The results roots whose rows the source answers about.
+
+    Returns:
+        The open source, which the caller closes when it is done with it.
+    """
+    return IndexRecordSource(open_index(url), [root.as_posix() for root in roots], url, ())
+
+
 @pytest.fixture
-def indexed_tree(
-    tmp_path: Path, quiet_logger: pdslogger.PdsLogger
-) -> Iterator[sqlalchemy.Connection]:
-    """Yield a connection to an index built from the frozen fixture tree.
+def indexed_tree(tmp_path: Path, quiet_logger: pdslogger.PdsLogger) -> Iterator[RecordSource]:
+    """Yield a record source over an index built from the frozen fixture tree.
 
     Parameters:
         tmp_path: Directory the index file is written into.
         quiet_logger: Logger the ingest reports through.
 
     Yields:
-        An open connection to the index.
+        The open source, reading rows.
     """
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [RESULTS_TREE], logger=quiet_logger)
-    engine = open_index(url)
-    try:
-        with engine.connect() as connection:
-            yield connection
-    finally:
-        engine.dispose()
+    with index_source(url, [RESULTS_TREE]) as source:
+        yield source
 
 
-def report_from_tree(url: str, out: Path, *, logger: pdslogger.PdsLogger, **options: Any) -> Path:
-    """Ingest the fixture tree into an index and write one report from it.
+@pytest.fixture
+def walked_tree() -> Iterator[RecordSource]:
+    """Yield a record source over the documents of the frozen fixture tree.
+
+    The other half of every parity comparison: the same records, read out of the
+    files themselves rather than out of an index ingested from them.
+
+    Yields:
+        The open source, reading documents.
+    """
+    with TreeRecordSource([RESULTS_TREE.as_posix()]) as source:
+        yield source
+
+
+def report_from_the_index(
+    url: str, out: Path, *, logger: pdslogger.PdsLogger, **options: Any
+) -> Path:
+    """Ingest the fixture tree into an index and write one report from its rows.
 
     One definition of the whole cycle -- ingest, open, build, dispose -- so that
     a change to the report's signature is made once rather than once per backend.
@@ -244,12 +401,24 @@ def report_from_tree(url: str, out: Path, *, logger: pdslogger.PdsLogger, **opti
     """
     ingest_tree(url, [RESULTS_TREE], logger=logger)
     out.mkdir(parents=True, exist_ok=True)
-    engine = open_index(url)
-    try:
-        with engine.connect() as connection:
-            build_report(connection, out, **options)
-    finally:
-        engine.dispose()
+    with index_source(url, [RESULTS_TREE]) as source:
+        build_report(source, out, **options)
+    return out
+
+
+def report_from_the_tree(out: Path, **options: Any) -> Path:
+    """Write one report over the documents of the fixture tree, opening no index.
+
+    Parameters:
+        out: Directory receiving the report.
+        options: Report options, passed through to ``build_report``.
+
+    Returns:
+        The directory the report was written into.
+    """
+    out.mkdir(parents=True, exist_ok=True)
+    with TreeRecordSource([RESULTS_TREE.as_posix()]) as source:
+        build_report(source, out, **options)
     return out
 
 

--- a/tests/spindoctor/cli/stats/data/golden/filtered/report.md
+++ b/tests/spindoctor/cli/stats/data/golden/filtered/report.md
@@ -10,6 +10,17 @@ Filters: instrument = coiss, image number >= 1294561202, image number <= 1294563
 
 Total images: 4
 
+## Files that yielded no record
+
+A file named like a navigation document that no record could be read out of is counted here and
+nowhere else: it records no instrument, no date and no image number, so this count covers the whole
+of every selected root and none of the filters above narrows it. One kind of such file is counted
+by a report over the documents and by no report from an index: one the storage could not deliver at
+all. An ingest records no refusal for that, because a retrieval that failed once is worth trying
+again rather than being remembered as a file that will not read.
+
+Files that yielded no record: 0
+
 ## Success / failure
 
 | status | coiss | total |

--- a/tests/spindoctor/cli/stats/data/golden/full/report.md
+++ b/tests/spindoctor/cli/stats/data/golden/full/report.md
@@ -1,6 +1,6 @@
 # Navigation statistics report
 
-Filters: none (full database)
+Filters: none (every image read)
 
 ## Images selected
 
@@ -11,6 +11,17 @@ Filters: none (full database)
 | vgiss | 2 (25.0%) | C1385455 | C1385460 | 1979-02-01T14:39:10 | 1979-02-01T14:55:50 |
 
 Total images: 8
+
+## Files that yielded no record
+
+A file named like a navigation document that no record could be read out of is counted here and
+nowhere else: it records no instrument, no date and no image number, so this count covers the whole
+of every selected root and none of the filters above narrows it. One kind of such file is counted
+by a report over the documents and by no report from an index: one the storage could not deliver at
+all. An ingest records no refusal for that, because a retrieval that failed once is worth trying
+again rather than being remembered as a file that will not read.
+
+Files that yielded no record: 0
 
 ## Success / failure
 

--- a/tests/spindoctor/cli/stats/test_postgres.py
+++ b/tests/spindoctor/cli/stats/test_postgres.py
@@ -23,6 +23,7 @@ import pytest
 import sqlalchemy
 from tests.spindoctor.cli.stats.conftest import (
     GOLDEN_DIR,
+    GOLDEN_VARIANTS,
     REFUSAL_REPORT_LEAD,
     build_tree,
     complete,
@@ -61,8 +62,15 @@ from spindoctor.results_index import (
 
 pytestmark = pytest.mark.postgres
 
-_FULL_VARIANT: dict[str, Any] = {'top_n': 5, 'filelists': True, 'csv_export': True}
-"""The unfiltered report invocation the frozen output was produced by."""
+_FULL_VARIANT: dict[str, Any] = GOLDEN_VARIANTS['full']
+"""The unfiltered report invocation the frozen ``full`` output was produced by.
+
+Read off the shared definition rather than restated beside it.  Every comparison
+below is against output frozen for that variant, so a restatement that drifted
+from it would have this module produce a report under one set of options and
+measure it against output produced under another, and fail for a reason that has
+nothing to do with the backend it is here to exercise.
+"""
 
 _TWIST_COVARIANCE = [
     [0.0961, 0.0100, 0.0025],

--- a/tests/spindoctor/cli/stats/test_postgres.py
+++ b/tests/spindoctor/cli/stats/test_postgres.py
@@ -29,7 +29,7 @@ from tests.spindoctor.cli.stats.conftest import (
     fan_out,
     recorded_lines,
     refusal_report,
-    report_from_tree,
+    report_from_the_index,
     reported,
     run_rows,
 )
@@ -76,7 +76,9 @@ def test_the_report_is_byte_identical_on_postgresql(
     postgres_url: str, tmp_path: Path, quiet_logger: pdslogger.PdsLogger
 ) -> None:
     """The same tree, the same report, on the backend the queries were written for."""
-    out = report_from_tree(postgres_url, tmp_path / 'full', logger=quiet_logger, **_FULL_VARIANT)
+    out = report_from_the_index(
+        postgres_url, tmp_path / 'full', logger=quiet_logger, **_FULL_VARIANT
+    )
     frozen = (GOLDEN_DIR / 'full' / 'report.md').read_text(encoding='utf-8')
     assert (out / 'report.md').read_text(encoding='utf-8') == frozen
 
@@ -84,14 +86,21 @@ def test_the_report_is_byte_identical_on_postgresql(
 def test_the_csv_carries_the_same_images_on_postgresql(
     postgres_url: str, tmp_path: Path, quiet_logger: pdslogger.PdsLogger
 ) -> None:
-    """The export orders and covers the same images, on the same key."""
-    out = report_from_tree(postgres_url, tmp_path / 'full', logger=quiet_logger, **_FULL_VARIANT)
-    produced = [
+    """The export covers the same images, on the same key.
+
+    Compared as sorted names: the rows are written where they are read, and a
+    server sorts the key under its own collation, so line order is not something
+    two backends are asked to agree on.
+    """
+    out = report_from_the_index(
+        postgres_url, tmp_path / 'full', logger=quiet_logger, **_FULL_VARIANT
+    )
+    produced = sorted(
         row['image_name']
         for row in csv.DictReader((out / 'images.csv').read_text(encoding='utf-8').splitlines())
-    ]
+    )
     frozen_text = (GOLDEN_DIR / 'full' / 'images.csv').read_text(encoding='utf-8')
-    frozen = [row['image_name'] for row in csv.DictReader(frozen_text.splitlines())]
+    frozen = sorted(row['image_name'] for row in csv.DictReader(frozen_text.splitlines()))
     assert produced == frozen
 
 
@@ -99,7 +108,9 @@ def test_the_json_columns_round_trip_on_postgresql(
     postgres_url: str, tmp_path: Path, quiet_logger: pdslogger.PdsLogger
 ) -> None:
     """A JSONB column decodes to a Python value, and the CSV re-encodes one."""
-    out = report_from_tree(postgres_url, tmp_path / 'full', logger=quiet_logger, **_FULL_VARIANT)
+    out = report_from_the_index(
+        postgres_url, tmp_path / 'full', logger=quiet_logger, **_FULL_VARIANT
+    )
     frozen_text = (GOLDEN_DIR / 'full' / 'images.csv').read_text(encoding='utf-8')
     frozen = {
         row['image_name']: row['excluded_from_consensus']

--- a/tests/spindoctor/cli/stats/test_report.py
+++ b/tests/spindoctor/cli/stats/test_report.py
@@ -1,22 +1,23 @@
-"""Tests for the statistics report over the results index.
+"""Tests for what each section of the statistics report says.
 
-The report is the one program that requires an index, and its output is a
-contract: the same rows and the same options always produce byte-identical
-Markdown.  These pin what each section says; the frozen comparison in
-``test_report_regression`` pins that the whole of it still says what it said
-before the queries moved onto the index.
+The report reads one pass of navigation records and its output is a contract:
+the same records and the same options always produce byte-identical Markdown.
+These pin what each section says, over records read out of an index; the frozen
+comparison in ``test_report_regression`` pins the whole of it against known
+output, and ``test_report_over_a_tree`` pins that reading the documents
+themselves says the same thing.
 """
 
 import contextlib
 import csv
 from collections.abc import Iterator
 from pathlib import Path
+from types import TracebackType
 from typing import Any
 
 import pdslogger
 import pytest
 from filecache import FCPath
-from sqlalchemy import Connection
 from tests.spindoctor.conftest import (
     index_url,
     ingest_tree,
@@ -26,11 +27,12 @@ from tests.spindoctor.conftest import (
 )
 
 from spindoctor.cli.stats.report import build_report
-from spindoctor.cli.stats.report_sections import IMAGE_COLUMNS
+from spindoctor.cli.stats.report_sections import IMAGE_COLUMNS, CsvExport
 from spindoctor.dataset import DataSetPDS3CassiniISS, DataSetPDS3VoyagerISS
-from spindoctor.results_index import open_index
+from spindoctor.nav_records import DocumentOrigin, RecordSource, facts_from_document
 
 from .conftest import (
+    index_source,
     write_metadata_in_each,
 )
 
@@ -38,8 +40,8 @@ from .conftest import (
 @contextlib.contextmanager
 def _indexed(
     tmp_path: Path, documents: dict[str, dict[str, Any]], logger: pdslogger.PdsLogger
-) -> Iterator[Connection]:
-    """Write documents into a tree, ingest them, and yield a connection.
+) -> Iterator[RecordSource]:
+    """Write documents into a tree, ingest them, and yield a source over the rows.
 
     Parameters:
         tmp_path: Directory the tree and the index live under.
@@ -47,19 +49,15 @@ def _indexed(
         logger: Logger the ingest reports through.
 
     Yields:
-        An open connection to the index.
+        An open record source reading the index.
     """
     root = tmp_path / 'results'
     for stub, document in documents.items():
         write_metadata(root, stub, document)
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [root], logger=logger)
-    engine = open_index(url)
-    try:
-        with engine.connect() as connection:
-            yield connection
-    finally:
-        engine.dispose()
+    with index_source(url, [root]) as source:
+        yield source
 
 
 def _standard_documents() -> dict[str, dict[str, Any]]:
@@ -103,18 +101,18 @@ def _standard_documents() -> dict[str, dict[str, Any]]:
 
 
 @pytest.fixture
-def standard(tmp_path: Path, quiet_logger: pdslogger.PdsLogger) -> Iterator[Connection]:
-    """Yield a connection to an index holding the three standard documents.
+def standard(tmp_path: Path, quiet_logger: pdslogger.PdsLogger) -> Iterator[RecordSource]:
+    """Yield a source over an index holding the three standard documents.
 
     Parameters:
         tmp_path: Directory the tree and the index live under.
         quiet_logger: Logger the ingest reports through.
 
     Yields:
-        An open connection.
+        An open record source.
     """
-    with _indexed(tmp_path, _standard_documents(), quiet_logger) as connection:
-        yield connection
+    with _indexed(tmp_path, _standard_documents(), quiet_logger) as source:
+        yield source
 
 
 # ---------------------------------------------------------------------------
@@ -122,25 +120,25 @@ def standard(tmp_path: Path, quiet_logger: pdslogger.PdsLogger) -> Iterator[Conn
 # ---------------------------------------------------------------------------
 
 
-def test_build_report_writes_the_status_table(standard: Connection, tmp_path: Path) -> None:
+def test_build_report_writes_the_status_table(standard: RecordSource, tmp_path: Path) -> None:
     """One column per instrument, then a total, every count with a percentage."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| status | coiss | vgiss | total |' in text
 
 
-def test_build_report_counts_successes(standard: Connection, tmp_path: Path) -> None:
+def test_build_report_counts_successes(standard: RecordSource, tmp_path: Path) -> None:
     """An instrument column's percentage is of that instrument's images."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| success | 2 (100.0%) | 0 (0.0%) | 2 (66.7%) |' in text
 
 
-def test_build_report_counts_failures(standard: Connection, tmp_path: Path) -> None:
+def test_build_report_counts_failures(standard: RecordSource, tmp_path: Path) -> None:
     """A failed image is counted under its own instrument."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| failed | 0 (0.0%) | 1 (100.0%) | 1 (33.3%) |' in text
 
 
-def test_build_report_names_the_failure_reason(standard: Connection, tmp_path: Path) -> None:
+def test_build_report_names_the_failure_reason(standard: RecordSource, tmp_path: Path) -> None:
     """The navigator's own explanation reaches the failure-reason table."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
     assert 'no_features_extracted' in text
@@ -163,8 +161,8 @@ def test_a_status_error_reaches_the_reason_table(
             offset=None,
         )
     }
-    with _indexed(tmp_path, documents, quiet_logger) as connection:
-        text = build_report(connection, tmp_path / 'report').read_text(encoding='utf-8')
+    with _indexed(tmp_path, documents, quiet_logger) as source:
+        text = build_report(source, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| error | missing_spice_data | 1 (100.0%) | 1 (100.0%) |' in text
 
 
@@ -181,26 +179,28 @@ def test_a_status_reason_wins_over_a_status_error(
             offset=None,
         )
     }
-    with _indexed(tmp_path, documents, quiet_logger) as connection:
-        text = build_report(connection, tmp_path / 'report').read_text(encoding='utf-8')
+    with _indexed(tmp_path, documents, quiet_logger) as source:
+        text = build_report(source, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| failed | no_features_extracted | 1 (100.0%) | 1 (100.0%) |' in text
 
 
-def test_build_report_writes_charts(standard: Connection, tmp_path: Path) -> None:
+def test_build_report_writes_charts(standard: RecordSource, tmp_path: Path) -> None:
     """Each categorical section gets a stacked bar chart beside its table."""
     out = tmp_path / 'report'
     build_report(standard, out)
     assert (out / 'status_counts.png').exists()
 
 
-def test_build_report_writes_one_histogram_per_camera(standard: Connection, tmp_path: Path) -> None:
+def test_build_report_writes_one_histogram_per_camera(
+    standard: RecordSource, tmp_path: Path
+) -> None:
     """Offsets are never pooled across cameras, and neither are their charts."""
     out = tmp_path / 'report'
     build_report(standard, out)
     assert (out / 'offsets_hist_coiss_NAC.png').exists()
 
 
-def test_build_report_selection_section(standard: Connection, tmp_path: Path) -> None:
+def test_build_report_selection_section(standard: RecordSource, tmp_path: Path) -> None:
     """The report opens with per-instrument counts and image/date bounds."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
     assert (
@@ -210,7 +210,7 @@ def test_build_report_selection_section(standard: Connection, tmp_path: Path) ->
 
 
 def test_build_report_selection_covers_every_instrument(
-    standard: Connection, tmp_path: Path
+    standard: RecordSource, tmp_path: Path
 ) -> None:
     """Each instrument gets a row, with its own image and date bounds."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
@@ -220,7 +220,7 @@ def test_build_report_selection_covers_every_instrument(
     )
 
 
-def test_build_report_reports_the_total(standard: Connection, tmp_path: Path) -> None:
+def test_build_report_reports_the_total(standard: RecordSource, tmp_path: Path) -> None:
     """The selection section closes with what the filters actually selected."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
     assert 'Total images: 3' in text
@@ -239,8 +239,8 @@ def test_dates_ignore_a_dateless_extreme_image(
         offset=None,
         image_et=None,
     )
-    with _indexed(tmp_path, documents, quiet_logger) as connection:
-        text = build_report(connection, tmp_path / 'report').read_text(encoding='utf-8')
+    with _indexed(tmp_path, documents, quiet_logger) as source:
+        text = build_report(source, tmp_path / 'report').read_text(encoding='utf-8')
     assert (
         '| coiss | 3 (75.0%) | N0000000001 | N1000000002 '
         '| 2000-01-01T11:58:56 | 2000-01-01T11:58:56 |' in text
@@ -256,8 +256,8 @@ def test_offsets_separate_nac_from_wac(tmp_path: Path, quiet_logger: pdslogger.P
         image_shape=[512, 512],
         offset=[0.4, 0.6],
     )
-    with _indexed(tmp_path, documents, quiet_logger) as connection:
-        text = build_report(connection, tmp_path / 'report').read_text(encoding='utf-8')
+    with _indexed(tmp_path, documents, quiet_logger) as source:
+        text = build_report(source, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| coiss | WAC | dV | 1 (33.3%) |' in text
 
 
@@ -273,19 +273,19 @@ def test_each_camera_gets_its_own_histogram(
         offset=[0.4, 0.6],
     )
     out = tmp_path / 'report'
-    with _indexed(tmp_path, documents, quiet_logger) as connection:
-        build_report(connection, out)
+    with _indexed(tmp_path, documents, quiet_logger) as source:
+        build_report(source, out)
     assert (out / 'offsets_hist_coiss_WAC.png').exists()
 
 
-def test_confidence_tiers_always_listed(standard: Connection, tmp_path: Path) -> None:
+def test_confidence_tiers_always_listed(standard: RecordSource, tmp_path: Path) -> None:
     """A tier with no images reads as an explicit zero, not a missing row."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
     section = text.split('## Confidence calibration')[1]
     assert '| low | 0 (0.0%) | 0 (0.0%) | 0 (0.0%) |' in section
 
 
-def test_confidence_tiers_are_in_tier_order(standard: Connection, tmp_path: Path) -> None:
+def test_confidence_tiers_are_in_tier_order(standard: RecordSource, tmp_path: Path) -> None:
     """Descending confidence, so the table reads as a calibration curve."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
     section = text.split('## Confidence calibration')[1]
@@ -293,14 +293,14 @@ def test_confidence_tiers_are_in_tier_order(standard: Connection, tmp_path: Path
     assert tiers[:6] == ['tier', 'high', 'medium', 'low', 'failed', 'conflicted']
 
 
-def test_offset_statistics_are_headed_per_camera(standard: Connection, tmp_path: Path) -> None:
+def test_offset_statistics_are_headed_per_camera(standard: RecordSource, tmp_path: Path) -> None:
     """Pointing error belongs to the camera, so the table is keyed by one."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| instrument | camera | axis | images | mean | median | stdev | min | max |' in text
 
 
 def test_a_failed_instrument_contributes_no_offset_group(
-    standard: Connection, tmp_path: Path
+    standard: RecordSource, tmp_path: Path
 ) -> None:
     """Only successful images have an offset to describe."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
@@ -308,14 +308,14 @@ def test_a_failed_instrument_contributes_no_offset_group(
     assert '| vgiss |' not in section
 
 
-def test_build_report_accepts_fcpath_output_dir(standard: Connection, tmp_path: Path) -> None:
+def test_build_report_accepts_fcpath_output_dir(standard: RecordSource, tmp_path: Path) -> None:
     """Every artifact writes through FCPath, so the output may be a cloud URL."""
     out = FCPath(str(tmp_path / 'report'))
     report_path = build_report(standard, out, top_n=2, filelists=True, csv_export=True)
     assert 'Total images: 3' in report_path.read_text(encoding='utf-8')
 
 
-def test_build_report_writes_the_csv_through_fcpath(standard: Connection, tmp_path: Path) -> None:
+def test_build_report_writes_the_csv_through_fcpath(standard: RecordSource, tmp_path: Path) -> None:
     """The CSV goes to the same place by the same route."""
     build_report(
         standard, FCPath(str(tmp_path / 'report')), top_n=2, filelists=True, csv_export=True
@@ -323,7 +323,9 @@ def test_build_report_writes_the_csv_through_fcpath(standard: Connection, tmp_pa
     assert (tmp_path / 'report' / 'images.csv').exists()
 
 
-def test_instrument_filter_excludes_other_instruments(standard: Connection, tmp_path: Path) -> None:
+def test_instrument_filter_excludes_other_instruments(
+    standard: RecordSource, tmp_path: Path
+) -> None:
     """A filtered report has no column for an instrument it filtered out."""
     text = build_report(standard, tmp_path / 'report', instrument='vgiss').read_text(
         encoding='utf-8'
@@ -332,7 +334,7 @@ def test_instrument_filter_excludes_other_instruments(standard: Connection, tmp_
 
 
 def test_instrument_filter_reports_only_that_instrument(
-    standard: Connection, tmp_path: Path
+    standard: RecordSource, tmp_path: Path
 ) -> None:
     """And no row for an outcome only the excluded instrument had."""
     text = build_report(standard, tmp_path / 'report', instrument='vgiss').read_text(
@@ -342,7 +344,7 @@ def test_instrument_filter_reports_only_that_instrument(
     assert '| success |' not in status_table
 
 
-def test_date_filter_excludes_out_of_range(standard: Connection, tmp_path: Path) -> None:
+def test_date_filter_excludes_out_of_range(standard: RecordSource, tmp_path: Path) -> None:
     """The Voyager frame is two decades outside this range."""
     text = build_report(
         standard, tmp_path / 'report', start_date='1999-01-01', end_date='2001-01-01'
@@ -350,7 +352,7 @@ def test_date_filter_excludes_out_of_range(standard: Connection, tmp_path: Path)
     assert 'Total images: 2' in text
 
 
-def test_min_image_filter(standard: Connection, tmp_path: Path) -> None:
+def test_min_image_filter(standard: RecordSource, tmp_path: Path) -> None:
     """The range filter compares the ingested column, on any backend."""
     text = build_report(standard, tmp_path / 'report', min_image='N1000000002').read_text(
         encoding='utf-8'
@@ -358,7 +360,7 @@ def test_min_image_filter(standard: Connection, tmp_path: Path) -> None:
     assert 'Total images: 1' in text
 
 
-def test_min_image_filter_is_reported(standard: Connection, tmp_path: Path) -> None:
+def test_min_image_filter_is_reported(standard: RecordSource, tmp_path: Path) -> None:
     """A report says what it was filtered by, so a stale one is recognizable."""
     text = build_report(standard, tmp_path / 'report', min_image='N1000000002').read_text(
         encoding='utf-8'
@@ -366,7 +368,7 @@ def test_min_image_filter_is_reported(standard: Connection, tmp_path: Path) -> N
     assert 'image number >= 1000000002' in text
 
 
-def test_max_image_filter(standard: Connection, tmp_path: Path) -> None:
+def test_max_image_filter(standard: RecordSource, tmp_path: Path) -> None:
     """Only the Voyager frame falls at or below this number."""
     text = build_report(standard, tmp_path / 'report', max_image='5000000').read_text(
         encoding='utf-8'
@@ -386,12 +388,10 @@ def test_root_filter_selects_one_root(tmp_path: Path, quiet_logger: pdslogger.Pd
     )
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [first, second], logger=quiet_logger)
-    engine = open_index(url)
-    with engine.connect() as connection:
-        text = build_report(connection, tmp_path / 'report', roots=[first.as_posix()]).read_text(
+    with index_source(url, [first, second]) as source:
+        text = build_report(source, tmp_path / 'report', roots=[first.as_posix()]).read_text(
             encoding='utf-8'
         )
-    engine.dispose()
     assert 'Total images: 1' in text
 
 
@@ -409,10 +409,8 @@ def test_a_report_over_every_root_sees_every_root(
     )
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [first, second], logger=quiet_logger)
-    engine = open_index(url)
-    with engine.connect() as connection:
-        text = build_report(connection, tmp_path / 'report').read_text(encoding='utf-8')
-    engine.dispose()
+    with index_source(url, [first, second]) as source:
+        text = build_report(source, tmp_path / 'report').read_text(encoding='utf-8')
     assert 'Total images: 2' in text
 
 
@@ -424,52 +422,50 @@ def test_a_named_root_is_reported_as_a_filter(
     write_metadata(root, 'VOL/N1000000001_1_CALIB', metadata_document())
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [root], logger=quiet_logger)
-    engine = open_index(url)
-    with engine.connect() as connection:
-        text = build_report(connection, tmp_path / 'report', roots=[root.as_posix()]).read_text(
+    with index_source(url, [root]) as source:
+        text = build_report(source, tmp_path / 'report', roots=[root.as_posix()]).read_text(
             encoding='utf-8'
         )
-    engine.dispose()
     assert f'root in {root.as_posix()}' in text
 
 
-def test_build_report_rejects_digitless_image_bound(standard: Connection, tmp_path: Path) -> None:
+def test_build_report_rejects_digitless_image_bound(standard: RecordSource, tmp_path: Path) -> None:
     """A bound with no digits names nothing and is refused rather than ignored."""
     with pytest.raises(ValueError, match='contains no digits'):
         build_report(standard, tmp_path / 'report', min_image='nodigits')
 
 
-def test_failure_taxonomy_classifies_by_content(standard: Connection, tmp_path: Path) -> None:
+def test_failure_taxonomy_classifies_by_content(standard: RecordSource, tmp_path: Path) -> None:
     """The failed Voyager frame recorded one body, so it is single-body."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| single-body | 0 (0.0%) | 1 (100.0%) | 1 (33.3%) |' in text
 
 
-def test_failure_taxonomy_breaks_down_by_reason(standard: Connection, tmp_path: Path) -> None:
+def test_failure_taxonomy_breaks_down_by_reason(standard: RecordSource, tmp_path: Path) -> None:
     """Each content category carries the reasons its images failed for."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| single-body | no_features_extracted | 0 (0.0%) | 1 (100.0%) | 1 (33.3%) |' in text
 
 
-def test_per_body_failure_share_counts_failures(standard: Connection, tmp_path: Path) -> None:
+def test_per_body_failure_share_counts_failures(standard: RecordSource, tmp_path: Path) -> None:
     """A body with a high failure share points at a modeling problem."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| IAPETUS | vgiss | 1 (100.0%) | 0 (0.0%) | 1.000 |' in text
 
 
-def test_per_body_failure_share_counts_successes(standard: Connection, tmp_path: Path) -> None:
+def test_per_body_failure_share_counts_successes(standard: RecordSource, tmp_path: Path) -> None:
     """The same body on the instrument where it worked."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| IAPETUS | coiss | 0 (0.0%) | 2 (100.0%) | 0.000 |' in text
 
 
-def test_offset_by_group_section(standard: Connection, tmp_path: Path) -> None:
+def test_offset_by_group_section(standard: RecordSource, tmp_path: Path) -> None:
     """Offsets additionally break down by camera and image size."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| coiss | NAC | 1024x1024 | 2 (100.0%) ' in text
 
 
-def test_technique_usage_counts_images(standard: Connection, tmp_path: Path) -> None:
+def test_technique_usage_counts_images(standard: RecordSource, tmp_path: Path) -> None:
     """Each technique is credited with the images it ran on."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| BodyDiscCorrelateNav | coiss | 1 (50.0%) | 1 (100.0%) | 0.700 |' in text
@@ -493,8 +489,8 @@ def test_technique_usage_counts_non_spurious_runs(
             per_technique=[technique('BodyLimbNav', (1.0, 1.0))],
         ),
     }
-    with _indexed(tmp_path, documents, quiet_logger) as connection:
-        text = build_report(connection, tmp_path / 'report').read_text(encoding='utf-8')
+    with _indexed(tmp_path, documents, quiet_logger) as source:
+        text = build_report(source, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| BodyLimbNav | coiss | 2 (100.0%) | 1 (50.0%) | 0.700 |' in text
 
 
@@ -511,12 +507,12 @@ def test_a_spurious_technique_is_left_out_of_the_agreement(
             ],
         )
     }
-    with _indexed(tmp_path, documents, quiet_logger) as connection:
-        text = build_report(connection, tmp_path / 'report').read_text(encoding='utf-8')
+    with _indexed(tmp_path, documents, quiet_logger) as source:
+        text = build_report(source, tmp_path / 'report').read_text(encoding='utf-8')
     assert 'BodyLimbNav vs StarUniqueMatchNav' not in text
 
 
-def test_source_usage_counts_images_once_per_source(standard: Connection, tmp_path: Path) -> None:
+def test_source_usage_counts_images_once_per_source(standard: RecordSource, tmp_path: Path) -> None:
     """An image contributing several feature types of one source counts once."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| body:IAPETUS | IAPETUS | 2 (100.0%) | 1 (100.0%) | 3 (100.0%) |' in text
@@ -531,8 +527,8 @@ def test_suspect_offset_section_flags_an_offset_near_the_limit(
     documents['COISS_2001/N1000000003_1_CALIB'] = metadata_document(
         image_name='N1000000003_1_CALIB.IMG', image_shape=[1024, 1024], offset=[49.0, 10.0]
     )
-    with _indexed(tmp_path, documents, quiet_logger) as connection:
-        text = build_report(connection, tmp_path / 'report').read_text(encoding='utf-8')
+    with _indexed(tmp_path, documents, quiet_logger) as source:
+        text = build_report(source, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| N1000000003 | coiss | 49.000 | 10.000 |' in text
 
 
@@ -544,8 +540,8 @@ def test_suspect_offset_section_counts_what_it_screened(
     documents['COISS_2001/N1000000003_1_CALIB'] = metadata_document(
         image_name='N1000000003_1_CALIB.IMG', image_shape=[1024, 1024], offset=[49.0, 10.0]
     )
-    with _indexed(tmp_path, documents, quiet_logger) as connection:
-        text = build_report(connection, tmp_path / 'report').read_text(encoding='utf-8')
+    with _indexed(tmp_path, documents, quiet_logger) as source:
+        text = build_report(source, tmp_path / 'report').read_text(encoding='utf-8')
     assert 'Suspect images: 1 (25.0%) of 3 screened.' in text
 
 
@@ -554,8 +550,8 @@ def test_suspect_offset_section_reports_unresolved_limits(
 ) -> None:
     """An image whose limit cannot be resolved is called out, not dropped."""
     documents = {'X9999999': metadata_document(image_name='X9999999.IMG', instrument='mystery')}
-    with _indexed(tmp_path, documents, quiet_logger) as connection:
-        text = build_report(connection, tmp_path / 'report').read_text(encoding='utf-8')
+    with _indexed(tmp_path, documents, quiet_logger) as source:
+        text = build_report(source, tmp_path / 'report').read_text(encoding='utf-8')
     assert "mystery: no configured search limit for instrument 'mystery' (1 image(s))" in text
 
 
@@ -589,8 +585,8 @@ def _botsim_documents() -> dict[str, dict[str, Any]]:
 
 def test_botsim_section_identifies_pairs(tmp_path: Path, quiet_logger: pdslogger.PdsLogger) -> None:
     """A pair is two frames sharing one spacecraft-clock count."""
-    with _indexed(tmp_path, _botsim_documents(), quiet_logger) as connection:
-        text = build_report(connection, tmp_path / 'report', top_n=5).read_text(encoding='utf-8')
+    with _indexed(tmp_path, _botsim_documents(), quiet_logger) as source:
+        text = build_report(source, tmp_path / 'report', top_n=5).read_text(encoding='utf-8')
     assert '| pairs identified | 3 |' in text
 
 
@@ -598,8 +594,8 @@ def test_botsim_section_compares_only_navigated_pairs(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger
 ) -> None:
     """A pair whose WAC frame failed is identified but not compared."""
-    with _indexed(tmp_path, _botsim_documents(), quiet_logger) as connection:
-        text = build_report(connection, tmp_path / 'report', top_n=5).read_text(encoding='utf-8')
+    with _indexed(tmp_path, _botsim_documents(), quiet_logger) as source:
+        text = build_report(source, tmp_path / 'report', top_n=5).read_text(encoding='utf-8')
     assert '| pairs with both navigated | 2 |' in text
 
 
@@ -607,8 +603,8 @@ def test_botsim_section_reports_the_residual(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger
 ) -> None:
     """Residuals are 0.0 and 2.0, so the median is 1.0."""
-    with _indexed(tmp_path, _botsim_documents(), quiet_logger) as connection:
-        text = build_report(connection, tmp_path / 'report', top_n=5).read_text(encoding='utf-8')
+    with _indexed(tmp_path, _botsim_documents(), quiet_logger) as source:
+        text = build_report(source, tmp_path / 'report', top_n=5).read_text(encoding='utf-8')
     assert '| median residual (px) | 1.000 |' in text
 
 
@@ -616,26 +612,26 @@ def test_botsim_section_names_the_worst_pair(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger
 ) -> None:
     """The worst-pairs table leads with the inconsistent pair, by image name."""
-    with _indexed(tmp_path, _botsim_documents(), quiet_logger) as connection:
-        text = build_report(connection, tmp_path / 'report', top_n=5).read_text(encoding='utf-8')
+    with _indexed(tmp_path, _botsim_documents(), quiet_logger) as source:
+        text = build_report(source, tmp_path / 'report', top_n=5).read_text(encoding='utf-8')
     assert '| 1454725900 | N1454725900 | W1454725900 | 2.000 | 0.000 | 2.000 |' in text
 
 
-def test_runtime_section_per_instrument(standard: Connection, tmp_path: Path) -> None:
+def test_runtime_section_per_instrument(standard: RecordSource, tmp_path: Path) -> None:
     """Per-instrument run times, as a share of that instrument's images."""
     text = build_report(standard, tmp_path / 'report', top_n=2).read_text(encoding='utf-8')
     assert '| coiss | 2 (100.0%) | 6.500 | 3.250 | 3.250 | 3.250 | 3.250 | 0.000 |' in text
 
 
 def test_runtime_section_pools_when_more_than_one_instrument(
-    standard: Connection, tmp_path: Path
+    standard: RecordSource, tmp_path: Path
 ) -> None:
     """The pooled row says something new only once two instruments fed it."""
     text = build_report(standard, tmp_path / 'report', top_n=2).read_text(encoding='utf-8')
     assert '| (all) | 3 (100.0%) | 9.750 | 3.250 | 3.250 | 3.250 | 3.250 | 0.000 |' in text
 
 
-def test_runtime_section_lists_the_slowest(standard: Connection, tmp_path: Path) -> None:
+def test_runtime_section_lists_the_slowest(standard: RecordSource, tmp_path: Path) -> None:
     """With a drill-down count, the slowest images are named."""
     text = build_report(standard, tmp_path / 'report', top_n=2).read_text(encoding='utf-8')
     assert 'Slowest 2 image(s):' in text
@@ -646,24 +642,24 @@ def test_runtime_section_skipped_without_timing(
 ) -> None:
     """A tree whose documents carry no timing gets no run-time section."""
     documents = {'COISS_2001/N1454725799_1_CALIB': metadata_document(elapsed_s=None)}
-    with _indexed(tmp_path, documents, quiet_logger) as connection:
-        text = build_report(connection, tmp_path / 'report').read_text(encoding='utf-8')
+    with _indexed(tmp_path, documents, quiet_logger) as source:
+        text = build_report(source, tmp_path / 'report').read_text(encoding='utf-8')
     assert '## Run-time statistics' not in text
 
 
-def test_top_n_lists_examples(standard: Connection, tmp_path: Path) -> None:
+def test_top_n_lists_examples(standard: RecordSource, tmp_path: Path) -> None:
     """Examples are grouped by instrument and printed as image names."""
     text = build_report(standard, tmp_path / 'report', top_n=5).read_text(encoding='utf-8')
     assert '- no_features_extracted / vgiss: C3250013' in text
 
 
-def test_top_n_lists_exclusion_examples(standard: Connection, tmp_path: Path) -> None:
+def test_top_n_lists_exclusion_examples(standard: RecordSource, tmp_path: Path) -> None:
     """The ensemble-exclusion section drills down the same way."""
     text = build_report(standard, tmp_path / 'report', top_n=5).read_text(encoding='utf-8')
     assert '- BodyBlobNav / coiss: N1000000002' in text
 
 
-def test_the_exclusion_section_counts_images(standard: Connection, tmp_path: Path) -> None:
+def test_the_exclusion_section_counts_images(standard: RecordSource, tmp_path: Path) -> None:
     """The exclusion set is a JSON column, and the empty set is not a category."""
     text = build_report(standard, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| BodyBlobNav | 1 (50.0%) | 0 (0.0%) | 1 (33.3%) |' in text
@@ -689,8 +685,8 @@ def test_two_orders_of_one_exclusion_set_are_one_category(
             excluded=['BodyBlobNav', 'StarUniqueMatchNav'],
         ),
     }
-    with _indexed(tmp_path, documents, quiet_logger) as connection:
-        text = build_report(connection, tmp_path / 'report').read_text(encoding='utf-8')
+    with _indexed(tmp_path, documents, quiet_logger) as source:
+        text = build_report(source, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| BodyBlobNav, StarUniqueMatchNav | 2 (100.0%) | 2 (100.0%) |' in text
 
 
@@ -699,12 +695,12 @@ def test_no_exclusions_means_no_exclusion_section(
 ) -> None:
     """An index where the ensemble excluded nothing has nothing to report."""
     documents = {'COISS_2001/N1454725799_1_CALIB': metadata_document()}
-    with _indexed(tmp_path, documents, quiet_logger) as connection:
-        text = build_report(connection, tmp_path / 'report').read_text(encoding='utf-8')
+    with _indexed(tmp_path, documents, quiet_logger) as source:
+        text = build_report(source, tmp_path / 'report').read_text(encoding='utf-8')
     assert '## Ensemble outlier exclusions' not in text
 
 
-def test_filelists_written(standard: Connection, tmp_path: Path) -> None:
+def test_filelists_written(standard: RecordSource, tmp_path: Path) -> None:
     """One full image-name list per category and instrument."""
     out = tmp_path / 'report'
     build_report(standard, out, filelists=True)
@@ -714,7 +710,7 @@ def test_filelists_written(standard: Connection, tmp_path: Path) -> None:
     )
 
 
-def test_filelists_cover_the_exclusion_section(standard: Connection, tmp_path: Path) -> None:
+def test_filelists_cover_the_exclusion_section(standard: RecordSource, tmp_path: Path) -> None:
     """Every drill-down section writes its lists, not only the first."""
     out = tmp_path / 'report'
     build_report(standard, out, filelists=True)
@@ -724,13 +720,13 @@ def test_filelists_cover_the_exclusion_section(standard: Connection, tmp_path: P
     )
 
 
-def test_filelists_are_referenced_from_the_report(standard: Connection, tmp_path: Path) -> None:
+def test_filelists_are_referenced_from_the_report(standard: RecordSource, tmp_path: Path) -> None:
     """A list nobody is pointed at is a list nobody reads."""
     text = build_report(standard, tmp_path / 'report', filelists=True).read_text(encoding='utf-8')
     assert 'filelists/failure_reason_no_features_extracted_vgiss.txt' in text
 
 
-def test_filelists_are_image_filelist_readable(standard: Connection, tmp_path: Path) -> None:
+def test_filelists_are_image_filelist_readable(standard: RecordSource, tmp_path: Path) -> None:
     """Every filelist line is a comment or a name the dataset layer accepts."""
     out = tmp_path / 'report'
     build_report(standard, out, filelists=True)
@@ -748,35 +744,135 @@ def test_filelists_are_image_filelist_readable(standard: Connection, tmp_path: P
     assert invalid == []
 
 
-def test_csv_export_is_announced(standard: Connection, tmp_path: Path) -> None:
+def test_csv_export_is_announced(standard: RecordSource, tmp_path: Path) -> None:
     """The report says the CSV exists and how many rows it holds."""
     text = build_report(standard, tmp_path / 'report', csv_export=True).read_text(encoding='utf-8')
     assert 'images.csv (3 row(s))' in text
 
 
-def test_csv_export_writes_one_row_per_image(standard: Connection, tmp_path: Path) -> None:
+def test_csv_export_writes_one_row_per_image(standard: RecordSource, tmp_path: Path) -> None:
     """Three images, plus the header."""
     out = tmp_path / 'report'
     build_report(standard, out, csv_export=True)
     assert len((out / 'images.csv').read_text(encoding='utf-8').splitlines()) == 4
 
 
-def test_csv_export_carries_every_column_in_schema_order(
-    standard: Connection, tmp_path: Path
+class _SpyHandle:
+    """A file handle recording what reached it, and whether it has been closed.
+
+    Stands in for the handle the export writes through, so a test can read what
+    had been written at a moment the export was still open.  Its size on disk
+    cannot answer that: the writer underneath buffers several kilobytes, so a
+    small export reaches the filesystem only when it is closed however it was
+    written.
+    """
+
+    def __init__(self) -> None:
+        self.written: list[str] = []
+        self.closed = False
+
+    def __enter__(self) -> '_SpyHandle':
+        """Enter the export's use of this handle.
+
+        Returns:
+            The handle itself, which is what the export writes through.
+        """
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Record that the export closed this handle.
+
+        Parameters:
+            exc_type: The exception's class, when the export is leaving on one.
+            exc: The exception, when the export is leaving on one.
+            traceback: Its traceback, when the export is leaving on one.
+        """
+        self.closed = True
+
+    def write(self, text: str) -> int:
+        """Record one piece of text the export wrote.
+
+        Parameters:
+            text: What was written.
+
+        Returns:
+            How many characters were taken, which is all of them.
+        """
+        self.written.append(text)
+        return len(text)
+
+
+def test_the_csv_export_writes_each_row_where_it_reads_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The export is the whole row, so a question the report skips is answerable."""
+    """A row collected and written at the end is a copy of the export held in memory.
+
+    The export exists so that a report over an archive-scale root pays for the
+    file rather than for a copy of it, and buffering the rows produces a
+    byte-identical file, so nothing about the output can tell the two apart.
+    What can is when a row reaches the handle: here it is read out of the spy
+    while the export is still open.
+    """
+    origin = DocumentOrigin(
+        root_url=(tmp_path / 'results').as_posix(),
+        results_path_stub='VOL/N1000000001_1_CALIB',
+        source_file=(tmp_path / 'results' / 'VOL' / 'N1000000001_1_CALIB_metadata.json').as_posix(),
+        mtime_ns=None,
+        size_bytes=None,
+    )
+    facts = facts_from_document(metadata_document(image_name='N1000000001_1_CALIB.IMG'), origin)
+    spy = _SpyHandle()
+    monkeypatch.setattr(FCPath, 'open', lambda *arguments, **options: spy)
+    with CsvExport(FCPath(tmp_path / 'images.csv')) as export:
+        export.add(facts)
+        while_open = ''.join(spy.written)
+    assert 'N1000000001_1_CALIB.IMG' in while_open
+
+
+def test_csv_export_carries_every_column_of_the_row(standard: RecordSource, tmp_path: Path) -> None:
+    """The export is the whole row, so a question the report skips is answerable.
+
+    Compared as a set of names: which column stands where is pinned by the
+    ratified header list in ``test_report_regression`` and by the leading column
+    below, and a column the export silently dropped would pass both of those.
+    """
     out = tmp_path / 'report'
     build_report(standard, out, csv_export=True)
     header = (out / 'images.csv').read_text(encoding='utf-8').splitlines()[0].split(',')
-    assert header[: len(IMAGE_COLUMNS)] == list(IMAGE_COLUMNS)
+    assert sorted(header[: len(IMAGE_COLUMNS)]) == sorted(IMAGE_COLUMNS)
 
 
-def test_csv_export_starts_at_the_key_columns() -> None:
-    """A row that does not say which image it is cannot be joined to anything."""
-    assert IMAGE_COLUMNS[:2] == ('root_url', 'results_path_stub')
+def test_csv_export_leads_with_the_column_an_operator_sorts_on(
+    standard: RecordSource, tmp_path: Path
+) -> None:
+    """The rows are written as they are read, so the file has to be sortable.
+
+    ``sort -t, -k1,1 images.csv`` is the whole of what an operator has to do to
+    put the export in key order, and it only works while the key the rows are
+    told apart by leads the row.
+    """
+    out = tmp_path / 'report'
+    build_report(standard, out, csv_export=True)
+    header = (out / 'images.csv').read_text(encoding='utf-8').splitlines()[0].split(',')
+    assert header[0] == 'results_path_stub'
 
 
-def test_csv_export_ends_with_the_aggregates(standard: Connection, tmp_path: Path) -> None:
+def test_csv_export_still_carries_the_root_of_each_row(
+    standard: RecordSource, tmp_path: Path
+) -> None:
+    """A stub is a key under a root, so a row naming one and not the other is unjoinable."""
+    out = tmp_path / 'report'
+    build_report(standard, out, csv_export=True)
+    header = (out / 'images.csv').read_text(encoding='utf-8').splitlines()[0].split(',')
+    assert 'root_url' in header
+
+
+def test_csv_export_ends_with_the_aggregates(standard: RecordSource, tmp_path: Path) -> None:
     """The per-image counts the row itself does not carry."""
     out = tmp_path / 'report'
     build_report(standard, out, csv_export=True)
@@ -790,13 +886,13 @@ def test_csv_export_counts_features_as_zero_when_there_are_none(
     """An image with no inventory exports a zero rather than an empty cell."""
     document = metadata_document()
     document['navigation_result']['feature_inventory'] = []
-    with _indexed(tmp_path, {'VOL/N1454725799_1_CALIB': document}, quiet_logger) as connection:
-        build_report(connection, tmp_path / 'report', csv_export=True)
+    with _indexed(tmp_path, {'VOL/N1454725799_1_CALIB': document}, quiet_logger) as source:
+        build_report(source, tmp_path / 'report', csv_export=True)
     row = (tmp_path / 'report' / 'images.csv').read_text(encoding='utf-8').splitlines()[1]
     assert row.endswith(',0,0,0,0')
 
 
-def test_report_is_deterministic(standard: Connection, tmp_path: Path) -> None:
+def test_report_is_deterministic(standard: RecordSource, tmp_path: Path) -> None:
     """The same index and options twice produce byte-identical Markdown."""
     first = build_report(
         standard, tmp_path / 'a', top_n=3, filelists=True, csv_export=True
@@ -816,8 +912,10 @@ _SHARED_STUB = 'COISS_2001/data/N1294561202_1_CALIB'
 
 
 @contextlib.contextmanager
-def _two_roots_sharing_a_stub(tmp_path: Path, logger: pdslogger.PdsLogger) -> Iterator[Connection]:
-    """Ingest one stub under two roots and yield a connection to the index.
+def _two_roots_sharing_a_stub(
+    tmp_path: Path, logger: pdslogger.PdsLogger
+) -> Iterator[RecordSource]:
+    """Ingest one stub under two roots and yield a source over the rows.
 
     An image keyed by its name alone merges the two, so every count over the
     child tables doubles and every technique appears to disagree with itself.
@@ -827,7 +925,7 @@ def _two_roots_sharing_a_stub(tmp_path: Path, logger: pdslogger.PdsLogger) -> It
         logger: Logger the ingest reports through.
 
     Yields:
-        An open connection to the index.
+        An open record source reading the index.
     """
     document = metadata_document(
         image_name='N1294561202_1_CALIB.IMG',
@@ -842,12 +940,8 @@ def _two_roots_sharing_a_stub(tmp_path: Path, logger: pdslogger.PdsLogger) -> It
     write_metadata_in_each([primary, rescue], _SHARED_STUB, document)
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [primary, rescue], logger=logger)
-    engine = open_index(url)
-    try:
-        with engine.connect() as connection:
-            yield connection
-    finally:
-        engine.dispose()
+    with index_source(url, [primary, rescue]) as source:
+        yield source
 
 
 def test_a_technique_is_counted_once_per_root(
@@ -859,8 +953,8 @@ def test_a_technique_is_counted_once_per_root(
     technique reports four images out of two: 200 percent of a total that is
     itself a count of images.
     """
-    with _two_roots_sharing_a_stub(tmp_path, quiet_logger) as connection:
-        report = build_report(connection, tmp_path / 'report').read_text(encoding='utf-8')
+    with _two_roots_sharing_a_stub(tmp_path, quiet_logger) as source:
+        report = build_report(source, tmp_path / 'report').read_text(encoding='utf-8')
     assert '| BodyLimbNav | 2 (100.0%) |' in report
 
 
@@ -873,8 +967,8 @@ def test_a_technique_does_not_disagree_with_itself_across_roots(
     has nothing to say; a name-only join manufactures one image carrying two
     copies of one technique and reports it disagreeing with itself.
     """
-    with _two_roots_sharing_a_stub(tmp_path, quiet_logger) as connection:
-        report = build_report(connection, tmp_path / 'report').read_text(encoding='utf-8')
+    with _two_roots_sharing_a_stub(tmp_path, quiet_logger) as source:
+        report = build_report(source, tmp_path / 'report').read_text(encoding='utf-8')
     assert 'BodyLimbNav vs BodyLimbNav' not in report
 
 
@@ -882,8 +976,8 @@ def test_the_csv_counts_one_images_child_rows_only(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger
 ) -> None:
     """Each correlated subquery of the export is keyed on the pair, not the name."""
-    with _two_roots_sharing_a_stub(tmp_path, quiet_logger) as connection:
-        build_report(connection, tmp_path / 'report', csv_export=True)
+    with _two_roots_sharing_a_stub(tmp_path, quiet_logger) as source:
+        build_report(source, tmp_path / 'report', csv_export=True)
     rows = list(
         csv.DictReader(
             (tmp_path / 'report' / 'images.csv').read_text(encoding='utf-8').splitlines()
@@ -896,8 +990,8 @@ def test_the_csv_counts_one_images_features_only(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger
 ) -> None:
     """The feature aggregates are the other two subqueries, and key the same way."""
-    with _two_roots_sharing_a_stub(tmp_path, quiet_logger) as connection:
-        build_report(connection, tmp_path / 'report', csv_export=True)
+    with _two_roots_sharing_a_stub(tmp_path, quiet_logger) as source:
+        build_report(source, tmp_path / 'report', csv_export=True)
     rows = list(
         csv.DictReader(
             (tmp_path / 'report' / 'images.csv').read_text(encoding='utf-8').splitlines()
@@ -912,7 +1006,7 @@ def test_the_csv_counts_one_images_features_only(
 
 
 def test_the_csv_export_ends_its_rows_with_one_newline(
-    standard: Connection, tmp_path: Path
+    standard: RecordSource, tmp_path: Path
 ) -> None:
     """A line ending that follows a library default is a diff nobody asked for.
 

--- a/tests/spindoctor/cli/stats/test_report.py
+++ b/tests/spindoctor/cli/stats/test_report.py
@@ -852,9 +852,9 @@ def test_csv_export_leads_with_the_column_an_operator_sorts_on(
 ) -> None:
     """The rows are written as they are read, so the file has to be sortable.
 
-    ``sort -t, -k1,1 images.csv`` is the whole of what an operator has to do to
-    put the export in key order, and it only works while the key the rows are
-    told apart by leads the row.
+    Sorting the export on field 1, with the header line held out of the sort, is
+    the whole of what an operator has to do to put it in key order, and it only
+    works while the key the rows are told apart by leads the row.
     """
     out = tmp_path / 'report'
     build_report(standard, out, csv_export=True)

--- a/tests/spindoctor/cli/stats/test_report_cli.py
+++ b/tests/spindoctor/cli/stats/test_report_cli.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pdslogger
 import pytest
+import sqlalchemy
 from tests.spindoctor.conftest import (
     index_url,
     ingest_tree,
@@ -23,7 +24,7 @@ from tests.spindoctor.conftest import (
 )
 
 from spindoctor.cli.stats.report import main_report
-from spindoctor.results_index import INGEST_RUNS, SCHEMA_VERSION, open_index
+from spindoctor.results_index import INGEST_RUNS, SCHEMA_VERSION, TECHNIQUES, open_index
 
 # ---------------------------------------------------------------------------
 # The command line
@@ -218,32 +219,121 @@ def test_main_report_leaves_no_database_behind(
     assert not missing.exists()
 
 
+def test_a_read_failure_while_streaming_fails_the_run(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An index that stops answering mid-pass is a failed run, not a bad command line.
+
+    The stream issues its queries while the report reads them, so an index that
+    can be opened and then cannot be read fails from inside the pass.  Reported
+    as a usage error it would exit 2 and print a usage line over a database
+    failure no command line could have avoided.  What kind of failure it is does
+    not matter, only that it lands while the pass is reading, so a table dropped
+    after the open stands in for a lost connection.
+    """
+    monkeypatch.delenv('NAV_RESULTS_DB', raising=False)
+    root = tmp_path / 'results'
+    write_metadata(root, 'VOL/N1454725799_1_CALIB', metadata_document())
+    url = index_url(tmp_path / 'index.sqlite3')
+    ingest_tree(url, [root], logger=quiet_logger)
+    engine = open_index(url)
+    try:
+        with engine.begin() as connection:
+            connection.execute(sqlalchemy.text(f'DROP TABLE {TECHNIQUES.name}'))
+    finally:
+        engine.dispose()
+    exit_code = main_report(['--results-db', url, '--output-dir', str(tmp_path / 'report')])
+    assert exit_code == 1
+
+
+def test_a_read_failure_while_streaming_says_the_index_could_not_be_read(
+    tmp_path: Path,
+    quiet_logger: pdslogger.PdsLogger,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The exit code says a run failed and the message has to say what failed.
+
+    Nothing else on the command line is at fault, so a line that did not name
+    the index would leave an operator looking at their own flags.
+    """
+    monkeypatch.delenv('NAV_RESULTS_DB', raising=False)
+    root = tmp_path / 'results'
+    write_metadata(root, 'VOL/N1454725799_1_CALIB', metadata_document())
+    url = index_url(tmp_path / 'index.sqlite3')
+    ingest_tree(url, [root], logger=quiet_logger)
+    engine = open_index(url)
+    try:
+        with engine.begin() as connection:
+            connection.execute(sqlalchemy.text(f'DROP TABLE {TECHNIQUES.name}'))
+    finally:
+        engine.dispose()
+    main_report(['--results-db', url, '--output-dir', str(tmp_path / 'report')])
+    assert 'Cannot read the results index' in capsys.readouterr().err
+
+
+def test_an_image_bound_with_no_digits_is_a_usage_error(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bound naming no number is a value on the command line, and exits 2 for it.
+
+    The bound is read before any storage is opened, which is what leaves a
+    failure raised later in the pass meaning one thing.  Read after the source
+    is open, it would arrive at the same place as an index that could not be
+    read, and one of the two would take the other's exit code.
+    """
+    monkeypatch.delenv('NAV_RESULTS_DB', raising=False)
+    root = tmp_path / 'results'
+    write_metadata(root, 'VOL/N1454725799_1_CALIB', metadata_document())
+    url = index_url(tmp_path / 'index.sqlite3')
+    ingest_tree(url, [root], logger=quiet_logger)
+    with pytest.raises(SystemExit) as caught:
+        main_report(
+            [
+                '--results-db',
+                url,
+                '--min-image',
+                'nodigits',
+                '--output-dir',
+                str(tmp_path / 'report'),
+            ]
+        )
+    assert caught.value.code == 2
+
+
 def test_main_report_honors_the_none_sentinel(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An exported index URL can be overridden on the command line.
+    """An exported index URL is overridden on the command line, and the tree answers.
 
-    The sentinel means here what it means everywhere: read the tree.  So it is
-    the tree that answers, and the exported index is not read at all -- which is
+    The sentinel means here what it means everywhere: read the tree -- which is
     what a machine with an index configured says to ask for a report over the
-    documents as they are now.
+    documents as they are now.  The tree therefore holds an image written after
+    the ingest, which the index carries no row for, and the report names it as
+    the highest-numbered image it selected.  Measured by exit code alone this
+    would pass on a run that read the exported index instead, since that index
+    reports on the same root and exits 0 doing it.
     """
     root = tmp_path / 'results'
     write_metadata(root, 'VOL/N1454725799_1_CALIB', metadata_document())
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [root], logger=quiet_logger)
+    write_metadata(
+        root, 'VOL/N1595336177_1_CALIB', metadata_document(image_name='N1595336177_1_CALIB.IMG')
+    )
     monkeypatch.setenv('NAV_RESULTS_DB', url)
-    exit_code = main_report(
+    out = tmp_path / 'report'
+    main_report(
         [
             '--results-db',
             'none',
             '--nav-results-root',
             str(root),
             '--output-dir',
-            str(tmp_path / 'report'),
+            str(out),
         ]
     )
-    assert exit_code == 0
+    assert 'N1595336177' in (out / 'report.md').read_text(encoding='utf-8')
 
 
 def test_main_report_reads_the_environment_variable(

--- a/tests/spindoctor/cli/stats/test_report_cli.py
+++ b/tests/spindoctor/cli/stats/test_report_cli.py
@@ -1,11 +1,14 @@
-"""Tests for the ``sd_stats_report`` command line.
+"""Tests for the ``sd_stats_report`` command line, reading an index it was named.
 
-This program is the one consumer that requires an index, so most of what its
-driver does is refuse: no index named, an index that is not there, an index it
-must not create, and a root the index holds no completed ingest of. The last is
-the load-bearing one -- absence of rows under a root is not evidence that
-nothing was navigated -- and it is decided by the root's newest ingest run
+What the driver does with an index is mostly refuse: an index that is not there,
+an index it must not create, and a root the index holds no completed ingest of.
+The last is the load-bearing one -- absence of rows under a root is not evidence
+that nothing was navigated -- and it is decided by the root's newest ingest run
 alone, however many earlier ones finished.
+
+Naming no index is not a refusal: it reads the results tree, which is
+``test_report_over_a_tree.py``. What is refused here is naming neither, which is
+a run with nothing to report on.
 """
 
 from pathlib import Path
@@ -136,22 +139,34 @@ def test_main_report_names_the_roots_it_does_hold(
     assert root.as_posix() in capsys.readouterr().err
 
 
-def test_main_report_without_an_index_says_so(
+def test_main_report_with_neither_an_index_nor_a_tree_says_so(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """This program has no file-reading mode, and the message says which flag."""
+    """Naming no index reads a tree, and naming no tree either leaves nothing."""
     monkeypatch.delenv('NAV_RESULTS_DB', raising=False)
+    monkeypatch.delenv('NAV_RESULTS_ROOT', raising=False)
     exit_code = main_report(['--output-dir', str(tmp_path / 'report')])
     assert exit_code == 1
 
 
-def test_main_report_without_an_index_names_the_flag(
+def test_main_report_with_neither_names_the_index_flag(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """A refusal that does not say what to type is a refusal nobody can act on."""
     monkeypatch.delenv('NAV_RESULTS_DB', raising=False)
+    monkeypatch.delenv('NAV_RESULTS_ROOT', raising=False)
     main_report(['--output-dir', str(tmp_path / 'report')])
     assert '--results-db' in capsys.readouterr().err
+
+
+def test_main_report_with_neither_names_the_tree_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Both ways forward are named, since either would let the run proceed."""
+    monkeypatch.delenv('NAV_RESULTS_DB', raising=False)
+    monkeypatch.delenv('NAV_RESULTS_ROOT', raising=False)
+    main_report(['--output-dir', str(tmp_path / 'report')])
+    assert '--nav-results-root' in capsys.readouterr().err
 
 
 def test_main_report_says_an_empty_index_variable_named_nothing(
@@ -206,14 +221,29 @@ def test_main_report_leaves_no_database_behind(
 def test_main_report_honors_the_none_sentinel(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An exported index URL can be overridden on the command line."""
+    """An exported index URL can be overridden on the command line.
+
+    The sentinel means here what it means everywhere: read the tree.  So it is
+    the tree that answers, and the exported index is not read at all -- which is
+    what a machine with an index configured says to ask for a report over the
+    documents as they are now.
+    """
     root = tmp_path / 'results'
     write_metadata(root, 'VOL/N1454725799_1_CALIB', metadata_document())
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [root], logger=quiet_logger)
     monkeypatch.setenv('NAV_RESULTS_DB', url)
-    exit_code = main_report(['--results-db', 'none', '--output-dir', str(tmp_path / 'report')])
-    assert exit_code == 1
+    exit_code = main_report(
+        [
+            '--results-db',
+            'none',
+            '--nav-results-root',
+            str(root),
+            '--output-dir',
+            str(tmp_path / 'report'),
+        ]
+    )
+    assert exit_code == 0
 
 
 def test_main_report_reads_the_environment_variable(

--- a/tests/spindoctor/cli/stats/test_report_helpers.py
+++ b/tests/spindoctor/cli/stats/test_report_helpers.py
@@ -1,18 +1,15 @@
 """Tests for the pure helpers the report is assembled from.
 
-None of these reads a database. They cover the values the report derives from an
-image name or an epoch, the search limit it resolves from configuration, the
-filter fragment every query splices in -- which carries named binds and its
-values beside it, because the fragment is spliced into statements that carry
-binds of their own and an inlined literal is a quoting bug waiting for a value
-that carries a quote -- and how one column value is rendered into a CSV cell.
+None of these reads a record. They cover the values the report derives from an
+image name or an epoch, the search limit it resolves from configuration, and how
+one column value is rendered into a CSV cell.
 """
 
 from typing import Any
 
 import pytest
 
-from spindoctor.cli.stats.report_common import count_pct, image_name_from_filename, where_clause
+from spindoctor.cli.stats.report_common import count_pct, image_name_from_filename
 from spindoctor.cli.stats.report_sections import _csv_value, resolve_offset_limit
 from spindoctor.nav_records.derived import (
     date_from_image_et,
@@ -117,7 +114,7 @@ def test_resolve_offset_limit_coiss_wac() -> None:
 def test_resolve_offset_limit_requires_shape_for_size_tables() -> None:
     """A size-keyed margin table cannot resolve without a recorded shape."""
     result = resolve_offset_limit('coiss', 'N1454725799_1_CALIB.IMG', None)
-    assert result == 'image shape not recorded in the database'
+    assert result == 'image shape not recorded'
 
 
 def test_resolve_offset_limit_unknown_instrument() -> None:
@@ -130,21 +127,6 @@ def test_resolve_offset_limit_missing_size_entry() -> None:
     """A size with no margin entry reports the failure instead of guessing."""
     result = resolve_offset_limit('vgiss', 'C3250013_GEOMED.IMG', 1024)
     assert 'no extfov_margin_vu entry for image size 1024' in str(result)
-
-
-# ---------------------------------------------------------------------------
-# The filter fragment
-# ---------------------------------------------------------------------------
-
-
-def test_a_filter_is_a_named_bind_carrying_its_value_beside_it() -> None:
-    """An inlined literal is a quoting bug waiting for a value that carries a quote.
-
-    The fragment is only half of it; the value travels beside it as a parameter.
-    """
-    where, params = where_clause(instrument='coiss', start_date=None, end_date=None)
-    assert where == ' WHERE instrument = :instrument'
-    assert params == {'instrument': 'coiss'}
 
 
 # ---------------------------------------------------------------------------
@@ -180,13 +162,13 @@ def test_a_json_container_is_written_as_json_text_and_nothing_else_is_touched(
 ) -> None:
     """A cell holding a Python container's repr is a cell nothing can read back.
 
-    Driven directly rather than through an export, because which backend hands
-    this function a container is the driver's decision: the export reads through
-    raw SQL, so only a backend that decodes JSON on the way out reaches the
-    container branch at all.
+    Driven directly rather than through an export, so that every shape a column
+    can hold is covered rather than the few the fixture documents happen to
+    carry.  A structured column reaches the export as the container it holds,
+    whichever storage answered, so this is what a reader of the file gets.
 
     Parameters:
-        value: The value as a driver would return it.
+        value: The value the facts carry for a column.
         expected: The cell it becomes.
     """
     assert _csv_value(value) == expected

--- a/tests/spindoctor/cli/stats/test_report_over_a_tree.py
+++ b/tests/spindoctor/cli/stats/test_report_over_a_tree.py
@@ -1,0 +1,1098 @@
+"""Reporting over a results tree, with the report from an index as the control.
+
+One pass of accumulators answers every section, and the pass reads the record
+seam rather than a storage, so the same report comes out of a results tree and
+out of an index ingested from that tree.  That parity is the acceptance
+criterion, and it is measured here over the same frozen fixture tree and the same
+two invocations the report's frozen output is measured over, so the comparison
+covers every section the report writes.
+
+Three things the frozen tree cannot show are tested over trees written for them.
+It is deliberately all readable, so the count of files that yielded no record is
+zero over it.  It holds one root, so the tie two roots holding one basename make
+is unreachable in it.  And it records no structured JSON column beyond a
+covariance, so what the export writes for a matrix or a kernel list is pinned
+over a document carrying every one of them.
+
+One thing it does hold is a document written for an image that never loaded, and
+so records no epoch, which is what the date bounds are measured against here: an
+image that cannot be placed in time is inside no range, and each bound has to say
+so on its own.
+"""
+
+import csv
+import json
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pdslogger
+import pytest
+import sqlalchemy
+from tests.spindoctor.conftest import (
+    index_url,
+    ingest_tree,
+    metadata_document,
+    technique,
+    write_metadata,
+    write_refusal,
+)
+
+from spindoctor.cli.stats.report import build_report, main_report
+from spindoctor.nav_records import (
+    ImageFacts,
+    Selection,
+    TreeRecordSource,
+    UnreadableFile,
+)
+from spindoctor.results_index import IMAGES, INGEST_RUNS, SCHEMA_VERSION, open_index
+
+from .conftest import (
+    GOLDEN_DIR,
+    GOLDEN_VARIANTS,
+    RESULTS_TREE,
+    ReplayedFacts,
+    index_source,
+    report_from_the_index,
+    report_from_the_tree,
+)
+
+_A_TREE_IMAGE = 'N1294561202'
+"""An image name the fixture tree holds, for telling a report from an empty one."""
+
+
+# ---------------------------------------------------------------------------
+# The same report, out of either storage
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope='module')
+def reports(tmp_path_factory: pytest.TempPathFactory) -> dict[str, tuple[Path, Path]]:
+    """Write each golden variant twice, once over the tree and once from an index.
+
+    Built once for the whole module: every comparison below only reads, and
+    building per test would ingest the same tree once per comparison.
+
+    Parameters:
+        tmp_path_factory: Factory the indexes and the outputs live under.
+
+    Returns:
+        Per variant name, the tree-read report directory and the index-read one.
+    """
+    logger = pdslogger.PdsLogger(f'stats_parity_{uuid.uuid4().hex}')
+    logger.set_level('ERROR')
+    root = tmp_path_factory.mktemp('parity')
+    written = {}
+    for variant, options in GOLDEN_VARIANTS.items():
+        from_tree = report_from_the_tree(root / f'{variant}-tree', **options)
+        from_index = report_from_the_index(
+            index_url(root / f'{variant}.sqlite3'),
+            root / f'{variant}-index',
+            logger=logger,
+            **options,
+        )
+        written[variant] = (from_tree, from_index)
+    return written
+
+
+@pytest.mark.parametrize('variant', sorted(GOLDEN_VARIANTS))
+def test_the_report_is_byte_identical_to_one_from_an_index(
+    reports: dict[str, tuple[Path, Path]], variant: str
+) -> None:
+    """The acceptance criterion: one set of statements answers either way.
+
+    Byte-identical rather than equivalent, because the report is deterministic
+    by design and a difference of any kind is a difference in the data or a
+    defect.
+
+    Parameters:
+        reports: The two report directories per variant.
+        variant: Which invocation is being compared.
+    """
+    from_tree, from_index = reports[variant]
+    assert (from_tree / 'report.md').read_bytes() == (from_index / 'report.md').read_bytes()
+
+
+@pytest.mark.parametrize('variant', sorted(GOLDEN_VARIANTS))
+def test_the_report_is_not_empty(reports: dict[str, tuple[Path, Path]], variant: str) -> None:
+    """Two empty reports would be byte-identical and would prove nothing.
+
+    The comparison above is an equality, so it would pass over a tree that
+    yielded no record at all.  This is what says the tree was read.
+
+    Parameters:
+        reports: The two report directories per variant.
+        variant: Which invocation is being read.
+    """
+    from_tree, _from_index = reports[variant]
+    assert _A_TREE_IMAGE in (from_tree / 'report.md').read_text(encoding='utf-8')
+
+
+@pytest.mark.parametrize('variant', sorted(GOLDEN_VARIANTS))
+def test_the_tree_reproduces_the_frozen_report(
+    reports: dict[str, tuple[Path, Path]], variant: str
+) -> None:
+    """The frozen output is written from the rows, and the documents reproduce it.
+
+    Held here as well as against the index, so the frozen file and the report it
+    pins are not both produced by one route: a defect the two storages shared
+    would pass the comparison against each other and this one would still see it.
+
+    Parameters:
+        reports: The two report directories per variant.
+        variant: Which invocation is being compared.
+    """
+    from_tree, _from_index = reports[variant]
+    frozen = (GOLDEN_DIR / variant / 'report.md').read_text(encoding='utf-8')
+    assert (from_tree / 'report.md').read_text(encoding='utf-8') == frozen
+
+
+def test_the_report_covers_every_image_the_tree_holds(
+    reports: dict[str, tuple[Path, Path]],
+) -> None:
+    """And the count is the tree's, not whatever the walk reached first.
+
+    The export writes one row per image plus its header, so an unfiltered run
+    over the tree exports as many rows as the tree holds documents.
+    """
+    from_tree, _from_index = reports['full']
+    rows = (from_tree / 'images.csv').read_text(encoding='utf-8').splitlines()
+    assert len(rows) == len(list(RESULTS_TREE.rglob('*_metadata.json'))) + 1
+
+
+def _csv_rows(path: Path) -> list[str]:
+    """Read the data rows of a CSV export as text, without its header.
+
+    Parameters:
+        path: The CSV file.
+
+    Returns:
+        One string per data row.
+    """
+    return path.read_text(encoding='utf-8').splitlines()[1:]
+
+
+def _csv_header(path: Path) -> str:
+    """Read the header row of a CSV export.
+
+    Parameters:
+        path: The CSV file.
+
+    Returns:
+        The header line.
+    """
+    return path.read_text(encoding='utf-8').splitlines()[0]
+
+
+@pytest.mark.parametrize('variant', sorted(GOLDEN_VARIANTS))
+def test_the_csv_export_holds_the_same_rows(
+    reports: dict[str, tuple[Path, Path]], variant: str
+) -> None:
+    """The export covers the same images with the same values, out of either storage.
+
+    Compared as sorted rows rather than as bytes, and deliberately: the export
+    writes a row where the pass reads it rather than collecting and sorting every
+    one of them, which is what makes it a streaming write.  The seam promises no
+    order, a walk finds documents in directory order and a query returns them in
+    the server's collation of the key, so the file says which images were
+    exported and not in what sequence.  The export leads with the column an
+    operator sorts on for exactly that reason.
+
+    Parameters:
+        reports: The two report directories per variant.
+        variant: Which invocation is being compared.
+    """
+    from_tree, from_index = reports[variant]
+    assert sorted(_csv_rows(from_tree / 'images.csv')) == sorted(
+        _csv_rows(from_index / 'images.csv')
+    )
+
+
+@pytest.mark.parametrize('variant', sorted(GOLDEN_VARIANTS))
+def test_the_csv_export_headers_match(reports: dict[str, tuple[Path, Path]], variant: str) -> None:
+    """The header is a header, not a row, so it is compared as one.
+
+    Sorting the whole file would let a header that differed between the two
+    storages sort into the middle of the rows and pass unnoticed.  What the
+    header holds, and in what order, is pinned against a written-out list in
+    ``test_report_regression``.
+
+    Parameters:
+        reports: The two report directories per variant.
+        variant: Which invocation is being compared.
+    """
+    from_tree, from_index = reports[variant]
+    assert _csv_header(from_tree / 'images.csv') == _csv_header(from_index / 'images.csv')
+
+
+@pytest.mark.parametrize('variant', sorted(GOLDEN_VARIANTS))
+def test_the_csv_export_writes_its_header_once(
+    reports: dict[str, tuple[Path, Path]], variant: str
+) -> None:
+    """A header repeated among the rows is a file every reader mis-parses.
+
+    The comparison above reads line one and the comparison before it reads the
+    rest, so a header written a second time among the rows would be compared as
+    a row by one of them and never as a header.
+
+    Parameters:
+        reports: The two report directories per variant.
+        variant: Which invocation is being read.
+    """
+    from_tree, _from_index = reports[variant]
+    assert _csv_header(from_tree / 'images.csv') not in _csv_rows(from_tree / 'images.csv')
+
+
+@pytest.mark.parametrize('variant', sorted(GOLDEN_VARIANTS))
+def test_every_filelist_is_written_alike(
+    reports: dict[str, tuple[Path, Path]], variant: str
+) -> None:
+    """The drill-down lists feed back into re-runs, so they are output too.
+
+    Parameters:
+        reports: The two report directories per variant.
+        variant: Which invocation is being compared.
+    """
+    from_tree, from_index = reports[variant]
+    written = {
+        path.name: path.read_text(encoding='utf-8')
+        for path in sorted(from_tree.glob('filelists/*.txt'))
+    }
+    control = {
+        path.name: path.read_text(encoding='utf-8')
+        for path in sorted(from_index.glob('filelists/*.txt'))
+    }
+    assert written == control
+
+
+def test_the_full_variant_wrote_filelists(reports: dict[str, tuple[Path, Path]]) -> None:
+    """Otherwise the comparison above is two empty mappings agreeing."""
+    from_tree, _from_index = reports['full']
+    assert len(list(from_tree.glob('filelists/*.txt'))) > 0
+
+
+# ---------------------------------------------------------------------------
+# Files that yielded no record
+# ---------------------------------------------------------------------------
+
+_NO_RECORD_LINE = 'Files that yielded no record: '
+"""How the line naming the count opens, for reading the number off a report."""
+
+
+def _no_record_count(out: Path) -> int:
+    """Read the count of files that yielded no record out of a written report.
+
+    Parameters:
+        out: The directory the report was written into.
+
+    Returns:
+        The number the report printed.
+
+    Raises:
+        ValueError: If the report printed no such line, which is a section that
+            stopped being printed rather than a count of zero.
+    """
+    for line in (out / 'report.md').read_text(encoding='utf-8').splitlines():
+        if line.startswith(_NO_RECORD_LINE):
+            return int(line[len(_NO_RECORD_LINE) :])
+    raise ValueError(f'{out / "report.md"} prints no line opening {_NO_RECORD_LINE!r}')
+
+
+def test_the_frozen_tree_yields_a_record_from_every_file(
+    reports: dict[str, tuple[Path, Path]],
+) -> None:
+    """The line is printed at zero, so a reader can tell it from a report that never looked.
+
+    Parameters:
+        reports: The two report directories per variant.
+    """
+    from_tree, _from_index = reports['full']
+    assert _no_record_count(from_tree) == 0
+
+
+# ---------------------------------------------------------------------------
+# A bound over the image that records no epoch
+# ---------------------------------------------------------------------------
+
+_DATED_TREE_IMAGES = 7
+"""How many of the frozen tree's images record an epoch a date bound can compare.
+
+One of its documents was written for an image that never loaded, so it records
+no provenance and no epoch.  A bound placed on the date is therefore satisfied
+by every other image of the tree and by none of that one.
+"""
+
+
+def test_a_start_date_leaves_out_the_image_that_records_no_epoch(tmp_path: Path) -> None:
+    """An image that cannot be placed in time cannot be shown to be inside a bound.
+
+    The bound here is earlier than every epoch the tree records, so the only
+    image it may exclude is the one recording none.  A report that read an
+    absent date as inside the range would count that image and report eight.
+    """
+    out = report_from_the_tree(tmp_path / 'report', start_date='1900-01-01')
+    assert f'Total images: {_DATED_TREE_IMAGES}' in (out / 'report.md').read_text(encoding='utf-8')
+
+
+def test_an_end_date_leaves_out_the_image_that_records_no_epoch(tmp_path: Path) -> None:
+    """The upper bound is the same rule, and a one-sided test would miss half of it.
+
+    The bound here is later than every epoch the tree records, so again the only
+    image it may exclude is the one recording none.
+    """
+    out = report_from_the_tree(tmp_path / 'report', end_date='2100-01-01')
+    assert f'Total images: {_DATED_TREE_IMAGES}' in (out / 'report.md').read_text(encoding='utf-8')
+
+
+_REFUSALS_PER_ROOT = 3
+"""How many files that yield no record each root of the fixture below holds."""
+
+
+def _two_roots_holding_refusals(tmp_path: Path) -> list[Path]:
+    """Write two results roots, each holding one image and three files that are not one.
+
+    Two roots holding the same stubs, because the count is of files rather than
+    of keys: a count that read the stub alone would report half of them.  The
+    three refusals differ in kind, since all three are ordinary in a real tree:
+    one is not JSON at all, one is JSON that is not a navigation document, and
+    one is JSON that names a mission and still holds no image to attribute to
+    it.  The last names a different mission under each root, so a count that
+    read the mission out of the document rather than out of the facts the
+    document failed to yield would keep one of the two and drop the other.
+
+    Parameters:
+        tmp_path: Directory the roots are written under.
+
+    Returns:
+        The two roots.
+    """
+    roots = [tmp_path / 'primary', tmp_path / 'rescue']
+    for root, mission in zip(roots, ('vgiss', 'coiss'), strict=True):
+        write_metadata(root, 'VOL/N1294561202_1_CALIB', metadata_document())
+        write_refusal(root, 'VOL/edges')
+        (root / 'VOL' / 'notes_metadata.json').write_text('{not json', encoding='utf-8')
+        write_metadata(root, 'VOL/earlier_schema', {'observation': {'instrument': mission}})
+    return roots
+
+
+def _report_over_roots(roots: Sequence[Path], out: Path, **options: Any) -> Path:
+    """Write one report over the documents of the named roots.
+
+    Parameters:
+        roots: The results roots to read.
+        out: Directory receiving the report.
+        options: Report options, passed through to ``build_report``.
+
+    Returns:
+        The directory the report was written into.
+    """
+    out.mkdir(parents=True, exist_ok=True)
+    with TreeRecordSource([root.as_posix() for root in roots]) as source:
+        build_report(source, out, **options)
+    return out
+
+
+def _report_over_an_index_of(
+    roots: Sequence[Path], out: Path, url: str, logger: pdslogger.PdsLogger, **options: Any
+) -> Path:
+    """Ingest the named roots and write one report from the rows.
+
+    Parameters:
+        roots: The results roots to ingest and read.
+        out: Directory receiving the report.
+        url: The index URL to create and ingest into.
+        logger: Logger the ingest reports through.
+        options: Report options, passed through to ``build_report``.
+
+    Returns:
+        The directory the report was written into.
+    """
+    ingest_tree(url, list(roots), logger=logger)
+    out.mkdir(parents=True, exist_ok=True)
+    with index_source(url, roots) as source:
+        build_report(source, out, **options)
+    return out
+
+
+def test_a_file_that_yielded_no_record_is_counted(tmp_path: Path) -> None:
+    """A report that quietly covered less than the tree is worse than one that says how much less.
+
+    Two roots hold three such files each, so a count keyed on the stub rather
+    than on the file would report three where six files were refused.
+    """
+    roots = _two_roots_holding_refusals(tmp_path)
+    out = _report_over_roots(roots, tmp_path / 'report')
+    assert _no_record_count(out) == len(roots) * _REFUSALS_PER_ROOT
+
+
+def test_the_two_storages_agree_on_the_count(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger
+) -> None:
+    """An ingest records what it refused, so an index answers this as the tree does."""
+    roots = _two_roots_holding_refusals(tmp_path)
+    over_the_tree = _no_record_count(_report_over_roots(roots, tmp_path / 'from-tree'))
+    over_an_index = _no_record_count(
+        _report_over_an_index_of(
+            roots, tmp_path / 'from-index', index_url(tmp_path / 'index.sqlite3'), quiet_logger
+        )
+    )
+    assert over_the_tree == over_an_index
+
+
+def test_the_refused_files_are_not_counted_as_images(tmp_path: Path) -> None:
+    """They record no instrument, so a per-instrument denominator must not hold them."""
+    roots = _two_roots_holding_refusals(tmp_path)
+    out = _report_over_roots(roots, tmp_path / 'report')
+    assert 'Total images: 2' in (out / 'report.md').read_text(encoding='utf-8')
+
+
+def test_an_instrument_filter_does_not_narrow_the_count(tmp_path: Path) -> None:
+    """A file that yielded no record stays counted whatever mission it happens to name.
+
+    One refusal under each root is a JSON object that names a mission and still
+    holds no image, and the two roots name different missions.  A mission filter
+    read out of the document rather than out of the facts the document failed to
+    yield would drop the one naming the other mission, and this report would
+    count five files where six were refused.
+    """
+    roots = _two_roots_holding_refusals(tmp_path)
+    out = _report_over_roots(roots, tmp_path / 'report', instrument='coiss')
+    assert _no_record_count(out) == len(roots) * _REFUSALS_PER_ROOT
+
+
+def test_the_two_storages_agree_on_the_count_under_a_mission_filter(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger
+) -> None:
+    """A row and a document are narrowed on the same values, so the two counts are one count.
+
+    The index cannot narrow a refusal at all -- a refusal row records no mission
+    -- so this is the comparison a walk that applied the filter to the document
+    would fail.
+    """
+    roots = _two_roots_holding_refusals(tmp_path)
+    over_the_tree = _no_record_count(
+        _report_over_roots(roots, tmp_path / 'from-tree', instrument='coiss')
+    )
+    over_an_index = _no_record_count(
+        _report_over_an_index_of(
+            roots,
+            tmp_path / 'from-index',
+            index_url(tmp_path / 'index.sqlite3'),
+            quiet_logger,
+            instrument='coiss',
+        )
+    )
+    assert over_the_tree == over_an_index
+
+
+def test_a_date_filter_does_not_narrow_the_count(tmp_path: Path) -> None:
+    """Nor a date: the file was never parsed, so it records no epoch to compare."""
+    roots = _two_roots_holding_refusals(tmp_path)
+    out = _report_over_roots(roots, tmp_path / 'report', start_date='1999-01-01')
+    assert _no_record_count(out) == len(roots) * _REFUSALS_PER_ROOT
+
+
+def test_an_image_number_filter_does_not_narrow_the_count(tmp_path: Path) -> None:
+    """Nor an image range, for the same reason: there is no image name to number."""
+    roots = _two_roots_holding_refusals(tmp_path)
+    out = _report_over_roots(roots, tmp_path / 'report', min_image='N9999999999')
+    assert _no_record_count(out) == len(roots) * _REFUSALS_PER_ROOT
+
+
+def test_a_filter_that_selects_nothing_still_reports_the_count(tmp_path: Path) -> None:
+    """The count is of the roots, so it survives a selection that empties the report."""
+    roots = _two_roots_holding_refusals(tmp_path)
+    out = _report_over_roots(roots, tmp_path / 'report', min_image='N9999999999')
+    assert 'No images match the filters.' in (out / 'report.md').read_text(encoding='utf-8')
+    assert _no_record_count(out) == len(roots) * _REFUSALS_PER_ROOT
+
+
+# ---------------------------------------------------------------------------
+# The stream promises no order
+# ---------------------------------------------------------------------------
+
+
+_TIED_STUB = 'VOL/N1294561202_1_CALIB'
+"""The stub two roots of the shuffled fixture both hold, which is the tie to break."""
+
+_ORDERS: tuple[tuple[int, ...], ...] = (
+    (0, 1, 2, 3),
+    (3, 2, 1, 0),
+    (1, 0, 3, 2),
+    (2, 3, 0, 1),
+    (3, 0, 1, 2),
+    (0, 3, 1, 2),
+)
+"""The orders the same facts are fed to the report in.
+
+Written out rather than drawn at random, so a failure is reproducible and so
+that the two orders that matter are certainly among them.  One root's copy of
+:data:`_TIED_STUB` arrives before the other's in some of them and after it in
+the rest, which is the tie a sort keyed on an image name alone leaks the input
+order through.  And the four confidences reach the mean in an order whose
+left-to-right sum rounds to 0.709 in some of them and to 0.710 in the rest,
+which is the drift an accumulated sum leaks the input order through.
+"""
+
+
+def _shuffled_fixture(root: Path) -> list[Path]:
+    """Write two roots that between them make the report's ordering assumptions visible.
+
+    Both roots hold :data:`_TIED_STUB`, under one image name, with offsets that
+    reach the same fraction of the search limit and print differently.  The two
+    are therefore one row apart in the suspect table on a key that reads the
+    image name alone, and the row that comes first is whichever the stream
+    yielded first.
+
+    Their four confidences are chosen so that adding them up left to right
+    rounds to two different numbers depending on the order they arrive in.
+
+    Parameters:
+        root: Directory the two roots are written under.
+
+    Returns:
+        The two roots.
+    """
+    primary = root / 'primary'
+    rescue = root / 'rescue'
+    # |dV| is 0.98 of the NAC 1024 CALIB margin of (50, 140) either way round.
+    write_metadata(
+        primary,
+        _TIED_STUB,
+        metadata_document(
+            image_name='N1294561202_1_CALIB.IMG',
+            image_shape=[1024, 1024],
+            offset=[49.0, 10.0],
+            per_technique=[technique('BodyLimbNav', (1.0, 1.0), confidence=0.949)],
+        ),
+    )
+    write_metadata(
+        primary,
+        'VOL/N1294562000_1_CALIB',
+        metadata_document(
+            image_name='N1294562000_1_CALIB.IMG',
+            image_shape=[1024, 1024],
+            offset=[1.0, 1.0],
+            per_technique=[technique('BodyLimbNav', (1.0, 1.0), confidence=0.924)],
+        ),
+    )
+    write_metadata(
+        rescue,
+        _TIED_STUB,
+        metadata_document(
+            image_name='N1294561202_1_CALIB.IMG',
+            image_shape=[1024, 1024],
+            offset=[-49.0, 10.0],
+            per_technique=[technique('BodyLimbNav', (1.0, 1.0), confidence=0.778)],
+        ),
+    )
+    write_metadata(
+        rescue,
+        'VOL/N1294563000_1_CALIB',
+        metadata_document(
+            image_name='N1294563000_1_CALIB.IMG',
+            image_shape=[1024, 1024],
+            offset=[2.0, 2.0],
+            per_technique=[technique('BodyLimbNav', (1.0, 1.0), confidence=0.187)],
+        ),
+    )
+    return [primary, rescue]
+
+
+@dataclass(frozen=True)
+class _ShuffledRun:
+    """What replaying one set of facts in several orders produced.
+
+    Parameters:
+        facts_read: How many facts the fixture tree yielded, so a comparison
+            over a stream shorter than the fixture is recognizable.
+        reports: The bytes of ``report.md`` from each order, in the order the
+            orders are written down.
+    """
+
+    facts_read: int
+    reports: tuple[bytes, ...]
+
+
+@pytest.fixture(scope='module')
+def shuffled_reports(tmp_path_factory: pytest.TempPathFactory) -> _ShuffledRun:
+    """Write the same facts into a report once per order, and return the reports.
+
+    Parameters:
+        tmp_path_factory: Factory the trees and the outputs live under.
+
+    Returns:
+        What each order produced, and how many facts were replayed into it.
+    """
+    root = tmp_path_factory.mktemp('shuffled')
+    roots = _shuffled_fixture(root)
+    with TreeRecordSource([one.as_posix() for one in roots]) as source:
+        found = list(source.facts(Selection()))
+    written = []
+    for index, order in enumerate(_ORDERS):
+        out = root / f'order-{index}'
+        out.mkdir()
+        build_report(ReplayedFacts([found[place] for place in order]), out, top_n=5)
+        written.append((out / 'report.md').read_bytes())
+    return _ShuffledRun(facts_read=len(found), reports=tuple(written))
+
+
+def test_every_document_of_the_shuffled_fixture_is_replayed(
+    shuffled_reports: _ShuffledRun,
+) -> None:
+    """An order over fewer facts than the fixture holds leaves the tie out of some of them."""
+    assert shuffled_reports.facts_read == len(_ORDERS[0])
+
+
+def test_every_order_produces_one_report(shuffled_reports: _ShuffledRun) -> None:
+    """A comparison over one report passes for the wrong reason."""
+    assert len(shuffled_reports.reports) == len(_ORDERS)
+
+
+def test_the_report_does_not_depend_on_the_order_the_facts_arrive_in(
+    shuffled_reports: _ShuffledRun,
+) -> None:
+    """The seam promises no order, so a report that depended on one would depend on the storage.
+
+    Every section either counts, reduces to a minimum, sums exactly, or sorts on
+    a key that carries the pair identifying an image; an image name alone is not
+    unique across roots, and Python's sort is stable, so a key that stopped at
+    the name would print two tied rows in whatever order the stream yielded them.
+    """
+    assert len(set(shuffled_reports.reports)) == 1
+
+
+def test_the_shuffled_reports_hold_both_tied_rows(shuffled_reports: _ShuffledRun) -> None:
+    """Otherwise the tie the orders are built around is not in the output at all.
+
+    Two rows of one image name in the one always-on table that prints a row per
+    image, reaching the same fraction of the search limit and printing different
+    offsets, is the whole of what a name-only sort key would order by arrival.
+    """
+    text = shuffled_reports.reports[0].decode('utf-8')
+    suspects = text.split('## Suspect offsets')[1].split('## BOTSIM')[0]
+    assert suspects.count('| N1294561202 | coiss | ') == 2
+
+
+def test_the_tied_rows_print_differently(shuffled_reports: _ShuffledRun) -> None:
+    """Two identical rows would swap places invisibly and prove nothing."""
+    text = shuffled_reports.reports[0].decode('utf-8')
+    suspects = text.split('## Suspect offsets')[1].split('## BOTSIM')[0]
+    offsets = [
+        line.split('|')[3].strip()
+        for line in suspects.splitlines()
+        if line.startswith('| N1294561202 | coiss | ')
+    ]
+    assert offsets == ['49.000', '-49.000']
+
+
+def test_the_shuffled_reports_hold_the_exact_mean_confidence(
+    shuffled_reports: _ShuffledRun,
+) -> None:
+    """The four confidences average to 0.7095, which rounds up only when summed exactly.
+
+    Added left to right in some of these orders they come to 0.7094999999999999
+    instead, which prints one digit lower.  The mean is computed over the values
+    rather than accumulated as they arrive, so the printed number is the one the
+    values have whichever order they came in.
+    """
+    text = shuffled_reports.reports[0].decode('utf-8')
+    assert '| BodyLimbNav | coiss | 4 (100.0%) | 4 (100.0%) | 0.710 |' in text
+
+
+# ---------------------------------------------------------------------------
+# What the export writes for a structured column
+# ---------------------------------------------------------------------------
+
+_COVARIANCE = [[0.0961, 0.01, 0.0025], [0.01, 0.0784, -0.005], [0.0025, -0.005, 0.0009]]
+"""A 3x3 covariance of the kind a twist-fitted result records."""
+
+_CMATRIX = [
+    0.955336489125606,
+    -0.29552020666133955,
+    0.0,
+    0.29552020666133955,
+    0.955336489125606,
+    0.0,
+    0.0,
+    0.0,
+    1.0,
+]
+"""A rotation whose terms need every digit a double carries to be written back."""
+
+_CMATRIX_ORIGINAL = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+"""The attitude the kernels gave, before the navigation corrected it."""
+
+_KERNELS = ['naif0012.tls', 'cas00172.tsc', 'cas_v40.tf']
+"""A kernel list, which is the one column holding a list of plain text."""
+
+_EXCLUDED = ['StarRefineNav', 'BodyBlobNav']
+"""An exclusion set, recorded in the order the ensemble wrote it."""
+
+_DIAGNOSTICS = {'peak': 0.9531, 'iterations': 7, 'converged': True}
+"""A technique's diagnostics, which is the one column holding a mapping."""
+
+_JSON_CELLS = {
+    'covariance_px2': '[[0.0961, 0.01, 0.0025], [0.01, 0.0784, -0.005], [0.0025, -0.005, 0.0009]]',
+    'excluded_from_consensus': '["StarRefineNav", "BodyBlobNav"]',
+    'spice_kernels': '["naif0012.tls", "cas00172.tsc", "cas_v40.tf"]',
+    'cmatrix': '[0.955336489125606, -0.29552020666133955, 0.0, 0.29552020666133955, '
+    '0.955336489125606, 0.0, 0.0, 0.0, 1.0]',
+    'cmatrix_original': '[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]',
+}
+"""What the export writes into each structured column of the document below.
+
+Written out rather than produced by encoding the values again, because that is
+the whole question: a container reaches the export as a container whichever
+storage answered, and what a reader gets back is whatever the export makes of
+it.  Neither the shortest round-trip form of a float nor the order of a
+mapping's keys is guaranteed by anything, so both are stated here.
+"""
+
+
+def _document_with_every_json_column() -> dict[str, Any]:
+    """Build a document populating every column the export encodes as JSON.
+
+    Returns:
+        The document.
+    """
+    document = metadata_document(
+        image_name='N1294561202_1_CALIB.IMG',
+        image_shape=[1024, 1024],
+        excluded=_EXCLUDED,
+        per_technique=[technique('BodyLimbNav', (1.0, 1.0))],
+        times={'midtime_et': 136576860.1724845},
+        pointing={
+            'camera_frame': 'CASSINI_ISS_NAC',
+            'camera_frame_id': -82360,
+            'ck_frame_id': -82000,
+            'cmatrix': _CMATRIX,
+            'cmatrix_original': _CMATRIX_ORIGINAL,
+        },
+    )
+    document['navigation_result']['covariance_px2'] = _COVARIANCE
+    document['navigation_result']['provenance']['spice_kernels'] = _KERNELS
+    document['navigation_result']['per_technique'][0]['diagnostics'] = _DIAGNOSTICS
+    return document
+
+
+@pytest.fixture
+def json_columns(tmp_path: Path, quiet_logger: pdslogger.PdsLogger) -> dict[str, dict[str, str]]:
+    """Export the same structured document out of each storage and read the cells back.
+
+    Parameters:
+        tmp_path: Directory the tree, the index and the exports live under.
+        quiet_logger: Logger the ingest reports through.
+
+    Returns:
+        Per storage name, the one exported row keyed by column name.
+    """
+    root = tmp_path / 'results'
+    write_metadata(root, 'VOL/N1294561202_1_CALIB', _document_with_every_json_column())
+    from_tree = _report_over_roots([root], tmp_path / 'from-tree', csv_export=True)
+    from_index = _report_over_an_index_of(
+        [root],
+        tmp_path / 'from-index',
+        index_url(tmp_path / 'index.sqlite3'),
+        quiet_logger,
+        csv_export=True,
+    )
+    return {
+        name: next(
+            iter(csv.DictReader((out / 'images.csv').read_text(encoding='utf-8').splitlines()))
+        )
+        for name, out in (('tree', from_tree), ('index', from_index))
+    }
+
+
+def test_the_export_writes_each_structured_column_as_the_json_it_holds(
+    json_columns: dict[str, dict[str, str]],
+) -> None:
+    """A CSV carrying a Python container's repr is one nothing else can read back."""
+    written = {column: json_columns['tree'][column] for column in _JSON_CELLS}
+    assert written == _JSON_CELLS
+
+
+def test_the_two_storages_write_the_same_json(
+    json_columns: dict[str, dict[str, str]],
+) -> None:
+    """One storage hands back stored text and the other a decoded container, and the file agrees."""
+    from_tree = {column: json_columns['tree'][column] for column in _JSON_CELLS}
+    from_index = {column: json_columns['index'][column] for column in _JSON_CELLS}
+    assert from_tree == from_index
+
+
+def test_a_technique_carries_its_diagnostics_through_either_storage(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger
+) -> None:
+    """The export writes the image's own columns, so this is read at the seam instead.
+
+    Diagnostics are a per-technique value and no column of ``images.csv``, so
+    what pins them is that both storages hand back the mapping the document
+    recorded.
+    """
+    root = tmp_path / 'results'
+    write_metadata(root, 'VOL/N1294561202_1_CALIB', _document_with_every_json_column())
+    url = index_url(tmp_path / 'index.sqlite3')
+    ingest_tree(url, [root], logger=quiet_logger)
+    with TreeRecordSource([root.as_posix()]) as walked:
+        from_tree = list(walked.facts(Selection()))
+    with index_source(url, [root]) as indexed:
+        from_index = list(indexed.facts(Selection()))
+    assert _diagnostics_of(from_tree) == _diagnostics_of(from_index)
+
+
+def _diagnostics_of(found: Sequence[ImageFacts | UnreadableFile]) -> list[Any]:
+    """Read every technique's diagnostics out of a stream of facts.
+
+    Parameters:
+        found: What a source yielded.
+
+    Returns:
+        One diagnostics mapping per technique entry, in stream order.
+    """
+    return [
+        entry['diagnostics']
+        for facts in found
+        if isinstance(facts, ImageFacts)
+        for entry in facts.techniques
+    ]
+
+
+def test_the_diagnostics_reaching_the_seam_are_the_recorded_ones(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger
+) -> None:
+    """Otherwise the comparison above is two storages agreeing on an empty mapping."""
+    root = tmp_path / 'results'
+    write_metadata(root, 'VOL/N1294561202_1_CALIB', _document_with_every_json_column())
+    with TreeRecordSource([root.as_posix()]) as walked:
+        found = list(walked.facts(Selection()))
+    assert _diagnostics_of(found) == [_DIAGNOSTICS]
+
+
+def test_the_covariance_reaching_the_export_is_the_recorded_one() -> None:
+    """The pinned cell has to be what encoding the recorded matrix produces."""
+    assert _JSON_CELLS['covariance_px2'] == json.dumps(_COVARIANCE)
+
+
+# ---------------------------------------------------------------------------
+# The command line, over a tree
+# ---------------------------------------------------------------------------
+
+
+def _from_the_tree_at(root: Path, out: Path, *options: str) -> int:
+    """Run the report over one named tree.
+
+    Parameters:
+        root: The results root to read.
+        out: Directory receiving the report.
+        options: Further command-line options.
+
+    Returns:
+        The exit code.
+    """
+    return main_report(['--nav-results-root', str(root), '--output-dir', str(out), *options])
+
+
+def test_naming_a_root_with_no_index_is_refused(tmp_path: Path) -> None:
+    """``--root`` selects among the roots an index holds, and there is no index.
+
+    Read as a second spelling of ``--nav-results-root`` it would quietly report
+    on a tree the operator did not name; refused, it says which flag to use.
+    """
+    with pytest.raises(SystemExit) as caught:
+        main_report(['--root', str(RESULTS_TREE), '--output-dir', str(tmp_path / 'report')])
+    assert caught.value.code == 2
+
+
+def test_the_refusal_names_the_flag_that_does_work(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A refusal that does not say what to type instead is one nobody can act on.
+
+    Asserted against the sentence the refusal is made of rather than against the
+    flag alone: argparse prints its usage line before any message it is given,
+    and that line names every flag this program takes, so a bare flag name is
+    satisfied by any refusal at all.
+    """
+    with pytest.raises(SystemExit):
+        main_report(['--root', str(RESULTS_TREE), '--output-dir', str(tmp_path / 'report')])
+    assert 'Name the trees to report on with --nav-results-root' in capsys.readouterr().err
+
+
+def test_a_root_that_cannot_be_listed_fails_the_run(tmp_path: Path) -> None:
+    """A report over a tree nobody could list would cover less and not say so."""
+    assert _from_the_tree_at(tmp_path / 'absent', tmp_path / 'report') == 1
+
+
+def test_a_root_that_cannot_be_listed_writes_no_report(tmp_path: Path) -> None:
+    """The exit status and the output agree: nothing was reported on."""
+    out = tmp_path / 'report'
+    _from_the_tree_at(tmp_path / 'absent', out)
+    assert not (out / 'report.md').exists()
+
+
+def test_a_root_that_cannot_be_listed_says_which(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An operator with several roots named needs to know which of them failed."""
+    _from_the_tree_at(tmp_path / 'absent', tmp_path / 'report')
+    assert 'absent' in capsys.readouterr().err
+
+
+def test_the_run_says_which_tree_it_read(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """One full read of every document is worth announcing before it starts."""
+    _from_the_tree_at(RESULTS_TREE, tmp_path / 'report')
+    assert str(RESULTS_TREE) in capsys.readouterr().out
+
+
+def test_two_trees_are_reported_on_together(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger
+) -> None:
+    """``--nav-results-root`` repeats, as it does for the ingest.
+
+    Held against an index ingested from both, so the second root is read rather
+    than merely accepted.
+    """
+    second = tmp_path / 'second'
+    write_metadata(
+        second, 'VOL/N1666666666_1_CALIB', metadata_document(image_name='N1666666666_1_CALIB.IMG')
+    )
+    from_tree = tmp_path / 'from-tree'
+    from_index = tmp_path / 'from-index'
+    exit_code = main_report(
+        [
+            '--nav-results-root',
+            str(RESULTS_TREE),
+            '--nav-results-root',
+            str(second),
+            '--output-dir',
+            str(from_tree),
+        ]
+    )
+    url = index_url(tmp_path / 'control.sqlite3')
+    ingest_tree(url, [RESULTS_TREE, second], logger=quiet_logger)
+    main_report(['--results-db', url, '--output-dir', str(from_index)])
+    assert exit_code == 0
+    assert (from_tree / 'report.md').read_bytes() == (from_index / 'report.md').read_bytes()
+
+
+def test_the_second_tree_reaches_the_report(tmp_path: Path) -> None:
+    """Otherwise the comparison above holds two reports of the first root."""
+    second = tmp_path / 'second'
+    write_metadata(
+        second, 'VOL/N1666666666_1_CALIB', metadata_document(image_name='N1666666666_1_CALIB.IMG')
+    )
+    out = tmp_path / 'report'
+    main_report(
+        [
+            '--nav-results-root',
+            str(RESULTS_TREE),
+            '--nav-results-root',
+            str(second),
+            '--output-dir',
+            str(out),
+        ]
+    )
+    assert 'N1666666666' in (out / 'report.md').read_text(encoding='utf-8')
+
+
+# ---------------------------------------------------------------------------
+# An index answers for the roots it finished ingesting
+# ---------------------------------------------------------------------------
+
+
+def _index_over_two_roots_one_half_ingested(
+    tmp_path: Path, logger: pdslogger.PdsLogger
+) -> tuple[str, Path, Path]:
+    """Ingest two roots, then leave the second one's newest run unfinished.
+
+    Parameters:
+        tmp_path: Directory the roots and the index live under.
+        logger: Logger the ingest reports through.
+
+    Returns:
+        The index URL, the root whose ingest completed, and the root whose
+        newest run did not.
+    """
+    finished = tmp_path / 'finished'
+    unfinished = tmp_path / 'unfinished'
+    write_metadata(
+        finished,
+        'VOL/N1294561202_1_CALIB',
+        metadata_document(image_name='N1294561202_1_CALIB.IMG'),
+    )
+    write_metadata(
+        unfinished,
+        'VOL/N1294562000_1_CALIB',
+        metadata_document(image_name='N1294562000_1_CALIB.IMG'),
+    )
+    url = index_url(tmp_path / 'index.sqlite3')
+    ingest_tree(url, [finished, unfinished], logger=logger)
+    engine = open_index(url)
+    with engine.begin() as connection:
+        connection.execute(
+            INGEST_RUNS.insert().values(
+                root_url=unfinished.as_posix(),
+                started_utc='2026-08-07T00:00:00+00:00',
+                finished_utc=None,
+                schema_version=SCHEMA_VERSION,
+            )
+        )
+    engine.dispose()
+    return url, finished, unfinished
+
+
+def test_a_report_over_every_root_leaves_out_a_half_ingested_one(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger
+) -> None:
+    """Under a root whose newest ingest died, absence of a row says nothing.
+
+    A report that counted such a root would be reading absence it has no licence
+    to read, so the roots reported over are the roots the index holds a completed
+    ingest of.
+    """
+    url, _finished, _unfinished = _index_over_two_roots_one_half_ingested(tmp_path, quiet_logger)
+    out = tmp_path / 'report'
+    main_report(['--results-db', url, '--output-dir', str(out)])
+    assert 'N1294562000' not in (out / 'report.md').read_text(encoding='utf-8')
+
+
+def test_the_completed_root_is_still_reported(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger
+) -> None:
+    """Otherwise the narrowing above is a report that covered nothing at all."""
+    url, _finished, _unfinished = _index_over_two_roots_one_half_ingested(tmp_path, quiet_logger)
+    out = tmp_path / 'report'
+    main_report(['--results-db', url, '--output-dir', str(out)])
+    assert 'N1294561202' in (out / 'report.md').read_text(encoding='utf-8')
+
+
+def test_the_half_ingested_root_holds_rows_to_leave_out(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger
+) -> None:
+    """Otherwise the narrowing is an empty root being left out of an empty report.
+
+    The row is there and the report does not read it, which is the whole of the
+    ruling: a root whose newest ingest died is one nothing may read absence from,
+    and the rows an earlier pass did write under it are not the root.
+    """
+    url, _finished, unfinished = _index_over_two_roots_one_half_ingested(tmp_path, quiet_logger)
+    engine = open_index(url)
+    try:
+        with engine.connect() as connection:
+            held = [
+                str(row[0])
+                for row in connection.execute(
+                    sqlalchemy.select(IMAGES.c.image_name).where(
+                        IMAGES.c.root_url == unfinished.as_posix()
+                    )
+                )
+            ]
+    finally:
+        engine.dispose()
+    assert held == ['N1294562000_1_CALIB.IMG']

--- a/tests/spindoctor/cli/stats/test_report_over_a_tree.py
+++ b/tests/spindoctor/cli/stats/test_report_over_a_tree.py
@@ -1052,7 +1052,7 @@ def test_a_report_over_every_root_leaves_out_a_half_ingested_one(
 ) -> None:
     """Under a root whose newest ingest died, absence of a row says nothing.
 
-    A report that counted such a root would be reading absence it has no licence
+    A report that counted such a root would be reading absence it has no license
     to read, so the roots reported over are the roots the index holds a completed
     ingest of.
     """

--- a/tests/spindoctor/cli/stats/test_report_regression.py
+++ b/tests/spindoctor/cli/stats/test_report_regression.py
@@ -1,54 +1,43 @@
-"""The report must still say what it said before its queries moved.
+"""The report says what the frozen output says, whichever storage answered.
 
-Every query the statistics user guide documents changed in the move onto the
-results index: the reason tables read two columns through a ``COALESCE``, the
-joins match a column pair instead of an image name, the boolean columns are used
-as booleans, and the image-number filter compares a column instead of calling a
-Python function registered on the connection.  A change in *how* a number is
-computed must not change the number.
-
-``data/golden`` holds ``report.md`` and ``images.csv`` as the statistics code
-produced them from ``data/results_tree`` before any of that moved.  The tree
-covers every section: two volumes and a bare-basename stub, successes, a
-failure, a fatal error with no navigation result at all, a BOTSIM pair, a
-suspect offset, an ensemble exclusion, a spurious technique, gated features, and
-an image whose search limit cannot be resolved.  A diff here is a defect, not
-drift.
+``data/golden`` holds ``report.md``, ``images.csv`` and the drill-down filelists
+as the statistics code produces them from ``data/results_tree``.  The tree covers
+every section: two volumes, a simulated scene and a bare-basename stub,
+successes, a failure, a fatal error with no navigation result at all, a BOTSIM
+pair, a suspect offset, an ensemble exclusion, a spurious technique, gated
+features, and an image whose search limit cannot be resolved.  A diff here is a
+defect, not drift.
 
 The fatal error is the one image of the tree that records no epoch: an epoch is
 the midtime of an observation, and that image's load failed before one existed.
 So its ``image_et`` and ``image_date`` cells are empty, and the ``filtered``
 variant's coiss time span ends at the image before it rather than at it.
 
-Two documented differences are the point of the change rather than a regression
-in it, and each is asserted for rather than waved past:
+The frozen ``images.csv`` is a hand-curated subset of the export's columns, and
+the comparison walks the *frozen* row's columns: a column the export gains, and
+an export that writes the same columns in another order, are both invisible to
+it.  A column the export drops is not: the produced row has no such key and the
+comparison raises a ``KeyError`` where it looks the value up.  Which columns the
+export writes, and in which order, is pinned instead by ``_CSV_HEADER`` below.
 
-- ``images.csv`` gains the columns the schema gained, in schema order, and its
-  ``status_reason`` column no longer carries a fatal error -- ``status_error``
-  is its own column now, and merging the two vocabularies is what the report
-  stopped doing.  Which columns it has is pinned against a list written out in
-  this file: the field-by-field comparison walks the *frozen* row's columns, so
-  a column the export gains, and an export that writes the same columns in
-  another order, are both invisible to it.  A column the export drops is not:
-  the produced row has no such key and the comparison raises a ``KeyError``
-  where it looks the value up.
-- The two feature-count aggregates come back as integers.  They are counts, and
-  the aggregate that produced a floating-point zero for an image with no
-  features was a SQLite spelling.
+Two differences between the frozen subset and the export are asserted for rather
+than waved past:
 
-One byte-level difference is disclosed rather than compared away.  The frozen
-``images.csv`` files carry LF line endings; the implementation that produced
-them left ``csv.writer`` at its CRLF default, and the committed blobs were
-normalized when they were frozen.  The export now states its line terminator
-instead of inheriting one, and states LF, so what it writes matches the frozen
-bytes.  The comparisons here read fields rather than lines and would not have
-noticed either way, so the terminator is pinned by a test of its own.
+- ``status_reason`` in the frozen subset carries a fatal error, and the export
+  keeps the two vocabularies in the two columns that hold them, so the pair is
+  compared against the one.
+- The two feature-count aggregates are integers, where the frozen subset renders
+  them as floating-point counts.
+
+Row order is deliberately not compared.  The export writes each row where it
+reads it rather than collecting and sorting them, so the file says which images
+were exported and not in what sequence; the rows are matched by image name here
+and the export leads with the column an operator sorts on.
 """
 
 import csv
 import uuid
 from pathlib import Path
-from typing import Any
 
 import pdslogger
 import pytest
@@ -58,24 +47,13 @@ from tests.spindoctor.conftest import (
 
 from .conftest import (
     GOLDEN_DIR,
+    GOLDEN_VARIANTS,
     RESULTS_TREE,
-    report_from_tree,
+    report_from_the_index,
 )
 
 _TREE_PLACEHOLDER = '{results_tree}'
 """What the frozen CSV holds in place of the tree's absolute path."""
-
-_VARIANTS: dict[str, dict[str, Any]] = {
-    'full': {'top_n': 5, 'filelists': True, 'csv_export': True},
-    'filtered': {
-        'instrument': 'coiss',
-        'min_image': '1294561202',
-        'max_image': '1294563000',
-        'top_n': 3,
-        'csv_export': True,
-    },
-}
-"""The two report invocations the frozen output was produced by."""
 
 _MERGED_REASON_COLUMN = 'status_reason'
 """The column the frozen CSV merged both reason vocabularies into."""
@@ -84,15 +62,15 @@ _COUNT_COLUMNS = ('n_features', 'n_gated')
 """Aggregates the frozen CSV rendered as floating-point counts."""
 
 
-@pytest.fixture(scope='module', params=sorted(_VARIANTS))
+@pytest.fixture(scope='module', params=sorted(GOLDEN_VARIANTS))
 def report_variant(
     request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory
 ) -> tuple[str, Path]:
     """Build one report variant once for the whole module.
 
-    Six comparisons are made against each variant and every one of them only
-    reads, so building the variant per test ingests the same tree twelve times
-    to produce two outputs.
+    Several comparisons are made against each variant and every one of them
+    only reads, so building the variant per test would ingest the same tree
+    once per comparison to produce two outputs.
 
     Parameters:
         request: The fixture request, carrying the variant name.
@@ -105,8 +83,8 @@ def report_variant(
     logger = pdslogger.PdsLogger(f'stats_regression_{uuid.uuid4().hex}')
     logger.set_level('ERROR')
     root = tmp_path_factory.mktemp('regression')
-    out = report_from_tree(
-        index_url(root / 'index.sqlite3'), root / variant, logger=logger, **_VARIANTS[variant]
+    out = report_from_the_index(
+        index_url(root / 'index.sqlite3'), root / variant, logger=logger, **GOLDEN_VARIANTS[variant]
     )
     return variant, out
 
@@ -127,7 +105,7 @@ def _frozen_csv_rows(variant: str) -> list[dict[str, str]]:
     """Read a frozen CSV export, restoring the tree's absolute path.
 
     Parameters:
-        variant: Which entry of :data:`_VARIANTS` to read.
+        variant: Which entry of :data:`GOLDEN_VARIANTS` to read.
 
     Returns:
         One mapping per data row, keyed by column name.
@@ -135,6 +113,30 @@ def _frozen_csv_rows(variant: str) -> list[dict[str, str]]:
     text = (GOLDEN_DIR / variant / 'images.csv').read_text(encoding='utf-8')
     text = text.replace(_TREE_PLACEHOLDER, RESULTS_TREE.as_posix())
     return list(csv.DictReader(text.splitlines()))
+
+
+def _paired_rows(variant: str, out: Path) -> list[tuple[dict[str, str], dict[str, str]]]:
+    """Pair each produced row with the frozen row for the same image.
+
+    Paired by image name rather than by position.  The export writes each row
+    where it reads it, so the file's line order is the order the storage found
+    the images in and is not a contract; the frozen subset carries no key
+    columns, and the fixture tree names each of its images once, so the name is
+    what the two files can be matched on.
+
+    Parameters:
+        variant: Which entry of :data:`GOLDEN_VARIANTS` to read.
+        out: The directory the report was written into.
+
+    Returns:
+        One ``(produced, frozen)`` pair per image, in frozen-file order.
+
+    Raises:
+        KeyError: If the export holds no row for an image the frozen file
+            names, which is a dropped image rather than a reordered one.
+    """
+    produced = {row['image_name']: row for row in _csv_rows(out / 'images.csv')}
+    return [(produced[row['image_name']], row) for row in _frozen_csv_rows(variant)]
 
 
 def test_the_report_is_byte_identical(report_variant: tuple[str, Path]) -> None:
@@ -149,15 +151,30 @@ def test_the_report_is_byte_identical(report_variant: tuple[str, Path]) -> None:
 
 
 def test_the_csv_holds_the_same_images(report_variant: tuple[str, Path]) -> None:
-    """The export covers the same images in the same order.
+    """The export covers the same images.
+
+    Compared as sorted names, because line order is not a contract: the export
+    writes a row where it reads it rather than collecting and sorting every one
+    of them, and the two storages find the same images in two orders.
 
     Parameters:
         report_variant: The variant name and the report it wrote.
     """
     variant, out = report_variant
-    produced = [row['image_name'] for row in _csv_rows(out / 'images.csv')]
-    frozen = [row['image_name'] for row in _frozen_csv_rows(variant)]
+    produced = sorted(row['image_name'] for row in _csv_rows(out / 'images.csv'))
+    frozen = sorted(row['image_name'] for row in _frozen_csv_rows(variant))
     assert produced == frozen
+
+
+def test_the_frozen_csv_names_each_image_once(report_variant: tuple[str, Path]) -> None:
+    """Otherwise matching the two files by image name silently drops a row.
+
+    Parameters:
+        report_variant: The variant name and the report it wrote.
+    """
+    variant, _out = report_variant
+    names = [row['image_name'] for row in _frozen_csv_rows(variant)]
+    assert len(set(names)) == len(names)
 
 
 def test_every_carried_over_csv_column_is_unchanged(report_variant: tuple[str, Path]) -> None:
@@ -170,11 +187,9 @@ def test_every_carried_over_csv_column_is_unchanged(report_variant: tuple[str, P
         report_variant: The variant name and the report it wrote.
     """
     variant, out = report_variant
-    produced = _csv_rows(out / 'images.csv')
-    frozen = _frozen_csv_rows(variant)
     differences = [
         f'{row["image_name"]}.{column}: {value!r} became {row[column]!r}'
-        for row, frozen_row in zip(produced, frozen, strict=True)
+        for row, frozen_row in _paired_rows(variant, out)
         for column, value in frozen_row.items()
         if column not in (_MERGED_REASON_COLUMN, *_COUNT_COLUMNS)
         if row[column] != value
@@ -191,12 +206,10 @@ def test_the_merged_reason_column_is_reproduced_by_the_pair(
         report_variant: The variant name and the report it wrote.
     """
     variant, out = report_variant
-    produced = _csv_rows(out / 'images.csv')
-    frozen = _frozen_csv_rows(variant)
     differences = [
         f'{row["image_name"]}: {frozen_row[_MERGED_REASON_COLUMN]!r} became '
         f'{row["status_reason"]!r} / {row["status_error"]!r}'
-        for row, frozen_row in zip(produced, frozen, strict=True)
+        for row, frozen_row in _paired_rows(variant, out)
         if (row['status_reason'] or row['status_error']) != frozen_row[_MERGED_REASON_COLUMN]
     ]
     assert differences == []
@@ -209,11 +222,9 @@ def test_the_count_aggregates_are_the_same_numbers(report_variant: tuple[str, Pa
         report_variant: The variant name and the report it wrote.
     """
     variant, out = report_variant
-    produced = _csv_rows(out / 'images.csv')
-    frozen = _frozen_csv_rows(variant)
     differences = [
         f'{row["image_name"]}.{column}: {frozen_row[column]!r} became {row[column]!r}'
-        for row, frozen_row in zip(produced, frozen, strict=True)
+        for row, frozen_row in _paired_rows(variant, out)
         for column in _COUNT_COLUMNS
         if float(row[column]) != float(frozen_row[column])
     ]
@@ -221,8 +232,8 @@ def test_the_count_aggregates_are_the_same_numbers(report_variant: tuple[str, Pa
 
 
 _CSV_HEADER = (
-    'root_url',
     'results_path_stub',
+    'root_url',
     'subtree',
     'image_name',
     'instrument',
@@ -293,9 +304,11 @@ Editing this list is therefore the deliberate act of ratifying a changed export,
 and it is worth the deliberation.  A CSV is read by position as often as by
 name -- by a spreadsheet, by a downstream script, by whoever cut a column out of
 it with ``cut -f`` -- so a column inserted in the middle silently re-points
-every reader that counts.  The first two are the key of the row, naming the root
-and the stub each one came from, and a reader joining the export back to a
-results tree needs them where they are.
+every reader that counts.  The first two are the key of the row, naming the stub
+and the root each one came from, and a reader joining the export back to a
+results tree needs them where they are.  The stub leads, because the rows are
+written where they are read and ``sort -t, -k1,1 images.csv`` is then all an
+operator has to type to put the file in key order.
 """
 
 
@@ -342,6 +355,7 @@ def test_the_frozen_report_covers_every_section() -> None:
         heading
         for heading in (
             '## Images selected',
+            '## Files that yielded no record',
             '## Success / failure',
             '### Failure reasons',
             '## Failure taxonomy by image content',

--- a/tests/spindoctor/cli/stats/test_report_regression.py
+++ b/tests/spindoctor/cli/stats/test_report_regression.py
@@ -307,8 +307,8 @@ it with ``cut -f`` -- so a column inserted in the middle silently re-points
 every reader that counts.  The first two are the key of the row, naming the stub
 and the root each one came from, and a reader joining the export back to a
 results tree needs them where they are.  The stub leads, because the rows are
-written where they are read and ``sort -t, -k1,1 images.csv`` is then all an
-operator has to type to put the file in key order.
+written where they are read and a sort on field 1 is then all an operator has to
+reach for to put the file in key order.
 """
 
 

--- a/tests/spindoctor/cli/stats/test_report_roots.py
+++ b/tests/spindoctor/cli/stats/test_report_roots.py
@@ -221,7 +221,7 @@ def test_a_report_covering_every_root_names_no_dropped_root(
 def test_a_dropped_root_contributes_no_images(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Reading rows under a root whose pass died is reading absence with no licence to.
+    """Reading rows under a root whose pass died is reading absence with no license to.
 
     The dropped root holds one image, and the index holds its row.  Counting it
     would report a number nothing stands behind: whatever else that root holds

--- a/tests/spindoctor/cli/stats/test_report_roots.py
+++ b/tests/spindoctor/cli/stats/test_report_roots.py
@@ -1,0 +1,279 @@
+"""What a report covers, root by root, and what it says about a root it did not.
+
+One index serves several results roots and one report may span them, so the root
+is half of every key the report reads and the whole of what it can be narrowed
+to without opening a document.  Two things follow, and both are measured here
+over two roots that differ in the value under test: a report handed two roots
+covers both of them, and a report that could be bound to only some of the roots
+it was pointed at says which ones those were.
+
+A root whose newest ingest run never finished is the second case.  Its rows are
+in the index and mean nothing -- absence under it is absence of a pass rather
+than absence of an image -- so the report covers none of it, and a narrowing
+nobody could see would read as an answer about the whole index.
+"""
+
+from pathlib import Path
+
+import pdslogger
+import pytest
+from tests.spindoctor.conftest import (
+    index_url,
+    ingest_tree,
+    metadata_document,
+    write_metadata,
+    write_refusal,
+)
+
+from spindoctor.cli.stats.report import build_report, main_report
+from spindoctor.nav_records import TreeRecordSource
+from spindoctor.results_index import INGEST_RUNS, SCHEMA_VERSION, open_index
+
+from .conftest import index_source
+
+_COVERED_STUB = 'VOL/N1000000001_1_CALIB'
+"""The image the root a report can be bound to holds."""
+
+_DROPPED_STUB = 'VGISS_5101/C1385455_GEOMED'
+"""The image the other root holds, of another mission and another numbering.
+
+Different in every value the report groups by, so a report that covered the
+wrong root, or only one of two, differs from one that covered both in more than
+a total.
+"""
+
+
+def _two_roots(tmp_path: Path) -> tuple[Path, Path]:
+    """Write two results roots, each holding one image the other does not.
+
+    Parameters:
+        tmp_path: Directory the roots are written under.
+
+    Returns:
+        The two roots.
+    """
+    first = tmp_path / 'primary'
+    second = tmp_path / 'rescue'
+    write_metadata(first, _COVERED_STUB, metadata_document())
+    write_metadata(
+        second,
+        _DROPPED_STUB,
+        metadata_document(
+            image_name='C1385455_GEOMED.IMG',
+            instrument='vgiss',
+            camera=None,
+            image_shape=[800, 800],
+        ),
+    )
+    return first, second
+
+
+# ---------------------------------------------------------------------------
+# Two roots, both covered
+# ---------------------------------------------------------------------------
+
+
+def test_a_report_over_two_named_roots_counts_the_images_of_both(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger
+) -> None:
+    """``--root`` accumulates, so naming two roots asks about two roots.
+
+    A selection built from the first of them alone would report one image and
+    say nothing about having narrowed itself: the header would still name both.
+    """
+    first, second = _two_roots(tmp_path)
+    url = index_url(tmp_path / 'index.sqlite3')
+    ingest_tree(url, [first, second], logger=quiet_logger)
+    with index_source(url, [first, second]) as source:
+        text = build_report(
+            source, tmp_path / 'report', roots=[first.as_posix(), second.as_posix()]
+        ).read_text(encoding='utf-8')
+    assert 'Total images: 2' in text
+
+
+def test_a_report_over_two_named_roots_names_both_of_them(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger
+) -> None:
+    """The header says what was covered, and covering two roots is two names.
+
+    Compared against the whole line, since a header naming the first root alone
+    is a prefix of one naming both.
+    """
+    first, second = _two_roots(tmp_path)
+    url = index_url(tmp_path / 'index.sqlite3')
+    ingest_tree(url, [first, second], logger=quiet_logger)
+    with index_source(url, [first, second]) as source:
+        text = build_report(
+            source, tmp_path / 'report', roots=[first.as_posix(), second.as_posix()]
+        ).read_text(encoding='utf-8')
+    expected = f'Filters: root in {first.as_posix()}, {second.as_posix()}'
+    assert expected in text.splitlines()
+
+
+# ---------------------------------------------------------------------------
+# A root the report could not be bound to
+# ---------------------------------------------------------------------------
+
+
+def _index_with_one_unfinished_root(
+    tmp_path: Path, logger: pdslogger.PdsLogger, *, dropped_holds_a_refusal: bool = False
+) -> tuple[str, Path, Path]:
+    """Ingest two roots and leave the second one's newest run unfinished.
+
+    Both roots' rows are in the index, which is the whole difficulty: the rows
+    are there and mean nothing, because the pass that would have written the
+    rest of them died.
+
+    Parameters:
+        tmp_path: Directory the roots and the index live under.
+        logger: Logger the ingest reports through.
+        dropped_holds_a_refusal: Whether the second root also holds a file no
+            record can be read out of.
+
+    Returns:
+        The index URL, the root with a completed ingest, and the root without
+        one.
+    """
+    covered, dropped = _two_roots(tmp_path)
+    if dropped_holds_a_refusal:
+        write_refusal(dropped, 'VGISS_5101/edges')
+    url = index_url(tmp_path / 'index.sqlite3')
+    ingest_tree(url, [covered, dropped], logger=logger)
+    engine = open_index(url)
+    try:
+        with engine.begin() as connection:
+            connection.execute(
+                INGEST_RUNS.insert().values(
+                    root_url=dropped.as_posix(),
+                    started_utc='2026-08-20T00:00:00+00:00',
+                    finished_utc=None,
+                    schema_version=SCHEMA_VERSION,
+                )
+            )
+    finally:
+        engine.dispose()
+    return url, covered, dropped
+
+
+def _report_over(url: str, out: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Run the driver against an index it was named, naming no root of its own.
+
+    Naming no root is the case the narrowing happens in: a run that names its
+    roots is refused outright when one of them has no completed ingest.
+
+    Parameters:
+        url: The index URL.
+        out: Directory receiving the report.
+        monkeypatch: Fixture the ambient index variable is cleared through, so
+            that what the run reads is what it was handed.
+
+    Returns:
+        The Markdown the report wrote.
+    """
+    monkeypatch.delenv('NAV_RESULTS_DB', raising=False)
+    main_report(['--results-db', url, '--output-dir', str(out)])
+    return (out / 'report.md').read_text(encoding='utf-8')
+
+
+def test_a_report_that_dropped_a_root_names_the_roots_it_covered(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A narrowing nobody can see is one an operator reads as an answer about everything.
+
+    The index holds rows under both roots and the report covers one of them, so
+    a header still saying that every image was read would be false about the
+    half of the index it never looked at.
+    """
+    url, covered, _dropped = _index_with_one_unfinished_root(tmp_path, quiet_logger)
+    text = _report_over(url, tmp_path / 'report', monkeypatch)
+    assert f'Filters: root in {covered.as_posix()}' in text.splitlines()
+
+
+def test_a_report_that_dropped_a_root_names_the_root_it_dropped(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Naming what was covered is half of it; the other half is what to ingest.
+
+    The root that was left out is the one thing the operator has to act on, and
+    the report is where they are reading.
+    """
+    url, _covered, dropped = _index_with_one_unfinished_root(tmp_path, quiet_logger)
+    text = _report_over(url, tmp_path / 'report', monkeypatch)
+    assert f'Roots dropped: {dropped.as_posix()}' in text.splitlines()
+
+
+def test_a_report_covering_every_root_names_no_dropped_root(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A line that appeared over a whole index would say a run had covered less.
+
+    The paragraph is printed because a root was left out, so an index with a
+    completed ingest of everything it holds prints neither it nor the roots
+    under it.
+    """
+    covered, dropped = _two_roots(tmp_path)
+    url = index_url(tmp_path / 'index.sqlite3')
+    ingest_tree(url, [covered, dropped], logger=quiet_logger)
+    text = _report_over(url, tmp_path / 'report', monkeypatch)
+    assert 'Roots dropped:' not in text
+
+
+def test_a_dropped_root_contributes_no_images(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reading rows under a root whose pass died is reading absence with no licence to.
+
+    The dropped root holds one image, and the index holds its row.  Counting it
+    would report a number nothing stands behind: whatever else that root holds
+    was never walked.
+    """
+    url, _covered, _dropped = _index_with_one_unfinished_root(tmp_path, quiet_logger)
+    text = _report_over(url, tmp_path / 'report', monkeypatch)
+    assert 'Total images: 1' in text
+
+
+def test_a_dropped_root_contributes_no_refusals_either(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A half-covered root is worse than an uncovered one, so it is not covered at all.
+
+    A refusal is the one thing under a dropped root a filter cannot exclude, so
+    it is the count that would leak.  Reporting a root's refused files while
+    reporting none of its images would describe a root the report never read.
+    """
+    url, _covered, _dropped = _index_with_one_unfinished_root(
+        tmp_path, quiet_logger, dropped_holds_a_refusal=True
+    )
+    text = _report_over(url, tmp_path / 'report', monkeypatch)
+    assert 'Files that yielded no record: 0' in text
+
+
+def test_a_dropped_roots_refusal_is_in_the_index_that_left_it_out(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The absence above is an absence of something, not of an empty fixture.
+
+    Ingested with both roots completed, the same index reports the refusal, so
+    the zero beside it is the dropped root being dropped rather than a file that
+    was never refused.
+    """
+    covered, dropped = _two_roots(tmp_path)
+    write_refusal(dropped, 'VGISS_5101/edges')
+    url = index_url(tmp_path / 'index.sqlite3')
+    ingest_tree(url, [covered, dropped], logger=quiet_logger)
+    text = _report_over(url, tmp_path / 'report', monkeypatch)
+    assert 'Files that yielded no record: 1' in text
+
+
+def test_the_tree_reports_over_every_root_it_was_named(tmp_path: Path) -> None:
+    """No index means no ingest to be incomplete, so a tree drops no root.
+
+    A results tree is read as it is now, so both roots are covered and neither
+    is named as one the report left out.
+    """
+    first, second = _two_roots(tmp_path)
+    out = tmp_path / 'report'
+    out.mkdir(parents=True, exist_ok=True)
+    with TreeRecordSource([first.as_posix(), second.as_posix()]) as source:
+        build_report(source, out)
+    assert 'Total images: 2' in (out / 'report.md').read_text(encoding='utf-8')

--- a/tests/spindoctor/cli/stats/test_report_screens.py
+++ b/tests/spindoctor/cli/stats/test_report_screens.py
@@ -1,0 +1,464 @@
+"""The report sections whose fixtures a tree of ordinary images cannot supply.
+
+Four sections say something only about images built to make them say it, and the
+frozen regression tree holds none of those images.  It has one image size per
+camera, so the per-camera statistics are never a pool of anything.  Every one of
+its successes is far inside the search box and no two of its Cassini frames
+share a spacecraft-clock count, so no table it produces is ever capped and no
+reduction it makes ever has two candidates to choose between.  And every
+document in it either succeeded or failed outright, so nothing in it is an image
+the navigator could not decide about.
+
+Each fixture here is written for one of those, and each is small enough that the
+number the section prints can be worked out by hand from the offsets that went
+in.
+"""
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+from tests.spindoctor.conftest import metadata_document, write_metadata
+
+from spindoctor.cli.stats.report import build_report
+from spindoctor.nav_records import ImageFacts, Selection, TreeRecordSource, UnreadableFile
+
+from .conftest import ReplayedFacts
+
+_SUSPECT_TABLE_HEADER = '| image | instrument | dV | dU | magnitude | limit (v, u) |'
+"""The header row of the suspect-offset table, for finding the rows under it."""
+
+
+def _tree_of(root: Path, documents: dict[str, dict[str, Any]]) -> Path:
+    """Write one document per stub into a results root.
+
+    Parameters:
+        root: The results root to write under.
+        documents: Results path stub to the document written at it.
+
+    Returns:
+        The root, written.
+    """
+    for stub, document in documents.items():
+        write_metadata(root, stub, document)
+    return root
+
+
+def _report_text(tmp_path: Path, documents: dict[str, dict[str, Any]], **options: Any) -> str:
+    """Write one report over a tree of the given documents and read it back.
+
+    Parameters:
+        tmp_path: Directory the tree and the report live under.
+        documents: Results path stub to the document written at it.
+        options: Report options, passed through to ``build_report``.
+
+    Returns:
+        The Markdown the report wrote.
+    """
+    root = _tree_of(tmp_path / 'results', documents)
+    out = tmp_path / 'report'
+    out.mkdir(parents=True, exist_ok=True)
+    with TreeRecordSource([root.as_posix()]) as source:
+        build_report(source, out, **options)
+    return (out / 'report.md').read_text(encoding='utf-8')
+
+
+def _suspect_rows(text: str) -> list[str]:
+    """The data rows of the suspect-offset table, in the order it printed them.
+
+    Parameters:
+        text: The whole report.
+
+    Returns:
+        One row per image the table listed, and an empty list when it listed
+        none.
+
+    Raises:
+        ValueError: If the report holds no suspect table at all, which is a
+            section that stopped being printed rather than a table with no rows.
+    """
+    lines = text.splitlines()
+    if _SUSPECT_TABLE_HEADER not in lines:
+        raise ValueError('the report prints no suspect-offset table')
+    start = lines.index(_SUSPECT_TABLE_HEADER) + 2
+    rows = []
+    for line in lines[start:]:
+        if not line.startswith('|'):
+            break
+        rows.append(line)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# An image the navigator could not decide about
+# ---------------------------------------------------------------------------
+
+
+def _conflicted_documents() -> dict[str, dict[str, Any]]:
+    """Return one Cassini success and one Cassini image the ensemble could not settle.
+
+    The conflicted image records an offset, because that is what the ensemble
+    writes when its techniques agree on nothing: a pointing it arrived at and
+    will not stand behind.  Its offset is close enough to the WAC search limit
+    to be screened as suspect, and its feature inventory names a body, so an
+    image counted as a success would show up in the offset statistics, in the
+    suspect screen and on the successful side of the per-body shares.
+
+    Returns:
+        Results path stub to document.
+    """
+    return {
+        'COISS_2001/N2000000001_1_CALIB': metadata_document(
+            image_name='N2000000001_1_CALIB.IMG',
+            camera='NAC',
+            image_shape=[1024, 1024],
+            offset=[1.5, -2.5],
+        ),
+        'COISS_2001/W2000000002_1_CALIB': metadata_document(
+            image_name='W2000000002_1_CALIB.IMG',
+            camera='WAC',
+            image_shape=[1024, 1024],
+            status='conflicted',
+            status_reason='techniques_disagree',
+            offset=[4.9, 0.0],
+            confidence=0.2,
+            confidence_rank='conflicted',
+        ),
+    }
+
+
+def test_a_conflicted_image_is_no_part_of_the_successful_offsets(tmp_path: Path) -> None:
+    """A pointing the ensemble would not stand behind is not one of the offsets it did.
+
+    The offset statistics, the per-camera histograms and the suspect screen are
+    all headed "successful images".  Counting an image the ensemble could not
+    settle would put a WAC row into a table with no navigated WAC image in it,
+    and would screen a second image against a limit it was never asked about.
+    """
+    text = _report_text(tmp_path, _conflicted_documents())
+    assert 'Suspect images: 0 (0.0%) of 1 screened.' in text
+    assert '| coiss | WAC |' not in text
+
+
+def test_a_conflicted_image_counts_as_a_failure_against_its_body(tmp_path: Path) -> None:
+    """Every outcome that is not success is a failure, and only success is success.
+
+    The per-body shares divide the images naming a body into the ones that
+    worked and the ones that did not, so a bucket keyed on one named failure
+    status rather than on the absence of success would count this image as a
+    body the navigator handled.
+    """
+    text = _report_text(tmp_path, _conflicted_documents())
+    assert '| IAPETUS | coiss | 1 (50.0%) | 1 (50.0%) | 0.500 |' in text
+
+
+# ---------------------------------------------------------------------------
+# The tables an option caps
+# ---------------------------------------------------------------------------
+
+_CAPPED_OFFSETS: dict[str, tuple[float, float]] = {
+    'COISS_2001/N1000000001_1_CALIB': (49.0, 0.0),
+    'COISS_2001/W1000000001_1_CALIB': (4.7, 0.0),
+    'COISS_2001/N1000000002_1_CALIB': (47.5, 0.0),
+    'COISS_2001/W1000000002_1_CALIB': (4.6, 0.0),
+    'COISS_2001/N1000000003_1_CALIB': (10.0, 130.0),
+    'COISS_2001/W1000000003_1_CALIB': (4.55, 0.0),
+}
+"""Three simultaneously shuttered Cassini pairs, every frame near its search limit.
+
+The configured CALIB limits are ``(50, 140)`` for the NAC and ``(5, 10)`` for
+the WAC, so every one of the six reaches at least 0.91 of a limit and no two of
+them reach the same fraction of one: the suspect table is six rows deep and its
+order is decided by the offsets rather than by a tie.  The third pair is the one
+that reaches its limit on the U axis alone, and it is also what makes the three
+BOTSIM residuals -- 2.000, 1.500 and 134.760 -- far enough apart that a
+percentile over them is not the smallest of them.
+"""
+
+_CAPPED_TOP_N = 2
+"""What the capped runs below pass as ``--top-n``, which is fewer than six."""
+
+
+def _capped_documents() -> dict[str, dict[str, Any]]:
+    """Return the six Cassini frames of :data:`_CAPPED_OFFSETS`.
+
+    Returns:
+        Results path stub to document.
+    """
+    documents = {}
+    for stub, offset in _CAPPED_OFFSETS.items():
+        name = stub.rsplit('/', 1)[-1]
+        documents[stub] = metadata_document(
+            image_name=f'{name}.IMG',
+            camera='NAC' if name.startswith('N') else 'WAC',
+            image_shape=[1024, 1024],
+            offset=list(offset),
+        )
+    return documents
+
+
+_MANY_SUSPECTS = 30
+"""How many suspect images the uncapped table is measured over.
+
+More than the twenty-five a bounded top-N structure elsewhere in the report
+holds, so that a cap borrowed from one of those and applied quietly here is a
+cap this measurement can see.
+"""
+
+
+def _many_suspect_documents() -> dict[str, dict[str, Any]]:
+    """Return :data:`_MANY_SUSPECTS` Cassini NAC frames, every one near its search limit.
+
+    The offsets run from 46.0 to 48.9 pixels against a V-axis limit of 50, so
+    each of them reaches between 0.92 and 0.98 of the limit and every one is
+    screened as suspect.
+
+    Returns:
+        Results path stub to document.
+    """
+    documents = {}
+    for index in range(_MANY_SUSPECTS):
+        name = f'N400000{4000 + index}_1_CALIB'
+        documents[f'COISS_2001/{name}'] = metadata_document(
+            image_name=f'{name}.IMG',
+            camera='NAC',
+            image_shape=[1024, 1024],
+            offset=[46.0 + index / 10.0, 0.0],
+        )
+    return documents
+
+
+def test_the_suspect_table_lists_every_suspect_by_default(tmp_path: Path) -> None:
+    """``--top-n 0`` means uncapped here, which is the opposite of what it means elsewhere.
+
+    An operator screening a run needs the whole list rather than the worst few
+    of it, so this is the one always-on section that prints a row per image.  A
+    quiet cap on it would be invisible wherever fewer images are suspect than
+    the cap allows, so this is measured over more images than any bounded
+    structure in the report holds.
+    """
+    text = _report_text(tmp_path, _many_suspect_documents(), top_n=0)
+    assert len(_suspect_rows(text)) == _MANY_SUSPECTS
+
+
+def test_top_n_caps_the_suspect_table(tmp_path: Path) -> None:
+    """Given, the option caps the table it says it caps, worst first."""
+    text = _report_text(tmp_path, _capped_documents(), top_n=_CAPPED_TOP_N)
+    assert len(_suspect_rows(text)) == _CAPPED_TOP_N
+
+
+def test_top_n_caps_the_names_a_drilldown_lists(tmp_path: Path) -> None:
+    """The line promises up to N names per category, and printing more would break it.
+
+    Six images are suspect and two may be named, so a drill-down that listed
+    what it held would print a line its own heading contradicts.  Compared
+    against the whole line rather than searched for inside it, since the capped
+    line is a prefix of the uncapped one.
+    """
+    text = _report_text(tmp_path, _capped_documents(), top_n=_CAPPED_TOP_N)
+    assert '- suspect / coiss: N1000000001, N1000000002' in text.splitlines()
+
+
+def test_top_n_caps_the_worst_botsim_pairs(tmp_path: Path) -> None:
+    """Three pairs are identified and two are listed, so the cap is what decides.
+
+    The count in the heading is the number of rows under it, so a cap that did
+    not bind would leave the heading naming two and three rows beneath it.
+    """
+    text = _report_text(tmp_path, _capped_documents(), top_n=_CAPPED_TOP_N)
+    assert f'Worst {_CAPPED_TOP_N} pair(s):' in text
+
+
+def test_the_worst_botsim_pair_is_the_one_with_the_largest_residual(tmp_path: Path) -> None:
+    """A cap that kept the wrong two would still print two rows and say nothing true.
+
+    The third pair's residual is sixty times the others', so the capped table
+    that leaves it out is one an operator would act on the wrong frames from.
+    """
+    text = _report_text(tmp_path, _capped_documents(), top_n=_CAPPED_TOP_N)
+    assert '| 1000000003 | N1000000003 | W1000000003 | -35.500 | 130.000 | 134.760 |' in text
+
+
+def test_the_p95_residual_is_taken_over_the_whole_population(tmp_path: Path) -> None:
+    """Three residuals, and the 95th percentile of them is the largest, not the smallest.
+
+    Every percentile in either frozen report runs over a population of one, so
+    a percentile that returned the first ordered value would agree with both of
+    them.  Here the three are 1.500, 2.000 and 134.760.
+    """
+    text = _report_text(tmp_path, _capped_documents(), top_n=_CAPPED_TOP_N)
+    assert '| p95 residual (px) | 134.760 |' in text
+
+
+def test_the_u_axis_is_screened_as_well_as_the_v_axis(tmp_path: Path) -> None:
+    """An offset pinned to the U edge of the search box is as suspect as one on V.
+
+    The Cassini NAC limits are far apart -- 50 pixels on V against 140 on U --
+    and the third NAC frame reaches 0.93 of the U limit while reaching 0.20 of
+    the V limit, so a screen reading the V axis alone would pass it.
+    """
+    text = _report_text(tmp_path, _capped_documents(), top_n=0)
+    assert '| N1000000003 | coiss | 10.000 | 130.000 | 130.384 | (50.0, 140.0) |' in text
+
+
+def test_the_suspect_fraction_decides_what_is_screened_as_suspect(tmp_path: Path) -> None:
+    """The option is what the ratio is compared against, not a number spelled twice.
+
+    At the default fraction all six frames are suspect; at 0.945 only the two
+    that reach 0.95 of a limit are.  A screen holding its own constant would
+    print six rows either way.
+    """
+    text = _report_text(tmp_path, _capped_documents(), top_n=0, suspect_fraction=0.945)
+    assert len(_suspect_rows(text)) == 2
+
+
+# ---------------------------------------------------------------------------
+# One camera at more than one image size
+# ---------------------------------------------------------------------------
+
+_POOLED_SIZES: dict[str, tuple[list[int], float]] = {
+    'COISS_2001/N3000000001_1_CALIB': ([1024, 1024], 10.0),
+    'COISS_2001/N3000000002_1_CALIB': ([1024, 1024], 20.0),
+    'COISS_2001/N3000000003_1_CALIB': ([512, 512], 3.0),
+}
+"""One Cassini camera at two image sizes, and the V-axis offset each frame records.
+
+Every real Cassini run holds several sizes of one camera -- the configured
+search margins are keyed by 256, 512 and 1024 for the NAC -- so the per-camera
+statistics are a pool of the per-size ones on every run there is.  The three
+offsets are chosen so that no size on its own has the pooled mean, median,
+minimum or maximum: over all three the mean is 11.000 and the median 10.000,
+where the 1024 frames alone give 15.000 and the 512 frame alone gives 3.000.
+"""
+
+
+def _pooled_size_documents() -> dict[str, dict[str, Any]]:
+    """Return the three Cassini NAC frames of :data:`_POOLED_SIZES`.
+
+    Returns:
+        Results path stub to document.
+    """
+    documents = {}
+    for stub, (shape, offset_dv) in _POOLED_SIZES.items():
+        name = stub.rsplit('/', 1)[-1]
+        documents[stub] = metadata_document(
+            image_name=f'{name}.IMG',
+            camera='NAC',
+            image_shape=shape,
+            offset=[offset_dv, 0.0],
+        )
+    return documents
+
+
+def test_the_per_camera_offsets_pool_the_image_sizes(tmp_path: Path) -> None:
+    """The per-camera row is every offset that camera recorded, whatever size it was.
+
+    The finer breakdown keys on the size as well, and the coarser one is that
+    breakdown pooled rather than a second copy of the values.  A pool that lost
+    a size would print one of the sizes' statistics under a heading that names
+    the camera, and the two frozen reports could not tell: neither tree holds
+    one camera at two sizes.
+    """
+    text = _report_text(tmp_path, _pooled_size_documents())
+    assert '| coiss | NAC | dV | 3 (100.0%) | 11.000 | 10.000 |' in text
+    assert '| coiss | NAC | 512x512 | 1 (33.3%) |' in text
+
+
+# ---------------------------------------------------------------------------
+# Two frames of one camera on one spacecraft-clock count
+# ---------------------------------------------------------------------------
+
+_COLLIDING_CALIB = 'VOL/N1454725799_1_CALIB'
+"""The calibrated product of the colliding Cassini image."""
+
+_COLLIDING_RAW = 'VOL/N1454725799_1'
+"""The raw product of the same image, which holdings carry beside the calibrated one."""
+
+_COLLIDING_WAC = 'VOL/W1454725799_1_CALIB'
+"""The WAC frame shuttered with it, which makes the two a BOTSIM pair."""
+
+
+def _colliding_documents() -> dict[str, dict[str, Any]]:
+    """Return one WAC frame and both products of the NAC frame beside it.
+
+    The version suffix and the ``_CALIB`` marker are both outside the clock
+    count a BOTSIM pair is keyed on, so the raw and the calibrated product of
+    one image are two frames of one camera on one clock count.  Their offsets
+    are far apart on purpose: the calibrated one gives the pair a residual of
+    30.000 and the raw one gives it 0.000, so which of them stands for the NAC
+    is visible in the number the section prints.
+
+    Returns:
+        Results path stub to document.
+    """
+    offsets = {_COLLIDING_CALIB: 35.0, _COLLIDING_RAW: 5.0, _COLLIDING_WAC: 0.5}
+    documents = {}
+    for stub, offset_dv in offsets.items():
+        name = stub.rsplit('/', 1)[-1]
+        documents[stub] = metadata_document(
+            image_name=f'{name}.IMG',
+            camera='WAC' if name.startswith('W') else 'NAC',
+            image_shape=[1024, 1024],
+            offset=[offset_dv, 0.0],
+        )
+    return documents
+
+
+def _facts_by_stub(tmp_path: Path, documents: dict[str, dict[str, Any]]) -> dict[str, ImageFacts]:
+    """Read the facts of a tree of documents, keyed by the stub each came from.
+
+    Parameters:
+        tmp_path: Directory the tree lives under.
+        documents: Results path stub to the document written at it.
+
+    Returns:
+        The facts, one per document.
+
+    Raises:
+        ValueError: If any document yielded no facts, which would make the
+            replay below one image short without saying so.
+    """
+    root = _tree_of(tmp_path / 'results', documents)
+    with TreeRecordSource([root.as_posix()]) as source:
+        found = list(source.facts(Selection()))
+    refused = [one.stub for one in found if isinstance(one, UnreadableFile)]
+    if len(refused) > 0:
+        raise ValueError(f'{root} holds documents that yielded no facts: {refused}')
+    return {
+        str(one.image['results_path_stub']): one for one in found if isinstance(one, ImageFacts)
+    }
+
+
+@pytest.mark.parametrize(
+    'order',
+    [
+        pytest.param(
+            (_COLLIDING_CALIB, _COLLIDING_RAW, _COLLIDING_WAC), id='calibrated-arrives-first'
+        ),
+        pytest.param(
+            (_COLLIDING_RAW, _COLLIDING_CALIB, _COLLIDING_WAC), id='calibrated-arrives-last'
+        ),
+    ],
+)
+def test_the_frame_standing_for_a_camera_is_the_one_with_the_smallest_identity(
+    order: Sequence[str], tmp_path: Path
+) -> None:
+    """Which of two colliding frames stands for a camera is a reduction, not an arrival.
+
+    A source promises no order, so a section that kept whichever frame it met
+    first -- or last -- would print one residual over a results tree and another
+    over an index ingested from it.  The raw product has the smaller identity,
+    so the residual is 0.000 whichever of the two the report meets first, and
+    the calibrated one would give 30.000.
+
+    Parameters:
+        order: The order the three frames are handed to the report in.
+        tmp_path: Directory the tree and the report live under.
+    """
+    facts = _facts_by_stub(tmp_path, _colliding_documents())
+    out = tmp_path / 'report'
+    out.mkdir(parents=True, exist_ok=True)
+    with ReplayedFacts([facts[stub] for stub in order]) as source:
+        build_report(source, out)
+    assert '| median residual (px) | 0.000 |' in (out / 'report.md').read_text(encoding='utf-8')

--- a/tests/spindoctor/cli/test_results_db_argument_surface.py
+++ b/tests/spindoctor/cli/test_results_db_argument_surface.py
@@ -57,8 +57,8 @@ _INDEX_BACKED: list[tuple[str, list[str]]] = [
 
 # Every program whose questions the index answers, named by the argv that
 # reaches its parser.  Beyond the per-image row readers above: the navigator
-# answers its image selection from one query, and the statistics programs read
-# and write the index as their whole subject.
+# answers its image selection from one query, and the statistics programs have
+# the index as their whole subject.
 _CONSUMERS: list[tuple[str, list[str]]] = [
     *_INDEX_BACKED,
     ('sd_offset', ['coiss_saturn']),
@@ -67,12 +67,15 @@ _CONSUMERS: list[tuple[str, list[str]]] = [
 ]
 
 # The consumers that also have a file-reading mode, which is what the sentinel
-# opts back into.  The statistics programs read and write the index by
-# construction and have no such mode, so naming the sentinel to them would
-# advertise an answer they refuse.
+# opts back into.  Only the ingest is absent: it writes the index, so an index is
+# its subject rather than one of two storages it can read, and naming the
+# sentinel to it would advertise an answer it refuses.  The report reads the
+# documents themselves where no index is named, so the sentinel means to it what
+# it means everywhere else.
 _WITH_A_FILE_MODE: list[tuple[str, list[str]]] = [
     *_INDEX_BACKED,
     ('sd_offset', ['coiss_saturn']),
+    ('sd_stats_report', []),
 ]
 
 _INDEX_BACKED_CLOUD_TASK_DRIVERS = [
@@ -82,9 +85,9 @@ _INDEX_BACKED_CLOUD_TASK_DRIVERS = [
 ]
 
 # The programs that read a results index in any capacity, as the paths of the
-# modules that resolve the URL, relative to the package root.  The statistics
-# programs read it as their whole subject; the pipeline stages read one row per
-# image; the kernel writer reads one mission's records in one query; the
+# modules that resolve the URL, relative to the package root.  The ingest writes
+# it and the report reads it as their whole subject; the pipeline stages read one
+# row per image; the kernel writer reads one mission's records in one query; the
 # navigator's dataset layer answers one selection query from it.  A
 # module absent from this list must not resolve a URL: it would then pick one up
 # from an exported NAV_RESULTS_DB without ever offering the option that opts

--- a/tests/spindoctor/results_index/test_roots.py
+++ b/tests/spindoctor/results_index/test_roots.py
@@ -24,10 +24,12 @@ from spindoctor import nav_records
 from spindoctor.results_index import (
     INGEST_RUNS,
     SCHEMA_VERSION,
+    ingested_roots,
     newest_finish_time,
     normalize_root_url,
     open_index,
     require_ingested_roots,
+    unfinished_roots,
 )
 
 PASSWORD = 'sup3rs3cr3t'
@@ -195,3 +197,82 @@ def test_a_run_that_never_finished_has_no_finish_time(tmp_path: Path) -> None:
         )
     with opened(url) as engine, engine.connect() as connection:
         assert newest_finish_time(connection, FIRST_ROOT) is None
+
+
+def _index_with_one_unfinished_root(tmp_path: Path) -> str:
+    """Build an index whose first root was walked to the end and whose second was not.
+
+    The second root's run is the newest in the table and carries no finish time,
+    which is what an ingest that started and died leaves behind.  The two roots
+    therefore differ in exactly the value the two queries below divide them on.
+
+    Parameters:
+        tmp_path: Directory the index file is written into.
+
+    Returns:
+        The connection URL of the index.
+    """
+    url = sqlite_url_for(tmp_path / 'index.sqlite3')
+    with opened(url, create=True) as engine, engine.begin() as connection:
+        connection.execute(
+            INGEST_RUNS.insert(),
+            [
+                {
+                    'root_url': root_url,
+                    'started_utc': FIRST_FINISHED,
+                    'finished_utc': finished,
+                    'schema_version': SCHEMA_VERSION,
+                }
+                for root_url, finished in (
+                    (FIRST_ROOT, FIRST_FINISHED),
+                    (SECOND_ROOT, None),
+                )
+            ],
+        )
+    return url
+
+
+def test_a_root_whose_newest_run_never_finished_is_named_as_unfinished(
+    tmp_path: Path,
+) -> None:
+    """A consumer bound to the roots it may read has to be able to name the rest.
+
+    A narrowing nobody can name reads as an answer about the whole index, so the
+    roots left out are asked for by name rather than inferred from the ones that
+    were kept.
+    """
+    url = _index_with_one_unfinished_root(tmp_path)
+    with opened(url) as engine, engine.connect() as connection:
+        assert unfinished_roots(connection) == [SECOND_ROOT]
+
+
+def test_a_root_whose_newest_run_finished_is_not_named_as_unfinished(
+    tmp_path: Path,
+) -> None:
+    """The two queries divide the index between them, so neither may claim both roots."""
+    url = _index_with_one_unfinished_root(tmp_path)
+    with opened(url) as engine, engine.connect() as connection:
+        assert ingested_roots(connection) == [FIRST_ROOT]
+
+
+def test_a_root_walked_to_the_end_after_a_run_that_died_is_not_unfinished(
+    tmp_path: Path,
+) -> None:
+    """The newest run decides, in both directions, and a later good pass repairs a root.
+
+    A root with a dead run followed by a completed one is a root a consumer may
+    read absence under, so it is named by neither this query nor a consumer's
+    report of what it left out.
+    """
+    url = _index_with_one_unfinished_root(tmp_path)
+    with opened(url, create=False) as engine, engine.begin() as connection:
+        connection.execute(
+            INGEST_RUNS.insert().values(
+                root_url=SECOND_ROOT,
+                started_utc=SECOND_FINISHED,
+                finished_utc=SECOND_FINISHED,
+                schema_version=SCHEMA_VERSION,
+            )
+        )
+    with opened(url) as engine, engine.connect() as connection:
+        assert unfinished_roots(connection) == []


### PR DESCRIPTION
Closes #510.

`sd_stats_report` issued nineteen SQL statements and required a results index. It now makes **one pass of accumulators over the record seam's per-image facts**, so it reports over a navigation results tree or an index and is the same report either way. Counters where the query grouped, packed population statistics where the Python aggregated a row set, bounded heaps for the two genuine top-N tables, and a streaming CSV write.

The acceptance criterion is byte-identical output, and it holds: the frozen goldens moved by exactly the new coverage section and two wording changes, and nothing else — not a number, not a table, not an ordering.

## The stream promises no order, so every section is order-independent

The BOTSIM pair becomes a min-reduction on `(image_name, root_url, results_path_stub)` rather than first-row-wins. Those are the same answer, because the ordering it replaced *was* that key: `image_order()` is literally that triple. Every weaker key disagrees, and both weakenings have producers in a real tree.

The per-technique mean confidence is computed from its population rather than accumulated. The case that bites is small: four values summed left to right land on `0.7094999999999999` and print a digit low. At 400k values a running sum gives 45 distinct raw means and exactly **one** distinct printed mean — the large-N case is the one where it does *not* show, because the report prints three decimals and hides everything below ~5e-4.

`report.md` is byte-identical between the two storages, and a test holds it there across shuffled arrival orders. **`images.csv` is not, deliberately.** The export is a streaming write now, so its line order stops being a contract: a directory walk and a key sort under the server's collation genuinely disagree, and they already do on the frozen fixture today. `results_path_stub` leads the file so an operator sorts in the shell (`{ head -n 1 images.csv; tail -n +2 images.csv | sort -t, -k1,1; } > sorted-images.csv`, holding the header out of the sort), and the parity assertions compare the two exports as sorted rows.

## A tree-side filter applies to the facts, not to the raw document

The walk read the mission out of a document and dropped another mission's file *before* deciding whether the document was a navigation result at all. So a refusable file that named a parseable mission vanished from the tree's no-record count while an index still counted it — 243 of 405 filter combinations diverged, while the report printed "none of the filters above narrows it" throughout.

A filter now compares the values an index filters its rows on. A file that yields no facts is an unreadable file under every filter, and the two storages agree on what they refuse **by construction** rather than by testing. Reading *records* is unchanged: a record is the document, and the document is what filters it. That one remaining difference is stated in the seam's docstring rather than tested around.

## Coverage is reported rather than assumed

The report prints how many files under the selected roots yielded no record, **including when that is zero** — a line that vanishes at zero cannot be told from a report that never looked. The count is root-scoped: a refused file records no instrument, date or image number, so no filter narrows it. It also says which kind of file an index cannot count, because the ingest deliberately records no refusal for a file it could not retrieve.

With no `--root`, an index-backed report covers the roots whose newest ingest run completed, and **names both the roots it covered and the ones it dropped**. Under a half-ingested root the report was reading absence it had no licence to read.

## Smaller changes, listed so review need not find them

- The run-time total is summed exactly rather than in arrival order.
- The unresolved-limit reason no longer names a storage.
- Every tie-break that was a SQL `ORDER BY` under the server's collation is now a Python comparison. They agree for ASCII, and it is what makes tree-against-index parity possible at all.
- `build_report` takes a record source rather than a connection. Two behaviours at its edge change with it: `roots=None` is no longer accepted, and a root the source does not hold raises rather than reporting empty.
- `_csv_value` always encodes a container, because from `facts()` a JSON column is always a Python container. Byte parity for all five image JSON columns is pinned rather than assumed.

## How it was checked

Six adversarial reviewers, then a seventh chartered to reject their findings, which cut roughly thirty to sixteen tests.

The pre-change report was rebuilt at the merge base and run side by side over 23 adversarial scenarios and 6 randomized two-root corpora: **no numeric divergence exists**. Order independence was attacked over ~700 arrival orders of fixtures up to 935 facts across 7 roots, with ties built into every ranking key: byte-identical throughout. Retention was measured rather than read — zero live `ImageFacts` on the heap after 50,000 images, and the CSV reaching each decile of its final size on disk mid-pass.

The findings that earned code were mostly **tests that could not fail**, which is this codebase's recurring defect. The sharpest: deleting the `status == 'success'` guard from the offset accumulator passed all 693 tests of the statistics suite, and `NavResult.conflicted()` writes exactly the document that would slip through — a non-success record carrying an offset, which would then enter three tables headed "successful images". Also untested until now: pooling offsets across image sizes, which every real Cassini run exercises and the fixture tree never did; the BOTSIM reduction this PR introduces; two `--root`s; and a date bound over the one fixture image that records no epoch.

Retention, corrected against the design: `C(k,2) + k + 4` doubles per image — quadratic in technique count, not linear. 22 MB at two techniques, 44 at four, 185 at ten. The Cassini BOTSIM map is the larger cost at 516 bytes per image, and a whole pass over the archive's 443,177 Cassini frames peaks at 696 MB.

## Verification

`11838 passed, 7 xfailed` (was 11806 at the merge base, +32 tests); postgres tier `145`; `ruff check`, `ruff format --check`, `mypy src tests`, `sphinx -W` and `pymarkdown` all clean.

## Follow-ups filed

- An unretrievable file is counted by a tree-backed report and by no index-backed one.
- SQLite does not preserve signed zero, so `images.csv` can export `-0.0` from a tree and `0.0` from an index.
- `--top-n N` retains every drill-down name where N per group would do.

## Review

CodeRabbit raised eight findings and all eight were implemented. Two were substantive and neither was caught by the six reviewers that ran before it: a storage that stopped answering mid-stream inherited the exit code of an unparseable command-line bound, because streaming put both on one `try`; and the `--results-db none` sentinel test could not fail, since its index was ingested from the same root the tree mode was given.