### PR TITLE
Fail an image whose model or technique raised

### DIFF
--- a/docs/dev_guide/dev_guide_troubleshooting.rst
+++ b/docs/dev_guide/dev_guide_troubleshooting.rst
@@ -177,6 +177,27 @@ Technique- and ensemble-stage failures
     image data. The full traceback is in the error log; file it as a
     defect rather than re-running with different settings.
 
+``internal_error``
+    A navigation model or technique raised an exception nothing anticipated,
+    so the image was not navigated as designed. Like ``contract_violation``
+    this is a defect rather than a setting to change, and the difference
+    between them is only where it came from: a violated invariant that core
+    code checked for, against anything else a plugin threw.
+
+    Read ``navigation_result.internal_error`` in the metadata document
+    first. It names the component (``NavModelRings.create_model``) and the
+    exception class (``AttributeError``), which is usually enough to place
+    the fault without opening the log; the log has the traceback.
+
+    An exception raised by one model or technique fails the whole image even
+    when others succeeded, and that is deliberate. Continuing on the
+    survivors produces an offset that looks exactly like a whole one, and a
+    frame silently navigated on less evidence than it should have been is
+    worse than a frame reported failed -- especially at campaign scale,
+    where nobody reads the logs. A dependency regression that costs one
+    model its output shows up as a batch of failures rather than as a
+    quiet, unmeasurable loss of accuracy.
+
 Conflicted results
 ==================
 

--- a/docs/dev_guide/dev_guide_troubleshooting.rst
+++ b/docs/dev_guide/dev_guide_troubleshooting.rst
@@ -185,7 +185,8 @@ Technique- and ensemble-stage failures
     code checked for, against anything else a plugin threw.
 
     Read ``navigation_result.internal_error`` in the metadata document
-    first. It names the component (``NavModelRings.create_model``) and the
+    first. It names the component as ``<registered name>.<method>``
+    (``rings:SATURN.create_model``, ``RingEdgeNav.navigate``) and the
     exception class (``AttributeError``), which is usually enough to place
     the fault without opening the log; the log has the traceback.
 

--- a/docs/user_guide/user_guide_metadata.rst
+++ b/docs/user_guide/user_guide_metadata.rst
@@ -431,9 +431,9 @@ A result whose ``status_reason`` is ``internal_error`` carries an
 ``internal_error`` object, and no other result carries one. It says which
 component raised and what class of exception it raised, so a consumer
 reading the document -- rather than a person reading the log -- can tell a
-navigation that hit a defect from one that simply found nothing. A ring
-model that raised an ``AttributeError`` while building records
-``component`` as ``NavModelRings.create_model`` and ``exception_type`` as
+navigation that hit a defect from one that simply found nothing. A Saturn
+ring model that raised an ``AttributeError`` while building records
+``component`` as ``rings:SATURN.create_model`` and ``exception_type`` as
 ``AttributeError``.
 
 .. list-table::
@@ -443,8 +443,10 @@ model that raised an ``AttributeError`` while building records
    * - Key
      - Meaning
    * - ``component``
-     - What raised, as ``name.method`` -- the model or technique's
-       registered name and the method called on it.
+     - What raised, as ``<registered name>.<method>``. The registered name
+       is the model's instance name (``stars``, ``rings:SATURN``,
+       ``body:TITAN``) or the technique's name (``RingEdgeNav``), which is
+       the name the logs and the configuration use -- not the Python class.
    * - ``exception_type``
      - The class name of the exception raised.
 

--- a/docs/user_guide/user_guide_metadata.rst
+++ b/docs/user_guide/user_guide_metadata.rst
@@ -417,6 +417,40 @@ accompanies ``failed``.
      - An internal navigation invariant was violated -- a programming
        error upstream, not bad image data. The full traceback is in the
        error log.
+   * - ``internal_error``
+     - A navigation model or technique raised an exception nothing
+       anticipated, so the image was not navigated as designed and is
+       reported failed rather than answered from the evidence that
+       survived. The ``internal_error`` block below names the component and
+       the exception class; the full traceback is in the error log.
+
+The internal-error block
+------------------------
+
+A result whose ``status_reason`` is ``internal_error`` carries an
+``internal_error`` object, and no other result carries one. It says which
+component raised and what class of exception it raised, so a consumer
+reading the document -- rather than a person reading the log -- can tell a
+navigation that hit a defect from one that simply found nothing. A ring
+model that raised an ``AttributeError`` while building records
+``component`` as ``NavModelRings.create_model`` and ``exception_type`` as
+``AttributeError``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Key
+     - Meaning
+   * - ``component``
+     - What raised, as ``name.method`` -- the model or technique's
+       registered name and the method called on it.
+   * - ``exception_type``
+     - The class name of the exception raised.
+
+The exception's message and traceback are deliberately not recorded here.
+They can carry local file paths and array contents, and this document is an
+archive product; the per-image error log holds both.
 
 Per-technique entries
 ---------------------

--- a/src/spindoctor/nav_orchestrator/curator.py
+++ b/src/spindoctor/nav_orchestrator/curator.py
@@ -342,6 +342,14 @@ def build_metadata_dict(result: NavResult) -> dict[str, Any]:
         out['sigma_rotation_deg'] = _round_float(
             math.degrees(result.sigma_rotation_rad), CONFIDENCE_DECIMALS
         )
+    if result.internal_error is not None:
+        # Present when and only when status_reason is internal_error, which
+        # NavResult holds in step, so a consumer that sees the reason can
+        # read the component without checking for the key's absence first.
+        out['internal_error'] = {
+            'component': result.internal_error.component,
+            'exception_type': result.internal_error.exception_type,
+        }
     if result.pointing is not None:
         out['pointing'] = _curate_pointing(result.pointing)
         out['times'] = _curate_times(result.pointing.baseline)

--- a/src/spindoctor/nav_orchestrator/nav_result.py
+++ b/src/spindoctor/nav_orchestrator/nav_result.py
@@ -54,21 +54,32 @@ class NavInternalErrorRecord:
             has both.
 
     Raises:
-        ValueError: If either field is empty.  A record naming nothing is
-            worse than no record: it says a component failed and declines to
-            say which, and every consumer of the document then has a field
-            it must special-case.
+        TypeError: If either field is not a ``str``.
+        ValueError: If either field is empty or only whitespace.  A record
+            naming nothing is worse than no record: it says a component
+            failed and declines to say which, and every consumer of the
+            document then has a field it must special-case.
     """
 
     component: str
     exception_type: str
 
     def __post_init__(self) -> None:
-        """Refuse a record that names no component or no exception."""
-        if not self.component:
-            raise ValueError('component must be a non-empty string')
-        if not self.exception_type:
-            raise ValueError('exception_type must be a non-empty string')
+        """Refuse a record that names no component or no exception.
+
+        Validated at runtime rather than left to the type checker because
+        this is a published package: mypy runs over this repository's call
+        sites and not over a third-party caller's.  The same pair of checks,
+        in the same order, guards ``ConfidenceTerm``.
+        """
+        for name in ('component', 'exception_type'):
+            value = getattr(self, name)
+            if not isinstance(value, str):
+                raise TypeError(
+                    f'NavInternalErrorRecord.{name} must be str; got {type(value).__name__}'
+                )
+            if not value.strip():
+                raise ValueError(f'NavInternalErrorRecord.{name} must be a non-empty string')
 
 
 @dataclass(frozen=True, eq=False)

--- a/src/spindoctor/nav_orchestrator/nav_result.py
+++ b/src/spindoctor/nav_orchestrator/nav_result.py
@@ -43,17 +43,32 @@ class NavInternalErrorRecord:
     nothing holds in step eventually disagree.
 
     Parameters:
-        component: What raised, as ``ClassName.method`` -- for example
-            ``NavModelRings.create_model``.
+        component: What raised, as ``<registered name>.<method>`` -- for a
+            model the instance name it was built under, as in
+            ``rings:SATURN.create_model``, and for a technique its
+            class-level name, as in ``RingEdgeNav.navigate``.
         exception_type: The class name of the exception raised, for example
             ``AttributeError``.  The message and traceback are deliberately
             not carried here: they can hold file paths and array contents,
             and the metadata document is an archive product.  The error log
             has both.
+
+    Raises:
+        ValueError: If either field is empty.  A record naming nothing is
+            worse than no record: it says a component failed and declines to
+            say which, and every consumer of the document then has a field
+            it must special-case.
     """
 
     component: str
     exception_type: str
+
+    def __post_init__(self) -> None:
+        """Refuse a record that names no component or no exception."""
+        if not self.component:
+            raise ValueError('component must be a non-empty string')
+        if not self.exception_type:
+            raise ValueError('exception_type must be a non-empty string')
 
 
 @dataclass(frozen=True, eq=False)
