### PR TITLE
fix: ask the backplane to name a ring key, not the array

### DIFF
--- a/src/spindoctor/nav_model/nav_model_rings.py
+++ b/src/spindoctor/nav_model/nav_model_rings.py
@@ -387,6 +387,12 @@ class NavModelRings(NavModelRingsBase):
         if bp_radii.is_all_masked():
             self._logger.info('No rings visible in observation')
             return
+        # Ask the backplane to name the key rather than reading bp_radii.key:
+        # oops attaches that attribute from outside polymath, so polymath drops
+        # it from any array it clones, and no array that was computed from this
+        # one carries it at all.  Resolved once because naming a key can cost a
+        # scan of every registered backplane.
+        bp_radii_key = obs.ext_bp.standardize_backplane_key(bp_radii)
         min_radius = float(bp_radii.min().vals)
         max_radius = float(bp_radii.max().vals)
         self._logger.info(
@@ -429,7 +435,7 @@ class NavModelRings(NavModelRingsBase):
                 extended FOV.
             """
             border_arr: NDArrayBoolType = (
-                obs.ext_bp.border_atop(bp_radii.key, a).mvals.astype('bool').filled(False)
+                obs.ext_bp.border_atop(bp_radii_key, a).mvals.astype('bool').filled(False)
             )
             res_at_edge = resolutions[border_arr]
             res_ma = np.ma.asarray(res_at_edge)

--- a/src/spindoctor/nav_model/rings/ring_feature.py
+++ b/src/spindoctor/nav_model/rings/ring_feature.py
@@ -416,7 +416,7 @@ class RingFeature:
             if len(mode_info) == 5:
                 mode, a, ae, long_peri_rad, rate_peri_rad_per_sec = mode_info
                 radii_bp = context.obs.ext_bp.radial_mode(
-                    radii_bp.key,
+                    context.obs.ext_bp.standardize_backplane_key(radii_bp),
                     mode,
                     context.epoch,
                     ae,
@@ -427,7 +427,7 @@ class RingFeature:
             else:
                 mode, amplitude, phase_rad, speed_rad_per_sec = mode_info
                 radii_bp = context.obs.ext_bp.radial_mode(
-                    radii_bp.key,
+                    context.obs.ext_bp.standardize_backplane_key(radii_bp),
                     mode,
                     context.epoch,
                     amplitude,
@@ -534,8 +534,9 @@ class RingFeature:
         ]:
             label = labels[edge_type]
             feature_name = self.name or 'UNNAMED'
+            edge_key = context.obs.ext_bp.standardize_backplane_key(edge_bp)
             edge_mask = (
-                context.obs.ext_bp.border_atop(edge_bp.key, a).mvals.astype('bool').filled(False)
+                context.obs.ext_bp.border_atop(edge_key, a).mvals.astype('bool').filled(False)
             )
             edge_info_list.append((edge_mask, f'{feature_name} {label}', label))
 
@@ -616,8 +617,9 @@ class RingFeature:
 
         label = labels[edge_type]
         feature_name = self.name or 'UNNAMED'
+        radii_key = context.obs.ext_bp.standardize_backplane_key(radii_bp)
         edge_mask: NDArrayBoolType = (
-            context.obs.ext_bp.border_atop(radii_bp.key, edge_a).mvals.astype('bool').filled(False)
+            context.obs.ext_bp.border_atop(radii_key, edge_a).mvals.astype('bool').filled(False)
         )
         edge_info_list: list[tuple[NDArrayBoolType, str, str]] = [
             (edge_mask, f'{feature_name} {label}', label)

--- a/tests/shims/backplane.py
+++ b/tests/shims/backplane.py
@@ -64,10 +64,10 @@ def _scalar(
 
     ``polymath.Scalar`` already covers ``.vals`` / ``.mvals`` /
     ``min`` / ``max`` / ``median`` / ``expand_mask`` / ``mask_where`` /
-    ``any`` / ``__getitem__`` natively.  The shim only needs to set the
-    ``key`` attribute the navigation pipeline reads back from
-    ``ring_radius`` results so it can call
-    :meth:`oops.Backplane.border_atop`.
+    ``any`` / ``__getitem__`` natively.  The shim adds only the ``key``
+    attribute that ``oops.Backplane`` sets on a registered backplane, so
+    that :meth:`FakeBackplane.standardize_backplane_key` answers from it
+    the way the real method does.
 
     Parameters:
         vals: Numpy array or scalar.
@@ -227,13 +227,15 @@ class FakeBackplane:
     def standardize_backplane_key(self, backplane_key: Any) -> tuple[Any, ...]:
         """Name the key an array is registered under, as ``oops.Backplane`` does.
 
-        Production code asks for a key this way rather than reading the array's
-        ``key`` attribute, because oops attaches that attribute from outside
-        polymath and polymath carries it only across a copy or a clone -- never
-        onto an array computed from one.  Mirrors the real method: an array is
-        answered from ``key`` when it has one and by searching the registry for
-        it by identity otherwise, a string becomes an upper-case one-tuple, and
-        a tuple passes through.
+        This is how production code names a key.  It does not read the array's
+        ``key`` attribute, which oops sets on what the registry hands out but
+        which is absent from any array computed from one -- correctly so, since
+        a computed array is not the registered backplane and a key claiming
+        otherwise would resolve to the wrong array without raising.
+
+        Mirrors the real method: an array is answered from ``key`` when it has
+        one and by searching the registry for it by identity otherwise, a
+        string becomes an upper-case one-tuple, and a tuple passes through.
 
         Parameters:
             backplane_key: An array obtained from this backplane, or a key
@@ -328,16 +330,19 @@ class FakeBackplane:
     # ------------------------------------------------------------------
 
     def ring_radius(self, ring_target: str) -> KeyedScalar:
-        """Return per-pixel ring-plane radius in km, tagged with its key.
+        """Return per-pixel ring-plane radius in km, registered under its key.
+
+        The array is registered under ``('ring_radius', ring_target)`` and
+        cached, so :meth:`standardize_backplane_key` -- which is how production
+        names it before calling :meth:`border_atop` -- can find it by identity.
+        Repeat calls answer with the one object, as ``oops.Backplane`` answers
+        from its cache.
 
         Parameters:
             ring_target: Ring target name, as keyed into ``per_ring``.
 
         Returns:
-            :class:`KeyedScalar` of per-pixel radii, masked outside the
-            configured ``ring_mask``, whose ``key`` is the
-            ``('ring_radius', ring_target)`` tuple the production code
-            reads back and hands to :meth:`border_atop`.
+            Per-pixel radii, masked outside the configured ``ring_mask``.
         """
         key = ('ring_radius', ring_target)
         if key in self.backplanes:
@@ -355,9 +360,9 @@ class FakeBackplane:
     def border_atop(self, key: tuple[Any, ...], a: float) -> polymath.Scalar:
         """Return a boolean Scalar marking pixels at ring radius ``a``.
 
-        ``key`` is the tuple read off ``ring_radius(...).key`` by the
-        production code; the head determines which ring's radius array
-        we threshold against ``a``.
+        ``key`` is the tuple production code obtains from
+        :meth:`standardize_backplane_key`; the head determines which ring's
+        radius array we threshold against ``a``.
         """
         if not key or key[0] != 'ring_radius':
             raise LookupError(f'FakeBackplane.border_atop expected a ring_radius key, got {key!r}')

--- a/tests/shims/backplane.py
+++ b/tests/shims/backplane.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import polymath
@@ -222,6 +222,43 @@ class FakeBackplane:
 
     per_body: dict[str, BodyBackplaneData] = field(default_factory=dict)
     per_ring: dict[str, RingBackplaneData] = field(default_factory=dict)
+    backplanes: dict[tuple[Any, ...], KeyedScalar] = field(default_factory=dict)
+
+    def standardize_backplane_key(self, backplane_key: Any) -> tuple[Any, ...]:
+        """Name the key an array is registered under, as ``oops.Backplane`` does.
+
+        Production code asks for a key this way rather than reading the array's
+        ``key`` attribute, because oops attaches that attribute from outside
+        polymath and polymath carries it only across a copy or a clone -- never
+        onto an array computed from one.  Mirrors the real method: an array is
+        answered from ``key`` when it has one and by searching the registry for
+        it by identity otherwise, a string becomes an upper-case one-tuple, and
+        a tuple passes through.
+
+        Parameters:
+            backplane_key: An array obtained from this backplane, or a key
+                already in string or tuple form.
+
+        Returns:
+            The registered backplane key.
+
+        Raises:
+            ValueError: If an array is not one this backplane handed out, or the
+                argument is neither an array nor a string nor a tuple.
+        """
+        if isinstance(backplane_key, polymath.Qube):
+            key = getattr(backplane_key, 'key', None)
+            if key is not None:
+                return cast('tuple[Any, ...]', key)
+            for registered_key, array in self.backplanes.items():
+                if array is backplane_key:
+                    return registered_key
+            raise ValueError('illegal backplane key type: ' + type(backplane_key).__name__)
+        if isinstance(backplane_key, str):
+            return (backplane_key.upper(),)
+        if isinstance(backplane_key, tuple):
+            return backplane_key
+        raise ValueError('illegal backplane key type: ' + type(backplane_key).__name__)
 
     def _body(self, body_name: str) -> BodyBackplaneData:
         key = body_name.upper()
@@ -302,12 +339,13 @@ class FakeBackplane:
             ``('ring_radius', ring_target)`` tuple the production code
             reads back and hands to :meth:`border_atop`.
         """
+        key = ('ring_radius', ring_target)
+        if key in self.backplanes:
+            return self.backplanes[key]
         data = self._ring(ring_target)
-        return _scalar(
-            data.ring_radius_km,
-            ~data.ring_mask,
-            key=('ring_radius', ring_target),
-        )
+        radii = _scalar(data.ring_radius_km, ~data.ring_mask, key=key)
+        self.backplanes[key] = radii
+        return radii
 
     def ring_radial_resolution(self, ring_target: str) -> polymath.Scalar:
         """Return per-pixel radial km/px scale."""

--- a/tests/shims_tests/test_shims_self.py
+++ b/tests/shims_tests/test_shims_self.py
@@ -142,6 +142,41 @@ def test_fake_backplane_ring_radius_carries_border_atop_key() -> None:
     assert radii.key == ('ring_radius', 'saturn:ring')
 
 
+def test_fake_backplane_names_the_key_of_a_ring_radius_array() -> None:
+    """``standardize_backplane_key`` answers for an array it handed out."""
+    ring = RingBackplaneData(
+        ring_radius_km=np.zeros((2, 2)),
+        ring_mask=np.ones((2, 2), dtype=bool),
+    )
+    bp = FakeBackplane(per_ring={'saturn:ring': ring})
+    radii = bp.ring_radius('saturn:ring')
+    assert bp.standardize_backplane_key(radii) == ('ring_radius', 'saturn:ring')
+
+
+def test_fake_backplane_names_the_key_without_the_attribute() -> None:
+    """An array carrying no ``key`` is found in the registry by identity."""
+    ring = RingBackplaneData(
+        ring_radius_km=np.zeros((2, 2)),
+        ring_mask=np.ones((2, 2), dtype=bool),
+    )
+    bp = FakeBackplane(per_ring={'saturn:ring': ring})
+    radii = bp.ring_radius('saturn:ring')
+    del radii.key
+    assert bp.standardize_backplane_key(radii) == ('ring_radius', 'saturn:ring')
+
+
+def test_fake_backplane_refuses_to_name_an_unregistered_array() -> None:
+    """An array this backplane never handed out has no key here."""
+    ring = RingBackplaneData(
+        ring_radius_km=np.zeros((2, 2)),
+        ring_mask=np.ones((2, 2), dtype=bool),
+    )
+    bp = FakeBackplane(per_ring={'saturn:ring': ring})
+    with pytest.raises(ValueError) as exc_info:
+        bp.standardize_backplane_key(polymath.Scalar(np.zeros((2, 2))))
+    assert 'illegal backplane key type' in str(exc_info.value)
+
+
 def test_fake_backplane_border_atop_uses_default_threshold() -> None:
     """``border_atop`` returns pixels whose ring radius is within 0.5 km of ``a``."""
     radius = np.array([[100_000.0, 100_000.4], [200_000.0, 100_000.8]])


### PR DESCRIPTION
## Purpose

The ring model named a backplane's key by reading it off the array (`bp_radii.key`). That attribute is not something a caller can rely on, so the five sites that did it now ask `Backplane.standardize_backplane_key`, which is the supported way and is correct under every oops version.

Issue #288 stays open; it also covers three genuine navigation disagreements needing operator ratification, attributed in a comment there.

## Changes

oops records the registration key as a plain attribute on the array it hands out. polymath carries an attribute added that way across a copy or a clone and onto nothing else, so **an array computed from a backplane never has it** -- and that part is correct, not a defect: a computed array is not the registered backplane, and a key claiming otherwise would resolve to the wrong array silently rather than raising.

Until `rms-oops` 0.2.1 it was worse than that: `register_backplane` set the attribute with a plain assignment that polymath's clone dropped, and the function clones on the way out for any backplane carrying derivatives, so `ring_radius(...)` returned an array without the key oops had just set. That raised `AttributeError` part-way through building the rings model on every Saturn frame. Fixed upstream in 0.2.1 and reported as SETI/rms-oops#211.

- **Five call sites** ask `standardize_backplane_key` instead: one in `nav_model_rings.py` (hoisted out of the per-edge closure, since naming a key can cost a registry scan) and four in `rings/ring_feature.py`.
- **`FakeBackplane` gains the same method**, and `ring_radius` now registers and caches the array it returns so the identity lookup has something to find.

## Type of Change

- [x] Bug fix (non-breaking)

## Testing

- [x] Unit tests pass
- [x] New or updated tests for changed code

`ruff check`, `ruff format --check`, `mypy src tests` (732 files) clean. **12130 unit tests pass** at `-n 4 --dist=loadfile` with the BLAS/OMP pins exported. Three new shim self-tests cover naming a key from the attribute, naming one without it via the registry, and refusing an array the backplane never handed out.

**What this change is worth, stated honestly.** With `rms-oops` 0.2.1 installed the old `.key` read also works, because every array these five sites receive comes straight from a register call. So this fixes no currently-red frame. It is worth having because the attribute is an oops implementation detail rather than a documented contract (SETI/rms-oops#211 asks for `standardize_backplane_key` to be named as the supported route), and because the attribute will never be present on a computed array -- an invariant these call sites rely on today and nothing enforces.

**And what it does not do.** A fuller version of this change also made `FakeBackplane` withhold the `key` attribute, which made twenty existing unit tests fail against the old call sites -- closing the gap that let this reach a fifteen-minute library run instead of a five-second unit one. This minimal version keeps the shim tagging the attribute, so **reverting these call sites to `.key` still passes the whole unit suite**. That coverage gap remains open.

## Potential Impacts

None functional under `rms-oops` >= 0.2.1. Under an older oops this restores the rings model on ring-bearing frames.

No public API change; `KeyedScalar` and the existing shim behaviour are untouched.

## Notes

`pyproject.toml` still asks for `rms-oops>=0.1.5`, a version no longer on PyPI, and 0.2.0 satisfies it while lacking the fix. Worth bumping to `>=0.2.1` -- not done here to keep this change minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UnCtxZeA2kVw6uUtCxWrU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ring and ringlet rendering by consistently resolving backplane identifiers.
  * Fixed edge and radius calculations when array metadata is unavailable, preventing potential rendering errors.
  * Preserved existing model, annotation, and mask output while improving reliability across cloned or derived data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->