### PR TITLE
Give the results index program its modes as subcommands

### DIFF
--- a/docs/dev_guide/dev_guide_introduction.rst
+++ b/docs/dev_guide/dev_guide_introduction.rst
@@ -147,8 +147,8 @@ Every CLI listed in ``[project.scripts]`` is installed onto ``$PATH`` by
        See :doc:`/user_guide/user_guide_ck_kernels`.
    * - ``sd_results_index`` / ``sd_results_index_cloud_tasks``
      - Read a navigation-results tree into the results index, in one process or
-       over a queue of workers. ``sd_results_index --drop-index`` empties the
-       index instead. See :doc:`/user_guide/user_guide_results_index`.
+       over a queue of workers. ``sd_results_index drop`` empties the index
+       instead. See :doc:`/user_guide/user_guide_results_index`.
    * - ``sd_stats_report``
      - Write the navigation statistics report and its charts, over a
        navigation-results tree or over the index. See

--- a/docs/dev_guide/dev_guide_reprojection.rst
+++ b/docs/dev_guide/dev_guide_reprojection.rst
@@ -362,7 +362,7 @@ The command-line tools are composed of three layers:
      ``cloud_tasks`` runs every task in a process it spawns for that task and
      passes the worker's shared data to it by serializing it, so an open results
      index left on that data in the parent reaches no task at all. A named index
-     that cannot be opened fails the task with ``unusable_results_db`` rather
+     that cannot be opened fails the task with ``unusable_results_index_db`` rather
      than letting it reproject its batch on uncorrected pointing. Mosaic
      combination is not performed here; run
      ``sd_mosaic <mode> <dataset_name> --skip-reproject`` after the queue drains

--- a/docs/dev_guide/dev_guide_results_index.rst
+++ b/docs/dev_guide/dev_guide_results_index.rst
@@ -667,7 +667,7 @@ cannot touch the same stub.
 
 **A pass may be told to keep them, and only presence is weakened by it.**
 ``ingest_metadata_files`` and ``fan_out_ingest_tasks`` both take ``prune``, and
-``sd_results_index --no-prune`` is what sets it. A row then outlives its
+``sd_results_index ingest --no-prune`` is what sets it. A row then outlives its
 document and presence of one stops implying the tree still holds the result;
 absence is untouched, because skipping a delete adds no row, so every rule above
 that reads absence is unaffected. The relaxation is bounded by there being no

--- a/docs/introduction_overview.rst
+++ b/docs/introduction_overview.rst
@@ -126,9 +126,9 @@ distributed processing:
   :doc:`/user_guide/user_guide_reprojection`.)
 
 * ``sd_results_index_cloud_tasks`` - Cloud tasks worker that reads one share of
-  a navigation-results root into the results index. ``sd_results_index`` lists
-  each root and divides it into shares, and adds the workers' tallies up again
-  when they have run; see :doc:`/user_guide/user_guide_results_index`.
+  a navigation-results root into the results index. ``sd_results_index divide``
+  lists each root and divides it into shares, and ``sd_results_index complete``
+  adds the workers' tallies up again when they have run; see :doc:`/user_guide/user_guide_results_index`.
 
 These cloud tasks variants read task payloads from a queue and process batches
 of files, making them suitable for large-scale processing in cloud

--- a/docs/user_guide/user_guide_backplanes.rst
+++ b/docs/user_guide/user_guide_backplanes.rst
@@ -120,7 +120,7 @@ other run.
 
 Under ``sd_backplanes_cloud_tasks`` each of those outcomes is reported in the
 task result rather than in a run log, because a cloud task has none: an
-unusable index is ``unusable_results_db``, an image nothing navigated is a
+unusable index is ``unusable_results_index_db``, an image nothing navigated is a
 skip named ``no_navigation_record``, and every other way one image can fail —
 a document the ingest refused among them — is ``backplanes_failed``. All three
 are returned rather than raised, so a queue configured to retry on an

--- a/docs/user_guide/user_guide_navigation.rst
+++ b/docs/user_guide/user_guide_navigation.rst
@@ -315,8 +315,8 @@ recently the last pass finished. A tree restored by a copy that preserves times,
 a document patched and stamped back from a sibling, and a backend reporting one
 modification time for two writes all produce it; an ordinary re-navigation
 writes a different length at a later time and does not. Running
-``sd_results_index --force`` over the root re-reads every document and is what
-puts such a row right.
+``sd_results_index ingest --force`` over the root re-reads every document and is
+what puts such a row right.
 
 An index is also a snapshot of the tree as of the last ingest over that root,
 with no staleness detection: an image navigated since is one the index does not
@@ -324,7 +324,8 @@ hold, so ``--has-no-offset-file`` selects it again, and a result file deleted
 since is one the index still holds, so ``--has-offset-file`` selects an image
 whose metadata file is gone. The run log says when the pass that filled the
 index finished and how long ago that was, which is what says whether either
-applies to this run. Run ``sd_results_index`` to bring the index up to date, or
+applies to this run. Run ``sd_results_index ingest`` to bring the index up to
+date, or
 pass ``--results-index-db none``, which names no index, for a run that must read
 the tree. That age is
 what decides the answer outside the paragraphs above; inside them it decides
@@ -336,7 +337,7 @@ holds a root that was only partly walked. A results root that cannot be listed
 at all is the other case and does not stop the pass: that root alone is left
 unfinished, which every consumer already refuses, and the ingest goes on to the
 next root. Fix what stopped the walk -- a directory permission, a share that was
-not answering -- and run ``sd_results_index`` again.
+not answering -- and run ``sd_results_index ingest`` again.
 
 Miscellaneous
 ^^^^^^^^^^^^^

--- a/docs/user_guide/user_guide_results_index.rst
+++ b/docs/user_guide/user_guide_results_index.rst
@@ -162,8 +162,8 @@ directions:
 - A result file deleted since the last pass is one the index still holds, so
   ``--has-offset-file`` hands on an image whose document is gone.
 
-Both are answered by running ``sd_results_index`` again, which is cheap over a
-tree that has barely changed: a document whose size and modification time still
+Both are answered by running ``sd_results_index ingest`` again, which is cheap
+over a tree that has barely changed: a document whose size and modification time still
 match is not read at all. Every run that answers from a results index reports
 when the pass that filled it finished and how long ago that was, so the age of
 the answer is in the run log beside the answer.
@@ -174,15 +174,47 @@ are enumerated in :doc:`user_guide_navigation` under the selection filters, and
 the reason vocabulary the backplane and reprojection stages report is in
 :doc:`user_guide_backplanes` and :doc:`user_guide_reprojection`.
 
+How a results index is asked for
+================================
+
+``sd_results_index`` takes the action as a subcommand:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Subcommand
+     - What it does
+   * - ``ingest``
+     - Walks each named results root and reads the documents under it into the
+       results index.
+   * - ``divide``
+     - Lists each root once, removes the rows whose documents have left it, and
+       writes out the shares a queue of workers reads.
+   * - ``complete``
+     - Adds up what those workers did and stamps each root's ingest as
+       finished.
+   * - ``drop``
+     - Removes the results index's own tables from the database and stops.
+
+Each subcommand takes the options it acts on and no others, so a command line
+asking for two different things is refused with a usage message naming the
+option instead of being run as one of them. ``--results-index-db``,
+``--config-file`` and the logging options belong to all four;
+``--nav-results-root`` to the three that read a tree; ``--force`` and
+``--no-prune`` to ``ingest`` and ``divide``; and ``--yes`` to ``drop``. Such a
+refusal exits 2 and does nothing at all --- no database is opened and no tree is
+walked.
+
 Building a results index
 ========================
 
 .. code-block:: bash
 
-    sd_results_index --nav-results-root /data/nav-offset-results \
+    sd_results_index ingest --nav-results-root /data/nav-offset-results \
         --results-index-db sqlite:////data/nav-offset-results/index.sqlite3
 
-``sd_results_index`` walks each navigation-results root recursively for
+``sd_results_index ingest`` walks each navigation-results root recursively for
 ``*_metadata.json`` files (the documents
 :func:`~spindoctor.navigate_image_files.navigate_image_files` writes under
 ``nav_results_root``) and loads them into the results index. Roots may be local
@@ -257,8 +289,8 @@ afterwards. A tree restored by a copy that preserves modification times, a
 document patched and then stamped back from a sibling, and a backend reporting
 one modification time for two writes of equal length all produce that; an
 ordinary re-navigation writes a different length at a later time and does not.
-``sd_results_index --force`` re-reads every document and is what puts such a row
-right. Reading each file to find out whether it needs reading is the retrieval
+``sd_results_index ingest --force`` re-reads every document and is what puts
+such a row right. Reading each file to find out whether it needs reading is the retrieval
 the skip exists to avoid, which is why the remedy is a flag rather than a finer
 comparison.
 
@@ -266,8 +298,8 @@ comparison.
 record says what was wrong with the file, not which build read it, so a document
 refused by one build is skipped by every later one, including a build that has
 since learned to read it. After upgrading SpinDoctor, run
-``sd_results_index --force`` once over each root to re-offer everything it
-refused.
+``sd_results_index ingest --force`` once over each root to re-offer everything
+it refused.
 
 **Ingestion is idempotent.** The results index holds one row per image, and
 re-ingesting the same or an updated document replaces that image's row and its
@@ -309,7 +341,7 @@ where nothing else wants the answer:
   saves the deletes and still runs the query. ``--no-prune --force`` saves the
   query as well, since a forced pass reads every document regardless and so has
   nothing to skip.
-* ``--output-cloud-tasks-file`` issues it for the removals alone; each worker
+* ``sd_results_index divide`` issues it for the removals alone; each worker
   decides what to skip from the metrics its own share carries. So ``--no-prune``
   saves the query there whether or not ``--force`` is given.
 
@@ -318,9 +350,10 @@ the count it would otherwise report, so a run log read later says which
 guarantee the results index under it was built with. Running the ingest again
 without the flag is what puts a root right.
 
-``--no-prune`` is refused with ``--complete-cloud-tasks-file``, which removes no
-row -- whether a fan-out's rows went was settled at the fan-out -- and with
-``--drop-index``, which reads no tree at all.
+``--no-prune`` belongs to ``ingest`` and ``divide``, and neither of the other two
+subcommands offers it: ``complete`` removes no row --- whether a fan-out's rows
+went was settled at the ``divide`` that listed the root --- and ``drop`` reads no
+tree at all.
 
 **A root the results index has no completed ingest of is refused, not
 answered.** Absence of a row would otherwise read as "this image was never
@@ -361,22 +394,24 @@ That tally is what this pass read, and not what the root holds. A refused file
 is recorded in ``failed_files``, and every pass after it skips the file
 unchanged rather than reading it again, so a second pass over the same tree
 refuses nothing and tallies nothing and a summary of zero refusals is a summary
-of what changed. ``sd_results_index --force`` reads every document again, which
-puts the reasons and the example files back into the summary; the root's whole
+of what changed. ``sd_results_index ingest --force`` reads every document again,
+which puts the reasons and the example files back into the summary; the root's whole
 set of them is otherwise a query over ``failed_files`` away.
 
 **A directory under a root that the walk cannot list stops the ingest.** One
 this user may not read, or on a share that stopped answering, is reported as an
 error naming the directory, and the pass ends there: the root it was under gets
 no finish time, no root named after it on the same command line is walked, and
-``sd_results_index`` exits 1. Fix what stopped the walk and run it again.
+``sd_results_index ingest`` exits 1. Fix what stopped the walk and run it
+again.
 
 **A document the results index will not store stops it too.** A file that read
 as a navigation result and whose rows the database then refused is a defect in
 SpinDoctor -- in what it writes, or in the columns it writes into -- rather than
 anything about the file, and the next document of that shape would be refused
 the same way. The pass ends there, naming the file and what the database said,
-the root gets no finish time, and ``sd_results_index`` exits 1. Every document
+the root gets no finish time, and ``sd_results_index ingest`` exits 1. Every
+document
 written before it stays in, so a rerun after the fix reads only what is left.
 The alternative -- counting the file and carrying on -- put it in neither
 ``images`` nor ``failed_files`` under a run stamped finished, which made an
@@ -432,14 +467,16 @@ a link *inside* the tree being walked, which is what the paragraph above is
 about.
 
 **The exit status says whether the pass completed, not what it found.**
-``sd_results_index`` exits 0 when every named root was walked, whatever mix of
-documents was read, skipped and refused, and 1 when the run could not complete:
-no index or no results root could be resolved, a named root is not a location
-that can be read, the results index could not be opened, a root could not be
-listed at all, or a directory under one could not be listed, which stops the
-pass where it is found. A scheduled invocation therefore reads the same status
-from the same tree every time, and a status of 1 always means something needs
-fixing rather than that a tree happens to hold no results.
+``sd_results_index ingest`` exits 0 when every named root was walked, whatever
+mix of documents was read, skipped and refused, and 1 when the run could not
+complete: no index or no results root could be resolved, a named root is not a
+location that can be read, the results index could not be opened, a root could
+not be listed at all, or a directory under one could not be listed, which stops
+the pass where it is found. A scheduled invocation therefore reads the same
+status from the same tree every time, and a status of 1 always means something
+needs fixing rather than that a tree happens to hold no results. A command line
+no subcommand takes exits 2 instead, with a usage message naming the option, and
+nothing is opened or walked.
 
 Ingesting over a queue of workers
 =================================
@@ -452,9 +489,9 @@ and the middle one is where the work happens:
 
     # 1. List each root, remove the rows of documents that have left it, and
     #    write out the shares.
-    sd_results_index --nav-results-root /data/nav-offset-results \
+    sd_results_index divide --nav-results-root /data/nav-offset-results \
         --results-index-db postgresql+psycopg://user@dbhost/spindoctor \
-        --output-cloud-tasks-file ingest_tasks.json
+        --tasks-file ingest_tasks.json
 
     # 2. Run the workers over those tasks, however the queue is driven. Each
     #    worker writes its results into an event log.
@@ -462,9 +499,9 @@ and the middle one is where the work happens:
         --results-index-db postgresql+psycopg://user@dbhost/spindoctor ...
 
     # 3. Add the workers' tallies up and record them against each root.
-    sd_results_index --nav-results-root /data/nav-offset-results \
+    sd_results_index complete --nav-results-root /data/nav-offset-results \
         --results-index-db postgresql+psycopg://user@dbhost/spindoctor \
-        --complete-cloud-tasks-file events.log
+        --events-log events.log
 
 **Workers on one machine can share a SQLite index**; workers on several cannot.
 A ``sqlite:`` URL names a local file, so a run spread across machines connects
@@ -499,7 +536,8 @@ results index. Nothing incorrect is lost -- the rows removed are exactly those
 whose documents the listing did not find -- and the root stays unfinished
 throughout, so no consumer reads a wrong answer from it. What it costs is the
 rest of the root's content in the index, which comes back by running the three
-steps through to the end, or an ordinary ``sd_results_index`` over the root.
+steps through to the end, or an ordinary ``sd_results_index ingest`` over the
+root.
 
 **Two passes over one root at the same time are a documented limit.** Nothing
 refuses a fan-out over a root whose newest run is still unfinished, and two that
@@ -516,8 +554,8 @@ time.
 many files it found; step 3 adds up how many the tasks ingested, skipped and
 refused, counting each task's report once. If the tasks account for fewer files
 than the listing found -- a task that failed, timed out, or was never run --
-the root is named, its run is left unfinished, and ``sd_results_index`` exits
-1. Re-run the outstanding tasks and run step 3 again over a log holding the
+the root is named, its run is left unfinished, and ``sd_results_index complete``
+exits 1. Re-run the outstanding tasks and run step 3 again over a log holding the
 re-run results; a task re-run over a share it already ingested reads nothing,
 because its files match what the results index records, so it reports them as
 skipped. A task that reports twice is still one task: the later report stands
@@ -557,11 +595,12 @@ of what it holds, and step 3 will not finish it: there is nothing for its tasks
 to be measured against, and a root completed on that basis would report every
 image under it as never navigated. Correct the root and run step 1 again.
 