@@ -172,6 +187,15 @@ class NavResult:
             raise ValueError(
                 'status_reason=internal_error and internal_error must be set together; got '
                 f'status_reason={self.status_reason!r}, internal_error={self.internal_error!r}'
+            )
+        # An internal error is always fatal to the image, so the status says
+        # so too.  Direct instantiation is supported, and without this a
+        # hand-built result could report success while carrying the block
+        # that says navigation did not complete -- the curator would emit
+        # both, and a consumer would have to decide which half to believe.
+        if self.status_reason is NavStatusReason.INTERNAL_ERROR and self.status != 'failed':
+            raise ValueError(
+                f'status_reason=internal_error requires status=failed; got status={self.status!r}'
             )
         if self.confidence_rank == 'failed' and self.status != 'failed':
             raise ValueError('confidence_rank=failed requires status=failed')

--- a/src/spindoctor/nav_orchestrator/nav_result.py
+++ b/src/spindoctor/nav_orchestrator/nav_result.py
@@ -21,7 +21,7 @@ from spindoctor.support.cmatrix import PointingSolution
 from spindoctor.support.status_reason import NavStatusReason
 from spindoctor.support.types import NDArrayFloatType
 
-__all__ = ['NavResult']
+__all__ = ['NavInternalErrorRecord', 'NavResult']
 
 
 Status = Literal['success', 'failed', 'conflicted']
@@ -29,6 +29,31 @@ Status = Literal['success', 'failed', 'conflicted']
 
 ConfidenceRank = Literal['high', 'medium', 'low', 'conflicted', 'failed']
 """Five-bucket confidence rank presented to downstream consumers."""
+
+
+@dataclass(frozen=True)
+class NavInternalErrorRecord:
+    """Which plugin raised, and what class of exception it raised.
+
+    Set on a result whose ``status_reason`` is
+    ``NavStatusReason.INTERNAL_ERROR``, and on no other, so that a document
+    saying the navigation hit an internal error always says which component
+    hit it.  The two travel together as one object rather than as two
+    optional fields for the same reason: two encodings of one fact that
+    nothing holds in step eventually disagree.
+
+    Parameters:
+        component: What raised, as ``ClassName.method`` -- for example
+            ``NavModelRings.create_model``.
+        exception_type: The class name of the exception raised, for example
+            ``AttributeError``.  The message and traceback are deliberately
+            not carried here: they can hold file paths and array contents,
+            and the metadata document is an archive product.  The error log
+            has both.
+    """
+
+    component: str
+    exception_type: str
 
 
 @dataclass(frozen=True, eq=False)
@@ -87,6 +112,9 @@ class NavResult:
             exposure times.  Stamped by the orchestrator once the
             observation is in hand; ``None`` for a host whose SPICE frames
             are unknown, or when the attitude could not be computed.
+        internal_error: Which NavModel or NavTechnique raised, and what it
+            raised.  Set when and only when ``status_reason`` is
+            ``NavStatusReason.INTERNAL_ERROR``.
     """
 
     status: Status
@@ -108,6 +136,7 @@ class NavResult:
     rotation_rad: float | None = None
     sigma_rotation_rad: float | None = None
     pointing: PointingSolution | None = None
+    internal_error: NavInternalErrorRecord | None = None
 
     def __post_init__(self) -> None:
         """Validate status against offset and reason, and the solution's finiteness."""
@@ -131,6 +160,18 @@ class NavResult:
         if self.sigma_rotation_rad is not None and not math.isfinite(self.sigma_rotation_rad):
             raise ValueError(
                 f'sigma_rotation_rad must be finite when set; got {self.sigma_rotation_rad!r}'
+            )
+        # The status reason and the record are two statements of one fact,
+        # so they are held in step here rather than left to each construction
+        # site to remember: a document reporting an internal error always
+        # says which component hit it, and no other document carries a
+        # component that never raised.
+        if (self.status_reason is NavStatusReason.INTERNAL_ERROR) != (
+            self.internal_error is not None
+        ):
+            raise ValueError(
+                'status_reason=internal_error and internal_error must be set together; got '
+                f'status_reason={self.status_reason!r}, internal_error={self.internal_error!r}'
             )
         if self.confidence_rank == 'failed' and self.status != 'failed':
             raise ValueError('confidence_rank=failed requires status=failed')
@@ -159,6 +200,7 @@ class NavResult:
         feature_inventory: list[NavFeatureSummary] | None = None,
         model_metadata: dict[str, dict[str, Any]] | None = None,
         annotations: Annotations | None = None,
+        internal_error: NavInternalErrorRecord | None = None,
     ) -> 'NavResult':
         """Construct a NavResult for a failed navigation.
 
@@ -172,6 +214,9 @@ class NavResult:
             model_metadata: Optional model metadata dict.
             annotations: Optional pre-built annotation collection
                 (typically empty on failure).
+            internal_error: Which component raised and what it raised.
+                Required when ``status_reason`` is
+                ``NavStatusReason.INTERNAL_ERROR``, and refused otherwise.
 
         Returns:
             NavResult with ``status='failed'``, ``confidence=0.0``,
@@ -192,6 +237,7 @@ class NavResult:
             provenance=provenance,
             model_metadata=model_metadata or {},
             annotations=annotations if annotations is not None else Annotations(),
+            internal_error=internal_error,
         )
 
     @classmethod

--- a/src/spindoctor/nav_orchestrator/orchestrator.py
+++ b/src/spindoctor/nav_orchestrator/orchestrator.py
@@ -50,7 +50,7 @@ from spindoctor.nav_orchestrator.instrument_config import (
     instrument_settings_from_obs,
 )
 from spindoctor.nav_orchestrator.nav_context import NavContext
-from spindoctor.nav_orchestrator.nav_result import NavResult
+from spindoctor.nav_orchestrator.nav_result import NavInternalErrorRecord, NavResult
 from spindoctor.nav_orchestrator.provenance import (
     Provenance,
     collect_provenance_metadata,
@@ -64,7 +64,11 @@ from spindoctor.nav_technique.nav_technique import (
 from spindoctor.nav_technique.technique_result import NavTechniqueResult
 from spindoctor.obs import obs_class_to_inst_name
 from spindoctor.support.cmatrix import compute_pointing
-from spindoctor.support.exceptions import NavContractError, NavPointingError
+from spindoctor.support.exceptions import (
+    NavContractError,
+    NavInternalError,
+    NavPointingError,
+)
 from spindoctor.support.filters import NavFilterKind, NavFilterSpec, apply_filter
 from spindoctor.support.image_quality import cosmic_ray_mask, saturation_mask
 from spindoctor.support.nav_base import NavBase
@@ -318,6 +322,11 @@ class NavOrchestrator(NavBase):
         **not** short-circuited — the caller (manual-nav dialog,
         debugger) decides what to do on a blank or saturated frame.
 
+        A NavModel that raises propagates here rather than being converted:
+        this method returns artifacts, not a ``NavResult``, so it has nothing
+        to record a failure on.  Its callers are interactive, where an
+        exception surfacing is the right outcome.
+
         Parameters:
             obs: The observation snapshot to prepare.
             apply_gate: When ``True`` (the default) the reliability gate
@@ -359,11 +368,20 @@ class NavOrchestrator(NavBase):
     def navigate(self, obs: ObsSnapshotInst) -> NavResult:
         """Run the full pipeline on one observation.
 
-        No image-data problem raises through to the caller: plugin failures
-        are sandboxed (see ``_extract_features`` / ``_run_pass``), and a
-        ``NavContractError`` (an internal invariant violated by upstream
-        code) is logged at error level and converted into a failed
-        ``NavResult`` with ``NavStatusReason.CONTRACT_VIOLATION``.
+        Nothing raises through to the caller.  Every exception out of a
+        NavModel or a NavTechnique arrives here as one of two kinds and
+        becomes a failed ``NavResult``: a ``NavContractError`` (an internal
+        invariant violated by upstream code) as
+        ``NavStatusReason.CONTRACT_VIOLATION``, and anything else, wrapped as
+        a ``NavInternalError`` naming the component, as
+        ``NavStatusReason.INTERNAL_ERROR`` with that name and the exception's
+        class recorded on the result.
+
+        Failing the image is the point.  The alternative -- continuing with
+        whatever evidence survived -- produces an offset that is plausible,
+        that reports ``success``, and that nothing downstream can tell apart
+        from one computed with every model and technique intact.  A batch
+        driver sees an ordinary failed frame either way and continues.
 
         A programming error inside :meth:`with_pointing`'s attitude
         computation does propagate, by design: see that method.
@@ -403,6 +421,26 @@ class NavOrchestrator(NavBase):
                 status_reason=NavStatusReason.CONTRACT_VIOLATION,
                 image_classifier=image_classifier,
                 provenance=provenance,
+            )
+        except NavInternalError as exc:
+            # error, not exception: the wrapper that raised this already
+            # logged the plugin's own traceback, which is the one worth
+            # reading.  Logging a second one here would print the re-raise
+            # chain under every internal error and bury the first.
+            self._logger.error(
+                'INTERNAL ERROR: %s; this image was not navigated as designed, '
+                'so it is failed rather than answered from the evidence that '
+                'survived; failing with status_reason=internal_error',
+                str(exc),
+            )
+            result = self._fail(
+                status_reason=NavStatusReason.INTERNAL_ERROR,
+                image_classifier=image_classifier,
+                provenance=provenance,
+                internal_error=NavInternalErrorRecord(
+                    component=exc.component,
+                    exception_type=exc.exception_type,
+                ),
             )
         return self.with_pointing(result, obs)
 
@@ -499,10 +537,10 @@ class NavOrchestrator(NavBase):
     ) -> NavResult:
         """Run the model / feature / technique / ensemble pipeline.
 
-        Called by :meth:`navigate` after the hard-failure short-circuit;
-        a ``NavContractError`` raised anywhere in here (including one
-        re-raised by a plugin sandbox) propagates to :meth:`navigate`,
-        which converts it into a failed ``NavResult``.
+        Called by :meth:`navigate` after the hard-failure short-circuit.
+        A ``NavContractError`` or ``NavInternalError`` raised anywhere in
+        here -- including one raised by a plugin wrapper -- propagates to
+        :meth:`navigate`, which converts it into a failed ``NavResult``.
 
         Parameters:
             context: Per-image NavContext.
@@ -690,11 +728,23 @@ class NavOrchestrator(NavBase):
     def _build_models(self) -> list[NavModel]:
         """Call ``create_model`` on every registered NavModel.
 
-        Wrapped so :meth:`prepare` and :meth:`navigate` share the same
-        log line and exception-sandbox behavior.  Models whose
-        ``create_model`` raises are dropped from the returned list so
-        downstream feature / annotation / metadata collection skips
-        them entirely (rather than processing partially-built state).
+        Wrapped so :meth:`prepare` and :meth:`navigate` share the same log
+        line and the same treatment of a model that raises: the exception is
+        logged with its traceback and re-raised as a ``NavInternalError``
+        naming the model, which fails the image.  A model that cannot build
+        is not a model that found nothing -- the returned list would be short
+        by a whole source of evidence, and every number computed from what
+        remained would be indistinguishable from one computed from all of it.
+
+        Returns:
+            Every registered model, built.  A partial list is never returned:
+            either all of them built or this raises.
+
+        Raises:
+            NavContractError: Propagated from a model that violated an
+                internal invariant, for :meth:`navigate` to convert.
+            NavInternalError: Raised for any other exception out of
+                ``create_model``, for :meth:`navigate` to convert.
         """
         self._logger.info(
             'Building %d NavModel(s): %s',
@@ -711,12 +761,14 @@ class NavOrchestrator(NavBase):
                     model.name,
                 )
                 raise
-            except Exception:  # plugin sandbox; mirrors _extract_features
+            except Exception as exc:
+                component = f'{model.name}.create_model'
                 self._logger.exception(
-                    'NavModel %s.create_model raised; skipping its features and annotations',
-                    model.name,
+                    'INTERNAL ERROR: %s raised; failing this image with '
+                    'status_reason=internal_error',
+                    component,
                 )
-                continue
+                raise NavInternalError(component, exc) from exc
             built_models.append(model)
         return built_models
 
@@ -760,6 +812,7 @@ class NavOrchestrator(NavBase):
         feature_inventory: list[NavFeatureSummary] | None = None,
         model_metadata: dict[str, dict[str, Any]] | None = None,
         annotations: Annotations | None = None,
+        internal_error: NavInternalErrorRecord | None = None,
     ) -> NavResult:
         """Emit the operator-readable INFO lines and return a failed NavResult.
 
@@ -775,6 +828,7 @@ class NavOrchestrator(NavBase):
             feature_inventory=feature_inventory or [],
             model_metadata=model_metadata or {},
             annotations=annotations or Annotations(),
+            internal_error=internal_error,
         )
 
     def _log_status_reason(self, status_reason: NavStatusReason) -> None:
@@ -792,9 +846,22 @@ class NavOrchestrator(NavBase):
     def _collect_annotations(self, context: NavContext, models: list[NavModel]) -> Annotations:
         """Merge per-NavModel annotation collections into one.
 
-        Each model's ``to_annotations`` is invoked; failures are logged and
-        treated as if the model emitted an empty collection so a misbehaving
-        model never blocks the rest of the pipeline.
+        Each model's ``to_annotations`` is invoked; one that raises is logged
+        with its traceback and re-raised as a ``NavInternalError`` naming the
+        model, which fails the image.  Annotations are only the summary PNG's
+        input, so failing the whole image for them may look severe -- but a
+        model that cannot describe what it found is a model in a state nobody
+        planned for, and this pipeline's rule is that no exception is
+        invisible and no image reports an outcome after one was raised.
+
+        Returns:
+            One collection merging every model's annotations.
+
+        Raises:
+            NavContractError: Propagated from a model that violated an
+                internal invariant, for :meth:`navigate` to convert.
+            NavInternalError: Raised for any other exception out of
+                ``to_annotations``, for :meth:`navigate` to convert.
         """
         merged = Annotations()
         for model in models:
@@ -806,27 +873,50 @@ class NavOrchestrator(NavBase):
                     model.name,
                 )
                 raise
-            except Exception:  # plugin sandbox; mirrors _extract_features
+            except Exception as exc:
+                component = f'{model.name}.to_annotations'
                 self._logger.exception(
-                    'NavModel %s.to_annotations raised; skipping its annotations',
-                    model.name,
+                    'INTERNAL ERROR: %s raised; failing this image with '
+                    'status_reason=internal_error',
+                    component,
                 )
-                continue
+                raise NavInternalError(component, exc) from exc
             merged.add_annotations(model_annotations)
         return merged
 
     def _extract_features(self, context: NavContext, models: list[NavModel]) -> list[NavFeature]:
         """Iterate built models and gather their features.
 
-        A misbehaving NavModel is logged with a full traceback and treated
-        as if it emitted zero features.  Catching every exception is
-        intentional: the orchestrator must never raise through to its
-        caller — failures surface on the returned ``NavResult`` instead.
-        Specific exceptions cannot be enumerated because every NavModel
-        plugin has its own failure modes.  The one exemption is
-        ``NavContractError``: a contract violation is a programming error,
-        not a plugin failure, so it is logged at error level and re-raised
-        for :meth:`navigate` to convert into a failed ``NavResult``.
+        A model that raises is logged with a full traceback and re-raised as
+        a ``NavInternalError`` naming it, which :meth:`navigate` converts
+        into a failed ``NavResult``.  Catching every exception is still
+        intentional and for the original reason -- the orchestrator must
+        never raise through to its caller, and specific exceptions cannot be
+        enumerated because every plugin has its own failure modes -- but
+        catching is no longer the same as continuing.  Failing the image is
+        not raising through to the caller: the result carries the failure and
+        the batch driver moves to the next frame as it does for any other
+        failed image.
+
+        A model that emitted zero features because there was nothing to find
+        is a different thing entirely, and reaches this method as an empty
+        list rather than as an exception; the feature and gating path already
+        models that outcome properly.  Conflating the two is what let an
+        image report ``success`` on evidence an exception had quietly
+        removed.
+
+        ``NavContractError`` keeps its own clause: it is a violated invariant
+        rather than an unanticipated failure, and stays classified as
+        ``CONTRACT_VIOLATION`` rather than ``INTERNAL_ERROR``.
+
+        Returns:
+            Every feature every model emitted, in model order.
+
+        Raises:
+            NavContractError: Propagated from a model that violated an
+                internal invariant, for :meth:`navigate` to convert.
+            NavInternalError: Raised for any other exception out of
+                ``to_features``, for :meth:`navigate` to convert.
         """
         all_features: list[NavFeature] = []
         for model in models:
@@ -838,12 +928,14 @@ class NavOrchestrator(NavBase):
                     model.name,
                 )
                 raise
-            except Exception:  # plugin sandbox; see docstring
+            except Exception as exc:
+                component = f'{model.name}.to_features'
                 self._logger.exception(
-                    'NavModel %s.to_features raised; treating as no features',
-                    model.name,
+                    'INTERNAL ERROR: %s raised; failing this image with '
+                    'status_reason=internal_error',
+                    component,
                 )
-                emitted = []
+                raise NavInternalError(component, exc) from exc
             all_features.extend(emitted)
         return all_features
 
@@ -885,24 +977,31 @@ class NavOrchestrator(NavBase):
         feasibility breakdown an engineer needs to answer "why didn't
         technique X run on image Y" from the log alone.
 
-        A misbehaving NavTechnique is logged with a full traceback and
-        omitted from the returned list, exactly as if it had produced no
-        result; the other techniques still contribute, so the navigation
-        can still succeed on their evidence.  Catching every exception is
-        intentional for the same reason as ``_extract_features``: one
-        technique's defect must not fail the image.  ``NavContractError``
-        is exempt (see ``_extract_features``): it is logged at error level
-        and re-raised for :meth:`navigate` to convert into a failed
-        ``NavResult``.
+        A NavTechnique that raises is logged with a full traceback and
+        re-raised as a ``NavInternalError`` naming it, which fails the image.
+        A technique failing among several is closer to a normal outcome than
+        a model failing to build, and treating it as one was considered; the
+        reason it is not exempted is that the pipeline has no way to record
+        the exemption honestly.  A technique with nothing to contribute
+        already has two ways to say so -- ``is_feasible`` returning false,
+        and a result marked spurious -- and both leave a trace in the
+        per-technique inventory.  An exception leaves none, so an exempted
+        technique failure would be a silently smaller ensemble, and the
+        ensemble's confidence is a function of how many witnesses agreed.
+
+        ``NavContractError`` keeps its own clause and stays classified as
+        ``CONTRACT_VIOLATION`` (see ``_extract_features``).
 
         Returns:
             One entry per technique that ran and produced a result, in