-``--force`` belongs to step 1, and is refused in step 3, which reads no
-document. A pass whose shares must ignore what the results index records is one
-whose fan-out was run with ``--force``. ``--no-prune`` is refused in step 3 on
-the same reasoning from the other side: step 3 removes no row, so whether a root
-keeps the rows of documents that have left it was settled at step 1.
+``--force`` belongs to step 1, and ``complete`` does not offer it, because step 3
+reads no document. A pass whose shares must ignore what the results index records
+is one whose ``divide`` was run with ``--force``. ``--no-prune`` is absent from
+step 3 on the same reasoning from the other side: step 3 removes no row, so
+whether a root keeps the rows of documents that have left it was settled at step
+1.
 
 The tasks file is a JSON array in the shape a ``cloud_tasks`` queue loads. Each
 entry has a ``task_id`` and a ``data`` object carrying ``run_id`` (the ingest
@@ -596,12 +635,12 @@ database and read the tree again.
 
 .. code-block:: bash
 
-    sd_results_index --drop-index \
+    sd_results_index drop \
         --results-index-db sqlite:////data/nav-offset-results/index.sqlite3
-    sd_results_index --nav-results-root /data/nav-offset-results \
+    sd_results_index ingest --nav-results-root /data/nav-offset-results \
         --results-index-db sqlite:////data/nav-offset-results/index.sqlite3
 
-Under ``--drop-index`` the exit status says whether the results index is gone: 0
+Under ``drop`` the exit status says whether the results index is gone: 0
 when the tables went, and 0 again when the database held none of them, since an
 index that is already absent is the state the command was asked for. It is 1
 when the database could not be opened or read, when it holds tables of those
@@ -609,11 +648,12 @@ names that nothing proves are the index's, when a table would not drop, and when
 whoever was asked answered anything but yes.
 
 Starting a results tree over -- delete the results, navigate again, ingest again
--- has a counterpart on the results index, and it is a flag on the same command:
+-- has a counterpart on the results index, and it is a subcommand of the same
+program:
 
 .. code-block:: bash
 
-    sd_results_index --drop-index \
+    sd_results_index drop \
         --results-index-db postgresql+psycopg://user@dbhost/spindoctor
 
 **It drops and stops.** No results root is read and no document is ingested, so
@@ -663,16 +703,15 @@ than as consent. Every refusal, the question itself, and the first line of the
 account name the index URL with its password hidden; the lines that continue
 that account carry the schema and the counts rather than repeating the URL.
 
-**It does one thing, so it refuses to be asked for two.** ``--drop-index``
-together with ``--force``, ``--no-prune``, ``--nav-results-root``,
-``--output-cloud-tasks-file`` or ``--complete-cloud-tasks-file`` is refused
-before anything is opened and exits 1, naming the option it will not combine
-with: a drop reads no document and walks no tree, so each of those was meant for
-a different command. A results
-root reaching the program from ``NAV_RESULTS_ROOT`` or from the configuration is
-a machine's standing setting rather than a request, and is simply unused.
-``--yes`` without ``--drop-index`` is refused for the same reason from the other
-side: it answers a question only the drop asks.
+**It does one thing, so it cannot be asked for two.** ``drop`` offers neither
+``--force``, ``--no-prune`` and ``--nav-results-root`` nor either of the two
+cloud-task paths: a drop reads no document and walks no tree, so each of those
+was meant for a different subcommand. Typing one is a usage error naming the
+option, before anything is opened and with a status of 2. A results root reaching
+the program from ``NAV_RESULTS_ROOT`` or from the configuration is a machine's
+standing setting rather than a request, and is simply unused. ``--yes`` is
+offered by ``drop`` alone for the same reason from the other side: it answers a
+question only the drop asks.
 
 **It works on the databases nothing else will open**, which is the point: an
 index stamped with a schema version this build does not read, or one whose stamp
@@ -697,12 +736,13 @@ neither leaves an empty database behind.
 **What is left behind is a database, not a hole.** Every consumer reads a
 dropped index exactly as it reads one nobody has ever ingested into -- "not
 ingested", with a message naming ``sd_results_index`` -- and the next
-``sd_results_index`` builds it again from the metadata documents. On PostgreSQL
-the two states are literally the same database. On SQLite the file itself
-remains, empty, and the drop deliberately does not delete it, so that one flag
-means one thing on both backends. Deleting the file instead removes the database
-rather than the results index, which every consumer reads the same way but which
-a later ``--drop-index`` refuses rather than reporting as nothing to do.
+``sd_results_index ingest`` builds it again from the metadata documents. On
+PostgreSQL the two states are literally the same database. On SQLite the file
+itself remains, empty, and the drop deliberately does not delete it, so that one
+subcommand means one thing on both backends. Deleting the file instead removes
+the database rather than the results index, which every consumer reads the same
+way but which a later ``sd_results_index drop`` refuses rather than reporting as
+nothing to do.
 
 **An interruption costs nothing.** The whole drop is one transaction on both
 backends: PostgreSQL rolls DDL back with everything else, and on SQLite -- whose

--- a/docs/user_guide/user_guide_statistics.rst
+++ b/docs/user_guide/user_guide_statistics.rst
@@ -33,8 +33,8 @@ An index built by an ingest run with ``--no-prune`` is the other way the two can
 differ, and it is a choice somebody made rather than a property of the storages:
 that ingest leaves in place the rows of documents that have left the tree, so
 the report from it counts images the tree no longer holds and the report over
-the tree does not. Running ``sd_results_index`` again without the flag removes
-them. :doc:`user_guide_results_index` says what the flag gives up and what it
+the tree does not. Running ``sd_results_index ingest`` again without the flag
+removes them. :doc:`user_guide_results_index` says what the flag gives up and what it
 saves.
 
 An index is optional here exactly as it is everywhere else, and
@@ -42,14 +42,14 @@ An index is optional here exactly as it is everywhere else, and
 ``environment.results_index_db`` configuration variable, then the
 ``NAV_RESULTS_INDEX_DB`` environment variable, with the literal ``none`` at any
 level meaning no index. The index is a database built from the navigation
-results tree by a separate pass, ``sd_results_index``, and
+results tree by a separate pass, ``sd_results_index ingest``, and
 :doc:`user_guide_results_index` is where it is documented: how it is named and
 resolved, how to build and rebuild one, the tables it holds, and how to query it
 directly for the questions this report does not answer.
 
 .. code-block:: bash
 
-    sd_results_index --nav-results-root /data/nav-offset-results \
+    sd_results_index ingest --nav-results-root /data/nav-offset-results \
         --results-index-db sqlite:////data/nav-offset-results/index.sqlite3
     sd_stats_report \
         --results-index-db sqlite:////data/nav-offset-results/index.sqlite3
@@ -70,7 +70,7 @@ every report run.** That is exactly the cost an index exists to remove -- a
 Cassini-scale root is several hundred thousand documents, and on a cloud root
 each one is a paid round trip. For a local tree and a single report that is
 the right trade; for a cloud root, or for a report you will run more than
-once, build an index with ``sd_results_index`` first and name it.
+once, build an index with ``sd_results_index ingest`` first and name it.
 
 A root, or a directory under one, that cannot be listed fails the run, and no
 report is written. A report that quietly covered less than the tree could not

--- a/plans/CK_KERNEL_PLAN.md
+++ b/plans/CK_KERNEL_PLAN.md
@@ -323,7 +323,7 @@ per instrument, and Voyager needs a different id per spacecraft under one
 key.
 
 These field names and shapes are also the ones the results-index schema
-declares in advance (`plans/RESULTS_DB_PLAN.md` section 2.3); changing them
+declares in advance (`plans/RESULTS_INDEX_PLAN.md` section 2.3); changing them
 here means changing them there.
 
 ### 2.4 Where it is computed

--- a/plans/ENGINEERING_PLAN.md
+++ b/plans/ENGINEERING_PLAN.md
@@ -286,7 +286,7 @@ An optional, rebuildable database index over the results tree, so that
 programs needing a few fields per image stop reading one JSON document
 each -- one paid cloud round trip per image per program today, at order
 400,000 images for a Cassini-scale run. Design is settled and detailed in
-`plans/RESULTS_DB_PLAN.md`, which is self-contained. The JSON documents
+`plans/RESULTS_INDEX_PLAN.md`, which is self-contained. The JSON documents
 stay authoritative, no program ever requires the index, and the
 file-reading paths remain the default.
 

--- a/plans/OPERATOR_PLAYBOOK.md
+++ b/plans/OPERATOR_PLAYBOOK.md
@@ -211,7 +211,7 @@ Independent review before done; all CI gates; one PR."
   #435/#436 are a pair and #436 waits on #435. Whether Cassini navigation
   should run from the predicted rather than the reconstructed kernels
   (#459) is a pending operator decision, not dispatchable work.
-- **#430 (results index)**: implement `plans/RESULTS_DB_PLAN.md` -- the
+- **#430 (results index)**: implement `plans/RESULTS_INDEX_PLAN.md` -- the
   plan is the specification and its section 8 is the session protocol
   (per-phase implementer + adversarial reviewer, both Opus-class). Ready to
   dispatch as written.

--- a/plans/PROGRAM_PLAN.md
+++ b/plans/PROGRAM_PLAN.md
@@ -15,7 +15,7 @@ reconciled 2026-08-07.*
 | `plans/COHORT_CURATION_PLAN.md` | The operational playbook for growing the curated image library: metadata-driven discovery, operator review votes, sidecar generation. |
 | `plans/OPERATOR_PLAYBOOK.md` | The operator's dispatch sheet: which decisions are pending, which sessions to launch, and in what order. |
 | `plans/CK_KERNEL_PLAN.md` | The design of record for recording each navigated image's corrected attitude as a C-matrix and generating SPICE C-kernels from it. Implemented; its section 0 carries the status and what remains. |
-| `plans/RESULTS_DB_PLAN.md` | Implementation plan for the optional, rebuildable index over the navigation results tree. Self-contained; executable without the plans above. |
+| `plans/RESULTS_INDEX_PLAN.md` | Implementation plan for the optional, rebuildable index over the navigation results tree. Self-contained; executable without the plans above. |
 | `plans/archive/` | Superseded and fully-executed plans, kept as historical records with dates in their filenames. Nothing in there is current work, though the executed designs remain the reference for what shipped. |
 
 ---
@@ -324,7 +324,7 @@ exists (with the pixel offset as the documented fallback for
 fitted-rotation, offset-only and malformed records, and uncorrected
 pointing with the reason recorded when neither is usable), closing #50. What that leaves is the
 follow-ups in the CK plan's section 7. The remaining decided item with a
-self-contained plan of its own is `plans/RESULTS_DB_PLAN.md` (an optional,
+self-contained plan of its own is `plans/RESULTS_INDEX_PLAN.md` (an optional,
 rebuildable index over the results tree, so programs stop reading one JSON
 document per image on a cloud root; #430).
 

--- a/plans/RESULTS_INDEX_PLAN.md
+++ b/plans/RESULTS_INDEX_PLAN.md
@@ -393,7 +393,7 @@ open_index(url: str, *, create: bool = False) -> Engine
   from the current opener's silent-create behavior.
 - Either way, a `schema_version` that does not match the version the code
   was built for raises, naming both versions and instructing the reader to
-  empty the database with `sd_results_index --drop-index` and re-ingest
+  empty the database with `sd_results_index drop` and re-ingest
   (section 2.11). The stamped version is read and checked
   before anything is written, so a refused `create=True` open creates no table
   and writes no row; creating this version's tables inside a database
@@ -571,7 +571,7 @@ reports every other misconfiguration: the dataset layer re-raises it as
 `SelectionError` so `sd_offset` prints it and exits 1; `sd_stats_report` prints
 it on the stream its other refusals print to and returns 1; `sd_results_index`
 logs it fatal and exits 1; the three cloud-task workers return it as
-`unusable_results_db` with the message attached; and `sd_backplanes`, `sd_mosaic`
+`unusable_results_index_db` with the message attached; and `sd_backplanes`, `sd_mosaic`
 and `sd_create_ck` let it out of `main` exactly as they let out an index that
 will not open and a malformed time bound.
 
@@ -713,7 +713,7 @@ of a root.
 
 **`--no-prune` keeps them, and is documented as a correctness relaxation rather than a speed feature.** Presence stops implying the document is still there: a row outlives its document, so a consumer asking whether an image has been navigated is answered yes for one whose result the tree no longer holds, and `--has-offset-file` hands such an image to a downstream stage. Absence is untouched, because skipping a delete adds no row -- `--has-no-offset-file`, "this image was never navigated" and `require_ingested_roots` all keep exactly the meaning they had. That is what makes the flag offerable at all, and it holds only because the ingest is whole-root: there is no subtree ingest, so a pass that reaches the prune listed everything.
 
-**What it saves is a query and the deletes, never the walk, and which of those depends on the mode.** The rows the index already holds for a root have two readers -- the skip rule in `_files_to_read` and the prune -- and one predicate, `_reads_recorded_rows`, decides whether to run the query on the strength of either wanting it. So an ordinary pass under `--no-prune` still runs it for the skip rule and stops only under `--force` as well; a fan-out, whose workers skip from the metrics their own shares carry, reads it for the prune alone and therefore stops running it either way. The closing summary says the pass left those rows in place, in the position the count of removals occupies otherwise, so a run log read later says which guarantee the index under it was built with. The flag is refused with `--complete-cloud-tasks-file`, which removes no row, and belongs to the list `--drop-index` refuses; nothing new is stored for it, because a field with no reader is not stored.
+**What it saves is a query and the deletes, never the walk, and which of those depends on the mode.** The rows the index already holds for a root have two readers -- the skip rule in `_files_to_read` and the prune -- and one predicate, `_reads_recorded_rows`, decides whether to run the query on the strength of either wanting it. So an ordinary pass under `--no-prune` still runs it for the skip rule and stops only under `--force` as well; a fan-out, whose workers skip from the metrics their own shares carry, reads it for the prune alone and therefore stops running it either way. The closing summary says the pass left those rows in place, in the position the count of removals occupies otherwise, so a run log read later says which guarantee the index under it was built with. The flag belongs to `ingest` and `divide` alone: `complete` removes no row, and `drop` reads no tree; nothing new is stored for it, because a field with no reader is not stored.
 
 **Per-root bookkeeping.** An `ingest_runs` table records, per root:
 `root_url`, `started_utc`, `finished_utc` (NULL while running),
@@ -859,12 +859,12 @@ counts return in task results and are aggregated and written to
 `ingest_runs` by the enqueuer at completion; workers never touch
 `ingest_runs`.
 
-**The enqueuer is `sd_results_index` in two further modes**, since the fan-out
-resolves the same roots and the same index URL as the pass it replaces:
-`--output-cloud-tasks-file` lists, prunes, records what the walk found on each
-run row, and writes the shares out; `--complete-cloud-tasks-file` reads the
-`cloud_tasks` event log, adds the tallies up, and stamps the runs. The two are
-mutually exclusive. Completion opens with `create=False`: the runs it means to
+**The enqueuer is `sd_results_index` in two further subcommands**, since the
+fan-out resolves the same roots and the same index URL as the pass it replaces:
+`divide --tasks-file` lists, prunes, records what the walk found on each run row,
+and writes the shares out; `complete --events-log` reads the `cloud_tasks` event
+log, adds the tallies up, and stamps the runs. The two are separate
+subcommands. Completion opens with `create=False`: the runs it means to
 finish are in the index the fan-out wrote, and creating an empty one would report
 every root as never fanned out.
 
@@ -1130,9 +1130,9 @@ version bump is deliberately not migrated, and the remedy that gate prescribes
 is delete-and-re-ingest. With no command behind it that remedy would be `rm` on
 SQLite and, on PostgreSQL, `psql` with the right connection string and a
 knowledge of which tables SpinDoctor owns in a database that may hold somebody
-else's; `--drop-index` is one flag for it on either backend.
+else's; `sd_results_index drop` is one command for it on either backend.
 
-`sd_results_index --drop-index` removes the index's tables from whatever backend
+`sd_results_index drop` removes the index's tables from whatever backend
 the URL names and **stops** -- it reads no results root and ingests no
 document. Dropping is a deliberate act rather than the first step of a long
 pass, and a command that did both would make a mistyped URL expensive twice
@@ -1248,7 +1248,7 @@ the messages and the exit status are the CLI's, in `spindoctor/cli/results_index
   emptied file remains and the drop deliberately does not delete it, so that one
   flag means one thing on both backends; deleting the file removes the database
   rather than the index, which reads the same to every consumer but which a
-  later `--drop-index` refuses rather than reporting as nothing to do.
+  later `sd_results_index drop` refuses rather than reporting as nothing to do.
 - **A failure is named as what it was.** A drop can fail for a lock somebody
   holds, a view or another object depending on one of these tables, an account
   that does not own one of them, or a table that went between the reading and
@@ -1303,7 +1303,7 @@ four ways:
 - The schema holds nothing: create the tables and stamp it.
 - The schema carries a stamp of SpinDoctor's: it is the index's own whatever
   version that stamp names, and the version gate decides. This is the case
-  `--drop-index` exists for, so it must keep working for a stamp of any version;
+  `drop` exists for, so it must keep working for a stamp of any version;
   the evidence is deliberately the two marks rather than the column set, since a
   stamp of an older version has our tables with other columns.
 - The schema holds a table of one of the index's own names with no such stamp:
@@ -1907,7 +1907,7 @@ Details settled during execution:
   before a single task ran. What crosses is the worker's parsed command line,
   which is what the root and the index are named by, so that is what a task
   builds from. A named index that cannot be opened returns
-  `unusable_results_db` in the task result, which is how a worker reports every
+  `unusable_results_index_db` in the task result, which is how a worker reports every
   other environment failure and is what keeps a task that could not obtain its
   source from reprojecting its whole batch on uncorrected pointing and
   reporting a clean one. Pinned by a test that stands up a real spawn context
@@ -2160,7 +2160,7 @@ Details settled during execution, none of them a change of intent:
 - **The subtree restriction is one restriction, made once, above both storages.** It is a field of `Selection`, so a walk narrows to the directories it names and a query restricts both its arms by it. A stub with no subtree above it is matched by neither arm, because SQL's `IN` is false for NULL -- which is also how a bare scene name falls outside a walk of the selected volumes' directories. The subtrees are asked about one at a time rather than all at once, so that a subtree the results root holds no directory for costs only itself: a single request ends at the first subtree it cannot read, and on an enumeration over volumes nobody has navigated yet that would be every volume after the first.
 - **The URL reaches the filter through the dataset layer, and only from a
   program that declares the option.** `_yield_image_files_index` takes a
-  `results_db_url` keyword; when its caller passes none it resolves one through
+  `results_index_db_url` keyword; when its caller passes none it resolves one through
   `get_results_index_db_url` and its `none` sentinel, but only when the arguments it
   was handed carry a `results_index_db` attribute, which is what declaring
   `--results-index-db` supplies. That is section 2.6's rule, and it is what keeps

--- a/src/spindoctor/cli/reproj/pointing_source.py
+++ b/src/spindoctor/cli/reproj/pointing_source.py
@@ -481,7 +481,7 @@ class IndexPointingSource:
 def build_pointing_source(
     nav_results_root: str | FCPath | None,
     *,
-    results_db_url: str | None,
+    results_index_db_url: str | None,
 ) -> PointingSource:
     """Build the source a program reads its navigation records through.
 
@@ -498,8 +498,8 @@ def build_pointing_source(
             means no pointing is looked for at all, which only a run with no
             index can ask for -- an index is keyed by root, so there is nothing
             to look a row up under.
-        results_db_url: Connection URL of the results index, or None to read
-            documents.
+        results_index_db_url: Connection URL of the results index, or None to
+            read documents.
 
     Returns:
         The source, which the caller closes when it is done with it.
@@ -510,13 +510,13 @@ def build_pointing_source(
             by another version of the schema; or if the root has no completed
             ingest run in it.
     """
-    if results_db_url is None:
+    if results_index_db_url is None:
         return FilePointingSource(nav_results_root)
     if nav_results_root is None:
         raise ValueError(
-            f'the results index {masked_url(results_db_url)} was named with no navigation '
+            f'the results index {masked_url(results_index_db_url)} was named with no navigation '
             f'results root; the index is keyed by root, so there is no root to read rows '
             f'under. Name one, or pass --results-index-db none to read navigation documents.'
         )
     root_url = normalize_root_url(nav_results_root)
-    return IndexPointingSource(open_index_for_roots(results_db_url, [root_url]), root_url)
+    return IndexPointingSource(open_index_for_roots(results_index_db_url, [root_url]), root_url)

--- a/src/spindoctor/cli/sd_backplanes.py
+++ b/src/spindoctor/cli/sd_backplanes.py
@@ -176,7 +176,7 @@ def main() -> None:
     backplane_results_root_str = get_backplane_results_root(arguments, DEFAULT_CONFIG)
     backplane_results_root = FileCache(None).new_path(backplane_results_root_str)
 
-    results_db_url = get_results_index_db_url(arguments, DEFAULT_CONFIG)
+    results_index_db_url = get_results_index_db_url(arguments, DEFAULT_CONFIG)
 
     MAIN_LOGGER.info('Starting backplanes generation')
     MAIN_LOGGER.info('Dataset: %s', DATASET_NAME)
@@ -184,7 +184,9 @@ def main() -> None:
     MAIN_LOGGER.info('Backplane results root: %s', backplane_results_root.as_posix())
     MAIN_LOGGER.info(
         'Results index: %s',
-        masked_url(results_db_url) if results_db_url is not None else 'none (reading files)',
+        masked_url(results_index_db_url)
+        if results_index_db_url is not None
+        else 'none (reading files)',
     )
     MAIN_LOGGER.info('Dry run: %s', arguments.dry_run)
     MAIN_LOGGER.info('No write output files: %s', arguments.no_write_output_files)
@@ -246,7 +248,9 @@ def main() -> None:
     # A resolved index that will not open, or a root it has not fully ingested,
     # fails the run here.  Falling back to reading files would turn a
     # misconfigured run into a slow, silently different one.
-    pointing_source = build_pointing_source(nav_results_root, results_db_url=results_db_url)
+    pointing_source = build_pointing_source(
+        nav_results_root, results_index_db_url=results_index_db_url
+    )
     n_done = 0
     n_skipped = 0
     n_failed = 0

--- a/src/spindoctor/cli/sd_backplanes_cloud_tasks.py
+++ b/src/spindoctor/cli/sd_backplanes_cloud_tasks.py
@@ -64,7 +64,7 @@ def _task_pointing_source(
             version of the schema, or has not fully ingested this root.
     """
     return build_pointing_source(
-        nav_results_root, results_db_url=get_results_index_db_url(arguments, DEFAULT_CONFIG)
+        nav_results_root, results_index_db_url=get_results_index_db_url(arguments, DEFAULT_CONFIG)
     )
 
 
@@ -82,7 +82,7 @@ def process_task(
     Returns:
         Tuple of ``(retry, result)``.  ``retry`` is always False.  ``result``
         names the error when the task could not run -- including
-        ``unusable_results_db`` when a level named the index with an empty
+        ``unusable_results_index_db`` when a level named the index with an empty
         value, or an index was named that cannot be opened or has not ingested
         this root, which fails the task rather than falling back to reading
         files -- and otherwise reports whether the image was processed or
@@ -161,7 +161,7 @@ def process_task(
     except ValueError as exc:
         return False, {
             'status': 'error',
-            'status_error': 'unusable_results_db',
+            'status_error': 'unusable_results_index_db',
             'status_exception': str(exc),
         }
 

--- a/src/spindoctor/cli/sd_create_ck.py
+++ b/src/spindoctor/cli/sd_create_ck.py
@@ -730,7 +730,7 @@ def main() -> None:
         load_default_and_user_config(arguments, DEFAULT_CONFIG)
 
     nav_results_root = FileCache(None).new_path(get_nav_results_root(arguments, DEFAULT_CONFIG))
-    results_db_url = get_results_index_db_url(arguments, DEFAULT_CONFIG)
+    results_index_db_url = get_results_index_db_url(arguments, DEFAULT_CONFIG)
     # Resolved to absolute, both of them, because the meta-kernel names the
     # kernels it furnishes by these paths and SPICE resolves a relative name
     # against the *consumer's* working directory.  A meta-kernel written with
@@ -756,7 +756,7 @@ def main() -> None:
     # instead.
     with open_record_source(
         [nav_results_root],
-        results_db_url=results_db_url,
+        results_index_db_url=results_index_db_url,
         columns=RECORD_COLUMNS,
         logger=MAIN_LOGGER,
     ) as source:

--- a/src/spindoctor/cli/sd_mosaic.py
+++ b/src/spindoctor/cli/sd_mosaic.py
@@ -694,10 +694,12 @@ def main() -> None:
             pr.print_stats(sort='cumulative')
         return
 
-    results_db_url = get_results_index_db_url(args, DEFAULT_CONFIG)
+    results_index_db_url = get_results_index_db_url(args, DEFAULT_CONFIG)
     MAIN_LOGGER.info(
         'Results index: %s',
-        masked_url(results_db_url) if results_db_url is not None else 'none (reading files)',
+        masked_url(results_index_db_url)
+        if results_index_db_url is not None
+        else 'none (reading files)',
     )
     # A resolved index that will not open, or a root it has not fully ingested,
     # fails the run here rather than quietly reverting to reading files -- but
@@ -708,7 +710,7 @@ def main() -> None:
     reads_navigation_records = not args.skip_reproject and not args.dry_run
     pointing_source = build_pointing_source(
         nav_results_root_path,
-        results_db_url=results_db_url if reads_navigation_records else None,
+        results_index_db_url=results_index_db_url if reads_navigation_records else None,
     )
 
     try:

--- a/src/spindoctor/cli/sd_mosaic_cloud_tasks.py
+++ b/src/spindoctor/cli/sd_mosaic_cloud_tasks.py
@@ -97,7 +97,7 @@ def _resolve_pointing_source(cli_args: argparse.Namespace) -> PointingSource:
         None if nav_results_root_str is None else FileCache(None).new_path(nav_results_root_str)
     )
     return build_pointing_source(
-        nav_results_root, results_db_url=get_results_index_db_url(cli_args, DEFAULT_CONFIG)
+        nav_results_root, results_index_db_url=get_results_index_db_url(cli_args, DEFAULT_CONFIG)
     )
 
 
@@ -153,7 +153,7 @@ def process_task(
         Tuple of ``(retry, result)``. ``retry`` is always ``False``. ``result``
         is ``{'status': 'error', 'status_error': ...}`` (and optionally
         ``status_exception``) when the task itself could not run -- including
-        ``unusable_results_db`` when a level named the index with an empty
+        ``unusable_results_index_db`` when a level named the index with an empty
         value, or an index was named that cannot be opened or has not ingested
         this root, which fails the task rather than letting it reproject a whole
         batch on uncorrected pointing.  Otherwise it
@@ -256,7 +256,7 @@ def process_task(
     except ValueError as exc:
         return False, {
             'status': 'error',
-            'status_error': 'unusable_results_db',
+            'status_error': 'unusable_results_index_db',
             'status_exception': str(exc),
         }
 

--- a/src/spindoctor/cli/sd_results_index.py
+++ b/src/spindoctor/cli/sd_results_index.py
@@ -659,7 +659,10 @@ def main() -> None:
     # sitting in the index the operator meant to name.
     completing = arguments.command == COMPLETE
 
-    MAIN_LOGGER.info('Starting results index ingest')
+    # The subcommand, not a fixed word: a run's log opens by saying which of the
+    # four it is, and a divide or a completion reported as an ingest is a log
+    # that names a pass nobody asked for.
+    MAIN_LOGGER.info('Starting results index %s', arguments.command)
     MAIN_LOGGER.info('Roots: %s', ', '.join(roots))
     if not completing:
         MAIN_LOGGER.info('Force: %s', arguments.force)

--- a/src/spindoctor/cli/sd_results_index.py
+++ b/src/spindoctor/cli/sd_results_index.py
@@ -5,6 +5,31 @@ Dispatch script for the ``sd_results_index`` console entry point.  See
 ``spindoctor.cli.results_index`` for what one pass does and
 ``spindoctor.cli.stats`` for the statistics-system overview.
 
+The program is a subject with four verbs under it, one of which every command
+line names:
+
+``ingest``
+    Walk each named results root and read the documents under it into the
+    index.
+``divide``
+    List each root once, remove the rows whose documents have left it, and
+    write out the shares ``sd_results_index_cloud_tasks`` reads.
+``complete``
+    Read the event log those workers wrote, add their tallies up, and stamp
+    each named root's ingest as finished.  Until that step a consumer treats
+    the roots as ones nobody has ingested, which is what keeps absence of a row
+    from being read as an answer while the workers are still writing.
+``drop``
+    Remove the index's own tables from the database and stop, reading no tree.
+
+Every option belongs to the verbs that act on it and to no others, so a command
+line asking for two different things is a usage error naming the option rather
+than a program deciding which half of it to do.  ``--results-index-db``,
+``--config-file`` and the logging options belong to all four; ``--nav-results-root``
+to the three that read a tree; ``--force`` and ``--no-prune`` to the two that
+read documents and remove rows; and ``--yes`` to the drop, which is the only
+thing this program asks about.
+
 The roots are resolved the way every consumer resolves a navigation results
 root -- the command line, then ``environment.nav_results_root``, then
 ``NAV_RESULTS_ROOT`` -- because the root is half of the key every row is stored
@@ -21,10 +46,10 @@ that the image was never navigated, since skipping a delete adds nothing, and
 what is saved is the deletes and, where nothing else wants it, the query that
 reads what the index already holds about the root.
 
-``--drop-index`` is the opposite operation and shares only the URL with the
-rest: it removes the index's own tables from the database that URL names and
-stops there, walking no tree.  It is what makes emptying an index and starting
-over something an operator can reach without hand-written SQL, on a shared
+``drop`` is the opposite operation and shares only the URL with the rest: it
+removes the index's own tables from the database that URL names and stops
+there, walking no tree.  It is what makes emptying an index and starting over
+something an operator can reach without hand-written SQL, on a shared
 PostgreSQL server as well as on a file -- which the schema version gate depends
 on, since a version bump is deliberately not migrated and rebuilding is the
 whole of the remedy.  It drops from one schema, the one this database's own
@@ -36,14 +61,6 @@ that holds nothing, or one already carrying a stamp of SpinDoctor's, and refuses
 a schema holding a table it did not create -- so a stamp never comes to stand
 over somebody else's table, and the six names the drop removes from a stamped
 schema are six tables SpinDoctor created.
-
-One pass may also be spread over a queue of workers.  ``--output-cloud-tasks-file``
-lists each root once, removes the rows whose documents have left the tree, and
-writes out the shares for ``sd_results_index_cloud_tasks`` to read; when those
-have run, ``--complete-cloud-tasks-file`` adds their tallies up and stamps each
-root's ingest as finished.  Until that last step a consumer treats the roots as
-ones nobody has ingested, which is what keeps absence of a row from being read
-as an answer while the workers are still writing.
 """
 
 import argparse
@@ -88,21 +105,38 @@ PROGRAM_NAME = SD_RESULTS_INDEX
 ``logging.programs`` configuration block for this program."""
 
 
-def parse_args(command_list: list[str]) -> argparse.Namespace:
-    """Build the parser and read the command line.
+INGEST = 'ingest'
+"""Subcommand that reads the documents under each results root into the index."""
+
+DIVIDE = 'divide'
+"""Subcommand that divides each results root into shares for a queue of workers."""
+
+COMPLETE = 'complete'
+"""Subcommand that adds up what those workers did and finishes each root's run."""
+
+DROP = 'drop'
+"""Subcommand that removes the results index's own tables and stops."""
+
+_READS_A_TREE = (INGEST, DIVIDE, COMPLETE)
+"""The subcommands a navigation results root is resolved for.
+
+The drop is about the database alone and names no root, so requiring one would
+refuse the command on a machine holding the index and not the tree.
+"""
+
+
+def _add_environment_arguments(parser: argparse.ArgumentParser, *, reads_a_tree: bool) -> None:
+    """Add the options a subcommand resolves its surroundings from.
 
     Parameters:
-        command_list: Arguments, without the program name.
-
-    Returns:
-        The parsed arguments.
+        parser: The subcommand's parser.
+        reads_a_tree: Whether this subcommand walks a navigation results tree.
+            False leaves ``--nav-results-root`` off, so a subcommand that reads
+            no tree refuses the option naming one instead of accepting it and
+            reading nothing.
     """
-    cmdparser = argparse.ArgumentParser(
-        description='Read navigation metadata documents into the results index.'
-    )
-
-    environment_group = cmdparser.add_argument_group('Environment')
-    environment_group.add_argument(
+    group = parser.add_argument_group('Environment')
+    group.add_argument(
         '--config-file',
         action='append',
         default=None,
@@ -110,42 +144,55 @@ def parse_args(command_list: list[str]) -> argparse.Namespace:
         may be specified multiple times. If not provided, attempts to load
         ./nav_default_config.yaml if present.""",
     )
-    environment_group.add_argument(
-        '--nav-results-root',
-        action='append',
-        dest='nav_results_roots',
-        default=None,
-        metavar='ROOT',
-        help="""Root directory of a navigation results tree to read (a local
-        directory or any URL the filecache layer accepts); may be specified
-        multiple times. Overrides NAV_RESULTS_ROOT and the nav_results_root
-        configuration variable.""",
-    )
-    environment_group.add_argument(
+    if reads_a_tree:
+        group.add_argument(
+            '--nav-results-root',
+            action='append',
+            dest='nav_results_roots',
+            default=None,
+            metavar='ROOT',
+            help="""Root directory of a navigation results tree to read (a local
+            directory or any URL the filecache layer accepts); may be specified
+            multiple times. Overrides NAV_RESULTS_ROOT and the nav_results_root
+            configuration variable.""",
+        )
+    group.add_argument(
         '--results-index-db',
         default=None,
         metavar='URL',
-        help="""Connection URL of the results index to write (a sqlite: URL
-        naming a local path, or a postgresql+psycopg: URL naming a server);
-        overrides the environment.results_index_db configuration variable and
-        NAV_RESULTS_INDEX_DB. The tables are created if they are absent, in the schema this
-        database's own schema_meta stamp was found in or, where there is no such
-        stamp, the one a table created without a schema name lands in. That
-        schema is refused, and nothing is created or stamped in it, when it
-        already holds any table the index does not own or any table of the
-        index's own names that no stamp of ours stands over.""",
+        help="""Connection URL of the results index (a sqlite: URL naming a
+        local path, or a postgresql+psycopg: URL naming a server); overrides the
+        environment.results_index_db configuration variable and
+        NAV_RESULTS_INDEX_DB. An ingest creates the tables if they are absent, in the
+        schema this database's own schema_meta stamp was found in or, where
+        there is no such stamp, the one a table created without a schema name
+        lands in. That schema is refused, and nothing is created or stamped in
+        it, when it already holds any table the index does not own or any table
+        of the index's own names that no stamp of ours stands over.""",
     )
 
-    ingest_group = cmdparser.add_argument_group('Ingest')
-    ingest_group.add_argument(
+
+def _add_reading_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add the options saying what a pass reads and what it removes.
+
+    Both belong to the two subcommands that read documents and remove rows.  A
+    completion does neither -- the fan-out that cut the shares held the one
+    listing of the root and removed there, and each worker reads its share from
+    the metrics that share carries -- and a drop reads no tree at all, so
+    neither of those offers either option.
+
+    Parameters:
+        parser: The subcommand's parser.
+    """
+    group = parser.add_argument_group('Ingest')
+    group.add_argument(
         '--force',
         action='store_true',
         default=False,
         help="""Read every document, including ones whose recorded size and
-        modification time still match the tree. Refused with
-        --complete-cloud-tasks-file, which reads no document.""",
+        modification time still match the tree.""",
     )
-    ingest_group.add_argument(
+    group.add_argument(
         '--no-prune',
         dest='prune',
         action='store_false',
@@ -157,64 +204,116 @@ def parse_args(command_list: list[str]) -> argparse.Namespace:
         longer has. Absence of a row is untouched and still means the image was
         never navigated, which is what makes this safe to offer at all. What it
         saves is the deletes, and, where nothing else wants it, the query that
-        reads what the index already holds about the root: with --force as well,
-        since the skip rule is then not consulting it either, and under
-        --output-cloud-tasks-file whether or not --force is given, since a
-        fan-out reads it for the removals alone. It saves no part of the walk.
-        Refused with --complete-cloud-tasks-file, which removes no row, and with
-        --drop-index.""",
+        reads what the index already holds about the root: under ingest with
+        --force as well, since the skip rule is then not consulting it either,
+        and under divide whether or not --force is given, since a fan-out reads
+        it for the removals alone. It saves no part of the walk.""",
     )
 
-    drop_group = cmdparser.add_argument_group('Drop')
-    drop_group.add_argument(
-        '--drop-index',
-        action='store_true',
-        default=False,
-        help="""Remove the results index's own tables from the database
-        --results-index-db names, and stop: no results root is read and no document is
-        ingested. The tables that go are the index's own six names, from the one
-        schema this database's own schema_meta stamp was found in; no other
-        table of that schema, and no other schema, is touched. What makes those
-        six SpinDoctor's own is that an ingest refuses to build an index in a
-        schema holding anything it did not create, so a schema carrying that
-        stamp holds this index and nothing else. A database holding none of
-        those tables is left alone and said to be, and one holding tables of
-        those names that no stamp of ours stands over is refused. Refused
-        together with --force, --nav-results-root and either cloud-tasks mode,
-        none of which this does.""",
+
+def parse_args(command_list: list[str]) -> argparse.Namespace:
+    """Build the parser and read the command line.
+
+    Each mode is a subcommand carrying the options that mode acts on, so two
+    modes cannot be asked for at once and an option belonging to another mode is
+    a usage error naming it rather than a request the program has to reconcile.
+
+    Parameters:
+        command_list: Arguments, without the program name.
+
+    Returns:
+        The parsed arguments, with the subcommand under ``command``.
+    """
+    cmdparser = argparse.ArgumentParser(
+        description='Read navigation metadata documents into the results index.'
     )
+    subcommands = cmdparser.add_subparsers(
+        title='Commands',
+        dest='command',
+        required=True,
+        metavar='COMMAND',
+    )
+
+    ingest = subcommands.add_parser(
+        INGEST,
+        help='Read the documents under each results root into the index',
+        description="""Walk each named navigation results root and read every
+        metadata document under it into the results index, removing the rows
+        whose documents have left the tree.""",
+    )
+    _add_environment_arguments(ingest, reads_a_tree=True)
+    _add_reading_arguments(ingest)
+    add_logging_arguments(ingest, has_image_logger=False)
+
+    divide = subcommands.add_parser(
+        DIVIDE,
+        help='Divide each results root into shares for a queue of workers',
+        description="""List each named navigation results root once, remove the
+        rows whose documents have left it, and write out the shares
+        sd_results_index_cloud_tasks reads. No document is read here, and each
+        root stays unfinished until sd_results_index complete adds up what the
+        workers did.""",
+    )
+    _add_environment_arguments(divide, reads_a_tree=True)
+    _add_reading_arguments(divide)
+    divide_group = divide.add_argument_group('Cloud tasks')
+    divide_group.add_argument(
+        '--tasks-file',
+        required=True,
+        metavar='PATH',
+        help="""Where to write the JSON task descriptions file, in the shape a
+        cloud_tasks queue loads and sd_results_index_cloud_tasks reads.""",
+    )
+    add_logging_arguments(divide, has_image_logger=False)
+
+    complete = subcommands.add_parser(
+        COMPLETE,
+        help="Add up what the workers did and finish each root's ingest run",
+        description="""Read the cloud_tasks event log the workers wrote, add up
+        what their tasks did, and record it against each named root's ingest
+        run. A root whose tasks do not account for exactly the files its listing
+        found is left unfinished and named. No document is read and no row is
+        removed here, so --force and --no-prune belong to the sd_results_index
+        divide that cut the shares and are not offered.""",
+    )
+    _add_environment_arguments(complete, reads_a_tree=True)
+    complete_group = complete.add_argument_group('Cloud tasks')
+    complete_group.add_argument(
+        '--events-log',
+        required=True,
+        metavar='PATH',
+        help="""The cloud_tasks event log the workers wrote, whose
+        task_completed events carry what each share ingested, skipped and could
+        not read.""",
+    )
+    add_logging_arguments(complete, has_image_logger=False)
+
+    drop = subcommands.add_parser(
+        DROP,
+        help="Remove the results index's tables from the database and stop",
+        description="""Remove the results index's own tables from the database
+        --results-index-db names, and stop: no results root is read and no
+        document is ingested. The tables that go are the index's own six names,
+        from the one schema this database's own schema_meta stamp was found in;
+        no other table of that schema, and no other schema, is touched. What
+        makes those six SpinDoctor's own is that an ingest refuses to build an
+        index in a schema holding anything it did not create, so a schema
+        carrying that stamp holds this index and nothing else. A database
+        holding none of those tables is left alone and said to be, and one
+        holding tables of those names that no stamp of ours stands over is
+        refused. It reads no tree and ingests nothing, so it offers none of the
+        options that describe an ingest.""",
+    )
+    _add_environment_arguments(drop, reads_a_tree=False)
+    drop_group = drop.add_argument_group('Drop')
     drop_group.add_argument(
         '--yes',
         action='store_true',
         default=False,
         help="""Drop without asking for confirmation, for a run with nobody at
-        the terminal. Refused without --drop-index, which is the only thing this
-        program asks about.""",
+        the terminal.""",
     )
-
-    cloud_group = cmdparser.add_argument_group('Cloud tasks')
-    cloud_mode = cloud_group.add_mutually_exclusive_group()
-    cloud_mode.add_argument(
-        '--output-cloud-tasks-file',
-        default=None,
-        metavar='PATH',
-        help="""Write a JSON task descriptions file suitable for loading into a
-        cloud_tasks queue (consumed by sd_results_index_cloud_tasks) and read no
-        document here. Each root is still listed once, and the rows whose
-        documents have left it are still removed; its ingest stays unfinished
-        until --complete-cloud-tasks-file adds up what the workers did.""",
-    )
-    cloud_mode.add_argument(
-        '--complete-cloud-tasks-file',
-        default=None,
-        metavar='PATH',
-        help="""Read the cloud_tasks event log the workers wrote, add up what
-        their tasks did, and record it against each named root's ingest run.
-        A root whose tasks do not account for exactly the files its listing
-        found is left unfinished and named.""",
-    )
-
-    add_logging_arguments(cmdparser, has_image_logger=False)
+    add_logging_arguments(drop, has_image_logger=False)
 
     return cmdparser.parse_args(command_list)
 
@@ -308,12 +407,12 @@ def _log_completion(completion: TaskCompletion) -> None:
         MAIN_LOGGER.error(
             'Left unfinished, because its ingest run never recorded what its listing found, '
             'so nothing says what this root holds: %s. Divide the root up with '
-            '--output-cloud-tasks-file, run its tasks, and complete that run.',
+            'sd_results_index divide, run its tasks, and complete that run.',
             root,
         )
     for root in completion.roots_without_a_run:
         MAIN_LOGGER.error(
-            'No unfinished ingest run to complete for %s: run --output-cloud-tasks-file over '
+            'No unfinished ingest run to complete for %s: run sd_results_index divide over '
             'that root first, and complete the run that fanned out',
             root,
         )
@@ -410,7 +509,7 @@ def _write_cloud_tasks(
         )
     MAIN_LOGGER.info(
         'Each root stays unfinished until the workers have run and '
-        '--complete-cloud-tasks-file has added up what they did'
+        'sd_results_index complete has added up what they did'
     )
     return 1 if fan_out.counts.roots_unreadable else 0
 
@@ -462,63 +561,14 @@ def _complete_cloud_tasks(engine: sqlalchemy.Engine, roots: list[str], *, path: 
     return 1 if unfinished else 0
 
 
-def _mode_refusal(arguments: argparse.Namespace) -> str | None:
-    """Return why a command line cannot be run as it stands, or None.
-
-    Refused rather than ignored, on the same grounds as ``--force`` under a
-    completion below: an operator who typed an option meant something by it, and
-    a program that silently does one of the two things asked of it has decided
-    which one on their behalf.  ``--drop-index`` removes the index and stops, so
-    every option describing an ingest is at odds with it rather than modifying
-    it; and ``--yes`` answers a question only the drop asks.
-
-    ``--nav-results-root`` is refused only when it was typed.  The same root
-    reaches this program from the configuration and from the environment, where
-    it is a machine's standing setting rather than a request, and refusing a
-    drop because the machine has a results tree would refuse it nearly
-    everywhere.
-
-    Parameters:
-        arguments: The parsed command line.
-
-    Returns:
-        The refusal to report, or None when the arguments agree with each other.
-    """
-    if not arguments.drop_index:
-        if arguments.yes:
-            return (
-                '--yes says not to ask before dropping the results index, and this command '
-                'line asks for no drop. Add --drop-index, or leave --yes off.'
-            )
-        return None
-    conflicting = [
-        name
-        for name, given in (
-            ('--force', arguments.force),
-            ('--no-prune', not arguments.prune),
-            ('--nav-results-root', arguments.nav_results_roots is not None),
-            ('--output-cloud-tasks-file', arguments.output_cloud_tasks_file is not None),
-            ('--complete-cloud-tasks-file', arguments.complete_cloud_tasks_file is not None),
-        )
-        if given
-    ]
-    if conflicting:
-        return (
-            f'--drop-index removes the index and stops, reading no document, so it has '
-            f'nothing to do with {", ".join(conflicting)}. Drop first, then run the ingest '
-            f'you want against what it left behind.'
-        )
-    return None
-
-
 def main() -> None:
     """Console entry point for ``sd_results_index``.
 
-    Resolves the index URL and, unless the command line asks for a drop, the
-    results roots as well; then, according to the mode named on the command
-    line, removes the index's tables, reads every document under those roots,
-    divides them into cloud tasks, or adds up what those tasks did.  The outcome
-    goes to the main log whichever mode ran.
+    Resolves the index URL and, for every subcommand but the drop, the results
+    roots as well; then does what the subcommand names -- removes the index's
+    tables, reads every document under those roots, divides them into cloud
+    tasks, or adds up what those tasks did.  The outcome goes to the main log
+    whichever subcommand ran.
 
     Raises:
         SystemExit: Always, since this is a console entry point.  The status
@@ -540,26 +590,28 @@ def main() -> None:
             when the database could not be opened or read, when it holds tables
             of those names that nothing proves are the index's, when a table
             would not drop, or when whoever was asked said anything but yes.
+            A command line the parser will not take exits 2 with a usage error
+            on standard error and does nothing at all: no subcommand, an unknown
+            one, a subcommand missing the path it acts on, or an option
+            belonging to one of the other three.
     """
     command_list = sys.argv[1:]
     arguments = parse_args(command_list)
-    # One pass may cover several roots, which is what makes ingest different
-    # from every other program; the shared root resolver reads one attribute,
-    # so the first named root is the one this run is logged under and the rest
-    # are further trees to walk.  With none named, the resolver falls through to
-    # the configuration variable and the environment as it does everywhere else.
-    arguments.nav_results_root = (arguments.nav_results_roots or [None])[0]
+    if arguments.command in _READS_A_TREE:
+        # One pass may cover several roots, which is what makes ingest different
+        # from every other program; the shared root resolver reads one
+        # attribute, so the first named root is the one this run is logged under
+        # and the rest are further trees to walk.  With none named, the resolver
+        # falls through to the configuration variable and the environment as it
+        # does everywhere else, which is also how it answers for the drop, whose
+        # command line has no root on it to read.
+        arguments.nav_results_root = (arguments.nav_results_roots or [None])[0]
 
     # Read configuration files
     with reporting_logging_errors():
         load_default_and_user_config(arguments, DEFAULT_CONFIG)
     with reporting_logging_errors():
         build_run_logging(PROGRAM_NAME, arguments, DEFAULT_CONFIG)
-
-    refusal = _mode_refusal(arguments)
-    if refusal is not None:
-        MAIN_LOGGER.fatal('%s', refusal)
-        sys.exit(1)
 
     # A level that names the index with an empty value is a different failure from
     # naming none at all, and its message names that level, so it is reported as
@@ -576,7 +628,7 @@ def main() -> None:
         )
         sys.exit(1)
 
-    if arguments.drop_index:
+    if arguments.command == DROP:
         # Before the roots are resolved, and instead of them: a drop is about
         # the database alone, and requiring a results root for it would refuse
         # the command on a machine that has the index and not the tree.
@@ -605,7 +657,7 @@ def main() -> None:
     # that is not there is a wrong URL rather than a first run: creating an
     # empty one would answer "no run to complete" for a root whose run is
     # sitting in the index the operator meant to name.
-    completing = arguments.complete_cloud_tasks_file is not None
+    completing = arguments.command == COMPLETE
 
     MAIN_LOGGER.info('Starting results index ingest')
     MAIN_LOGGER.info('Roots: %s', ', '.join(roots))
@@ -613,45 +665,22 @@ def main() -> None:
         MAIN_LOGGER.info('Force: %s', arguments.force)
     MAIN_LOGGER.info('Arguments: %s', masked_command_line(command_list))
 
-    if completing and arguments.force:
-        # Refused rather than ignored.  Completion reads no document, so there
-        # is nothing for --force to re-read; an operator who typed it meant the
-        # shares to be read again, and that is a property of the fan-out that
-        # cut them, decided one step earlier.
-        MAIN_LOGGER.fatal(
-            '--force has no meaning when adding up what the workers did, since no document '
-            'is read here. Re-run --output-cloud-tasks-file with --force and run the tasks '
-            'it writes.'
-        )
-        sys.exit(1)
-    if completing and not arguments.prune:
-        # Refused rather than ignored, on the same grounds as --force above.
-        # Completion removes no row: the fan-out that cut the shares held the
-        # one listing of the root and removed there, so whether this index keeps
-        # the rows of documents that have left the tree was settled a step
-        # earlier and cannot be revisited here.
-        MAIN_LOGGER.fatal(
-            '--no-prune has no meaning when adding up what the workers did, since no row is '
-            'removed here. The rows of documents that have left the tree go, or stay, at the '
-            '--output-cloud-tasks-file that listed the root.'
-        )
-        sys.exit(1)
     try:
         engine = open_index(url, create=not completing)
     except ValueError as exc:
         MAIN_LOGGER.fatal('Cannot open the results index: %s', exc)
         sys.exit(1)
     try:
-        if arguments.output_cloud_tasks_file is not None:
+        if arguments.command == DIVIDE:
             status = _write_cloud_tasks(
                 engine,
                 roots,
                 force=arguments.force,
                 prune=arguments.prune,
-                path=arguments.output_cloud_tasks_file,
+                path=arguments.tasks_file,
             )
         elif completing:
-            status = _complete_cloud_tasks(engine, roots, path=arguments.complete_cloud_tasks_file)
+            status = _complete_cloud_tasks(engine, roots, path=arguments.events_log)
         else:
             status = _run_ingest(engine, roots, force=arguments.force, prune=arguments.prune)
     except UnwritableRowError as exc:

--- a/src/spindoctor/cli/sd_results_index_cloud_tasks.py
+++ b/src/spindoctor/cli/sd_results_index_cloud_tasks.py
@@ -2,9 +2,9 @@
 """Ingest one share of a navigation results root, driven by a cloud-tasks queue.
 
 Dispatch script for the ``sd_results_index_cloud_tasks`` console entry point.
-Its interactive sibling ``sd_results_index`` divides a root into shares with
-``--output-cloud-tasks-file`` and adds up what the workers did with
-``--complete-cloud-tasks-file``; this is what reads one of those shares.
+Its interactive sibling ``sd_results_index divide`` divides a root into shares
+and ``sd_results_index complete`` adds up what the workers did; this is what
+reads one of those shares.
 
 A worker is handed the files of its share, not a root to walk: the listing
 happens once, where the work is divided up.  It therefore also removes no row.
@@ -85,11 +85,11 @@ def process_task(
         # all and is reported as its own status so a tally can tell them apart.
         return False, {
             'status': 'error',
-            'status_error': 'unusable_results_db',
+            'status_error': 'unusable_results_index_db',
             'status_exception': str(exc),
         }
     if url is None:
-        return False, {'status': 'error', 'status_error': 'no_results_db'}
+        return False, {'status': 'error', 'status_error': 'no_results_index_db'}
 
     try:
         # create=False: the program that divided the work up made the schema.

--- a/src/spindoctor/dataset/dataset_pds3.py
+++ b/src/spindoctor/dataset/dataset_pds3.py
@@ -630,7 +630,7 @@ class DataSetPDS3(DataSet):
             nav_results_root: str | Path | FCPath | None = None,
                 Results root for the filters above.  None resolves via the
                 arguments, configuration, or NAV_RESULTS_ROOT environment variable.
-            results_db_url: str | None = None,
+            results_index_db_url: str | None = None,
                 Results index answering the filters above, so that an
                 enumeration reads rows instead of walking the results tree and
                 reading its documents.  None resolves via the arguments,
@@ -669,7 +669,7 @@ class DataSetPDS3(DataSet):
         has_offset_spice_error: bool = kwargs.pop('has_offset_spice_error', False)
         has_offset_nonspice_error: bool = kwargs.pop('has_offset_nonspice_error', False)
         nav_results_root: str | Path | FCPath | None = kwargs.pop('nav_results_root', None)
-        results_db_url: str | None = kwargs.pop('results_db_url', None)
+        results_index_db_url: str | None = kwargs.pop('results_index_db_url', None)
         choose_random_images: int | None = kwargs.pop('choose_random_images', None)
         if choose_random_images is not None and choose_random_images <= 0:
             raise ValueError(
@@ -763,7 +763,7 @@ class DataSetPDS3(DataSet):
             resolved_arguments = arguments if arguments is not None else argparse.Namespace()
             if nav_results_root is None:
                 nav_results_root = get_nav_results_root(resolved_arguments, self.config)
-            if results_db_url is None and 'results_index_db' in vars(resolved_arguments):
+            if results_index_db_url is None and 'results_index_db' in vars(resolved_arguments):
                 # Only a program that declares --results-index-db reads an index, and
                 # the presence of the argument is that declaration. The URL
                 # resolves from the configuration and the environment as every
@@ -773,7 +773,7 @@ class DataSetPDS3(DataSet):
                 # exported for another one, and a caller that names no argument
                 # at all is asking for the tree.
                 try:
-                    results_db_url = get_results_index_db_url(resolved_arguments, self.config)
+                    results_index_db_url = get_results_index_db_url(resolved_arguments, self.config)
                 except ValueError as exc:
                     # A level that named the index with an empty value is a run
                     # that was configured wrong, and its message already says
@@ -787,7 +787,7 @@ class DataSetPDS3(DataSet):
                 valid_volumes,
                 nav_results_root,
                 logger=logger,
-                results_db_url=results_db_url,
+                results_index_db_url=results_index_db_url,
                 **results_filter_flags,
             )
 

--- a/src/spindoctor/dataset/results_filter.py
+++ b/src/spindoctor/dataset/results_filter.py
@@ -364,7 +364,7 @@ class ResultsFilter:
         has_no_offset_error: bool = False,
         has_offset_spice_error: bool = False,
         has_offset_nonspice_error: bool = False,
-        results_db_url: str | None = None,
+        results_index_db_url: str | None = None,
         logger: PdsLogger,
     ) -> None:
         """Validates the flag combination and asks what the results root holds.
@@ -395,7 +395,7 @@ class ResultsFilter:
                 indicates a fatal error from missing SPICE data.
             has_offset_nonspice_error: Only keep images whose offset metadata
                 file indicates a fatal error other than missing SPICE data.
-            results_db_url: Connection URL of a results index to answer every
+            results_index_db_url: Connection URL of a results index to answer every
                 filter from, or None to read the results tree.  A URL that
                 cannot be used is an error rather than a reason to fall back
                 to the tree.
@@ -486,7 +486,7 @@ class ResultsFilter:
             nav_results_root if isinstance(nav_results_root, FCPath) else FCPath(nav_results_root)
         )
         self._logger = logger
-        self._results_db_url = results_db_url
+        self._results_index_db_url = results_index_db_url
         # Held open only while there is a second question to ask, since a source
         # over an index holds a connection pool and a run that has nothing left
         # to ask should not.
@@ -713,7 +713,7 @@ class ResultsFilter:
         try:
             return open_record_source(
                 [self._nav_results_root],
-                results_db_url=self._results_db_url,
+                results_index_db_url=self._results_index_db_url,
                 logger=self._logger,
             )
         except ValueError as exc:
@@ -872,7 +872,7 @@ class ResultsFilter:
             SelectionError: If the index cannot be read for the age of its
                 answer, which is the same refusal reading it for the answer is.
         """
-        if self._results_db_url is None:
+        if self._results_index_db_url is None:
             if documents is None:
                 self._logger.info(
                     '*** Results scan will ask %s about each candidate image',
@@ -886,7 +886,7 @@ class ResultsFilter:
                 )
             return
         try:
-            ingested_utc = snapshot_finish_time(self._results_db_url, self._nav_results_root)
+            ingested_utc = snapshot_finish_time(self._results_index_db_url, self._nav_results_root)
         except ValueError as exc:
             raise SelectionError(str(exc)) from exc
         if documents is None:

--- a/src/spindoctor/results_index/engine.py
+++ b/src/spindoctor/results_index/engine.py
@@ -718,7 +718,7 @@ def _verify_schema_version(stamped: int | None, url: str) -> None:
         raise _IndexOpenError(
             f'{url}: results index schema version {stamped} is not the '
             f'version {SCHEMA_VERSION} this code reads. There are no migrations: empty '
-            f'the database with sd_results_index --drop-index and re-run sd_results_index.'
+            f'the database with sd_results_index drop and re-run sd_results_index ingest.'
         )
 
 

--- a/src/spindoctor/results_index/open_source.py
+++ b/src/spindoctor/results_index/open_source.py
@@ -30,7 +30,7 @@ __all__ = ['open_record_source']
 def open_record_source(
     roots: Sequence[str | Path | FCPath],
     *,
-    results_db_url: str | None = None,
+    results_index_db_url: str | None = None,
     columns: Sequence[sqlalchemy.Column[Any]] = (),
     logger: PdsLogger | None = None,
 ) -> RecordSource:
@@ -44,8 +44,8 @@ def open_record_source(
     Parameters:
         roots: The results roots to read, in the order questions are answered
             about them.  Two spellings of one root are one root.
-        results_db_url: Connection URL of the results index, or None to read the
-            documents.
+        results_index_db_url: Connection URL of the results index, or None to
+            read the documents.
         columns: The columns of ``images`` a consumer's *records* are rebuilt
             from.  Ignored when the documents are read, which carry every field
             whatever is selected; ignored by a stream of facts, which is the
@@ -71,7 +71,7 @@ def open_record_source(
     root_urls = distinct_roots(roots)
     if not root_urls:
         raise ValueError('a record source needs at least one results root to read')
-    if results_db_url is None:
+    if results_index_db_url is None:
         return TreeRecordSource(root_urls, logger=logger)
-    engine = open_index_for_roots(results_db_url, root_urls)
-    return IndexRecordSource(engine, root_urls, results_db_url, columns)
+    engine = open_index_for_roots(results_index_db_url, root_urls)
+    return IndexRecordSource(engine, root_urls, results_index_db_url, columns)

--- a/tests/spindoctor/cli/ck/test_records.py
+++ b/tests/spindoctor/cli/ck/test_records.py
@@ -145,7 +145,7 @@ def _both_sources(tmp_path: Path) -> tuple[TreeRecordSource, IndexRecordSource]:
     root = _tree(tmp_path)
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [root], logger=null_logger())
-    index_source = open_record_source([root], results_db_url=url, columns=RECORD_COLUMNS)
+    index_source = open_record_source([root], results_index_db_url=url, columns=RECORD_COLUMNS)
     assert isinstance(index_source, IndexRecordSource)
     return TreeRecordSource([root]), index_source
 
@@ -233,7 +233,7 @@ def test_the_run_orders_the_records_rather_than_trusting_their_order(tmp_path: P
             connection.execute(IMAGES.insert(), list(reversed(stored)))
     finally:
         engine.dispose()
-    with open_record_source([root], results_db_url=url, columns=RECORD_COLUMNS) as source:
+    with open_record_source([root], results_index_db_url=url, columns=RECORD_COLUMNS) as source:
         # The premise, asserted rather than assumed: an unordered query is the
         # server's to answer how it likes, and one that handed them back already
         # sorted would leave the run's own sort untested and this test unable to
@@ -374,7 +374,7 @@ def test_another_roots_images_are_not_this_runs(tmp_path: Path) -> None:
     write_metadata(other, 'COISS_2002/data/N1454999999_1_CALIB', _navigated('N1454999999_1.IMG'))
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [root, other], logger=null_logger())
-    with open_record_source([root], results_db_url=url, columns=RECORD_COLUMNS) as source:
+    with open_record_source([root], results_index_db_url=url, columns=RECORD_COLUMNS) as source:
         documents, _unreadable = _one_mission(source)
     assert [document.stub for document in documents] == [
         'COISS_2001/data/N1454725799_1_CALIB',
@@ -393,7 +393,7 @@ def test_a_document_the_ingest_refused_is_reported_as_unreadable(tmp_path: Path)
     (root / 'COISS_2001' / 'data' / 'junk_metadata.json').write_text('{}', encoding='utf-8')
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [root], logger=null_logger())
-    with open_record_source([root], results_db_url=url, columns=RECORD_COLUMNS) as source:
+    with open_record_source([root], results_index_db_url=url, columns=RECORD_COLUMNS) as source:
         _documents, unreadable = _one_mission(source)
     assert [entry.path.as_posix() for entry in unreadable] == [
         (root / 'COISS_2001' / 'data' / 'junk_metadata.json').as_posix()
@@ -406,7 +406,7 @@ def test_the_refusal_reason_travels_with_the_file(tmp_path: Path) -> None:
     (root / 'COISS_2001' / 'data' / 'junk_metadata.json').write_text('{}', encoding='utf-8')
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [root], logger=null_logger())
-    with open_record_source([root], results_db_url=url, columns=RECORD_COLUMNS) as source:
+    with open_record_source([root], results_index_db_url=url, columns=RECORD_COLUMNS) as source:
         _documents, unreadable = _one_mission(source)
     assert 'navigation document' in unreadable[0].reason
 
@@ -419,13 +419,13 @@ def test_a_root_with_no_completed_ingest_is_refused(tmp_path: Path) -> None:
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [other], logger=null_logger())
     with pytest.raises(ValueError, match='no completed ingest'):
-        open_record_source([root], results_db_url=url, columns=RECORD_COLUMNS)
+        open_record_source([root], results_index_db_url=url, columns=RECORD_COLUMNS)
 
 
 def test_no_index_url_reads_the_tree(tmp_path: Path) -> None:
     """Reading files is the default, and nothing opens a database to do it."""
     root = _tree(tmp_path)
-    with open_record_source([root], results_db_url=None, columns=RECORD_COLUMNS) as source:
+    with open_record_source([root], results_index_db_url=None, columns=RECORD_COLUMNS) as source:
         assert isinstance(source, TreeRecordSource)
 
 
@@ -479,7 +479,7 @@ def test_a_value_the_ingest_could_not_store_reads_as_one_never_recorded(
     )
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [root], logger=null_logger())
-    with open_record_source([root], results_db_url=url, columns=RECORD_COLUMNS) as source:
+    with open_record_source([root], results_index_db_url=url, columns=RECORD_COLUMNS) as source:
         documents, _unreadable = _one_mission(source)
     assert read_image_report_facts(documents[0].metadata).offset_dv is None
 

--- a/tests/spindoctor/cli/reproj/test_pointing_source.py
+++ b/tests/spindoctor/cli/reproj/test_pointing_source.py
@@ -798,7 +798,7 @@ def test_a_stub_recorded_only_under_another_root_is_absent(
 
 def test_no_url_reads_documents(tmp_path: Path) -> None:
     """No index is every program's default, and it reads the tree."""
-    source = build_pointing_source(FCPath(tmp_path), results_db_url=None)
+    source = build_pointing_source(FCPath(tmp_path), results_index_db_url=None)
     assert isinstance(source, FilePointingSource)
 
 
@@ -808,7 +808,9 @@ def test_a_url_reads_rows(tmp_path: Path, quiet_ingest_logger: pdslogger.PdsLogg
     build_tree(root, {CMATRIX_STUB: document(CMATRIX_STUB, offset=OFFSET)})
     database = tmp_path / 'index.sqlite3'
     index_for([root], database, logger=quiet_ingest_logger).dispose()
-    source = build_pointing_source(FCPath(root), results_db_url=f'sqlite:///{database.as_posix()}')
+    source = build_pointing_source(
+        FCPath(root), results_index_db_url=f'sqlite:///{database.as_posix()}'
+    )
     try:
         assert isinstance(source, IndexPointingSource)
     finally:
@@ -843,7 +845,9 @@ def test_an_unopenable_url_fails_rather_than_falling_back(tmp_path: Path) -> Non
     """A misconfigured index is a failed run, not a slow and different one."""
     missing = tmp_path / 'nowhere' / 'index.sqlite3'
     with pytest.raises(ValueError) as excinfo:
-        build_pointing_source(FCPath(tmp_path), results_db_url=f'sqlite:///{missing.as_posix()}')
+        build_pointing_source(
+            FCPath(tmp_path), results_index_db_url=f'sqlite:///{missing.as_posix()}'
+        )
     assert 'sd_results_index' in str(excinfo.value)
 
 
@@ -851,7 +855,9 @@ def test_an_unopenable_url_leaves_no_database_behind(tmp_path: Path) -> None:
     """And it does not create the index it was told to read."""
     missing = tmp_path / 'index.sqlite3'
     with pytest.raises(ValueError, match='sd_results_index') as excinfo:
-        build_pointing_source(FCPath(tmp_path), results_db_url=f'sqlite:///{missing.as_posix()}')
+        build_pointing_source(
+            FCPath(tmp_path), results_index_db_url=f'sqlite:///{missing.as_posix()}'
+        )
     assert 'index.sqlite3' in str(excinfo.value)
     assert not missing.exists()
 
@@ -865,7 +871,7 @@ def test_an_index_with_no_root_to_read_under_is_refused(
     database = tmp_path / 'index.sqlite3'
     index_for([root], database, logger=quiet_ingest_logger).dispose()
     with pytest.raises(ValueError, match='no navigation results root'):
-        build_pointing_source(None, results_db_url=f'sqlite:///{database.as_posix()}')
+        build_pointing_source(None, results_index_db_url=f'sqlite:///{database.as_posix()}')
 
 
 def test_a_root_nobody_ingested_is_refused(
@@ -883,7 +889,9 @@ def test_a_root_nobody_ingested_is_refused(
     database = tmp_path / 'index.sqlite3'
     index_for([ingested], database, logger=quiet_ingest_logger).dispose()
     with pytest.raises(ValueError) as excinfo:
-        build_pointing_source(FCPath(other), results_db_url=f'sqlite:///{database.as_posix()}')
+        build_pointing_source(
+            FCPath(other), results_index_db_url=f'sqlite:///{database.as_posix()}'
+        )
     assert normalize_root_url(other) in str(excinfo.value)
 
 
@@ -898,7 +906,9 @@ def test_the_refusal_names_the_roots_the_index_does_hold(
     database = tmp_path / 'index.sqlite3'
     index_for([ingested], database, logger=quiet_ingest_logger).dispose()
     with pytest.raises(ValueError) as excinfo:
-        build_pointing_source(FCPath(other), results_db_url=f'sqlite:///{database.as_posix()}')
+        build_pointing_source(
+            FCPath(other), results_index_db_url=f'sqlite:///{database.as_posix()}'
+        )
     assert normalize_root_url(ingested) in str(excinfo.value)
 
 
@@ -929,7 +939,7 @@ def test_a_run_that_died_halfway_leaves_a_root_unreadable(
     finally:
         engine.dispose()
     with pytest.raises(ValueError, match='no completed ingest'):
-        build_pointing_source(FCPath(root), results_db_url=url)
+        build_pointing_source(FCPath(root), results_index_db_url=url)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/spindoctor/cli/results_index/ingest_driver_helpers.py
+++ b/tests/spindoctor/cli/results_index/ingest_driver_helpers.py
@@ -63,7 +63,8 @@ def run_driver(
     """Run ``sd_results_index`` and return its exit status and its main log.
 
     Parameters:
-        argv: Arguments, without the program name.
+        argv: Arguments, without the program name, beginning with the
+            subcommand.
         monkeypatch: Fixture the argument vector and logger are replaced through.
         tmp_path: Directory the run's log files are written under.
 
@@ -75,8 +76,10 @@ def run_driver(
     def recording(message: Any, *args: Any) -> None:
         written.append(str(message) % args if args else str(message))
 
+    # The log root goes last, because every subcommand declares it and none of
+    # them is reached until the subcommand itself has been read.
     monkeypatch.setattr(
-        sys, 'argv', ['sd_results_index', '--log-root', str(tmp_path / 'logs'), *argv]
+        sys, 'argv', ['sd_results_index', *argv, '--log-root', str(tmp_path / 'logs')]
     )
     for level in ('info', 'warning', 'error', 'fatal', 'exception'):
         monkeypatch.setattr(MAIN_LOGGER, level, recording)
@@ -131,11 +134,12 @@ def fanned_out(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, count: int = 
     url = index_url(tmp_path / 'index.sqlite3')
     run_driver(
         [
+            'divide',
             '--results-index-db',
             url,
             '--nav-results-root',
             root.as_posix(),
-            '--output-cloud-tasks-file',
+            '--tasks-file',
             str(tmp_path / 'tasks.json'),
         ],
         monkeypatch,
@@ -160,11 +164,12 @@ def fanned_out_with_a_refusal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     url = index_url(tmp_path / 'index.sqlite3')
     run_driver(
         [
+            'divide',
             '--results-index-db',
             url,
             '--nav-results-root',
             root.as_posix(),
-            '--output-cloud-tasks-file',
+            '--tasks-file',
             str(tmp_path / 'tasks.json'),
         ],
         monkeypatch,

--- a/tests/spindoctor/cli/results_index/test_drop_cli.py
+++ b/tests/spindoctor/cli/results_index/test_drop_cli.py
@@ -1,4 +1,4 @@
-"""Tests for ``sd_results_index --drop-index``.
+"""Tests for ``sd_results_index drop``.
 
 The destructive command, so what is asked of it is mostly what it does *not* do:
 it does not drop without an answer, it does not treat a closed standard input as
@@ -138,7 +138,7 @@ def _drop(
     Returns:
         The exit status, and one entry per line written to the main log.
     """
-    return run_driver(['--results-index-db', url, '--drop-index', *extra], monkeypatch, tmp_path)
+    return run_driver(['drop', '--results-index-db', url, *extra], monkeypatch, tmp_path)
 
 
 def _tables(url: str) -> list[str]:
@@ -388,11 +388,12 @@ def test_an_unfinished_ingest_run_is_reported_before_the_question(
     url = index_url(tmp_path / 'index.sqlite3')
     run_driver(
         [
+            'divide',
             '--results-index-db',
             url,
             '--nav-results-root',
             root.as_posix(),
-            '--output-cloud-tasks-file',
+            '--tasks-file',
             str(tmp_path / 'tasks.json'),
         ],
         monkeypatch,
@@ -422,11 +423,12 @@ def test_an_unfinished_ingest_run_is_named_in_the_question_itself(
     url = index_url(tmp_path / 'index.sqlite3')
     run_driver(
         [
+            'divide',
             '--results-index-db',
             url,
             '--nav-results-root',
             root.as_posix(),
-            '--output-cloud-tasks-file',
+            '--tasks-file',
             str(tmp_path / 'tasks.json'),
         ],
         monkeypatch,
@@ -512,100 +514,6 @@ def test_nobody_is_asked_when_there_is_nothing_to_drop(
     _answering(monkeypatch, '')
     status, _written = _drop(url, monkeypatch, tmp_path)
     assert status == 0
-
-
-# ---------------------------------------------------------------------------
-# What a drop refuses to be combined with
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    ('extra', 'named'),
-    [
-        (['--force'], '--force'),
-        (['--output-cloud-tasks-file', 'tasks.json'], '--output-cloud-tasks-file'),
-        (['--complete-cloud-tasks-file', 'events.log'], '--complete-cloud-tasks-file'),
-    ],
-)
-def test_a_drop_refuses_the_ingest_options(
-    extra: list[str],
-    named: str,
-    tmp_path: Path,
-    quiet_logger: pdslogger.PdsLogger,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Refused rather than ignored: a program may not choose which half to do.
-
-    Parameters:
-        extra: The ingest option the command line also carries.
-        named: What the refusal has to name.
-        tmp_path: Directory the tree and the index live under.
-        quiet_logger: Logger the ingest reports through.
-        monkeypatch: Fixture the driver is run through.
-    """
-    url = _tree_with_an_index(tmp_path, quiet_logger)
-    _status, written = _drop(url, monkeypatch, tmp_path, *extra)
-    assert any(named in line for line in written)
-
-
-def test_a_refused_combination_leaves_the_index_alone(
-    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The refusal is before the open, so nothing is opened and nothing goes.
-
-    Parameters:
-        tmp_path: Directory the tree and the index live under.
-        quiet_logger: Logger the ingest reports through.
-        monkeypatch: Fixture the driver is run through.
-    """
-    url = _tree_with_an_index(tmp_path, quiet_logger)
-    _drop(url, monkeypatch, tmp_path, '--force', '--yes')
-    assert _tables(url) == sorted(index_table_names())
-
-
-def test_a_refused_combination_exits_nonzero(
-    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The status has to say the command did not run, not that it ran.
-
-    Parameters:
-        tmp_path: Directory the tree and the index live under.
-        quiet_logger: Logger the ingest reports through.
-        monkeypatch: Fixture the driver is run through.
-    """
-    url = _tree_with_an_index(tmp_path, quiet_logger)
-    status, _written = _drop(url, monkeypatch, tmp_path, '--force', '--yes')
-    assert status == 1
-
-
-def test_yes_without_a_drop_is_refused(
-    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """It answers a question only the drop asks, so on its own it means nothing.
-
-    Parameters:
-        tmp_path: Directory the tree and the index live under.
-        quiet_logger: Logger the ingest reports through.
-        monkeypatch: Fixture the driver is run through.
-    """
-    url = _tree_with_an_index(tmp_path, quiet_logger)
-    status, _written = run_driver(['--results-index-db', url, '--yes'], monkeypatch, tmp_path)
-    assert status == 1
-
-
-def test_the_refusal_of_yes_alone_says_what_to_add(
-    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """An operator who typed it meant something, so the refusal says what.
-
-    Parameters:
-        tmp_path: Directory the tree and the index live under.
-        quiet_logger: Logger the ingest reports through.
-        monkeypatch: Fixture the driver is run through.
-    """
-    url = _tree_with_an_index(tmp_path, quiet_logger)
-    _status, written = run_driver(['--results-index-db', url, '--yes'], monkeypatch, tmp_path)
-    assert any('--drop-index' in line for line in written)
 
 
 # ---------------------------------------------------------------------------
@@ -804,7 +712,7 @@ def _selecting_against(url: str, tmp_path: Path, quiet_logger: pdslogger.PdsLogg
         ['VOL'],
         tmp_path / 'results',
         logger=quiet_logger,
-        results_db_url=url,
+        results_index_db_url=url,
         has_offset_file=True,
     )
 
@@ -1266,40 +1174,8 @@ def test_ctrl_c_during_the_drop_leaves_every_table(
 
 
 # ---------------------------------------------------------------------------
-# The option a drop has nothing to do with
+# A results root the drop never reads
 # ---------------------------------------------------------------------------
-
-
-def test_a_drop_refuses_a_results_root_that_was_typed(
-    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A drop reads no tree, so a root named on the command line meant something else.
-
-    Parameters:
-        tmp_path: Directory the tree and the index live under.
-        quiet_logger: Logger the ingest reports through.
-        monkeypatch: Fixture the driver is run through.
-    """
-    url = _tree_with_an_index(tmp_path, quiet_logger)
-    _status, written = _drop(
-        url, monkeypatch, tmp_path, '--nav-results-root', str(tmp_path / 'results')
-    )
-    assert any('--nav-results-root' in line for line in written)
-
-
-def test_such_a_command_line_leaves_the_index_alone(
-    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Refused before the open, so nothing is opened and nothing goes.
-
-    Parameters:
-        tmp_path: Directory the tree and the index live under.
-        quiet_logger: Logger the ingest reports through.
-        monkeypatch: Fixture the driver is run through.
-    """
-    url = _tree_with_an_index(tmp_path, quiet_logger)
-    _drop(url, monkeypatch, tmp_path, '--yes', '--nav-results-root', str(tmp_path / 'results'))
-    assert _tables(url) == sorted(index_table_names())
 
 
 def test_a_results_root_from_the_environment_does_not_refuse_a_drop(
@@ -1473,11 +1349,12 @@ def test_neither_state_lets_a_fan_out_be_completed(
     statuses = [
         run_driver(
             [
+                'complete',
                 '--results-index-db',
                 url,
                 '--nav-results-root',
                 str(tmp_path / 'results'),
-                '--complete-cloud-tasks-file',
+                '--events-log',
                 str(events),
             ],
             monkeypatch,
@@ -1501,7 +1378,7 @@ def test_both_states_are_rebuilt_by_the_ingest_that_creates(
     root = tmp_path / 'results'
     statuses = [
         run_driver(
-            ['--results-index-db', url, '--nav-results-root', root.as_posix()],
+            ['ingest', '--results-index-db', url, '--nav-results-root', root.as_posix()],
             monkeypatch,
             tmp_path,
         )[0]

--- a/tests/spindoctor/cli/results_index/test_ingest_cloud_tasks_driver.py
+++ b/tests/spindoctor/cli/results_index/test_ingest_cloud_tasks_driver.py
@@ -12,7 +12,6 @@ The worker between the two is in ``test_ingest_cloud_tasks_worker``.
 """
 
 import json
-import sys
 from pathlib import Path
 from typing import Any
 
@@ -32,7 +31,6 @@ from tests.spindoctor.conftest import (
     write_metadata,
 )
 
-from spindoctor.cli import sd_results_index
 from spindoctor.results_index import IMAGES, INGEST_RUNS, normalize_root_url, open_index
 
 # ---------------------------------------------------------------------------
@@ -83,11 +81,12 @@ def dividing_a_root_that_is_not_there(
     """
     return run_driver(
         [
+            'divide',
             '--results-index-db',
             index_url(tmp_path / 'index.sqlite3'),
             '--nav-results-root',
             str(tmp_path / 'absent'),
-            '--output-cloud-tasks-file',
+            '--tasks-file',
             str(tmp_path / 'tasks.json'),
         ],
         monkeypatch,
@@ -128,13 +127,14 @@ def test_two_spellings_of_one_root_are_logged_once(
     write_metadata(root, STUB, metadata_document())
     _status, written = run_driver(
         [
+            'divide',
             '--results-index-db',
             index_url(tmp_path / 'index.sqlite3'),
             '--nav-results-root',
             root.as_posix(),
             '--nav-results-root',
             f'{root.as_posix()}/',
-            '--output-cloud-tasks-file',
+            '--tasks-file',
             str(tmp_path / 'tasks.json'),
         ],
         monkeypatch,
@@ -158,11 +158,12 @@ def naming_a_root_that_is_not_a_location(
     """
     return run_driver(
         [
+            'divide',
             '--results-index-db',
             index_url(tmp_path / 'index.sqlite3'),
             '--nav-results-root',
             spelling,
-            '--output-cloud-tasks-file',
+            '--tasks-file',
             str(tmp_path / 'tasks.json'),
         ],
         monkeypatch,
@@ -210,56 +211,6 @@ def test_a_root_that_is_not_a_location_says_so(
     assert any('is not a location that can be read' in line for line in written)
 
 
-def refusing_both_cloud_modes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SystemExit:
-    """Parse a command line asking for both cloud modes at once.
-
-    Parameters:
-        tmp_path: Directory the two named files would live under.
-        monkeypatch: Fixture the argument vector is replaced through.
-
-    Returns:
-        The exit the parser raised.
-    """
-    monkeypatch.setattr(sys, 'argv', ['sd_results_index'])
-    with pytest.raises(SystemExit) as caught:
-        sd_results_index.parse_args(
-            [
-                '--output-cloud-tasks-file',
-                str(tmp_path / 'tasks.json'),
-                '--complete-cloud-tasks-file',
-                str(tmp_path / 'events.log'),
-            ]
-        )
-    return caught.value
-
-
-def test_the_two_cloud_modes_cannot_be_asked_for_at_once(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Dividing the work up and adding it together are different runs.
-
-    Asking for both would write a tasks file and then complete the run it had
-    just created, before a single worker had read anything.
-    """
-    assert refusing_both_cloud_modes(tmp_path, monkeypatch).code == 2
-
-
-def test_the_two_cloud_modes_are_refused_by_name(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """A status of 2 is what argparse exits with for any command line at all.
-
-    A renamed option, a missing value, a typo: all of them are status 2, so what
-    says this refusal is the one meant is the message naming the two options and
-    the reason.  Naming one of them is not enough either: an option that does
-    not exist is spelled back in the "unrecognized arguments" message, so a
-    parser that had dropped both would satisfy that much of it.
-    """
-    refusing_both_cloud_modes(tmp_path, monkeypatch)
-    refusal = '--complete-cloud-tasks-file: not allowed with argument --output-cloud-tasks-file'
-    assert refusal in capsys.readouterr().err
-
-
 # ---------------------------------------------------------------------------
 # The command line that puts it back together
 # ---------------------------------------------------------------------------
@@ -298,11 +249,12 @@ def test_the_driver_completes_the_run_from_an_event_log(
     write_event_log_of_results(tmp_path / 'events.log', results)
     status, _written = run_driver(
         [
+            'complete',
             '--results-index-db',
             url,
             '--nav-results-root',
             (tmp_path / 'results').as_posix(),
-            '--complete-cloud-tasks-file',
+            '--events-log',
             str(tmp_path / 'events.log'),
         ],
         monkeypatch,
@@ -319,11 +271,12 @@ def test_completing_a_run_the_tasks_did_not_cover_exits_one(
     write_event_log_of_results(tmp_path / 'events.log', [])
     status, _written = run_driver(
         [
+            'complete',
             '--results-index-db',
             url,
             '--nav-results-root',
             (tmp_path / 'results').as_posix(),
-            '--complete-cloud-tasks-file',
+            '--events-log',
             str(tmp_path / 'events.log'),
         ],
         monkeypatch,
@@ -340,11 +293,12 @@ def test_completing_a_run_the_tasks_did_not_cover_says_so(
     write_event_log_of_results(tmp_path / 'events.log', [])
     _status, written = run_driver(
         [
+            'complete',
             '--results-index-db',
             url,
             '--nav-results-root',
             (tmp_path / 'results').as_posix(),
-            '--complete-cloud-tasks-file',
+            '--events-log',
             str(tmp_path / 'events.log'),
         ],
         monkeypatch,
@@ -369,11 +323,12 @@ def test_the_completion_summary_says_why_a_file_was_refused(
     write_event_log_of_results(tmp_path / 'events.log', results)
     _status, written = run_driver(
         [
+            'complete',
             '--results-index-db',
             url,
             '--nav-results-root',
             (tmp_path / 'results').as_posix(),
-            '--complete-cloud-tasks-file',
+            '--events-log',
             str(tmp_path / 'events.log'),
         ],
         monkeypatch,
@@ -409,11 +364,12 @@ def test_a_result_written_under_another_root_is_named_in_the_summary(
     )
     _status, written = run_driver(
         [
+            'complete',
             '--results-index-db',
             url,
             '--nav-results-root',
             (tmp_path / 'results').as_posix(),
-            '--complete-cloud-tasks-file',
+            '--events-log',
             str(tmp_path / 'events.log'),
         ],
         monkeypatch,
@@ -439,11 +395,12 @@ def completing_a_mistyped_root(
     url = index_url(tmp_path / 'index.sqlite3')
     run_driver(
         [
+            'divide',
             '--results-index-db',
             url,
             '--nav-results-root',
             str(mistyped),
-            '--output-cloud-tasks-file',
+            '--tasks-file',
             str(tmp_path / 'tasks.json'),
         ],
         monkeypatch,
@@ -452,11 +409,12 @@ def completing_a_mistyped_root(
     write_event_log_of_results(tmp_path / 'events.log', [])
     return run_driver(
         [
+            'complete',
             '--results-index-db',
             url,
             '--nav-results-root',
             str(mistyped),
-            '--complete-cloud-tasks-file',
+            '--events-log',
             str(tmp_path / 'events.log'),
         ],
         monkeypatch,
@@ -529,11 +487,12 @@ def missing_event_log_run(
     url = fanned_out(tmp_path, monkeypatch)
     return run_driver(
         [
+            'complete',
             '--results-index-db',
             url,
             '--nav-results-root',
             (tmp_path / 'results').as_posix(),
-            '--complete-cloud-tasks-file',
+            '--events-log',
             str(tmp_path / 'nowhere.log'),
         ],
         monkeypatch,
@@ -590,11 +549,12 @@ def binary_event_log_run(
     (tmp_path / 'events.log.gz').write_bytes(b'\x1f\x8b\x08\x00\xff\xfe\x00\x00')
     return run_driver(
         [
+            'complete',
             '--results-index-db',
             url,
             '--nav-results-root',
             (tmp_path / 'results').as_posix(),
-            '--complete-cloud-tasks-file',
+            '--events-log',
             str(tmp_path / 'events.log.gz'),
         ],
         monkeypatch,
@@ -631,52 +591,6 @@ def test_an_event_log_that_is_not_text_exits_one(
     assert status == 1
 
 
-def test_forcing_a_completion_is_refused(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Nothing is read here, so --force could only ever be ignored.
-
-    An operator who typed it meant the documents to be read again, which is a
-    property of the fan-out that cut the shares and is decided one step earlier.
-    """
-    url = fanned_out(tmp_path, monkeypatch)
-    write_event_log_of_results(tmp_path / 'events.log', [])
-    status, _written = run_driver(
-        [
-            '--results-index-db',
-            url,
-            '--nav-results-root',
-            (tmp_path / 'results').as_posix(),
-            '--complete-cloud-tasks-file',
-            str(tmp_path / 'events.log'),
-            '--force',
-        ],
-        monkeypatch,
-        tmp_path,
-    )
-    assert status == 1
-
-
-def test_forcing_a_completion_says_what_to_do_instead(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A refusal nobody can act on is only half a refusal."""
-    url = fanned_out(tmp_path, monkeypatch)
-    write_event_log_of_results(tmp_path / 'events.log', [])
-    _status, written = run_driver(
-        [
-            '--results-index-db',
-            url,
-            '--nav-results-root',
-            (tmp_path / 'results').as_posix(),
-            '--complete-cloud-tasks-file',
-            str(tmp_path / 'events.log'),
-            '--force',
-        ],
-        monkeypatch,
-        tmp_path,
-    )
-    assert any('--output-cloud-tasks-file with --force' in line for line in written)
-
-
 def completing_a_root_nobody_divided_up(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> tuple[int | None, list[str]]:
@@ -695,11 +609,12 @@ def completing_a_root_nobody_divided_up(
     write_event_log_of_results(tmp_path / 'events.log', [])
     return run_driver(
         [
+            'complete',
             '--results-index-db',
             url,
             '--nav-results-root',
             str(tmp_path / 'other-results'),
-            '--complete-cloud-tasks-file',
+            '--events-log',
             str(tmp_path / 'events.log'),
         ],
         monkeypatch,
@@ -739,11 +654,12 @@ def test_completing_against_an_index_that_is_not_there_is_refused(
     database = tmp_path / 'index.sqlite3'
     status, _written = run_driver(
         [
+            'complete',
             '--results-index-db',
             index_url(database),
             '--nav-results-root',
             str(tmp_path / 'results'),
-            '--complete-cloud-tasks-file',
+            '--events-log',
             str(tmp_path / 'events.log'),
         ],
         monkeypatch,
@@ -760,11 +676,12 @@ def test_completing_against_an_index_that_is_not_there_creates_none(
     database = tmp_path / 'index.sqlite3'
     run_driver(
         [
+            'complete',
             '--results-index-db',
             index_url(database),
             '--nav-results-root',
             str(tmp_path / 'results'),
-            '--complete-cloud-tasks-file',
+            '--events-log',
             str(tmp_path / 'events.log'),
         ],
         monkeypatch,

--- a/tests/spindoctor/cli/results_index/test_ingest_cloud_tasks_worker.py
+++ b/tests/spindoctor/cli/results_index/test_ingest_cloud_tasks_worker.py
@@ -44,11 +44,12 @@ def test_the_fan_out_creates_the_index(tmp_path: Path, monkeypatch: pytest.Monke
     database = tmp_path / 'index.sqlite3'
     run_driver(
         [
+            'divide',
             '--results-index-db',
             index_url(database),
             '--nav-results-root',
             root.as_posix(),
-            '--output-cloud-tasks-file',
+            '--tasks-file',
             str(tmp_path / 'tasks.json'),
         ],
         monkeypatch,
@@ -136,7 +137,7 @@ def test_a_worker_with_no_index_url_reports_it() -> None:
     _retry, result = sd_results_index_cloud_tasks.process_task(
         'ingest-1-000000', {}, worker_data(results_index_db=None)
     )
-    assert result['status_error'] == 'no_results_db'
+    assert result['status_error'] == 'no_results_index_db'
 
 
 def test_a_worker_given_an_empty_index_url_reports_it_as_unusable() -> None:
@@ -148,7 +149,7 @@ def test_a_worker_given_an_empty_index_url_reports_it_as_unusable() -> None:
     _retry, result = sd_results_index_cloud_tasks.process_task(
         'ingest-1-000000', {}, worker_data(results_index_db='')
     )
-    assert result['status_error'] == 'unusable_results_db'
+    assert result['status_error'] == 'unusable_results_index_db'
 
 
 def test_such_a_worker_says_which_level_named_the_empty_value() -> None:
@@ -171,7 +172,7 @@ def test_a_worker_told_to_use_no_index_reports_it(
     _retry, result = sd_results_index_cloud_tasks.process_task(
         'ingest-1-000000', {}, worker_data(results_index_db='none')
     )
-    assert result['status_error'] == 'no_results_db'
+    assert result['status_error'] == 'no_results_index_db'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/spindoctor/cli/results_index/test_ingest_driver.py
+++ b/tests/spindoctor/cli/results_index/test_ingest_driver.py
@@ -44,7 +44,8 @@ def _run(
     """Run the driver and return its exit status and what it told the main log.
 
     Parameters:
-        argv: Arguments, without the program name.
+        argv: Arguments, without the program name, beginning with the
+            subcommand.
         monkeypatch: Fixture the argument vector and logger are replaced through.
         tmp_path: Directory the run's log files are written under.
 
@@ -56,8 +57,10 @@ def _run(
     def recording(message: Any, *args: Any) -> None:
         written.append(str(message) % args if args else str(message))
 
+    # The log root goes last, because every subcommand declares it and none of
+    # them is reached until the subcommand itself has been read.
     monkeypatch.setattr(
-        sys, 'argv', ['sd_results_index', '--log-root', str(tmp_path / 'logs'), *argv]
+        sys, 'argv', ['sd_results_index', *argv, '--log-root', str(tmp_path / 'logs')]
     )
     monkeypatch.setattr(MAIN_LOGGER, 'info', recording)
     monkeypatch.setattr(MAIN_LOGGER, 'warning', recording)
@@ -77,7 +80,9 @@ def test_no_navigation_root_is_reported_and_not_raised(
     monkeypatch.delenv('NAV_RESULTS_ROOT', raising=False)
     monkeypatch.delenv('NAV_RESULTS_INDEX_DB', raising=False)
     status, _written = _run(
-        ['--results-index-db', index_url(tmp_path / 'index.sqlite3')], monkeypatch, tmp_path
+        ['ingest', '--results-index-db', index_url(tmp_path / 'index.sqlite3')],
+        monkeypatch,
+        tmp_path,
     )
     assert status == 1
 
@@ -89,7 +94,9 @@ def test_no_navigation_root_says_which_settings_supply_one(
     monkeypatch.delenv('NAV_RESULTS_ROOT', raising=False)
     monkeypatch.delenv('NAV_RESULTS_INDEX_DB', raising=False)
     _status, written = _run(
-        ['--results-index-db', index_url(tmp_path / 'index.sqlite3')], monkeypatch, tmp_path
+        ['ingest', '--results-index-db', index_url(tmp_path / 'index.sqlite3')],
+        monkeypatch,
+        tmp_path,
     )
     assert any('--nav-results-root' in line for line in written)
 
@@ -108,7 +115,7 @@ def test_no_index_is_reported_and_not_raised(
     """
     root = tmp_path / 'results'
     write_metadata(root, 'VOL/N1454725799_1_CALIB', metadata_document())
-    status, written = _run(['--nav-results-root', str(root)], monkeypatch, tmp_path)
+    status, written = _run(['ingest', '--nav-results-root', str(root)], monkeypatch, tmp_path)
     assert status == 1
     assert any('NAV_RESULTS_INDEX_DB' in line for line in written)
 
@@ -125,7 +132,7 @@ def test_an_index_named_with_an_empty_value_is_reported_and_not_raised(
     root = tmp_path / 'results'
     write_metadata(root, 'VOL/N1454725799_1_CALIB', metadata_document())
     status, _written = _run(
-        ['--nav-results-root', str(root), '--results-index-db', ''], monkeypatch, tmp_path
+        ['ingest', '--nav-results-root', str(root), '--results-index-db', ''], monkeypatch, tmp_path
     )
     assert status == 1
 
@@ -142,7 +149,7 @@ def test_an_index_named_with_an_empty_value_says_which_level_named_it(
     root = tmp_path / 'results'
     write_metadata(root, 'VOL/N1454725799_1_CALIB', metadata_document())
     _status, written = _run(
-        ['--nav-results-root', str(root), '--results-index-db', ''], monkeypatch, tmp_path
+        ['ingest', '--nav-results-root', str(root), '--results-index-db', ''], monkeypatch, tmp_path
     )
     assert any('--results-index-db is set to an empty value' in line for line in written)
 
@@ -155,7 +162,7 @@ def test_the_run_log_does_not_carry_a_database_password(
     root = tmp_path / 'results'
     write_metadata(root, 'VOL/N1454725799_1_CALIB', metadata_document())
     _status, written = _run(
-        ['--results-index-db', SERVER_URL, '--nav-results-root', root.as_posix()],
+        ['ingest', '--results-index-db', SERVER_URL, '--nav-results-root', root.as_posix()],
         monkeypatch,
         tmp_path,
     )
@@ -174,7 +181,7 @@ def test_the_run_log_still_names_the_index_it_was_given(
     root = tmp_path / 'results'
     write_metadata(root, 'VOL/N1454725799_1_CALIB', metadata_document())
     _status, written = _run(
-        ['--results-index-db', SERVER_URL, '--nav-results-root', root.as_posix()],
+        ['ingest', '--results-index-db', SERVER_URL, '--nav-results-root', root.as_posix()],
         monkeypatch,
         tmp_path,
     )
@@ -190,6 +197,7 @@ def test_the_run_log_names_the_roots_it_was_given(
     write_metadata(root, 'VOL/N1454725799_1_CALIB', metadata_document())
     _status, written = _run(
         [
+            'ingest',
             '--results-index-db',
             index_url(tmp_path / 'index.sqlite3'),
             '--nav-results-root',
@@ -208,6 +216,7 @@ def test_a_root_that_is_not_there_is_reported(
     monkeypatch.delenv('NAV_RESULTS_INDEX_DB', raising=False)
     status, _written = _run(
         [
+            'ingest',
             '--results-index-db',
             index_url(tmp_path / 'index.sqlite3'),
             '--nav-results-root',
@@ -226,6 +235,7 @@ def test_a_root_that_is_not_there_is_named_in_the_summary(
     monkeypatch.delenv('NAV_RESULTS_INDEX_DB', raising=False)
     _status, written = _run(
         [
+            'ingest',
             '--results-index-db',
             index_url(tmp_path / 'index.sqlite3'),
             '--nav-results-root',
@@ -258,6 +268,7 @@ def _run_over_an_unlistable_directory(
     try:
         return _run(
             [
+                'ingest',
                 '--results-index-db',
                 index_url(tmp_path / 'index.sqlite3'),
                 '--nav-results-root',
@@ -337,6 +348,7 @@ def test_a_failure_nobody_enumerated_exits_rather_than_raising(
     monkeypatch.setattr(sd_results_index, 'ingest_metadata_files', exploding)
     status, _written = _run(
         [
+            'ingest',
             '--results-index-db',
             index_url(tmp_path / 'index.sqlite3'),
             '--nav-results-root',
@@ -362,6 +374,7 @@ def test_a_failure_nobody_enumerated_says_what_it_was(
     monkeypatch.setattr(sd_results_index, 'ingest_metadata_files', exploding)
     _status, written = _run(
         [
+            'ingest',
             '--results-index-db',
             index_url(tmp_path / 'index.sqlite3'),
             '--nav-results-root',
@@ -384,6 +397,7 @@ def test_a_failure_reason_names_one_example_file(
     write_metadata(root, 'VOL/N1454725799_1_CALIB', metadata_document())
     _status, written = _run(
         [
+            'ingest',
             '--results-index-db',
             index_url(tmp_path / 'index.sqlite3'),
             '--nav-results-root',
@@ -421,6 +435,7 @@ def _two_passes(
     (root / 'VOL' / 'edges_metadata.json').write_text('{"edges": []}', encoding='utf-8')
     (root / 'VOL' / 'rings_metadata.json').write_text('{"rings": []}', encoding='utf-8')
     argv = [
+        'ingest',
         '--results-index-db',
         index_url(tmp_path / 'index.sqlite3'),
         '--nav-results-root',

--- a/tests/spindoctor/cli/results_index/test_ingest_no_prune.py
+++ b/tests/spindoctor/cli/results_index/test_ingest_no_prune.py
@@ -383,9 +383,14 @@ def test_a_fan_out_that_does_not_prune_still_cuts_every_document_into_a_share(
 
 
 def _run(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, url: str, root: Path, *extra: str
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    url: str,
+    root: Path,
+    *extra: str,
+    command: str = 'ingest',
 ) -> tuple[int | None, list[str]]:
-    """Run ``sd_results_index`` over one root.
+    """Run one ``sd_results_index`` subcommand over one root.
 
     Parameters:
         tmp_path: Directory the logs are written under.
@@ -393,12 +398,13 @@ def _run(
         url: The index URL.
         root: The results root.
         *extra: Further arguments.
+        command: The subcommand to run.
 
     Returns:
         The exit status, and one entry per line written to the main log.
     """
     return run_driver(
-        ['--results-index-db', url, '--nav-results-root', root.as_posix(), *extra],
+        [command, '--results-index-db', url, '--nav-results-root', root.as_posix(), *extra],
         monkeypatch,
         tmp_path,
     )
@@ -451,9 +457,10 @@ def test_a_fan_out_from_the_command_line_says_it_did_not_prune(
         monkeypatch,
         url,
         root,
-        '--output-cloud-tasks-file',
+        '--tasks-file',
         str(tmp_path / 'tasks.json'),
         '--no-prune',
+        command='divide',
     )
     assert any('left in place' in line for line in written)
 
@@ -471,9 +478,10 @@ def test_a_fan_out_from_the_command_line_leaves_the_row_of_a_deleted_document(
         monkeypatch,
         url,
         root,
-        '--output-cloud-tasks-file',
+        '--tasks-file',
         str(tmp_path / 'tasks.json'),
         '--no-prune',
+        command='divide',
     )
     assert _stubs(url, IMAGES) == [KEPT, LEFT]
 
@@ -524,25 +532,22 @@ def _complete(
         monkeypatch,
         url,
         tmp_path / 'results',
-        '--complete-cloud-tasks-file',
+        '--events-log',
         str(tmp_path / 'events.log'),
         *extra,
+        command='complete',
     )
 
 
-def test_a_completion_that_would_otherwise_finish_refuses_the_flag(
+def test_a_completion_of_a_covered_root_finishes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A completion removes no row, so an operator who typed it meant something else."""
-    url = _a_completed_fan_out(tmp_path, monkeypatch)
-    status, _written = _complete(tmp_path, monkeypatch, url, '--no-prune')
-    assert status == 1
+    """A completion whose tasks account for the root exits 0.
 
-
-def test_the_same_completion_without_the_flag_finishes(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The control that makes the refusal above a refusal rather than a coincidence."""
+    The control for the subcommand surface's refusal of --no-prune here: over a
+    root nobody fanned out, or an index that is not there, this exits nonzero of
+    its own accord and a refusal could not be told from it.
+    """
     url = _a_completed_fan_out(tmp_path, monkeypatch)
     status, _written = _complete(tmp_path, monkeypatch, url)
     assert status == 0
@@ -568,55 +573,19 @@ def test_a_completion_does_not_say_a_document_left_the_tree(
     assert claims == []
 
 
-def test_a_completion_that_refuses_the_flag_says_where_it_belongs(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A refusal nobody can act on is only half a refusal."""
-    url = _a_completed_fan_out(tmp_path, monkeypatch)
-    _status, written = _complete(tmp_path, monkeypatch, url, '--no-prune')
-    refusals = [line for line in written if '--no-prune has no meaning' in line]
-    assert '--output-cloud-tasks-file' in refusals[0]
-
-
-def test_a_drop_that_would_otherwise_run_refuses_the_flag(
+def test_a_drop_of_a_real_index_runs(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A drop removes the index and stops, so it has no tree to have pruned from.
+    """A drop of an index that is really there exits 0.
 
-    The index is a real one, because a drop pointed at a database that is not
-    there exits 1 of its own accord and could not tell a refusal from that.
+    The control for the subcommand surface's refusal of --no-prune here: a drop
+    pointed at a database that is not there exits 1 of its own accord, and a
+    refusal could not be told from it.
     """
     root, _leaving = _tree_of_two(tmp_path)
     url = index_url(tmp_path / 'index.sqlite3')
     _ingest(url, root, logger=quiet_logger)
     status, _written = run_driver(
-        ['--results-index-db', url, '--drop-index', '--yes', '--no-prune'], monkeypatch, tmp_path
-    )
-    assert status == 1
-
-
-def test_the_same_drop_without_the_flag_runs(
-    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The control that makes the refusal above a refusal rather than a coincidence."""
-    root, _leaving = _tree_of_two(tmp_path)
-    url = index_url(tmp_path / 'index.sqlite3')
-    _ingest(url, root, logger=quiet_logger)
-    status, _written = run_driver(
-        ['--results-index-db', url, '--drop-index', '--yes'], monkeypatch, tmp_path
+        ['drop', '--results-index-db', url, '--yes'], monkeypatch, tmp_path
     )
     assert status == 0
-
-
-def test_a_drop_that_refuses_the_flag_names_it(
-    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The refusal names the option it will not combine with, as it does for the others."""
-    root, _leaving = _tree_of_two(tmp_path)
-    url = index_url(tmp_path / 'index.sqlite3')
-    _ingest(url, root, logger=quiet_logger)
-    _status, written = run_driver(
-        ['--results-index-db', url, '--drop-index', '--yes', '--no-prune'], monkeypatch, tmp_path
-    )
-    refusals = [line for line in written if 'nothing to do with' in line]
-    assert '--no-prune' in refusals[0]

--- a/tests/spindoctor/cli/results_index/test_subcommand_surface.py
+++ b/tests/spindoctor/cli/results_index/test_subcommand_surface.py
@@ -116,11 +116,7 @@ def test_the_refusal_of_an_unknown_subcommand_names_the_known_ones(
 def test_a_second_subcommand_is_refused(
     subcommand: str, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Two modes cannot be asked for at once, which is the point of the change.
-
-    Parameters:
-        subcommand: The mode named second, after an ingest.
-    """
+    """Two modes cannot be asked for at once, which is the point of the change."""
     assert subcommand in _refused([sd_results_index.INGEST, subcommand], capsys)
 
 
@@ -143,11 +139,7 @@ def test_dividing_and_completing_cannot_be_asked_for_at_once(
 
 @pytest.mark.parametrize('subcommand', _EVERY_SUBCOMMAND)
 def test_each_subcommand_parses_on_its_own(subcommand: str) -> None:
-    """The control for all of the above, which a parser refusing everything passes.
-
-    Parameters:
-        subcommand: The mode under test.
-    """
+    """The control for all of the above, which a parser refusing everything passes."""
     assert sd_results_index.parse_args(_line(subcommand)).command == subcommand
 
 
@@ -160,11 +152,7 @@ def test_each_subcommand_parses_on_its_own(subcommand: str) -> None:
 def test_the_confirmation_flag_is_refused_by_every_other_subcommand(
     subcommand: str, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """``--yes`` answers a question only the drop asks, so elsewhere it means nothing.
-
-    Parameters:
-        subcommand: The mode that must not take it.
-    """
+    """``--yes`` answers a question only the drop asks, so elsewhere it means nothing."""
     assert '--yes' in _refused(_line(subcommand, '--yes'), capsys)
 
 
@@ -191,22 +179,14 @@ def test_the_drop_is_refused_a_results_root(capsys: pytest.CaptureFixture[str]) 
 
 @pytest.mark.parametrize('subcommand', _READ_A_TREE)
 def test_every_subcommand_that_reads_a_tree_takes_a_results_root(subcommand: str) -> None:
-    """The control: the three that walk one are told which one.
-
-    Parameters:
-        subcommand: The mode under test.
-    """
+    """The control: the three that walk one are told which one."""
     arguments = sd_results_index.parse_args(_line(subcommand, '--nav-results-root', '/data/nav'))
     assert arguments.nav_results_roots == ['/data/nav']
 
 
 @pytest.mark.parametrize('subcommand', _READ_A_TREE)
 def test_a_results_root_may_be_named_more_than_once(subcommand: str) -> None:
-    """One pass may cover several roots, which is what makes this program different.
-
-    Parameters:
-        subcommand: The mode under test.
-    """
+    """One pass may cover several roots, which is what makes this program different."""
     arguments = sd_results_index.parse_args(
         _line(subcommand, '--nav-results-root', '/data/one', '--nav-results-root', '/data/two')
     )
@@ -226,9 +206,6 @@ def test_a_completion_is_refused_the_reading_options(
 
     Whether the shares were read again, and whether the rows of documents that
     have left the tree went, were both settled by the divide that cut them.
-
-    Parameters:
-        option: The option a completion does not take.
     """
     assert option in _refused(_line(sd_results_index.COMPLETE, option), capsys)
 
@@ -237,41 +214,25 @@ def test_a_completion_is_refused_the_reading_options(
 def test_a_drop_is_refused_the_reading_options(
     option: str, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A drop removes the index and stops, so it has no documents and no rows to spare.
-
-    Parameters:
-        option: The option a drop does not take.
-    """
+    """A drop removes the index and stops, so it has no documents and no rows to spare."""
     assert option in _refused(_line(sd_results_index.DROP, option), capsys)
 
 
 @pytest.mark.parametrize('subcommand', _READ_DOCUMENTS)
 def test_the_two_reading_subcommands_take_force(subcommand: str) -> None:
-    """The control for the refusals above, on the option that says what is read.
-
-    Parameters:
-        subcommand: The mode under test.
-    """
+    """The control for the refusals above, on the option that says what is read."""
     assert sd_results_index.parse_args(_line(subcommand, '--force')).force is True
 
 
 @pytest.mark.parametrize('subcommand', _READ_DOCUMENTS)
 def test_the_two_reading_subcommands_take_no_prune(subcommand: str) -> None:
-    """The control for them on the option that says what is removed.
-
-    Parameters:
-        subcommand: The mode under test.
-    """
+    """The control for them on the option that says what is removed."""
     assert sd_results_index.parse_args(_line(subcommand, '--no-prune')).prune is False
 
 
 @pytest.mark.parametrize('subcommand', _READ_DOCUMENTS)
 def test_a_pass_prunes_unless_it_is_told_not_to(subcommand: str) -> None:
-    """Presence of a row meaning what absence means is the default, not an option.
-
-    Parameters:
-        subcommand: The mode under test.
-    """
+    """Presence of a row meaning what absence means is the default, not an option."""
     assert sd_results_index.parse_args(_line(subcommand)).prune is True
 
 
@@ -286,11 +247,7 @@ def test_a_pass_prunes_unless_it_is_told_not_to(subcommand: str) -> None:
 def test_the_tasks_file_belongs_to_the_divide_alone(
     subcommand: str, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Only the pass that cuts the shares writes them out.
-
-    Parameters:
-        subcommand: The mode that must not take it.
-    """
+    """Only the pass that cuts the shares writes them out."""
     assert '--tasks-file' in _refused(_line(subcommand, '--tasks-file', 'tasks.json'), capsys)
 
 
@@ -300,11 +257,7 @@ def test_the_tasks_file_belongs_to_the_divide_alone(
 def test_the_events_log_belongs_to_the_completion_alone(
     subcommand: str, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Only the pass that adds the shares up reads what the workers wrote.
-
-    Parameters:
-        subcommand: The mode that must not take it.
-    """
+    """Only the pass that adds the shares up reads what the workers wrote."""
     assert '--events-log' in _refused(_line(subcommand, '--events-log', 'events.log'), capsys)
 
 
@@ -341,32 +294,20 @@ def test_a_completion_without_an_events_log_is_refused(
 
 @pytest.mark.parametrize('subcommand', _EVERY_SUBCOMMAND)
 def test_every_subcommand_takes_the_index_url(subcommand: str) -> None:
-    """The index is the one thing all four are about.
-
-    Parameters:
-        subcommand: The mode under test.
-    """
+    """The index is the one thing all four are about."""
     assert sd_results_index.parse_args(_line(subcommand)).results_index_db == _URL
 
 
 @pytest.mark.parametrize('subcommand', _EVERY_SUBCOMMAND)
 def test_every_subcommand_takes_a_configuration_file(subcommand: str) -> None:
-    """A machine's settings reach every mode, including the one that reads no tree.
-
-    Parameters:
-        subcommand: The mode under test.
-    """
+    """A machine's settings reach every mode, including the one that reads no tree."""
     arguments = sd_results_index.parse_args(_line(subcommand, '--config-file', 'nav.yaml'))
     assert arguments.config_file == ['nav.yaml']
 
 
 @pytest.mark.parametrize('subcommand', _EVERY_SUBCOMMAND)
 def test_every_subcommand_takes_the_logging_options(subcommand: str) -> None:
-    """A run that fails partway has to appear in a log rather than only in a status.
-
-    Parameters:
-        subcommand: The mode under test.
-    """
+    """A run that fails partway has to appear in a log rather than only in a status."""
     arguments = sd_results_index.parse_args(_line(subcommand, '--log-root', '/var/log/nav'))
     assert arguments.log_root == '/var/log/nav'
 
@@ -412,13 +353,7 @@ def _table_names(url: str) -> list[str]:
 def test_a_refused_command_line_exits_two(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The status of a command line the program never ran is a usage error.
-
-    Parameters:
-        tmp_path: Directory the tree and the index live under.
-        quiet_logger: Logger the ingest reports through.
-        monkeypatch: Fixture the driver is run through.
-    """
+    """The status of a command line the program never ran is a usage error."""
     url = _index_of_one_document(tmp_path, quiet_logger)
     status, _written = run_driver(
         [sd_results_index.DROP, '--results-index-db', url, '--yes', '--force'],
@@ -428,16 +363,41 @@ def test_a_refused_command_line_exits_two(
     assert status == 2
 
 
+@pytest.mark.parametrize(
+    'command',
+    [sd_results_index.INGEST, sd_results_index.DIVIDE, sd_results_index.COMPLETE],
+)
+def test_the_run_header_names_the_subcommand_that_is_running(
+    command: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A log that opens by naming a pass nobody asked for is worse than none."""
+    url = f'sqlite:///{tmp_path / "index.sqlite3"}'
+    argv = [command, '--results-index-db', url, '--nav-results-root', str(tmp_path / 'results')]
+    if command == sd_results_index.DIVIDE:
+        argv += ['--tasks-file', str(tmp_path / 'tasks.json')]
+    if command == sd_results_index.COMPLETE:
+        argv += ['--events-log', str(tmp_path / 'events.jsonl')]
+    _status, written = run_driver(argv, monkeypatch, tmp_path)
+    headers = [line for line in written if line.startswith('Starting results index ')]
+    assert headers[0] == f'Starting results index {command}'
+
+
+def test_a_drop_says_it_is_dropping(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fourth subcommand takes a different path to its own header."""
+    url = _index_of_one_document(tmp_path, quiet_logger)
+    _status, written = run_driver(
+        [sd_results_index.DROP, '--results-index-db', url, '--yes'], monkeypatch, tmp_path
+    )
+    headers = [line for line in written if line.startswith('Starting results index ')]
+    assert headers[0] == f'Starting results index {sd_results_index.DROP}'
+
+
 def test_a_refused_command_line_leaves_the_index_alone(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Refused before anything is opened, so the tables a real drop removes stay.
-
-    Parameters:
-        tmp_path: Directory the tree and the index live under.
-        quiet_logger: Logger the ingest reports through.
-        monkeypatch: Fixture the driver is run through.
-    """
+    """Refused before anything is opened, so the tables a real drop removes stay."""
     url = _index_of_one_document(tmp_path, quiet_logger)
     run_driver(
         [sd_results_index.DROP, '--results-index-db', url, '--yes', '--force'],
@@ -450,13 +410,7 @@ def test_a_refused_command_line_leaves_the_index_alone(
 def test_the_same_command_line_without_the_refused_option_empties_the_index(
     tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The control: without ``--force`` the drop runs and the tables really go.
-
-    Parameters:
-        tmp_path: Directory the tree and the index live under.
-        quiet_logger: Logger the ingest reports through.
-        monkeypatch: Fixture the driver is run through.
-    """
+    """The control: without ``--force`` the drop runs and the tables really go."""
     url = _index_of_one_document(tmp_path, quiet_logger)
     run_driver([sd_results_index.DROP, '--results-index-db', url, '--yes'], monkeypatch, tmp_path)
     assert _table_names(url) == []

--- a/tests/spindoctor/cli/results_index/test_subcommand_surface.py
+++ b/tests/spindoctor/cli/results_index/test_subcommand_surface.py
@@ -371,7 +371,7 @@ def test_the_run_header_names_the_subcommand_that_is_running(
     command: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A log that opens by naming a pass nobody asked for is worse than none."""
-    url = f'sqlite:///{tmp_path / "index.sqlite3"}'
+    url = index_url(tmp_path / 'index.sqlite3')
     argv = [command, '--results-index-db', url, '--nav-results-root', str(tmp_path / 'results')]
     if command == sd_results_index.DIVIDE:
         argv += ['--tasks-file', str(tmp_path / 'tasks.json')]

--- a/tests/spindoctor/cli/results_index/test_subcommand_surface.py
+++ b/tests/spindoctor/cli/results_index/test_subcommand_surface.py
@@ -1,0 +1,462 @@
+"""Which options each ``sd_results_index`` subcommand takes, and which it will not.
+
+The program's four modes are subcommands, so the parser is what makes them
+exclusive: a mode is named once and each carries the options that mode acts on.
+Everything asserted here is an exclusion the program would otherwise have had to
+police itself, and each is asserted twice -- that the option is refused where it
+does not belong, and that it is accepted where it does.  An exclusion asserted
+only in the negative is satisfied by a parser that refuses everything.
+
+The refusals are read from the parser's own error, because that is what an
+operator meets: argparse writes a usage message naming the option to standard
+error and exits 2, and a message that stopped naming the option would leave
+somebody guessing which word of their command line was the problem.
+
+One test runs a refused command line all the way through ``main`` over a real
+index, because "refused" has to mean the database was never opened rather than
+that a message was printed after it was.
+"""
+
+from pathlib import Path
+
+import pdslogger
+import pytest
+import sqlalchemy
+from tests.spindoctor.cli.results_index.ingest_driver_helpers import run_driver
+from tests.spindoctor.conftest import (
+    index_url,
+    ingest_tree,
+    metadata_document,
+    write_metadata,
+)
+
+from spindoctor.cli import sd_results_index
+from spindoctor.results_index import index_table_names
+
+STUB = 'VOL/N1454725799_1_CALIB'
+"""The stub of the document the tree below holds."""
+
+_URL = 'sqlite:///tmp/index.sqlite3'
+"""A well-formed index URL, which parsing never connects to."""
+
+_READ_A_TREE = [sd_results_index.INGEST, sd_results_index.DIVIDE, sd_results_index.COMPLETE]
+"""The subcommands that walk a navigation results tree."""
+
+_READ_DOCUMENTS = [sd_results_index.INGEST, sd_results_index.DIVIDE]
+"""The subcommands that read documents and remove rows."""
+
+_EVERY_SUBCOMMAND = [*_READ_A_TREE, sd_results_index.DROP]
+"""Every subcommand the program offers."""
+
+# The arguments each subcommand needs before it will parse at all, so that a
+# refusal under test is the option it is about rather than a missing path.
+_REQUIRED_OF: dict[str, list[str]] = {
+    sd_results_index.INGEST: [],
+    sd_results_index.DIVIDE: ['--tasks-file', 'tasks.json'],
+    sd_results_index.COMPLETE: ['--events-log', 'events.log'],
+    sd_results_index.DROP: [],
+}
+
+
+def _refused(argv: list[str], capsys: pytest.CaptureFixture[str]) -> str:
+    """Parse a command line that must not parse, and return what was said about it.
+
+    Parameters:
+        argv: The whole command line, without the program name.
+        capsys: Fixture the parser's error is captured through.
+
+    Returns:
+        The parser's message on standard error.
+    """
+    with pytest.raises(SystemExit) as caught:
+        sd_results_index.parse_args(argv)
+    assert caught.value.code == 2
+    return capsys.readouterr().err
+
+
+def _line(subcommand: str, *extra: str) -> list[str]:
+    """Return a command line for one subcommand, carrying whatever it requires.
+
+    Parameters:
+        subcommand: The subcommand to run.
+        *extra: Further arguments, appended after the required ones.
+
+    Returns:
+        The arguments, without the program name.
+    """
+    return [subcommand, '--results-index-db', _URL, *_REQUIRED_OF[subcommand], *extra]
+
+
+# ---------------------------------------------------------------------------
+# One subcommand, named once
+# ---------------------------------------------------------------------------
+
+
+def test_a_command_line_naming_no_subcommand_is_refused(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The mode is the first thing typed, so a line without one asks for nothing."""
+    assert 'COMMAND' in _refused([], capsys)
+
+
+def test_an_unknown_subcommand_is_refused(capsys: pytest.CaptureFixture[str]) -> None:
+    """And the refusal lists the four, which is what somebody who mistyped needs."""
+    assert "invalid choice: 'summarize'" in _refused(['summarize'], capsys)
+
+
+def test_the_refusal_of_an_unknown_subcommand_names_the_known_ones(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A list of what is on offer is the whole use of that refusal."""
+    said = _refused(['summarize'], capsys)
+    assert all(subcommand in said for subcommand in _EVERY_SUBCOMMAND)
+
+
+@pytest.mark.parametrize('subcommand', _EVERY_SUBCOMMAND)
+def test_a_second_subcommand_is_refused(
+    subcommand: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Two modes cannot be asked for at once, which is the point of the change.
+
+    Parameters:
+        subcommand: The mode named second, after an ingest.
+    """
+    assert subcommand in _refused([sd_results_index.INGEST, subcommand], capsys)
+
+
+def test_dividing_and_completing_cannot_be_asked_for_at_once(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Dividing the work up and adding it together are different runs.
+
+    Asking for both would write a tasks file and then complete the run it had
+    just created, before a single worker had read anything.  Each is its own
+    subcommand carrying its own path, so a divide handed the completion's path
+    is refused by the name of that path.
+    """
+    said = _refused(
+        [sd_results_index.DIVIDE, '--tasks-file', 'tasks.json', '--events-log', 'events.log'],
+        capsys,
+    )
+    assert '--events-log' in said
+
+
+@pytest.mark.parametrize('subcommand', _EVERY_SUBCOMMAND)
+def test_each_subcommand_parses_on_its_own(subcommand: str) -> None:
+    """The control for all of the above, which a parser refusing everything passes.
+
+    Parameters:
+        subcommand: The mode under test.
+    """
+    assert sd_results_index.parse_args(_line(subcommand)).command == subcommand
+
+
+# ---------------------------------------------------------------------------
+# The confirmation, which only the drop asks for
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('subcommand', _READ_A_TREE)
+def test_the_confirmation_flag_is_refused_by_every_other_subcommand(
+    subcommand: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--yes`` answers a question only the drop asks, so elsewhere it means nothing.
+
+    Parameters:
+        subcommand: The mode that must not take it.
+    """
+    assert '--yes' in _refused(_line(subcommand, '--yes'), capsys)
+
+
+def test_the_drop_takes_the_confirmation_flag() -> None:
+    """The control: the one subcommand that asks a question can be answered."""
+    assert sd_results_index.parse_args(_line(sd_results_index.DROP, '--yes')).yes is True
+
+
+def test_a_drop_without_the_flag_still_intends_to_ask() -> None:
+    """The default is to ask, so the flag is an opt-out rather than the only path."""
+    assert sd_results_index.parse_args(_line(sd_results_index.DROP)).yes is False
+
+
+# ---------------------------------------------------------------------------
+# The results root, which the drop never reads
+# ---------------------------------------------------------------------------
+
+
+def test_the_drop_is_refused_a_results_root(capsys: pytest.CaptureFixture[str]) -> None:
+    """A drop walks no tree, so a root named on its command line meant another one."""
+    said = _refused(_line(sd_results_index.DROP, '--nav-results-root', '/data/nav'), capsys)
+    assert '--nav-results-root' in said
+
+
+@pytest.mark.parametrize('subcommand', _READ_A_TREE)
+def test_every_subcommand_that_reads_a_tree_takes_a_results_root(subcommand: str) -> None:
+    """The control: the three that walk one are told which one.
+
+    Parameters:
+        subcommand: The mode under test.
+    """
+    arguments = sd_results_index.parse_args(_line(subcommand, '--nav-results-root', '/data/nav'))
+    assert arguments.nav_results_roots == ['/data/nav']
+
+
+@pytest.mark.parametrize('subcommand', _READ_A_TREE)
+def test_a_results_root_may_be_named_more_than_once(subcommand: str) -> None:
+    """One pass may cover several roots, which is what makes this program different.
+
+    Parameters:
+        subcommand: The mode under test.
+    """
+    arguments = sd_results_index.parse_args(
+        _line(subcommand, '--nav-results-root', '/data/one', '--nav-results-root', '/data/two')
+    )
+    assert arguments.nav_results_roots == ['/data/one', '/data/two']
+
+
+# ---------------------------------------------------------------------------
+# What a pass reads and what it removes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('option', ['--force', '--no-prune'])
+def test_a_completion_is_refused_the_reading_options(
+    option: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A completion reads no document and removes no row, so neither asks anything of it.
+
+    Whether the shares were read again, and whether the rows of documents that
+    have left the tree went, were both settled by the divide that cut them.
+
+    Parameters:
+        option: The option a completion does not take.
+    """
+    assert option in _refused(_line(sd_results_index.COMPLETE, option), capsys)
+
+
+@pytest.mark.parametrize('option', ['--force', '--no-prune'])
+def test_a_drop_is_refused_the_reading_options(
+    option: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A drop removes the index and stops, so it has no documents and no rows to spare.
+
+    Parameters:
+        option: The option a drop does not take.
+    """
+    assert option in _refused(_line(sd_results_index.DROP, option), capsys)
+
+
+@pytest.mark.parametrize('subcommand', _READ_DOCUMENTS)
+def test_the_two_reading_subcommands_take_force(subcommand: str) -> None:
+    """The control for the refusals above, on the option that says what is read.
+
+    Parameters:
+        subcommand: The mode under test.
+    """
+    assert sd_results_index.parse_args(_line(subcommand, '--force')).force is True
+
+
+@pytest.mark.parametrize('subcommand', _READ_DOCUMENTS)
+def test_the_two_reading_subcommands_take_no_prune(subcommand: str) -> None:
+    """The control for them on the option that says what is removed.
+
+    Parameters:
+        subcommand: The mode under test.
+    """
+    assert sd_results_index.parse_args(_line(subcommand, '--no-prune')).prune is False
+
+
+@pytest.mark.parametrize('subcommand', _READ_DOCUMENTS)
+def test_a_pass_prunes_unless_it_is_told_not_to(subcommand: str) -> None:
+    """Presence of a row meaning what absence means is the default, not an option.
+
+    Parameters:
+        subcommand: The mode under test.
+    """
+    assert sd_results_index.parse_args(_line(subcommand)).prune is True
+
+
+# ---------------------------------------------------------------------------
+# The two paths, each belonging to one subcommand
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'subcommand', [sd_results_index.INGEST, sd_results_index.COMPLETE, sd_results_index.DROP]
+)
+def test_the_tasks_file_belongs_to_the_divide_alone(
+    subcommand: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Only the pass that cuts the shares writes them out.
+
+    Parameters:
+        subcommand: The mode that must not take it.
+    """
+    assert '--tasks-file' in _refused(_line(subcommand, '--tasks-file', 'tasks.json'), capsys)
+
+
+@pytest.mark.parametrize(
+    'subcommand', [sd_results_index.INGEST, sd_results_index.DIVIDE, sd_results_index.DROP]
+)
+def test_the_events_log_belongs_to_the_completion_alone(
+    subcommand: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Only the pass that adds the shares up reads what the workers wrote.
+
+    Parameters:
+        subcommand: The mode that must not take it.
+    """
+    assert '--events-log' in _refused(_line(subcommand, '--events-log', 'events.log'), capsys)
+
+
+def test_a_divide_takes_the_tasks_file() -> None:
+    """The control: the shares are written where the command line says."""
+    arguments = sd_results_index.parse_args([sd_results_index.DIVIDE, '--tasks-file', 'tasks.json'])
+    assert arguments.tasks_file == 'tasks.json'
+
+
+def test_a_completion_takes_the_events_log() -> None:
+    """The control: the log is read from where the command line says."""
+    arguments = sd_results_index.parse_args(
+        [sd_results_index.COMPLETE, '--events-log', 'events.log']
+    )
+    assert arguments.events_log == 'events.log'
+
+
+def test_a_divide_without_a_tasks_file_is_refused(capsys: pytest.CaptureFixture[str]) -> None:
+    """The shares have to go somewhere, so the path is the subcommand's own subject."""
+    assert '--tasks-file' in _refused([sd_results_index.DIVIDE], capsys)
+
+
+def test_a_completion_without_an_events_log_is_refused(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """And there is nothing to add up without one."""
+    assert '--events-log' in _refused([sd_results_index.COMPLETE], capsys)
+
+
+# ---------------------------------------------------------------------------
+# What every subcommand shares
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('subcommand', _EVERY_SUBCOMMAND)
+def test_every_subcommand_takes_the_index_url(subcommand: str) -> None:
+    """The index is the one thing all four are about.
+
+    Parameters:
+        subcommand: The mode under test.
+    """
+    assert sd_results_index.parse_args(_line(subcommand)).results_index_db == _URL
+
+
+@pytest.mark.parametrize('subcommand', _EVERY_SUBCOMMAND)
+def test_every_subcommand_takes_a_configuration_file(subcommand: str) -> None:
+    """A machine's settings reach every mode, including the one that reads no tree.
+
+    Parameters:
+        subcommand: The mode under test.
+    """
+    arguments = sd_results_index.parse_args(_line(subcommand, '--config-file', 'nav.yaml'))
+    assert arguments.config_file == ['nav.yaml']
+
+
+@pytest.mark.parametrize('subcommand', _EVERY_SUBCOMMAND)
+def test_every_subcommand_takes_the_logging_options(subcommand: str) -> None:
+    """A run that fails partway has to appear in a log rather than only in a status.
+
+    Parameters:
+        subcommand: The mode under test.
+    """
+    arguments = sd_results_index.parse_args(_line(subcommand, '--log-root', '/var/log/nav'))
+    assert arguments.log_root == '/var/log/nav'
+
+
+# ---------------------------------------------------------------------------
+# A refused command line reaches nothing
+# ---------------------------------------------------------------------------
+
+
+def _index_of_one_document(tmp_path: Path, logger: pdslogger.PdsLogger) -> str:
+    """Write a one-document results tree, ingest it, and return the index URL.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        logger: Logger the ingest reports through.
+
+    Returns:
+        The index URL.
+    """
+    root = tmp_path / 'results'
+    write_metadata(root, STUB, metadata_document())
+    url = index_url(tmp_path / 'index.sqlite3')
+    ingest_tree(url, [root], logger=logger)
+    return url
+
+
+def _table_names(url: str) -> list[str]:
+    """Return every table a database holds.
+
+    Parameters:
+        url: The database URL.
+
+    Returns:
+        The table names, sorted.
+    """
+    engine = sqlalchemy.create_engine(url)
+    try:
+        return sorted(sqlalchemy.inspect(engine).get_table_names())
+    finally:
+        engine.dispose()
+
+
+def test_a_refused_command_line_exits_two(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The status of a command line the program never ran is a usage error.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _index_of_one_document(tmp_path, quiet_logger)
+    status, _written = run_driver(
+        [sd_results_index.DROP, '--results-index-db', url, '--yes', '--force'],
+        monkeypatch,
+        tmp_path,
+    )
+    assert status == 2
+
+
+def test_a_refused_command_line_leaves_the_index_alone(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Refused before anything is opened, so the tables a real drop removes stay.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _index_of_one_document(tmp_path, quiet_logger)
+    run_driver(
+        [sd_results_index.DROP, '--results-index-db', url, '--yes', '--force'],
+        monkeypatch,
+        tmp_path,
+    )
+    assert _table_names(url) == sorted(index_table_names())
+
+
+def test_the_same_command_line_without_the_refused_option_empties_the_index(
+    tmp_path: Path, quiet_logger: pdslogger.PdsLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The control: without ``--force`` the drop runs and the tables really go.
+
+    Parameters:
+        tmp_path: Directory the tree and the index live under.
+        quiet_logger: Logger the ingest reports through.
+        monkeypatch: Fixture the driver is run through.
+    """
+    url = _index_of_one_document(tmp_path, quiet_logger)
+    run_driver([sd_results_index.DROP, '--results-index-db', url, '--yes'], monkeypatch, tmp_path)
+    assert _table_names(url) == []

--- a/tests/spindoctor/cli/test_index_opened_only_when_read.py
+++ b/tests/spindoctor/cli/test_index_opened_only_when_read.py
@@ -81,9 +81,9 @@ def _urls_asked_for(module: Any, monkeypatch: pytest.MonkeyPatch) -> list[str | 
     urls: list[str | None] = []
     real = module.build_pointing_source
 
-    def spy(nav_results_root: Any, *, results_db_url: str | None = None) -> Any:
-        urls.append(results_db_url)
-        return real(nav_results_root, results_db_url=results_db_url)
+    def spy(nav_results_root: Any, *, results_index_db_url: str | None = None) -> Any:
+        urls.append(results_index_db_url)
+        return real(nav_results_root, results_index_db_url=results_index_db_url)
 
     monkeypatch.setattr(module, 'build_pointing_source', spy)
     return urls

--- a/tests/spindoctor/cli/test_logging_argument_surface.py
+++ b/tests/spindoctor/cli/test_logging_argument_surface.py
@@ -48,9 +48,14 @@ _WITHOUT_IMAGE_LOGGER = [
     ('sd_consolidate_metadata', ['coiss_saturn']),
     ('sd_create_bundle', ['labels', 'coiss_saturn']),
     ('sd_create_bundle', ['summary', 'coiss_saturn']),
-    # Ingest processes documents rather than images, but a partial or failed
-    # pass has to appear in a run log rather than only in an exit code.
-    ('sd_results_index', []),
+    # The results index processes documents rather than images, but a partial or
+    # failed pass has to appear in a run log rather than only in an exit code --
+    # and that is true of every one of its subcommands, each of which builds a
+    # parser of its own, so each is asked separately.
+    ('sd_results_index', ['ingest']),
+    ('sd_results_index', ['divide']),
+    ('sd_results_index', ['complete']),
+    ('sd_results_index', ['drop']),
 ]
 
 _WITH_ANY_LOGGER = _WITH_IMAGE_LOGGER + _WITHOUT_IMAGE_LOGGER

--- a/tests/spindoctor/cli/test_results_index_db_argument_surface.py
+++ b/tests/spindoctor/cli/test_results_index_db_argument_surface.py
@@ -79,7 +79,12 @@ _INDEX_BACKED: list[tuple[str, list[str]]] = [
 _CONSUMERS: list[tuple[str, list[str]]] = [
     *_INDEX_BACKED,
     ('sd_offset', ['coiss_saturn']),
-    ('sd_results_index', []),
+    # The results index offers the option under each of its four subcommands,
+    # every one of which builds a parser of its own, so each is asked separately.
+    ('sd_results_index', ['ingest']),
+    ('sd_results_index', ['divide']),
+    ('sd_results_index', ['complete']),
+    ('sd_results_index', ['drop']),
     ('sd_stats_report', []),
 ]
 

--- a/tests/spindoctor/cli/test_worker_pointing_source.py
+++ b/tests/spindoctor/cli/test_worker_pointing_source.py
@@ -248,7 +248,7 @@ def test_an_index_that_cannot_be_opened_fails_the_task(
         driver: Which of the two drivers is under test.
     """
     _, result = _refused_index_result(tmp_path, monkeypatch, driver)
-    assert result['status_error'] == 'unusable_results_db'
+    assert result['status_error'] == 'unusable_results_index_db'
 
 
 @pytest.mark.parametrize('driver', ['backplanes', 'mosaic'])
@@ -296,7 +296,7 @@ def test_an_index_named_with_an_empty_value_fails_the_task(
         driver: Which of the two drivers is under test.
     """
     _, result = _empty_index_result(tmp_path, monkeypatch, driver)
-    assert result['status_error'] == 'unusable_results_db'
+    assert result['status_error'] == 'unusable_results_index_db'
 
 
 @pytest.mark.parametrize('driver', ['backplanes', 'mosaic'])

--- a/tests/spindoctor/dataset/conftest.py
+++ b/tests/spindoctor/dataset/conftest.py
@@ -284,13 +284,15 @@ def select_from(results_filter: ResultsFilter, images: list[ImageFile]) -> list[
     return [image.results_path_stub for image in selected]
 
 
-def selection_of(root: Path, flags: dict[str, bool], *, results_db_url: str | None) -> list[str]:
+def selection_of(
+    root: Path, flags: dict[str, bool], *, results_index_db_url: str | None
+) -> list[str]:
     """Answer one filter combination over the fixture tree.
 
     Parameters:
         root: The results root under test.
         flags: The selection flags to apply.
-        results_db_url: The index to answer from, or None to read the tree.
+        results_index_db_url: The index to answer from, or None to read the tree.
 
     Returns:
         The stubs that passed, in enumeration order.
@@ -299,7 +301,7 @@ def selection_of(root: Path, flags: dict[str, bool], *, results_db_url: str | No
         VOLUMES,
         str(root),
         logger=null_logger(),
-        results_db_url=results_db_url,
+        results_index_db_url=results_index_db_url,
         **flags,
     )
     return select_from(results_filter, candidate_files(root))

--- a/tests/spindoctor/dataset/test_carried_record_enumeration.py
+++ b/tests/spindoctor/dataset/test_carried_record_enumeration.py
@@ -162,7 +162,7 @@ def enumerate_images(
     dataset: DataSetPDS3CassiniISS,
     results_root: Path,
     *,
-    results_db_url: str | None = None,
+    results_index_db_url: str | None = None,
     **flags: bool,
 ) -> list[ImageFile]:
     """Run the enumeration exactly as a program does, and collect what it yields.
@@ -170,8 +170,8 @@ def enumerate_images(
     Parameters:
         dataset: The dataset, with its volume index already installed.
         results_root: The navigation results root the filter reads.
-        results_db_url: An index to answer the filter from, or None to read the
-            documents.
+        results_index_db_url: An index to answer the filter from, or None to
+            read the documents.
         flags: The selection flags to apply.
 
     Returns:
@@ -180,7 +180,7 @@ def enumerate_images(
     groups = dataset.yield_image_files_index(
         volumes=[VOLUME],
         nav_results_root=str(results_root),
-        results_db_url=results_db_url,
+        results_index_db_url=results_index_db_url,
         **flags,
     )
     return [image for group in groups for image in group.image_files]
@@ -365,7 +365,7 @@ def test_an_index_backed_run_carries_no_record(
 ) -> None:
     """A row is narrowed on columns, and the record a consumer wants is another read."""
     kept = enumerate_images(
-        ds_with_an_index, results_root, results_db_url=indexed, has_no_offset_error=True
+        ds_with_an_index, results_root, results_index_db_url=indexed, has_no_offset_error=True
     )
 
     assert [image.nav_record for image in kept] == [None]
@@ -376,7 +376,7 @@ def test_an_index_backed_run_selects_the_same_images(
 ) -> None:
     """Stated so that the assertion above is about an image the run kept."""
     kept = enumerate_images(
-        ds_with_an_index, results_root, results_db_url=indexed, has_no_offset_error=True
+        ds_with_an_index, results_root, results_index_db_url=indexed, has_no_offset_error=True
     )
 
     assert [image.results_path_stub for image in kept] == [SUCCEEDED]
@@ -390,7 +390,7 @@ def test_an_index_backed_run_reads_no_document_at_all(
 ) -> None:
     """The filter reads rows, so the enumeration opens none of the documents."""
     enumerate_images(
-        ds_with_an_index, results_root, results_db_url=indexed, has_no_offset_error=True
+        ds_with_an_index, results_root, results_index_db_url=indexed, has_no_offset_error=True
     )
 
     assert count_reads == []

--- a/tests/spindoctor/dataset/test_dataset_pds3.py
+++ b/tests/spindoctor/dataset/test_dataset_pds3.py
@@ -276,7 +276,7 @@ def test_a_results_index_answers_the_offset_file_filter(
             volumes=['COISS_2001'],
             has_offset_file=True,
             nav_results_root=str(results_root),
-            results_db_url=url,
+            results_index_db_url=url,
         )
     )
 

--- a/tests/spindoctor/dataset/test_results_filter_dropped.py
+++ b/tests/spindoctor/dataset/test_results_filter_dropped.py
@@ -123,7 +123,7 @@ def _scan(root: Path, stubs: Sequence[str]) -> list[str]:
         VOLUMES,
         str(root),
         logger=reporting_logger(),
-        results_db_url=None,
+        results_index_db_url=None,
         has_offset_spice_error=True,
     ) as under_test:
         return select_from(under_test, _candidate_files(root, stubs))
@@ -262,7 +262,7 @@ def test_a_filter_closed_again_does_not_report_a_second_scan(
         VOLUMES,
         str(root),
         logger=reporting_logger(),
-        results_db_url=None,
+        results_index_db_url=None,
         has_offset_spice_error=True,
     )
     select_from(under_test, _candidate_files(root, [EARLIER_SCHEMA]))

--- a/tests/spindoctor/dataset/test_results_filter_index.py
+++ b/tests/spindoctor/dataset/test_results_filter_index.py
@@ -94,7 +94,7 @@ def test_the_tree_answers_each_filter(
     tree: Path, flags: dict[str, bool], expected: list[str]
 ) -> None:
     """What reading the results tree selects, stated rather than compared."""
-    assert selection_of(tree, flags, results_db_url=None) == expected
+    assert selection_of(tree, flags, results_index_db_url=None) == expected
 
 
 @pytest.mark.parametrize(('flags', 'expected'), _MATRIX)
@@ -102,7 +102,7 @@ def test_the_index_answers_each_filter_the_same_way(
     tree: Path, indexed: str, flags: dict[str, bool], expected: list[str]
 ) -> None:
     """One query reaches the answer the walk and the per-image reads reach."""
-    assert selection_of(tree, flags, results_db_url=indexed) == expected
+    assert selection_of(tree, flags, results_index_db_url=indexed) == expected
 
 
 @pytest.mark.parametrize(('flags', 'expected'), _MATRIX)
@@ -135,7 +135,7 @@ def test_the_index_path_reads_no_file_at_all(
     monkeypatch.setattr(FCPath, 'walk', refuse)
     monkeypatch.setattr(FCPath, 'exists', refuse)
     monkeypatch.setattr(FCPath, 'retrieve', refuse)
-    assert selection_of(tree, flags, results_db_url=indexed) == expected
+    assert selection_of(tree, flags, results_index_db_url=indexed) == expected
 
 
 def test_an_image_with_no_document_is_not_one_recording_no_error_in_the_tree(tree: Path) -> None:
@@ -145,7 +145,7 @@ def test_an_image_with_no_document_is_not_one_recording_no_error_in_the_tree(tre
     selects.  Reading its absence as an outcome would put it in both selections
     at once and leave no way to ask for either without the other.
     """
-    kept = selection_of(tree, {'has_no_offset_error': True}, results_db_url=None)
+    kept = selection_of(tree, {'has_no_offset_error': True}, results_index_db_url=None)
     assert NO_RESULT not in kept
 
 
@@ -174,7 +174,7 @@ def test_an_error_filter_passes_over_an_image_with_no_document(tree: Path, flag:
         flag: The error filter, one per flag that reads a document.
     """
     results_filter = ResultsFilter(
-        VOLUMES, str(tree), logger=null_logger(), results_db_url=None, **{flag: True}
+        VOLUMES, str(tree), logger=null_logger(), results_index_db_url=None, **{flag: True}
     )
     assert results_filter.passes(NO_RESULT) is False
 
@@ -183,7 +183,7 @@ def test_an_image_with_no_row_is_not_one_recording_no_error_in_the_index(
     tree: Path, indexed: str
 ) -> None:
     """Absence of a row is absence of a document, and reads the same way here."""
-    kept = selection_of(tree, {'has_no_offset_error': True}, results_db_url=indexed)
+    kept = selection_of(tree, {'has_no_offset_error': True}, results_index_db_url=indexed)
     assert NO_RESULT not in kept
 
 
@@ -279,7 +279,7 @@ def test_the_tree_reads_a_document_naming_no_outcome(
     root = tmp_path / 'results'
     images = _naming_no_outcome(root, status)
     results_filter = ResultsFilter(
-        VOLUMES, str(root), logger=null_logger(), results_db_url=None, **flags
+        VOLUMES, str(root), logger=null_logger(), results_index_db_url=None, **flags
     )
     assert select_from(results_filter, images) == expected
 
@@ -309,7 +309,7 @@ def test_the_index_reads_a_document_naming_no_outcome_the_same_way(
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [root], logger=null_logger())
     results_filter = ResultsFilter(
-        VOLUMES, str(root), logger=null_logger(), results_db_url=url, **flags
+        VOLUMES, str(root), logger=null_logger(), results_index_db_url=url, **flags
     )
     assert select_from(results_filter, images) == expected
 
@@ -368,7 +368,7 @@ def _selecting_one_object(
         url = index_url(tmp_path / 'index.sqlite3')
         ingest_tree(url, [root], logger=null_logger())
     results_filter = ResultsFilter(
-        VOLUMES, str(root), logger=null_logger(), results_db_url=url, **flags
+        VOLUMES, str(root), logger=null_logger(), results_index_db_url=url, **flags
     )
     return select_from(results_filter, images)
 
@@ -476,7 +476,7 @@ def test_a_document_that_left_the_tree_reads_as_absent_in_the_index(tmp_path: Pa
     """
     root, images, url = _index_after_a_document_left_the_tree(tmp_path)
     results_filter = ResultsFilter(
-        VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_offset_file=True
+        VOLUMES, str(root), logger=null_logger(), results_index_db_url=url, has_offset_file=True
     )
     assert select_from(results_filter, images) == [SECOND_SUCCESS]
 
@@ -500,7 +500,7 @@ def test_the_index_offers_a_document_that_left_the_tree_to_the_absence_filter(
     """
     root, images, url = _index_after_a_document_left_the_tree(tmp_path)
     results_filter = ResultsFilter(
-        VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_no_offset_file=True
+        VOLUMES, str(root), logger=null_logger(), results_index_db_url=url, has_no_offset_file=True
     )
     assert select_from(results_filter, images) == [SPICE_ERROR]
 
@@ -555,7 +555,7 @@ def test_a_document_the_database_would_not_store_leaves_the_root_unreadable(
     monkeypatch.undo()
     with pytest.raises(SelectionError, match='no completed ingest'):
         ResultsFilter(
-            VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_offset_file=True
+            VOLUMES, str(root), logger=null_logger(), results_index_db_url=url, has_offset_file=True
         )
 
 
@@ -622,7 +622,7 @@ def _engines_built_answering(
     monkeypatch.setattr(sqlalchemy, 'create_engine', recording)
     monkeypatch.setattr(sqlalchemy.Engine, 'dispose', counting)
     ResultsFilter(
-        VOLUMES, str(tree), logger=null_logger(), results_db_url=indexed, has_offset_file=True
+        VOLUMES, str(tree), logger=null_logger(), results_index_db_url=indexed, has_offset_file=True
     )
     assert built != []
     return built

--- a/tests/spindoctor/dataset/test_results_filter_index_divergence.py
+++ b/tests/spindoctor/dataset/test_results_filter_index_divergence.py
@@ -60,7 +60,7 @@ def test_a_file_the_pass_could_not_retrieve_reads_as_absent(
     ingest_tree(url, [root], logger=null_logger())
     monkeypatch.undo()
     results_filter = ResultsFilter(
-        VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_offset_file=True
+        VOLUMES, str(root), logger=null_logger(), results_index_db_url=url, has_offset_file=True
     )
     assert select_from(results_filter, images) == []
 
@@ -166,7 +166,11 @@ def test_a_document_rewritten_in_place_reads_as_its_previous_self_in_the_index(
     """
     root, images, url = _index_after_a_document_was_rewritten_in_place(tmp_path)
     results_filter = ResultsFilter(
-        VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_offset_spice_error=True
+        VOLUMES,
+        str(root),
+        logger=null_logger(),
+        results_index_db_url=url,
+        has_offset_spice_error=True,
     )
     assert select_from(results_filter, images) == [SPICE_ERROR]
 
@@ -181,7 +185,11 @@ def test_a_rewrite_that_changes_the_length_is_read_again(tmp_path: Path) -> None
         tmp_path, keeping_its_size=False
     )
     results_filter = ResultsFilter(
-        VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_offset_spice_error=True
+        VOLUMES,
+        str(root),
+        logger=null_logger(),
+        results_index_db_url=url,
+        has_offset_spice_error=True,
     )
     assert select_from(results_filter, images) == []
 
@@ -195,6 +203,10 @@ def test_a_forced_pass_corrects_a_document_rewritten_in_place(tmp_path: Path) ->
     root, images, url = _index_after_a_document_was_rewritten_in_place(tmp_path)
     ingest_tree(url, [root], logger=null_logger(), force=True)
     results_filter = ResultsFilter(
-        VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_offset_spice_error=True
+        VOLUMES,
+        str(root),
+        logger=null_logger(),
+        results_index_db_url=url,
+        has_offset_spice_error=True,
     )
     assert select_from(results_filter, images) == []

--- a/tests/spindoctor/dataset/test_results_filter_index_reporting.py
+++ b/tests/spindoctor/dataset/test_results_filter_index_reporting.py
@@ -43,7 +43,7 @@ def test_the_report_says_how_old_the_index_answer_is(
         VOLUMES,
         str(root),
         logger=reporting_logger(),
-        results_db_url=url,
+        results_index_db_url=url,
         has_no_offset_file=True,
     )
     assert '2 days ago' in capsys.readouterr().out
@@ -61,7 +61,7 @@ def test_the_report_names_the_moment_as_well_as_the_interval(
         VOLUMES,
         str(root),
         logger=reporting_logger(),
-        results_db_url=url,
+        results_index_db_url=url,
         has_no_offset_file=True,
     )
     assert stamp in capsys.readouterr().out
@@ -79,7 +79,7 @@ def test_the_age_is_that_of_this_roots_pass_and_not_another(
         VOLUMES,
         str(root),
         logger=reporting_logger(),
-        results_db_url=url,
+        results_index_db_url=url,
         has_no_offset_file=True,
     )
     assert '2026-03-04T05:06:07+00:00' not in capsys.readouterr().out
@@ -100,7 +100,7 @@ def test_a_finish_time_that_will_not_parse_is_reported_as_it_stands(
         VOLUMES,
         str(root),
         logger=reporting_logger(),
-        results_db_url=url,
+        results_index_db_url=url,
         has_no_offset_file=True,
     )
     assert 'ingested whenever it was' in capsys.readouterr().out
@@ -124,7 +124,7 @@ def test_a_finish_time_in_the_future_is_reported_as_it_stands(
         VOLUMES,
         str(root),
         logger=reporting_logger(),
-        results_db_url=url,
+        results_index_db_url=url,
         has_no_offset_file=True,
     )
     assert reported_line(capsys.readouterr().out).endswith(stamp)
@@ -148,7 +148,7 @@ def test_a_finish_time_with_no_offset_is_read_as_utc(
         VOLUMES,
         str(root),
         logger=reporting_logger(),
-        results_db_url=url,
+        results_index_db_url=url,
         has_no_offset_file=True,
     )
     assert reported_line(capsys.readouterr().out).endswith(f'{naive} (2 days ago)')
@@ -173,7 +173,7 @@ def test_a_recorded_finish_time_of_nothing_is_reported_as_nothing(
         VOLUMES,
         str(root),
         logger=reporting_logger(),
-        results_db_url=url,
+        results_index_db_url=url,
         has_no_offset_file=True,
     )
     assert 'at a time this index does not record' in capsys.readouterr().out

--- a/tests/spindoctor/dataset/test_results_filter_refusals.py
+++ b/tests/spindoctor/dataset/test_results_filter_refusals.py
@@ -145,7 +145,7 @@ def _refusal_of(tree: Path, names: Sequence[str]) -> str | None:
     """
     flags = dict.fromkeys(names, True)
     try:
-        ResultsFilter(VOLUMES, str(tree), logger=null_logger(), results_db_url=None, **flags)
+        ResultsFilter(VOLUMES, str(tree), logger=null_logger(), results_index_db_url=None, **flags)
     except SelectionError as exc:
         return str(exc)
     return None
@@ -229,7 +229,9 @@ def test_a_contradictory_pair_is_refused_before_the_index_is_opened(
     """
     absent = index_url(tmp_path / 'not-an-index.sqlite3')
     with pytest.raises(ValueError, match=CONTRADICTION_REFUSAL) as excinfo:
-        ResultsFilter(VOLUMES, str(tree), logger=null_logger(), results_db_url=absent, **flags)
+        ResultsFilter(
+            VOLUMES, str(tree), logger=null_logger(), results_index_db_url=absent, **flags
+        )
     assert 'not-an-index.sqlite3' not in str(excinfo.value)
 
 
@@ -250,7 +252,7 @@ def test_a_refusal_names_every_flag_that_made_the_selection_impossible(
         flags: The contradictory pair.
     """
     with pytest.raises(SelectionError) as excinfo:
-        ResultsFilter(VOLUMES, str(tree), logger=null_logger(), results_db_url=None, **flags)
+        ResultsFilter(VOLUMES, str(tree), logger=null_logger(), results_index_db_url=None, **flags)
     assert [name for name in flags if name not in str(excinfo.value)] == []
 
 
@@ -262,7 +264,7 @@ def test_a_root_with_no_completed_ingest_is_refused(tree: Path, indexed: str) ->
             VOLUMES,
             str(other_root),
             logger=null_logger(),
-            results_db_url=indexed,
+            results_index_db_url=indexed,
             has_offset_file=True,
         )
     assert other_root.as_posix() in str(excinfo.value)
@@ -275,7 +277,11 @@ def test_an_index_that_cannot_be_opened_is_not_a_reason_to_read_files(
     absent = index_url(tmp_path / 'not-an-index.sqlite3')
     with pytest.raises(ValueError, match='sd_results_index') as excinfo:
         ResultsFilter(
-            VOLUMES, str(tree), logger=null_logger(), results_db_url=absent, has_offset_file=True
+            VOLUMES,
+            str(tree),
+            logger=null_logger(),
+            results_index_db_url=absent,
+            has_offset_file=True,
         )
     assert 'not-an-index.sqlite3' in str(excinfo.value)
 
@@ -291,7 +297,7 @@ def test_an_index_that_will_not_answer_refuses_the_selection(tmp_path: Path) -> 
     url = index_without_a_table(tmp_path, root, 'failed_files')
     with pytest.raises(SelectionError, match='could not be read'):
         ResultsFilter(
-            VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_offset_file=True
+            VOLUMES, str(root), logger=null_logger(), results_index_db_url=url, has_offset_file=True
         )
 
 
@@ -301,7 +307,7 @@ def test_an_index_that_will_not_answer_raises_no_database_exception(tmp_path: Pa
     url = index_without_a_table(tmp_path, root, 'failed_files')
     with pytest.raises(SelectionError) as excinfo:
         ResultsFilter(
-            VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_offset_file=True
+            VOLUMES, str(root), logger=null_logger(), results_index_db_url=url, has_offset_file=True
         )
     assert not isinstance(excinfo.value, sqlalchemy.exc.SQLAlchemyError)
 
@@ -312,7 +318,11 @@ def test_an_index_that_cannot_be_opened_refuses_the_selection(tmp_path: Path) ->
     absent = index_url(tmp_path / 'not-an-index.sqlite3')
     with pytest.raises(SelectionError, match='sd_results_index'):
         ResultsFilter(
-            VOLUMES, str(root), logger=null_logger(), results_db_url=absent, has_offset_file=True
+            VOLUMES,
+            str(root),
+            logger=null_logger(),
+            results_index_db_url=absent,
+            has_offset_file=True,
         )
 
 
@@ -323,7 +333,7 @@ def test_a_root_the_index_does_not_cover_refuses_the_selection(tree: Path, index
             VOLUMES,
             str(tree.parent / 'never-ingested'),
             logger=null_logger(),
-            results_db_url=indexed,
+            results_index_db_url=indexed,
             has_offset_file=True,
         )
 
@@ -351,7 +361,7 @@ def test_the_refusal_does_not_repeat_the_query_that_failed(tmp_path: Path) -> No
     url = index_without_a_table(tmp_path, root, 'failed_files')
     with pytest.raises(SelectionError) as excinfo:
         ResultsFilter(
-            VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_offset_file=True
+            VOLUMES, str(root), logger=null_logger(), results_index_db_url=url, has_offset_file=True
         )
     assert 'SELECT' not in str(excinfo.value)
 
@@ -362,7 +372,7 @@ def test_the_refusal_carries_what_the_driver_said(tmp_path: Path) -> None:
     url = index_without_a_table(tmp_path, root, 'failed_files')
     with pytest.raises(SelectionError, match='no such table: failed_files'):
         ResultsFilter(
-            VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_offset_file=True
+            VOLUMES, str(root), logger=null_logger(), results_index_db_url=url, has_offset_file=True
         )
 
 
@@ -382,7 +392,7 @@ def test_a_failure_of_the_bookkeeping_query_is_translated_too(tmp_path: Path) ->
     url = index_without_a_table(tmp_path, root, 'ingest_runs')
     with pytest.raises(SelectionError, match='could not be read'):
         ResultsFilter(
-            VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_offset_file=True
+            VOLUMES, str(root), logger=null_logger(), results_index_db_url=url, has_offset_file=True
         )
 
 
@@ -398,7 +408,7 @@ def test_a_failure_of_the_bookkeeping_query_raises_no_database_exception(
     url = index_without_a_table(tmp_path, root, 'ingest_runs')
     with pytest.raises(SelectionError) as excinfo:
         ResultsFilter(
-            VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_offset_file=True
+            VOLUMES, str(root), logger=null_logger(), results_index_db_url=url, has_offset_file=True
         )
     assert not isinstance(excinfo.value, sqlalchemy.exc.SQLAlchemyError)
 
@@ -413,7 +423,7 @@ def test_a_failure_of_the_bookkeeping_query_names_the_table(tmp_path: Path) -> N
     url = index_without_a_table(tmp_path, root, 'ingest_runs')
     with pytest.raises(SelectionError, match='no such table: ingest_runs'):
         ResultsFilter(
-            VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_offset_file=True
+            VOLUMES, str(root), logger=null_logger(), results_index_db_url=url, has_offset_file=True
         )
 
 
@@ -432,7 +442,7 @@ def test_an_index_that_stops_answering_a_scan_of_candidates_refuses_the_selectio
     root, images = one_image_tree(tmp_path)
     url = index_without_a_table(tmp_path, root, 'failed_files')
     scan = ResultsFilter(
-        VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_no_offset_file=True
+        VOLUMES, str(root), logger=null_logger(), results_index_db_url=url, has_no_offset_file=True
     )
     with scan, pytest.raises(SelectionError, match='could not be read'):
         scan.filter_batch(images)
@@ -449,7 +459,7 @@ def test_an_index_that_stops_answering_a_scan_of_candidates_raises_no_database_e
     root, images = one_image_tree(tmp_path)
     url = index_without_a_table(tmp_path, root, 'failed_files')
     scan = ResultsFilter(
-        VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_no_offset_file=True
+        VOLUMES, str(root), logger=null_logger(), results_index_db_url=url, has_no_offset_file=True
     )
     with scan, pytest.raises(SelectionError) as excinfo:
         scan.filter_batch(images)
@@ -479,7 +489,11 @@ def test_a_scan_of_candidates_refused_at_the_bookkeeping_query_leaves_no_storage
     monkeypatch.setattr(results_filter, 'open_record_source', opening)
     with pytest.raises(SelectionError, match='could not be read'):
         ResultsFilter(
-            VOLUMES, str(root), logger=null_logger(), results_db_url=url, has_no_offset_file=True
+            VOLUMES,
+            str(root),
+            logger=null_logger(),
+            results_index_db_url=url,
+            has_no_offset_file=True,
         )
     assert source.closes == 1
 
@@ -610,7 +624,7 @@ def test_a_refusal_from_the_report_releases_the_storage_as_well(
     source = _CountingSource()
     _opening(monkeypatch, source)
 
-    def refusing(results_db_url: str, root: Any) -> str:
+    def refusing(results_index_db_url: str, root: Any) -> str:
         raise ValueError('this results index could not be read')
 
     monkeypatch.setattr(results_filter, 'snapshot_finish_time', refusing)
@@ -619,7 +633,7 @@ def test_a_refusal_from_the_report_releases_the_storage_as_well(
             VOLUMES,
             str(tmp_path),
             logger=null_logger(),
-            results_db_url='sqlite+pysqlite:///nothing-is-opened',
+            results_index_db_url='sqlite+pysqlite:///nothing-is-opened',
             has_offset_error=True,
         )
     assert source.closes == 1

--- a/tests/spindoctor/dataset/test_results_filter_scan_report.py
+++ b/tests/spindoctor/dataset/test_results_filter_scan_report.py
@@ -41,19 +41,19 @@ def _tree(tmp_path: Path) -> Path:
     return root
 
 
-def _scanned(root: Path, *, results_db_url: str | None, **flags: bool) -> None:
+def _scanned(root: Path, *, results_index_db_url: str | None, **flags: bool) -> None:
     """Run every candidate of the fixture tree through one filter and close it.
 
     Parameters:
         root: The results root under test.
-        results_db_url: The index to answer from, or None to read the tree.
+        results_index_db_url: The index to answer from, or None to read the tree.
         flags: The selection flags to apply.
     """
     with ResultsFilter(
         VOLUMES,
         str(root),
         logger=reporting_logger(),
-        results_db_url=results_db_url,
+        results_index_db_url=results_index_db_url,
         **flags,
     ) as results_filter:
         select_from(results_filter, candidate_files(root))
@@ -69,7 +69,7 @@ def test_a_scan_that_listed_the_volumes_says_what_the_tree_holds(
         capsys: Fixture the logger's own stream is read back through.
     """
     root = _tree(tmp_path)
-    _scanned(root, results_db_url=None, has_offset_file=True)
+    _scanned(root, results_index_db_url=None, has_offset_file=True)
     found = f'Results scan found {len(CANDIDATES) - 1} offset metadata files'
     assert found in capsys.readouterr().out
 
@@ -84,7 +84,7 @@ def test_a_scan_that_listed_the_volumes_says_what_the_index_holds(
         capsys: Fixture the logger's own stream is read back through.
     """
     root = _tree(tmp_path)
-    _scanned(root, results_db_url=index_of_two_roots(tmp_path, root), has_offset_file=True)
+    _scanned(root, results_index_db_url=index_of_two_roots(tmp_path, root), has_offset_file=True)
     held = f'Results index holds {len(CANDIDATES) - 1} offset metadata files'
     assert held in capsys.readouterr().out
 
@@ -99,7 +99,7 @@ def test_a_scan_that_names_its_candidates_says_so_before_it_starts(
         capsys: Fixture the logger's own stream is read back through.
     """
     root = _tree(tmp_path)
-    _scanned(root, results_db_url=None, has_no_offset_file=True)
+    _scanned(root, results_index_db_url=None, has_no_offset_file=True)
     assert 'Results scan will ask' in capsys.readouterr().out
 
 
@@ -116,7 +116,7 @@ def test_a_scan_that_names_its_candidates_still_reports_the_age_of_an_index(
         capsys: Fixture the logger's own stream is read back through.
     """
     root = _tree(tmp_path)
-    _scanned(root, results_db_url=index_of_two_roots(tmp_path, root), has_no_offset_file=True)
+    _scanned(root, results_index_db_url=index_of_two_roots(tmp_path, root), has_no_offset_file=True)
     assert 'Results index answers about the images under' in capsys.readouterr().out
 
 
@@ -130,7 +130,7 @@ def test_a_closed_scan_says_how_many_candidates_it_asked_about(
         capsys: Fixture the logger's own stream is read back through.
     """
     root = _tree(tmp_path)
-    _scanned(root, results_db_url=None, has_no_offset_file=True)
+    _scanned(root, results_index_db_url=None, has_no_offset_file=True)
     assert f'Results scan asked about {len(CANDIDATES)} images' in capsys.readouterr().out
 
 
@@ -144,7 +144,7 @@ def test_a_closed_scan_says_how_many_of_them_were_already_navigated(
         capsys: Fixture the logger's own stream is read back through.
     """
     root = _tree(tmp_path)
-    _scanned(root, results_db_url=None, has_no_offset_file=True)
+    _scanned(root, results_index_db_url=None, has_no_offset_file=True)
     found = len(CANDIDATES) - 1
     assert f'{found} of which had a navigation document' in capsys.readouterr().out
 

--- a/tests/spindoctor/dataset/test_results_filter_scope.py
+++ b/tests/spindoctor/dataset/test_results_filter_scope.py
@@ -255,7 +255,7 @@ def _answering(
     root = _write_roots(tmp_path)
     url = _ingested(tmp_path, root) if from_an_index else None
     results_filter = ResultsFilter(
-        volumes, str(root), logger=null_logger(), results_db_url=url, **flags
+        volumes, str(root), logger=null_logger(), results_index_db_url=url, **flags
     )
     return select_from(results_filter, _candidate_files(root))
 
@@ -480,7 +480,7 @@ def test_a_relative_results_root_names_the_root_the_ingest_recorded(
     url = _ingested(tmp_path, root)
     monkeypatch.chdir(tmp_path)
     results_filter = ResultsFilter(
-        VOLUMES, root.name, logger=null_logger(), results_db_url=url, has_offset_file=True
+        VOLUMES, root.name, logger=null_logger(), results_index_db_url=url, has_offset_file=True
     )
     assert select_from(results_filter, _candidate_files(root)) == [
         SELECTED,
@@ -508,7 +508,7 @@ def test_a_root_named_through_a_parent_segment_is_the_root_the_ingest_recorded(
         VOLUMES,
         f'{tmp_path.as_posix()}/other-results/../results',
         logger=null_logger(),
-        results_db_url=url,
+        results_index_db_url=url,
         has_offset_file=True,
     )
     assert select_from(results_filter, _candidate_files(root)) == [
@@ -703,7 +703,9 @@ def _subtrees_asked_about(
         return _RecordingSource(asked, [])
 
     monkeypatch.setattr(results_filter, 'open_record_source', recording)
-    ResultsFilter(iter(VOLUMES), str(tmp_path), logger=null_logger(), results_db_url=None, **flags)
+    ResultsFilter(
+        iter(VOLUMES), str(tmp_path), logger=null_logger(), results_index_db_url=None, **flags
+    )
     return asked
 
 
@@ -875,7 +877,9 @@ def _source_of(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, **flags: bool) -
         return source
 
     monkeypatch.setattr(results_filter, 'open_record_source', recording)
-    with ResultsFilter(VOLUMES, str(tmp_path), logger=null_logger(), results_db_url=None, **flags):
+    with ResultsFilter(
+        VOLUMES, str(tmp_path), logger=null_logger(), results_index_db_url=None, **flags
+    ):
         pass
     return source
 
@@ -954,7 +958,7 @@ def test_only_a_filter_that_reads_documents_asks_the_enumeration_to_batch(
         batches: Whether this filter has anything left to ask per batch.
     """
     with ResultsFilter(
-        VOLUMES, str(tmp_path), logger=null_logger(), results_db_url=None, **flags
+        VOLUMES, str(tmp_path), logger=null_logger(), results_index_db_url=None, **flags
     ) as results_filter_under_test:
         assert results_filter_under_test.needs_batch_filtering is batches
 

--- a/tests/spindoctor/results_index/conftest.py
+++ b/tests/spindoctor/results_index/conftest.py
@@ -804,7 +804,9 @@ def facts_from_index(
     Returns:
         What the stream yielded, in stub order.
     """
-    with open_record_source([held.root(which)], results_db_url=held.url, columns=COLUMNS) as source:
+    with open_record_source(
+        [held.root(which)], results_index_db_url=held.url, columns=COLUMNS
+    ) as source:
         return _in_order(source.facts(selection))
 
 
@@ -825,7 +827,9 @@ def named_facts_from_index(
     Returns:
         What the stream yielded, in the order it yielded it.
     """
-    with open_record_source([held.root(which)], results_db_url=held.url, columns=COLUMNS) as source:
+    with open_record_source(
+        [held.root(which)], results_index_db_url=held.url, columns=COLUMNS
+    ) as source:
         return list(source.facts(selection))
 
 

--- a/tests/spindoctor/results_index/test_engine.py
+++ b/tests/spindoctor/results_index/test_engine.py
@@ -220,7 +220,7 @@ def test_the_version_message_says_to_delete_and_re_ingest(tmp_path: Path) -> Non
         tmp_path: Directory holding the database.
     """
     path = _index_stamped_with_another_version(tmp_path)
-    with pytest.raises(ValueError, match='empty the database with sd_results_index --drop-index'):
+    with pytest.raises(ValueError, match='empty the database with sd_results_index drop'):
         open_index(sqlite_url_for(path))
 
 

--- a/tests/spindoctor/results_index/test_enumeration_lists.py
+++ b/tests/spindoctor/results_index/test_enumeration_lists.py
@@ -64,7 +64,7 @@ validating any of them.
 """
 
 PLANS = FCPath(Path(__file__).resolve().parents[3]) / 'plans'
-PLAN = PLANS / 'RESULTS_DB_PLAN.md'
+PLAN = PLANS / 'RESULTS_INDEX_PLAN.md'
 """The plan, which states the enumeration twice: in Phase 5 and in criterion 1."""
 
 NAVIGATION_GUIDE = (

--- a/tests/spindoctor/results_index/test_facts_stream_index.py
+++ b/tests/spindoctor/results_index/test_facts_stream_index.py
@@ -271,7 +271,7 @@ def test_a_selection_naming_a_root_the_source_does_not_hold_is_refused(
     """
     with (
         open_record_source(
-            [two_roots.first], results_db_url=two_roots.url, columns=COLUMNS
+            [two_roots.first], results_index_db_url=two_roots.url, columns=COLUMNS
         ) as source,
         pytest.raises(ValueError, match='does not hold'),
     ):

--- a/tests/spindoctor/results_index/test_facts_stream_merge.py
+++ b/tests/spindoctor/results_index/test_facts_stream_merge.py
@@ -337,7 +337,7 @@ def test_a_child_row_belonging_to_no_yielded_image_fails_the_read(
     )
     with (
         open_record_source(
-            [two_roots.first], results_db_url=two_roots.url, columns=COLUMNS
+            [two_roots.first], results_index_db_url=two_roots.url, columns=COLUMNS
         ) as source,
         pytest.raises(ValueError, match='did not answer from one state'),
     ):

--- a/tests/spindoctor/results_index/test_postgres.py
+++ b/tests/spindoctor/results_index/test_postgres.py
@@ -216,7 +216,7 @@ def test_the_version_message_says_to_delete_and_re_ingest(postgres_url: str) -> 
     """
     with opened(postgres_url, create=True) as engine, engine.begin() as connection:
         connection.execute(SCHEMA_META.update().values(schema_version=SCHEMA_VERSION + 1))
-    with pytest.raises(ValueError, match='empty the database with sd_results_index --drop-index'):
+    with pytest.raises(ValueError, match='empty the database with sd_results_index drop'):
         open_index(postgres_url)
 
 
@@ -698,7 +698,7 @@ def _selecting(url: str, **flags: bool) -> list[str]:
         [SELECTION_SUBTREE],
         SELECTION_ROOT,
         logger=pdslogger.NullLogger(),
-        results_db_url=url,
+        results_index_db_url=url,
         **flags,
     ) as results_filter:
         kept = [stub for stub in SELECTION_CANDIDATES if results_filter.passes(stub)]
@@ -822,7 +822,7 @@ def test_the_snapshot_time_answers_for_one_root_on_postgresql(
         [SELECTION_SUBTREE],
         SELECTION_ROOT,
         logger=pdslogger.PdsLogger(f'postgres_selection_{uuid.uuid4().hex}'),
-        results_db_url=postgres_url,
+        results_index_db_url=postgres_url,
         has_offset_file=True,
     )
     assert SELECTION_INGESTED in capsys.readouterr().out
@@ -1046,7 +1046,9 @@ def _record_source(url: str, *roots: str) -> Iterator[RecordSource]:
     Yields:
         The source.
     """
-    with open_record_source(list(roots), results_db_url=url, columns=RECORD_COLUMNS) as source:
+    with open_record_source(
+        list(roots), results_index_db_url=url, columns=RECORD_COLUMNS
+    ) as source:
         yield source
 
 

--- a/tests/spindoctor/results_index/test_record_source.py
+++ b/tests/spindoctor/results_index/test_record_source.py
@@ -232,7 +232,7 @@ def _index_over(held: TwoRoots, *which: Path) -> IndexRecordSource:
     Returns:
         The source, which the caller closes.
     """
-    source = open_record_source(list(which), results_db_url=held.url, columns=COLUMNS)
+    source = open_record_source(list(which), results_index_db_url=held.url, columns=COLUMNS)
     assert isinstance(source, IndexRecordSource)
     return source
 
@@ -543,7 +543,7 @@ def test_a_time_bound_drops_a_row_recording_no_midtime(
     write_metadata(root, FIRST_STUB, metadata_document(instrument=MISSION, times=None))
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [root], logger=quiet_logger)
-    with open_record_source([root], results_db_url=url, columns=COLUMNS) as source:
+    with open_record_source([root], results_index_db_url=url, columns=COLUMNS) as source:
         found = list(source.records(Selection(start_et=0.0)))
     assert found == []
 
@@ -1335,7 +1335,7 @@ def test_an_index_url_reads_the_index(two_roots: TwoRoots) -> None:
         two_roots: The two ingested roots and their index.
     """
     with open_record_source(
-        [two_roots.first], results_db_url=two_roots.url, columns=COLUMNS
+        [two_roots.first], results_index_db_url=two_roots.url, columns=COLUMNS
     ) as source:
         assert isinstance(source, IndexRecordSource)
 
@@ -1367,7 +1367,7 @@ def test_every_root_is_checked_before_anything_is_read(
     url = index_url(tmp_path / 'index.sqlite3')
     ingest_tree(url, [first], logger=quiet_logger)
     with pytest.raises(ValueError, match='no completed ingest'):
-        open_record_source([first, second], results_db_url=url, columns=COLUMNS)
+        open_record_source([first, second], results_index_db_url=url, columns=COLUMNS)
 
 
 def test_opening_for_a_root_nobody_ingested_is_refused(tmp_path: Path) -> None:
@@ -1381,7 +1381,7 @@ def test_opening_for_a_root_nobody_ingested_is_refused(tmp_path: Path) -> None:
     url = index_url(tmp_path / 'index.sqlite3')
     open_index(url, create=True).dispose()
     with pytest.raises(ValueError, match='no completed ingest'):
-        open_record_source([root], results_db_url=url, columns=COLUMNS)
+        open_record_source([root], results_index_db_url=url, columns=COLUMNS)
 
 
 class _WatchedEngine:
@@ -1471,7 +1471,7 @@ def test_an_index_backed_run_reads_the_columns_it_declared(two_roots: TwoRoots) 
         two_roots: The two ingested roots and their index.
     """
     with open_record_source(
-        [two_roots.first], results_db_url=two_roots.url, columns=(IMAGES.c.status,)
+        [two_roots.first], results_index_db_url=two_roots.url, columns=(IMAGES.c.status,)
     ) as source:
         rebuilt = source.record(FIRST_STUB).metadata
     assert 'offset' not in rebuilt


### PR DESCRIPTION
## Purpose

Step 5a-2, into `rf_results_index`, and the last of the rename. PR #544 swept the names; this changes the shape the program is asked for them in.

`sd_results_index` took its modes as flags, so nothing but a hand-written check could stop two of them being asked for at once, and `--drop-index` contradicted a program whose other flags all described an ingest. The modes become subcommands — `ingest`, `divide`, `complete`, `drop` — the subject in the program name and the action in the subcommand. A later mode slots in without renaming anything.

**`_mode_refusal` is deleted, because subparsers make the modes exclusive by construction.** That is the argument for the change and also its risk: deleting a refusal without proving the exclusion still happens is how a guarantee quietly disappears. Every exclusion it enforced, and the two hand-written ones in `main`, still happens and each has a test that it does.

## Changes

| Was | Is |
|---|---|
| `sd_results_index [--force] [--no-prune]` | `sd_results_index ingest [--force] [--no-prune]` |
| `sd_results_index --output-cloud-tasks-file PATH` | `sd_results_index divide --tasks-file PATH` |
| `sd_results_index --complete-cloud-tasks-file PATH` | `sd_results_index complete --events-log PATH` |
| `sd_results_index --drop-index [--yes]` | `sd_results_index drop [--yes]` |

Each subcommand carries only the options its mode has a use for:

| Option | ingest | divide | complete | drop |
|---|:-:|:-:|:-:|:-:|
| `--results-index-db`, `--config-file`, logging | yes | yes | yes | yes |
| `--nav-results-root` | yes | yes | yes | — |
| `--force`, `--no-prune` | yes | yes | — | — |
| `--tasks-file` (required) | — | yes | — | — |
| `--events-log` (required) | — | — | yes | — |
| `--yes` | — | — | — | yes |

`--nav-results-root` stays on `complete` because completion resolves and names the roots whose runs it stamps. The two paths are required on their own subcommand: the mode is the subcommand now, so the path is that mode's subject rather than the thing that selects it.

**Three identifier families**, left out of #544 only to keep it under the size past which CodeRabbit skips a PR: `results_db_url` becomes `results_index_db_url` (29 files), the cloud-task `status_error` values `unusable_results_db` and `no_results_db` take the option's spelling (8 files), and `plans/RESULTS_DB_PLAN.md` becomes `plans/RESULTS_INDEX_PLAN.md` with its four path references (6 files). `plans/archive/` is untouched, as before: an archived plan records what was decided at the time.

## Type of Change

- [x] Breaking change (fix or feature that alters existing behavior or public API)
- [x] Refactor (no functional or API changes)
- [x] Documentation

## Testing

- [x] Unit tests pass
- [x] New or updated tests for changed code

**12104 passed, 7 xfailed, 0 skipped**, against 12023 passed / 7 xfailed / 0 skipped on `1d67fb13`. Postgres tier **148**, unchanged. `ruff check`, `ruff format --check`, `mypy src tests` (732 files), `sphinx -W` and `pymarkdown` all clean. Skips were watched for as well as failures — a test that starts skipping is a test that stopped checking, which has happened twice on this branch.

`tests/spindoctor/cli/results_index/test_subcommand_surface.py` is new, 59 tests, and holds the exclusions one for one against what `_mode_refusal` used to do:

| Old refusal | New test |
|---|---|
| `--yes` without `--drop-index` | `test_the_confirmation_flag_is_refused_by_every_other_subcommand[ingest\|divide\|complete]` |
| `--drop-index` with `--force` | `test_a_drop_is_refused_the_reading_options[--force]` |
| `--drop-index` with `--no-prune` | `test_a_drop_is_refused_the_reading_options[--no-prune]` |
| `--drop-index` with `--nav-results-root` | `test_the_drop_is_refused_a_results_root` |
| `--drop-index` with either cloud mode | `test_the_tasks_file_belongs_to_the_divide_alone[drop]`, `test_the_events_log_belongs_to_the_completion_alone[drop]` |
| both cloud modes at once | `test_dividing_and_completing_cannot_be_asked_for_at_once`, `test_a_second_subcommand_is_refused` |
| completion with `--force` | `test_a_completion_is_refused_the_reading_options[--force]` |
| completion with `--no-prune` | `test_a_completion_is_refused_the_reading_options[--no-prune]` |

Each has a control asserting the option **is** accepted where it belongs, because an exclusion asserted only in the negative is satisfied by a parser that refuses everything.

Mutations, actually run, each killing at least one test: delete `--force` from both reading subcommands (2), from `divide` alone (1); move `--yes` to the shared parser (3); give `drop` a results root (1); give `complete` the reading options (2); give `drop` the reading options (4); give `drop` both mode paths (2).

## Potential Impacts

**Breaking, deliberately and without a shim.** Any script or cron entry using the old flags must be rewritten. The old spellings now get argparse's error, which is correct.

**The surviving refusals exit 2 rather than 1**, because they are argparse usage errors — which is what this codebase already reports a usage error as, and what `sd_stats_report` does for a root with no completed ingest. `main`'s `Raises:`, the program's module docstring and the guide's account of the exit status all name it.

**The bespoke refusal wording is gone** where the refusal became structural. The reason each one gave has moved into the subcommand's own `description`, so `sd_results_index complete --help` says it reads no document and removes no row, and that `--force` and `--no-prune` belong to the `divide`.

The shared `--results-index-db` help was untrue under a drop — it said the tables are created if absent, and a drop creates nothing. Reworded, with the resolution-ladder sentence left byte-identical, since re-flowing it is the known way to put its order back to front.

## Checklist

- [x] Code follows project style (`ruff check`, `ruff format`)
- [x] Type annotations present and `mypy` passes
- [x] Docstrings and Sphinx docs updated
- [x] No temporary or debug code left in

## Notes

**A test that could not fail, found while building this — the third of its kind on this branch.** The shared `run_driver` helper built its argv as `['sd_results_index', '--log-root', <path>, *argv]`. With a required subcommand, the log-root *path* parses as the subcommand, so two of the relocated refusal tests were passing on exit 2 from `invalid choice: '/tmp/pytest-.../logs'` rather than from the option under test. Both helpers now append `--log-root` after the rest of argv, with a comment saying why.

**The design of record names `sd_mosaic` and `sd_create_bundle` as the subcommand precedent, and they are not subparsers** — both hand-dispatch on `sys.argv[1]`, because each takes a dynamic dataset name as the next positional. Nothing here does, so this uses real `add_subparsers`, which is what makes the exclusion structural rather than another hand-written check, while following the precedent's shape of one shared argument-adding helper called per mode.

**One commit, not the two the design of record asks for.** That shape was written when the sweep and the subcommands were to land together; the sweep landed on its own in #544, which is what the split was for. Within this PR four files carry hunks of both kinds and the plan is a whole-file rename, so a by-hunk split would be reconstructed rather than authored — and a reconstructed commit nobody verified builds is worth less than one honest one.

**The argparse error text was checked on Python 3.11 as well as 3.12 and 3.13**, since CI's oldest is 3.11 and this branch has already been broken once by a construct that only existed from 3.12. Byte-identical on all three.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `sd_results_index` now uses clear subcommands: `ingest`, `divide`, `complete`, and `drop`.
  * Cloud-task workflows now use `--tasks-file` and `--events-log`.
  * Command options are limited to the subcommands where they apply.

* **Documentation**
  * Updated user, developer, and operator guidance for commands, options, statuses, and planning references.

* **Bug Fixes**
  * Standardized results-index terminology across commands, diagnostics, and reporting.
  * Corrected examples for rebuilding, dividing, completing, and dropping results indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->