-            registry order.  A skipped, infeasible, or failed technique
-            contributes no entry, so the list may be empty.
+            registry order.  A skipped or infeasible technique contributes
+            no entry, so the list may be empty.
 
         Raises:
             NavContractError: Propagated from a technique that violated an
                 internal invariant, for :meth:`navigate` to convert.
+            NavInternalError: Raised for any other exception out of a
+                technique, for :meth:`navigate` to convert.
         """
         results: list[NavTechniqueResult] = []
         names = [
@@ -978,11 +1077,14 @@ class NavOrchestrator(NavBase):
                     cls.name,
                 )
                 raise
-            except Exception:  # plugin sandbox; see docstring
+            except Exception as exc:
+                component = f'{cls.name}.navigate'
                 self._logger.exception(
-                    'NavTechnique %s.navigate raised; treating as no result',
-                    cls.name,
+                    'INTERNAL ERROR: %s raised; failing this image with '
+                    'status_reason=internal_error',
+                    component,
                 )
+                raise NavInternalError(component, exc) from exc
         return results
 
     def _make_context(

--- a/src/spindoctor/nav_orchestrator/orchestrator.py
+++ b/src/spindoctor/nav_orchestrator/orchestrator.py
@@ -368,10 +368,10 @@ class NavOrchestrator(NavBase):
     def navigate(self, obs: ObsSnapshotInst) -> NavResult:
         """Run the full pipeline on one observation.
 
-        Nothing raises through to the caller.  Every exception out of a
-        NavModel or a NavTechnique arrives here as one of two kinds and
-        becomes a failed ``NavResult``: a ``NavContractError`` (an internal
-        invariant violated by upstream code) as
+        No failure of a NavModel or a NavTechnique raises through to the
+        caller.  Every exception out of one arrives here as one of two kinds
+        and becomes a failed ``NavResult``: a ``NavContractError`` (an
+        internal invariant violated by upstream code) as
         ``NavStatusReason.CONTRACT_VIOLATION``, and anything else, wrapped as
         a ``NavInternalError`` naming the component, as
         ``NavStatusReason.INTERNAL_ERROR`` with that name and the exception's
@@ -383,14 +383,21 @@ class NavOrchestrator(NavBase):
         from one computed with every model and technique intact.  A batch
         driver sees an ordinary failed frame either way and continues.
 
-        A programming error inside :meth:`with_pointing`'s attitude
-        computation does propagate, by design: see that method.
+        The attitude computation is outside that guarantee: an unexpected
+        error inside :meth:`with_pointing` propagates, by design, so a
+        defect there fails the run on its first image rather than degrading
+        every image quietly.  See that method.
 
         Parameters:
             obs: The observation snapshot to navigate.
 
         Returns:
             A single ``NavResult`` summarizing the navigation outcome.
+
+        Raises:
+            Exception: Propagated from :meth:`with_pointing` when the
+                corrected-attitude computation hits anything other than the
+                ``NavPointingError`` it expects and absorbs.
         """
         provenance = self._make_provenance(obs)
         context, image_classifier = self._make_context(obs, provenance)

--- a/src/spindoctor/nav_orchestrator/status_reason_info.py
+++ b/src/spindoctor/nav_orchestrator/status_reason_info.py
@@ -86,4 +86,10 @@ STATUS_REASON_INFO_TEMPLATE: dict[NavStatusReason, list[str]] = {
         'Final: status=failed',
         'Internal contract violation (programming error); see the error log',
     ],
+    NavStatusReason.INTERNAL_ERROR: [
+        'Final: status=failed',
+        'A NavModel or NavTechnique raised; the image was not navigated as '
+        'designed. The failing component and exception class are in the '
+        'metadata document; the traceback is in the error log',
+    ],
 }

--- a/src/spindoctor/support/exceptions.py
+++ b/src/spindoctor/support/exceptions.py
@@ -1,12 +1,17 @@
 """Typed exceptions shared across the navigation core.
 
 Contract violations must not be expressed as bare ``assert`` statements:
-asserts are stripped under ``python -O``, and inside the orchestrator's
-broad plugin sandboxes an ``AssertionError`` would be swallowed as an
-ordinary technique failure.  Raising :class:`NavContractError` instead
-keeps the check active in optimized runs and lets the orchestrator treat
-the violation distinctly (error-level log plus a failed ``NavResult``
+asserts are stripped under ``python -O``.  Raising :class:`NavContractError`
+instead keeps the check active in optimized runs and lets the orchestrator
+treat the violation distinctly (error-level log plus a failed ``NavResult``
 with ``NavStatusReason.CONTRACT_VIOLATION``).
+
+:class:`NavInternalError` is what every other exception out of a NavModel or
+a NavTechnique becomes.  The orchestrator wraps each plugin call, and the
+wrapper's job is to name the component and fail the image rather than to
+absorb the failure: an exception nothing planned for means the image was not
+navigated as designed, and an offset computed from whatever else survived is
+an answer with no way to tell it apart from a whole one.
 
 :class:`NavPointingError` serves the mirror-image purpose: it names the
 failures the corrected-attitude computation can legitimately hit, so the
@@ -14,7 +19,7 @@ one caller that must survive them absorbs exactly those and everything
 else -- a programming defect -- keeps propagating.
 """
 
-__all__ = ['NavContractError', 'NavPointingError']
+__all__ = ['NavContractError', 'NavInternalError', 'NavPointingError']
 
 
 class NavContractError(Exception):
@@ -23,12 +28,52 @@ class NavContractError(Exception):
     Raised when an upstream component hands core code a value outside its
     documented bounds (for example a 3-DoF technique result whose rotation
     exceeds the ensemble's small-angle bound).  A ``NavContractError``
-    always indicates a programming error, never bad image data, so it is
-    never swallowed by the orchestrator's plugin sandboxes: the sandboxes
-    log it at error level and re-raise, and ``NavOrchestrator.navigate``
-    converts it into a failed ``NavResult`` with
-    ``NavStatusReason.CONTRACT_VIOLATION``.
+    always indicates a programming error, never bad image data, so the
+    orchestrator's plugin wrappers log it at error level and re-raise it
+    unwrapped, and ``NavOrchestrator.navigate`` converts it into a failed
+    ``NavResult`` with ``NavStatusReason.CONTRACT_VIOLATION``.  Keeping it
+    distinct from :class:`NavInternalError` is what separates "upstream code
+    handed us a value outside its documented bounds" from "a plugin raised
+    something nobody anticipated".
     """
+
+
+class NavInternalError(Exception):
+    """A NavModel or NavTechnique raised an exception nothing anticipated.
+
+    The orchestrator wraps every plugin call -- ``create_model``,
+    ``to_features``, ``to_annotations`` and ``navigate`` -- and converts any
+    exception other than :class:`NavContractError` into one of these.
+    ``NavOrchestrator.navigate`` then converts it into a failed ``NavResult``
+    with ``NavStatusReason.INTERNAL_ERROR``, carrying ``component`` and
+    ``exception_type`` into the metadata document so the failure is visible
+    to every consumer that reads the document rather than only to a human
+    reading the log.
+
+    Failing the image is not the same as raising through to the caller: the
+    batch drivers see an ordinary failed frame and continue to the next one,
+    exactly as they do for any other failure.  What no longer happens is an
+    image reporting ``success`` on an offset computed from whatever evidence
+    survived the exception.
+
+    ``prepare`` is the exception to that, and deliberately: it has no
+    ``NavResult`` to fail, so this propagates to its caller as
+    :class:`NavContractError` already does.
+
+    Parameters:
+        component: What raised, as ``ClassName.method`` -- for example
+            ``NavModelRings.create_model``.  Named rather than derived so
+            the wrapper reports the plugin's registered name and not
+            whatever the traceback's innermost frame happens to be.
+        cause: The exception the plugin raised.  Only its class name is
+            kept; the traceback reaches the log through ``raise ... from``.
+    """
+
+    def __init__(self, component: str, cause: BaseException) -> None:
+        """Build the exception from the component that raised and what it raised."""
+        self.component = component
+        self.exception_type = type(cause).__name__
+        super().__init__(f'{component} raised {self.exception_type}: {cause}')
 
 
 class NavPointingError(Exception):

--- a/src/spindoctor/support/exceptions.py
+++ b/src/spindoctor/support/exceptions.py
@@ -61,10 +61,15 @@ class NavInternalError(Exception):
     :class:`NavContractError` already does.
 
     Parameters:
-        component: What raised, as ``ClassName.method`` -- for example
-            ``NavModelRings.create_model``.  Named rather than derived so
-            the wrapper reports the plugin's registered name and not
-            whatever the traceback's innermost frame happens to be.
+        component: What raised, as ``<registered name>.<method>``.  The
+            registered name is the plugin's own, which for a model is the
+            instance name it was built under (``stars``,
+            ``rings:SATURN``) and for a technique is its class-level
+            ``name`` (``RingEdgeNav``) -- not the Python class in either
+            case.  It is passed in rather than derived so the wrapper
+            reports the name an operator sees in the log and the
+            configuration, not whatever the traceback's innermost frame
+            happens to be.
         cause: The exception the plugin raised.  Only its class name is
             kept; the traceback reaches the log through ``raise ... from``.
     """

--- a/src/spindoctor/support/status_reason.py
+++ b/src/spindoctor/support/status_reason.py
@@ -64,6 +64,12 @@ class NavStatusReason(StrEnum):
     - ``CONTRACT_VIOLATION``: an internal navigation invariant was violated
       (``NavContractError``); a programming error upstream, not bad image
       data.  The full traceback is in the error log.
+    - ``INTERNAL_ERROR``: a NavModel or NavTechnique raised an exception
+      nothing anticipated (``NavInternalError``), so the image was not
+      navigated as designed and is failed rather than answered from the
+      evidence that survived.  The failing component and the exception class
+      are recorded on the result and in the metadata document; the full
+      traceback is in the error log.
     """
 
     OK = 'ok'
@@ -85,3 +91,4 @@ class NavStatusReason(StrEnum):
     FINAL_SIGMA_ABOVE_THRESHOLD = 'final_sigma_above_threshold'
     UNOBSERVABLE_OFFSET = 'unobservable_offset'
     CONTRACT_VIOLATION = 'contract_violation'
+    INTERNAL_ERROR = 'internal_error'

--- a/tests/spindoctor/nav_orchestrator/test_curator.py
+++ b/tests/spindoctor/nav_orchestrator/test_curator.py
@@ -468,7 +468,7 @@ def _internal_error_result() -> NavResult:
         image_classifier=_classifier(),
         provenance=_provenance(),
         internal_error=NavInternalErrorRecord(
-            component='NavModelRings.create_model',
+            component='rings:SATURN.create_model',
             exception_type='AttributeError',
         ),
     )
@@ -482,7 +482,7 @@ def test_an_internal_error_names_its_component_in_the_json() -> None:
     only in the log is a failure they cannot see.
     """
     md = _json_round_trip(_internal_error_result())
-    assert md['internal_error']['component'] == 'NavModelRings.create_model'
+    assert md['internal_error']['component'] == 'rings:SATURN.create_model'
 
 
 def test_an_internal_error_names_its_exception_type_in_the_json() -> None:

--- a/tests/spindoctor/nav_orchestrator/test_curator.py
+++ b/tests/spindoctor/nav_orchestrator/test_curator.py
@@ -16,7 +16,7 @@ from spindoctor.nav_orchestrator.curator import (
 )
 from spindoctor.nav_orchestrator.feature_summary import NavFeatureSummary
 from spindoctor.nav_orchestrator.image_classifier_result import NavImageClassifierResult
-from spindoctor.nav_orchestrator.nav_result import NavResult
+from spindoctor.nav_orchestrator.nav_result import NavInternalErrorRecord, NavResult
 from spindoctor.nav_orchestrator.provenance import Provenance
 from spindoctor.nav_technique.diagnostics import BodyLimbDiagnostics
 from spindoctor.nav_technique.technique_result import NavTechniqueResult
@@ -459,3 +459,45 @@ def test_uncorrectable_result_still_records_its_times() -> None:
     """A solution with no corrected attitude still records the exposure times."""
     md = _json_round_trip(_result_with_pointing(corrected=False))
     assert md['times']['exposure_s'] == 0.18
+
+
+def _internal_error_result() -> NavResult:
+    """A result failed by a ring model that raised while building."""
+    return NavResult.failed(
+        status_reason=NavStatusReason.INTERNAL_ERROR,
+        image_classifier=_classifier(),
+        provenance=_provenance(),
+        internal_error=NavInternalErrorRecord(
+            component='NavModelRings.create_model',
+            exception_type='AttributeError',
+        ),
+    )
+
+
+def test_an_internal_error_names_its_component_in_the_json() -> None:
+    """The document says which component raised, not only the per-image log.
+
+    Every consumer downstream of navigation -- the results index, the bundle
+    stage, the backplane stage -- reads the document.  A failure recorded
+    only in the log is a failure they cannot see.
+    """
+    md = _json_round_trip(_internal_error_result())
+    assert md['internal_error']['component'] == 'NavModelRings.create_model'
+
+
+def test_an_internal_error_names_its_exception_type_in_the_json() -> None:
+    """The document says what class of exception was raised."""
+    md = _json_round_trip(_internal_error_result())
+    assert md['internal_error']['exception_type'] == 'AttributeError'
+
+
+def test_an_internal_error_document_carries_the_matching_status_reason() -> None:
+    """The block and the reason agree, so neither can be read without the other."""
+    md = _json_round_trip(_internal_error_result())
+    assert md['status_reason'] == 'internal_error'
+
+
+def test_a_result_with_no_internal_error_emits_no_block() -> None:
+    """An ordinary failure carries no internal_error key at all."""
+    md = _json_round_trip(_gated_titan_result())
+    assert 'internal_error' not in md

--- a/tests/spindoctor/nav_orchestrator/test_nav_result.py
+++ b/tests/spindoctor/nav_orchestrator/test_nav_result.py
@@ -289,3 +289,43 @@ def test_an_internal_error_result_carries_both_halves() -> None:
         component='NavModelStars.to_features',
         exception_type='RuntimeError',
     )
+
+
+def test_a_record_naming_no_component_is_refused() -> None:
+    """A record that says a component failed must say which one."""
+    with pytest.raises(ValueError, match='component must be a non-empty string'):
+        NavInternalErrorRecord(component='', exception_type='RuntimeError')
+
+
+def test_a_record_naming_no_exception_is_refused() -> None:
+    """A record must say what class of exception was raised."""
+    with pytest.raises(ValueError, match='exception_type must be a non-empty string'):
+        NavInternalErrorRecord(component='stars.to_features', exception_type='')
+
+
+def test_an_internal_error_cannot_be_reported_as_a_success() -> None:
+    """A hand-built success cannot carry the block that says navigation failed.
+
+    ``NavResult`` supports direct instantiation, so the two encodings of the
+    outcome are held in step here rather than only at the one construction
+    site that happens to build them together today.
+    """
+    with pytest.raises(ValueError, match='requires status=failed'):
+        NavResult(
+            status='success',
+            offset_px=(1.0, 2.0),
+            sigma_px=(0.1, 0.1),
+            sigma_along_unobservable_px=None,
+            confidence_rank='high',
+            confidence=0.9,
+            status_reason=NavStatusReason.INTERNAL_ERROR,
+            covariance_px2=None,
+            per_technique=[],
+            feature_inventory=[],
+            image_classifier=_classifier(),
+            provenance=_provenance(),
+            internal_error=NavInternalErrorRecord(
+                component='stars.to_features',
+                exception_type='RuntimeError',
+            ),
+        )

--- a/tests/spindoctor/nav_orchestrator/test_nav_result.py
+++ b/tests/spindoctor/nav_orchestrator/test_nav_result.py
@@ -303,6 +303,30 @@ def test_a_record_naming_no_exception_is_refused() -> None:
         NavInternalErrorRecord(component='stars.to_features', exception_type='')
 
 
+def test_a_whitespace_only_component_is_refused() -> None:
+    """A component of blanks names nothing, and passes an emptiness check."""
+    with pytest.raises(ValueError, match='component must be a non-empty string'):
+        NavInternalErrorRecord(component='   ', exception_type='RuntimeError')
+
+
+def test_a_non_string_component_is_refused() -> None:
+    """An untyped caller cannot put a non-string into the document."""
+    with pytest.raises(TypeError, match='component must be str'):
+        NavInternalErrorRecord(
+            component=object(),  # type: ignore[arg-type]
+            exception_type='RuntimeError',
+        )
+
+
+def test_a_non_string_exception_type_is_refused() -> None:
+    """The exception class name is a string or the record is refused."""
+    with pytest.raises(TypeError, match='exception_type must be str'):
+        NavInternalErrorRecord(
+            component='stars.to_features',
+            exception_type=42,  # type: ignore[arg-type]
+        )
+
+
 def test_an_internal_error_cannot_be_reported_as_a_success() -> None:
     """A hand-built success cannot carry the block that says navigation failed.
 

--- a/tests/spindoctor/nav_orchestrator/test_nav_result.py
+++ b/tests/spindoctor/nav_orchestrator/test_nav_result.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from spindoctor.nav_orchestrator.image_classifier_result import NavImageClassifierResult
-from spindoctor.nav_orchestrator.nav_result import NavResult
+from spindoctor.nav_orchestrator.nav_result import NavInternalErrorRecord, NavResult
 from spindoctor.nav_orchestrator.provenance import Provenance
 from spindoctor.support.status_reason import NavStatusReason
 
@@ -248,3 +248,44 @@ def test_navresult_keeps_an_infinite_unobservable_sigma() -> None:
     """
     result = _success(sigma_along_unobservable_px=math.inf)
     assert result.sigma_along_unobservable_px == math.inf
+
+
+def test_an_internal_error_reason_requires_the_record() -> None:
+    """A result claiming an internal error must say which component raised."""
+    with pytest.raises(ValueError, match='must be set together'):
+        NavResult.failed(
+            status_reason=NavStatusReason.INTERNAL_ERROR,
+            image_classifier=_classifier(),
+            provenance=_provenance(),
+        )
+
+
+def test_an_internal_error_record_requires_the_reason() -> None:
+    """A component that raised cannot be recorded under any other reason."""
+    with pytest.raises(ValueError, match='must be set together'):
+        NavResult.failed(
+            status_reason=NavStatusReason.NO_FEATURES_EXTRACTED,
+            image_classifier=_classifier(),
+            provenance=_provenance(),
+            internal_error=NavInternalErrorRecord(
+                component='NavModelStars.to_features',
+                exception_type='RuntimeError',
+            ),
+        )
+
+
+def test_an_internal_error_result_carries_both_halves() -> None:
+    """The two set together construct, and the record survives on the result."""
+    result = NavResult.failed(
+        status_reason=NavStatusReason.INTERNAL_ERROR,
+        image_classifier=_classifier(),
+        provenance=_provenance(),
+        internal_error=NavInternalErrorRecord(
+            component='NavModelStars.to_features',
+            exception_type='RuntimeError',
+        ),
+    )
+    assert result.internal_error == NavInternalErrorRecord(
+        component='NavModelStars.to_features',
+        exception_type='RuntimeError',
+    )

--- a/tests/spindoctor/nav_orchestrator/test_orchestrator.py
+++ b/tests/spindoctor/nav_orchestrator/test_orchestrator.py
@@ -226,10 +226,16 @@ def _register_fakes() -> Iterator[None]:
     name-resolvable (``only_techniques=['_FakeStarTechnique']``) inside
     this module's tests only, and guarantees no other test in the same
     process ever sees them.
+
+    ``_RaisingTechnique`` is deliberately not among them and is registered by
+    its own fixture instead.  A technique that raises now fails the image it
+    raised on, so a module-wide registration would fail every test in this
+    file whose scene offers a STAR feature -- and would fail them with a
+    status reason describing the fake rather than whatever each test is
+    about.
     """
     fakes: list[type[NavTechnique]] = [
         _FakeStarTechnique,
-        _RaisingTechnique,
         _PassTwoTechnique,
         _InfeasibleTechnique,
         _FakeBodyPrimary,
@@ -440,7 +446,6 @@ def test_orchestrator_only_techniques_filter_drops_techniques(
         [model],
         only_techniques=[
             '!_FakeStarTechnique',
-            '!_RaisingTechnique',
             '!Star*',
         ],
     )
@@ -602,32 +607,112 @@ class _InfeasibleTechnique(NavTechnique):
         raise AssertionError('an infeasible technique must never be navigated')
 
 
-def test_orchestrator_logs_when_to_features_raises(
+@pytest.fixture
+def _register_raising_technique() -> Iterator[None]:
+    """Make ``_RaisingTechnique`` name-resolvable for one test.
+
+    Scoped to the tests that want it because a technique that raises fails
+    the image, so a module-wide registration would fail every star-bearing
+    scene in this file.
+    """
+    NavTechnique._registry.append(_RaisingTechnique)
+    try:
+        yield
+    finally:
+        NavTechnique._registry.remove(_RaisingTechnique)
+
+
+def test_a_raising_to_features_fails_the_image(
     fake_obs: _FakeObs, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A misbehaving NavModel.to_features is logged and treated as zero features."""
+    """A NavModel.to_features that raises fails the image as internal_error."""
     obs = fake_obs
     model = _RaisingModel(obs)
     orch = NavOrchestrator([model])
     result = orch.navigate(obs)  # type: ignore[arg-type]
     captured = capsys.readouterr()
-    assert result.status_reason == NavStatusReason.NO_FEATURES_EXTRACTED
-    assert 'to_features raised' in captured.out
+    assert result.status == 'failed'
+    assert result.status_reason == NavStatusReason.INTERNAL_ERROR
+    assert result.internal_error is not None
+    assert result.internal_error.component == 'raising.to_features'
+    assert result.internal_error.exception_type == 'RuntimeError'
     assert 'synthetic to_features failure' in captured.out
 
 
-def test_orchestrator_logs_when_technique_raises(
+def test_a_raising_create_model_fails_the_image(fake_obs: _FakeObs) -> None:
+    """A NavModel.create_model that raises fails the image as internal_error."""
+    obs = fake_obs
+
+    class _BadBuildModel(_FakeStarModel):
+        """Star model whose ``create_model`` raises."""
+
+        def create_model(self) -> None:
+            """Raise instead of building."""
+            raise ValueError('synthetic create_model failure')
+
+    orch = NavOrchestrator([_BadBuildModel(obs, feature_count=2)])
+    result = orch.navigate(obs)  # type: ignore[arg-type]
+    assert result.status == 'failed'
+    assert result.status_reason == NavStatusReason.INTERNAL_ERROR
+    assert result.internal_error is not None
+    assert result.internal_error.component == 'stars.create_model'
+    assert result.internal_error.exception_type == 'ValueError'
+
+
+@pytest.mark.usefixtures('_register_raising_technique')
+def test_a_raising_technique_fails_the_image(
     fake_obs: _FakeObs, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A misbehaving NavTechnique.navigate is logged and treated as no result."""
+    """A NavTechnique.navigate that raises fails the image as internal_error."""
     obs = fake_obs
     model = _FakeStarModel(obs, feature_count=3)
     orch = NavOrchestrator([model], only_techniques='_RaisingTechnique')
     result = orch.navigate(obs)  # type: ignore[arg-type]
     captured = capsys.readouterr()
-    assert result.status_reason == NavStatusReason.NO_FEASIBLE_TECHNIQUES
-    assert 'navigate raised' in captured.out
+    assert result.status == 'failed'
+    assert result.status_reason == NavStatusReason.INTERNAL_ERROR
+    assert result.internal_error is not None
+    assert result.internal_error.component == '_RaisingTechnique.navigate'
+    assert result.internal_error.exception_type == 'RuntimeError'
     assert 'synthetic navigate failure' in captured.out
+
+
+@pytest.mark.usefixtures('_register_raising_technique')
+def test_a_raising_technique_is_not_answered_from_the_survivors(
+    fake_obs: _FakeObs,
+) -> None:
+    """One technique raising fails the image although another one succeeded.
+
+    This is the property the whole change exists for: before it, the working
+    technique's offset was reported as a success and nothing downstream could
+    tell that answer apart from one computed with every technique intact.
+    """
+    obs = fake_obs
+    model = _FakeStarModel(obs, feature_count=3)
+    orch = NavOrchestrator([model], only_techniques=['_FakeStarTechnique', '_RaisingTechnique'])
+    result = orch.navigate(obs)  # type: ignore[arg-type]
+    assert result.status == 'failed'
+    assert result.status_reason == NavStatusReason.INTERNAL_ERROR
+    assert result.offset_px is None
+
+
+def test_a_contract_violation_is_not_reclassified_as_an_internal_error(
+    fake_obs: _FakeObs,
+) -> None:
+    """A NavContractError still reports contract_violation, carrying no record."""
+    obs = fake_obs
+
+    class _ContractBreakingModel(_FakeStarModel):
+        """Star model whose ``to_features`` violates an internal contract."""
+
+        def to_features(self, context: NavContext) -> list[NavFeature]:
+            """Raise the contract error."""
+            raise NavContractError('synthetic contract violation')
+
+    orch = NavOrchestrator([_ContractBreakingModel(obs, feature_count=2)])
+    result = orch.navigate(obs)  # type: ignore[arg-type]
+    assert result.status_reason == NavStatusReason.CONTRACT_VIOLATION
+    assert result.internal_error is None
 
 
 def test_orchestrator_ensemble_contract_violation_yields_failed_result(
@@ -735,11 +820,17 @@ def test_orchestrator_records_model_metadata(fake_obs: _FakeObs) -> None:
 
 
 def test_orchestrator_records_annotations(fake_obs: _FakeObs) -> None:
-    """Annotations from every NavModel are merged into NavResult.annotations."""
+    """Annotations from every NavModel are merged into NavResult.annotations.
+
+    The navigation is asserted to have reached the merge, because a failed
+    result carries an empty ``Annotations`` too: checking only the type
+    passes on a run that never called ``to_annotations`` at all.
+    """
     obs = fake_obs
     model = _FakeStarModel(obs, feature_count=2)
     orch = NavOrchestrator([model])
     result = orch.navigate(obs)  # type: ignore[arg-type]
+    assert result.status_reason != NavStatusReason.INTERNAL_ERROR
     assert isinstance(result.annotations, Annotations)
 
 
@@ -757,17 +848,27 @@ def test_orchestrator_low_reliability_features_all_gated(fake_obs: _FakeObs) -> 
     assert result.status_reason == NavStatusReason.ALL_FEATURES_GATED
 
 
-def test_collect_annotations_skips_failing_model(
+def test_a_raising_to_annotations_fails_the_image(
     fake_obs: _FakeObs, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A failing to_annotations doesn't break the rest of the pipeline."""
+    """A failing to_annotations fails the image, though a sibling model worked.
+
+    Annotations only feed the summary PNG, so failing the whole image for one
+    is the severest reading of the rule.  It is the rule all the same: a model
+    that cannot describe what it found is in a state nobody planned for, and
+    an offset reported from a run that hit one would be indistinguishable from
+    an offset reported from a run that did not.
+    """
     obs = fake_obs
 
     class _GoodModel(_FakeStarModel):
-        pass
+        """Star model that annotates normally."""
 
     class _BadAnnotationModel(_FakeStarModel):
+        """Star model whose ``to_annotations`` raises."""
+
         def to_annotations(self, context: NavContext) -> Annotations:
+            """Raise instead of annotating."""
             raise RuntimeError('synthetic to_annotations failure')
 
     bad = _BadAnnotationModel(obs, feature_count=2)
@@ -775,8 +876,10 @@ def test_collect_annotations_skips_failing_model(
     orch = NavOrchestrator([bad, good], only_techniques=['_FakeStarTechnique'])
     result = orch.navigate(obs)  # type: ignore[arg-type]
     captured = capsys.readouterr()
-    assert result.status == 'success'
-    assert 'to_annotations raised' in captured.out
+    assert result.status == 'failed'
+    assert result.status_reason == NavStatusReason.INTERNAL_ERROR
+    assert result.internal_error is not None
+    assert result.internal_error.component == 'stars.to_annotations'
     assert 'synthetic to_annotations failure' in captured.out
 
 
@@ -1188,7 +1291,6 @@ def test_no_feasible_techniques_emits_status_reason_info(
         [model],
         only_techniques=[
             '!_FakeStarTechnique',
-            '!_RaisingTechnique',
             '!_InfeasibleTechnique',
             '!Star*',
         ],

--- a/tests/spindoctor/support/test_status_reason.py
+++ b/tests/spindoctor/support/test_status_reason.py
@@ -25,6 +25,7 @@ from spindoctor.support.status_reason import NavStatusReason
         'FINAL_SIGMA_ABOVE_THRESHOLD',
         'UNOBSERVABLE_OFFSET',
         'CONTRACT_VIOLATION',
+        'INTERNAL_ERROR',
     ],
 )
 def test_navstatusreason_has_value(name: str) -> None:
@@ -33,8 +34,8 @@ def test_navstatusreason_has_value(name: str) -> None:
 
 
 def test_navstatusreason_count_matches_plan() -> None:
-    """Exactly 19 values are defined; adding a value must update tests."""
-    assert len(list(NavStatusReason)) == 19
+    """Exactly 20 values are defined; adding a value must update tests."""
+    assert len(list(NavStatusReason)) == 20
 
 
 @pytest.mark.parametrize(
@@ -43,6 +44,7 @@ def test_navstatusreason_count_matches_plan() -> None:
         (NavStatusReason.OK, 'ok'),
         (NavStatusReason.RANK_1_ONLY, 'rank_1_only'),
         (NavStatusReason.UNOBSERVABLE_OFFSET, 'unobservable_offset'),
+        (NavStatusReason.INTERNAL_ERROR, 'internal_error'),
         (NavStatusReason.ALL_FEATURES_GATED, 'all_features_gated'),
     ],
 )

--- a/tests/spindoctor/test_metadata_format_doc.py
+++ b/tests/spindoctor/test_metadata_format_doc.py
@@ -36,7 +36,7 @@ from spindoctor.feature.feature import NavReliabilityBreakdown
 from spindoctor.feature.feature_type import NavFeatureType
 from spindoctor.nav_orchestrator.feature_summary import NavFeatureSummary
 from spindoctor.nav_orchestrator.image_classifier_result import NavImageClassifierResult
-from spindoctor.nav_orchestrator.nav_result import NavResult
+from spindoctor.nav_orchestrator.nav_result import NavInternalErrorRecord, NavResult
 from spindoctor.nav_orchestrator.provenance import Provenance
 from spindoctor.nav_technique.diagnostics import BodyLimbDiagnostics
 from spindoctor.nav_technique.technique_result import NavTechniqueResult
@@ -319,6 +319,25 @@ def _failed_document() -> dict[str, Any]:
     return _document(_with_pointing(result, corrected=False), shutter_mode=None)
 
 
+def _internal_error_document() -> dict[str, Any]:
+    """The written document for a navigation a plugin's exception failed.
+
+    Carried by the writer-to-chapter guard because its ``internal_error``
+    block appears on no other document shape: without it the chapter could
+    stop documenting the block and every check here would still pass.
+    """
+    result = NavResult.failed(
+        status_reason=NavStatusReason.INTERNAL_ERROR,
+        image_classifier=_classifier(),
+        provenance=_provenance(),
+        internal_error=NavInternalErrorRecord(
+            component='NavModelRings.create_model',
+            exception_type='AttributeError',
+        ),
+    )
+    return _document(_with_pointing(result, corrected=False), shutter_mode=None)
+
+
 class _LoadErrorObsClass:
     """Observation class whose load always fails with a SPICE coverage error."""
 
@@ -384,6 +403,7 @@ def test_every_writer_key_is_documented(tmp_path: Path) -> None:
     emitted |= _leaf_key_names(_success_document())
     emitted |= _leaf_key_names(_rotation_document())
     emitted |= _leaf_key_names(_failed_document())
+    emitted |= _leaf_key_names(_internal_error_document())
     emitted |= _leaf_key_names(_load_error_document(tmp_path))
     emitted |= _leaf_key_names(_early_return_document(tmp_path))
     missing = emitted - _documented_key_literals()

--- a/tests/spindoctor/test_metadata_format_doc.py
+++ b/tests/spindoctor/test_metadata_format_doc.py
@@ -331,7 +331,7 @@ def _internal_error_document() -> dict[str, Any]:
         image_classifier=_classifier(),
         provenance=_provenance(),
         internal_error=NavInternalErrorRecord(
-            component='NavModelRings.create_model',
+            component='rings:SATURN.create_model',
             exception_type='AttributeError',
         ),
     )

--- a/tests/spindoctor/test_navigate_image_files.py
+++ b/tests/spindoctor/test_navigate_image_files.py
@@ -162,11 +162,16 @@ def _make_image_files(tmp_path: Path, *, camera: str | None = None) -> ImageFile
 
 
 def test_navigate_image_files_no_features_path(tmp_path: Path) -> None:
-    """A clean image with no registered models yields a status='failed' result.
+    """A clean image with no models selected yields a status='failed' result.
 
-    The fake observation class returns an empty NavModel set (no
-    real-scene models are registered), so the orchestrator reports
-    ``NO_FEATURES_EXTRACTED``.
+    ``nav_models='!*'`` selects no model, so nothing emits a feature and the
+    orchestrator reports ``NO_FEATURES_EXTRACTED``.  Selecting none is what
+    makes the premise true rather than merely stated: this fake observation
+    is not one the real scene models can read, and left unselected they build
+    against it and raise.  Until an unexpected exception became fatal that
+    raise was absorbed and the run reported ``no_features_extracted`` anyway
+    -- the same reason this test asserts, arrived at by an entirely different
+    route, which is the confusion the fatal path exists to remove.
     """
     obs_class = _make_fake_obs_class()
     image_files = _make_image_files(tmp_path)
@@ -174,6 +179,7 @@ def test_navigate_image_files_no_features_path(tmp_path: Path) -> None:
         obs_class,
         image_files,
         FCPath(str(tmp_path / 'results')),
+        nav_models=['!*'],
         write_output_files=False,
     )
     assert success is False
@@ -187,12 +193,8 @@ def test_navigate_image_files_no_features_path(tmp_path: Path) -> None:
     assert metadata['timing']['end_iso8601'].endswith('Z')
     assert 'navigation_result' in metadata
     nav_result = metadata['navigation_result']
-    # Without registered real-scene models the classifier still runs.
-    assert nav_result['status_reason'] in (
-        'no_features_extracted',
-        'no_signal_in_image',
-        'no_feasible_techniques',
-    )
+    assert nav_result['status_reason'] == 'no_features_extracted'
+    assert 'internal_error' not in nav_result
 
 
 def test_navigate_image_files_writes_metadata(tmp_path: Path) -> None:


### PR DESCRIPTION
## Purpose

The orchestrator wrapped every `NavModel` and `NavTechnique` call in a broad `except Exception` that logged a traceback and continued. Anything that was not a `NavContractError` was absorbed: the model or technique was dropped, navigation proceeded on whatever survived, and the image could still report `success` with an offset built from silently reduced evidence.

Nothing about the failure reached the metadata document. The results index, the PDS4 stage and the backplane stage all read the document rather than the log, so none of them could tell a fully navigated image from a degraded one. At campaign scale, where nobody reads per-image logs, a dependency regression that costs one model its output was an unmeasurable loss of accuracy rather than a batch of failures.

The intent behind the original design was sound — one misbehaving plugin should not take down a batch, and specific exception types cannot be enumerated across plugins. What it could not do is separate the two cases it straddled. "This model legitimately found nothing here" is a normal outcome the feature and gating path already models properly; "this model is broken, or its dependencies are" is a defect, and giving both the same `except Exception` converted a detectable failure into a quiet one.

Closes #503

## Changes

- **All four wrappers now fail the image.** `create_model`, `to_features`, `to_annotations` and `technique.navigate` wrap any non-`NavContractError` exception as a new `NavInternalError` naming the component, and `navigate()` converts it into a failed `NavResult`. Failing the image is not raising through to the caller: a batch driver sees an ordinary failed frame and continues, exactly as it does for any other failure.
- **A distinct status reason.** `NavStatusReason.INTERNAL_ERROR`, kept separate from `CONTRACT_VIOLATION` (an invariant core code checked for) and from the data-driven reasons. The issue's benchmark is why: the one image that did fail reported `no_features_extracted`, which describes the symptom and misdirects from the cause.
- **The document says which component raised.** A new `internal_error` block carries `component` (`NavModelRings.create_model`) and `exception_type` (`AttributeError`). The exception's message and traceback are deliberately not recorded there — they can carry local file paths and array contents, and the document is an archive product. The per-image error log has both.
- **`NavResult` holds the reason and the record in step.** Construction refuses a result that carries one without the other, so a document reporting an internal error always says which component hit it, and no other document carries a component that never raised. Two encodings of one fact that nothing holds in step eventually disagree.
- **One traceback per failure.** The wrapper logs the plugin's own traceback, which is the one worth reading; `navigate()` logs at error level rather than exception level so the re-raise chain does not bury it.
- Docstrings and the `# plugin sandbox` comments at all four sites, which documented the swallow as intentional, are rewritten to describe what now happens and why.

### The judgment call the issue left open

The issue asked whether technique-level failures warrant the same treatment as model-level ones, given that a single technique failing among several is closer to a normal outcome than a model failing to build.

They are treated the same, and the reason is that the pipeline has no way to record an exemption honestly. A technique with nothing to contribute already has two ways to say so — `is_feasible` returning false, and a result marked spurious — and both leave a trace in the per-technique inventory. An exception leaves none, so an exempted technique failure would be a silently smaller ensemble, and the ensemble's confidence is a function of how many witnesses agreed.

`prepare()` is the one deliberate exception to the whole rule: it returns artifacts rather than a `NavResult`, so it has nothing to record a failure on, and an exception propagates to its interactive callers as `NavContractError` already does.

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (fix or feature that alters existing behavior or public API)
- [ ] Refactor (no functional or API changes)
- [x] Documentation
- [ ] Tests only (no production code change)
- [ ] CI / Build / Dependencies

Flagged as breaking because an image that previously reported `success` on reduced evidence now reports `failed`. That is the point of the change rather than a side effect of it, and no run on a healthy pipeline is affected — see Potential Impacts.

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] End-to-end tests pass (if applicable)
- [x] New or updated tests for changed code
- [x] Tested manually (describe below if applicable)

**Unit suite** — 29 failures, byte-identical to the `main` baseline captured before any edit; all 29 are the pre-existing environment-dependent dataset tests. Run at `-n 4 --dist=loadfile` with the BLAS/OMP thread pins.

**Integration** — `tests/integration/test_sim_navigation.py` and `test_sim_regression.py` pass. This is the check that matters most: real models and techniques run through the new fatal path on healthy simulated scenes without a single image changing outcome, which is the evidence that the change does not fail images on a working pipeline.

**Every guarantee verified by breaking the source**, per the project's protocol that a test which passes against a deliberately broken implementation is a defect in the test:

| Break | Test that failed |
|---|---|
| `create_model` wrapper reverted to swallowing | `test_a_raising_create_model_fails_the_image` |
| `to_features` wrapper reverted to swallowing | `test_a_raising_to_features_fails_the_image` |
| `to_annotations` wrapper reverted to swallowing | `test_a_raising_to_annotations_fails_the_image` |
| `technique.navigate` wrapper reverted to swallowing | `test_a_raising_technique_fails_the_image`, `test_a_raising_technique_is_not_answered_from_the_survivors` |
| Contract errors reclassified as internal errors | `test_a_contract_violation_is_not_reclassified_as_an_internal_error` |
| `NavResult` reason/record invariant disabled | `test_an_internal_error_reason_requires_the_record`, `test_an_internal_error_record_requires_the_reason` |
| `component` / `exception_type` literals stripped from the metadata chapter | `test_every_writer_key_is_documented` |

**New tests** — the four raising paths and the contract-violation split (`test_orchestrator.py`); the document-level assertions that the JSON names the component and the exception class (`test_curator.py`); the invariant in both directions (`test_nav_result.py`); and one test for the property the whole change exists for, `test_a_raising_technique_is_not_answered_from_the_survivors`, which asserts that one technique raising fails the image although another one succeeded.

**Other gates** — `ruff check`, `ruff format --check`, `mypy src tests` (732 files), `pymarkdown`, and a clean `sphinx -W` build with zero warnings.

## Potential Impacts

**Behavioral, and intended.** An image whose model or technique raises now reports `failed` where it previously reported `success` on reduced evidence. On a healthy pipeline nothing changes: the raises this converts are argument-validation `TypeError`/`ValueError` guards and dependency breakage, not control flow. Every `raise` in `nav_model/` and `nav_technique/` was surveyed to confirm none is used to signal "skip me" — that is what `is_feasible` and `spurious` are for — and the sim navigation integration tier passing on real models and techniques is the empirical half of the same check.

**Where it will show up.** A dependency regression that costs one model its output now produces a batch of failed frames instead of a batch of plausible-looking successes. That is a louder failure mode by design, and it is the one the issue's benchmark case would have made visible: 5 of 22 images lost their ring model, and 4 of the 5 still reported `success`.

**Public API** — `NavResult` gains an optional `internal_error` field and `NavResult.failed` an optional keyword; both default to `None`, so existing construction sites are unaffected. `NavStatusReason` gains a twentieth value, which every consumer that derives its vocabulary from the enum (`sim/scene_checks.py`, `tests/integration/sidecar.py`) picks up automatically.

**Results index** — `status_reason` is a text column, so `internal_error` flows through with no schema change. `component` and `exception_type` are not columns, so an index-backed query can tell you an image hit an internal error but not which component. See Notes.

## Checklist

- [x] Code follows project style (`ruff check`, `ruff format`)
- [x] Type annotations present and `mypy` passes
- [x] Docstrings and Sphinx docs updated (if applicable)
- [ ] CHANGES.md updated (if user-facing change) — the repository has no `CHANGES.md`
- [x] No temporary or debug code left in
- [x] Breaking changes flagged in Type of Change above

## Notes

**Two things this surfaced that are worth a reviewer's attention.**

`test_navigate_image_files_no_features_path` asserted `no_features_extracted` on the stated premise that no models were registered. In fact a real `NavModelStars` was building against the fake observation, raising `AttributeError`, and being swallowed — the same status reason reached by an entirely different route. That is the misdirection this issue describes, sitting in the test suite. The premise is now true (`nav_models=['!*']`) rather than merely stated, and the docstring records what was actually happening.

The metadata chapter's writer-to-chapter staleness guard had no document shape carrying an `internal_error` block, so it could not have caught the chapter failing to document one. `_internal_error_document()` closes that, verified by stripping the literals from the chapter and confirming the guard fails.

**Follow-up worth filing, not done here:** making `component` and `exception_type` index columns, so a campaign-scale query can group internal errors by which component raised rather than only counting them. Out of scope for this issue, which asks for the metadata document.

**Plan reconciliation:** this branch is cut from `main`, so its `plans/` are the pre-reconcile versions and are untouched here deliberately — every PR that edits `plans/PROGRAM_PLAN.md` re-conflicts the others. The `rf_plan_reconcile` branch puts #503 at the top of Track B and as step zero of the operator playbook's sequencing; whichever of the two merges second needs those entries moved to closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `internal_error` failure status for unexpected navigation model or technique errors.
  * Failed results now identify the affected component and exception type in metadata.
  * Unexpected errors now fail the image instead of being silently skipped.

* **Documentation**
  * Added operator guidance for troubleshooting internal navigation failures, including logs and tracebacks.
  * Documented the new status reason and metadata fields in the user guide.

* **Bug Fixes**
  * Contract violations remain distinctly reported from unexpected internal errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->